### PR TITLE
Handle free memberships (e.g. Staff, Friend)

### DIFF
--- a/app/client/components/cancel/cancellationSummary.tsx
+++ b/app/client/components/cancel/cancellationSummary.tsx
@@ -5,13 +5,17 @@ import { GenericErrorScreen } from "../genericErrorScreen";
 import { PageContainerSection } from "../page";
 import { formatDate, Subscription } from "../user";
 
-const actuallyCancelled = (cancelType: string, subscription: Subscription) => (
+const actuallyCancelled = (cancelType: string, subscription?: Subscription) => (
   <PageContainerSection>
     <h2>Your {cancelType} is cancelled.</h2>
-    <p>
-      You will continue to receive the benefits of your {cancelType} until{" "}
-      <b>{formatDate(subscription.end)}</b>. You will not be charged again.
-    </p>
+    {subscription ? (
+      <p>
+        You will continue to receive the benefits of your {cancelType} until{" "}
+        <b>{formatDate(subscription.end)}</b>. You will not be charged again.
+      </p>
+    ) : (
+      undefined
+    )}
     <p>
       If you are interested in supporting our journalism in other ways, please
       consider either a contribution or a subscription.
@@ -29,9 +33,9 @@ const actuallyCancelled = (cancelType: string, subscription: Subscription) => (
 );
 
 export const CancellationSummary = (cancelType: string) => (
-  subscription: Subscription
+  subscription?: Subscription
 ) =>
-  subscription.cancelledAt ? (
+  subscription && subscription.cancelledAt ? (
     actuallyCancelled(cancelType, subscription)
   ) : (
     <GenericErrorScreen />

--- a/app/client/components/cancel/cancellationSummary.tsx
+++ b/app/client/components/cancel/cancellationSummary.tsx
@@ -5,16 +5,16 @@ import { GenericErrorScreen } from "../genericErrorScreen";
 import { PageContainerSection } from "../page";
 import { formatDate, Subscription } from "../user";
 
-const actuallyCancelled = (cancelType: string, subscription?: Subscription) => (
+const actuallyCancelled = (cancelType: string, subscription: Subscription) => (
   <PageContainerSection>
     <h2>Your {cancelType} is cancelled.</h2>
-    {subscription ? (
+    {subscription.end ? (
       <p>
         You will continue to receive the benefits of your {cancelType} until{" "}
         <b>{formatDate(subscription.end)}</b>. You will not be charged again.
       </p>
     ) : (
-      undefined
+      <p>Your cancellation is effective immediately.</p>
     )}
     <p>
       If you are interested in supporting our journalism in other ways, please
@@ -33,9 +33,9 @@ const actuallyCancelled = (cancelType: string, subscription?: Subscription) => (
 );
 
 export const CancellationSummary = (cancelType: string) => (
-  subscription?: Subscription
+  subscription: Subscription
 ) =>
-  subscription && subscription.cancelledAt ? (
+  Object.keys(subscription).length === 0 || subscription.cancelledAt ? (
     actuallyCancelled(cancelType, subscription)
   ) : (
     <GenericErrorScreen />

--- a/app/client/components/cancel/paidMembership/paidMembershipFlow.tsx
+++ b/app/client/components/cancel/paidMembership/paidMembershipFlow.tsx
@@ -186,7 +186,12 @@ const getReasonsRenderer = (routeableProps: RouteableProps) => (
     );
   }
 
-  return <h2>No Membership</h2>;
+  return (
+    <>
+      <h2>No Membership</h2>
+      <ReturnToYourAccountButton />
+    </>
+  );
 };
 
 export const PaidMembershipFlow = (props: RouteableProps) => (

--- a/app/client/components/cancel/paidMembership/paidMembershipFlow.tsx
+++ b/app/client/components/cancel/paidMembership/paidMembershipFlow.tsx
@@ -201,7 +201,7 @@ export const PaidMembershipFlow = (props: RouteableProps) => (
       <div css={{ height: "50px" }} />
       <CheckFlowIsValid
         checkingFor="membership"
-        validator={(me: MeResponse) => me.contentAccess.paidMember}
+        validator={(me: MeResponse) => me.contentAccess.member}
       >
         <MembershipAsyncLoader
           fetch={loadMembershipData}

--- a/app/client/components/cancel/stages/executeCancellation.tsx
+++ b/app/client/components/cancel/stages/executeCancellation.tsx
@@ -28,16 +28,15 @@ export const getCancelFunc = (
     | WithSubscription
     | {} = await withSubscriptionPromiseFetcher();
 
-  const subscriptionPromise = Promise.resolve(
-    (mightHaveSubscription as WithSubscription).subscription
-  );
+  const subscription =
+    (mightHaveSubscription as WithSubscription).subscription || {};
 
   await getUpdateCasePromise(caseId, {
     Journey__c: "SV - Cancellation - MB",
     Subject: "Online Cancellation Completed"
   });
 
-  return subscriptionPromise;
+  return Promise.resolve(subscription);
 };
 
 export interface ExecuteCancellationRouteableProps extends RouteableProps {

--- a/app/client/components/membership.tsx
+++ b/app/client/components/membership.tsx
@@ -13,6 +13,7 @@ export interface MembershipData extends WithSubscription {
   regNumber?: string;
   tier: string;
   isPaidTier: boolean;
+  joinDate: string;
 }
 
 export type MembersDataApiResponse = MembershipData | {};
@@ -88,10 +89,6 @@ const renderMembershipData = (data: MembersDataApiResponse) => {
       paymentPart = (
         <React.Fragment>
           <MembershipRow
-            label={"Start date"}
-            data={formatDate(data.subscription.start)}
-          />
-          <MembershipRow
             label={"Next payment date"}
             data={formatDate(data.subscription.nextPaymentDate)}
           />
@@ -119,7 +116,11 @@ const renderMembershipData = (data: MembersDataApiResponse) => {
 
     return (
       <div>
-        <MembershipRow label={"Membership number"} data={data.regNumber} />
+        {data.regNumber ? (
+          <MembershipRow label={"Membership number"} data={data.regNumber} />
+        ) : (
+          undefined
+        )}
         <MembershipRow
           label={"Membership tier"}
           data={
@@ -137,6 +138,10 @@ const renderMembershipData = (data: MembersDataApiResponse) => {
               )}
             </React.Fragment>
           }
+        />
+        <MembershipRow
+          label={"Start date"}
+          data={formatDate(data.subscription.start || data.joinDate)}
         />
         {paymentPart}
       </div>

--- a/app/server/server.ts
+++ b/app/server/server.ts
@@ -6,7 +6,6 @@ import Raven from "raven";
 import { renderToString } from "react-dom/server";
 import { ServerUser } from "../client/components/user";
 import { Globals } from "../globals";
-import { MeResponse } from "../shared/meResponse";
 import { conf, Environments } from "./config";
 import { renderStylesToString } from "./emotion-server";
 import html from "./html";


### PR DESCRIPTION
Because free memberships (e.g. Staff, Friend) cancel immediately and the `members-data-api` response is `{}` it used think that was an error (because no `subscription` property in the response) now it handles and shows an appropriate message.