### PR TITLE
switch on per-usage polyfills for older browsers

### DIFF
--- a/app/client/components/main.tsx
+++ b/app/client/components/main.tsx
@@ -1,3 +1,4 @@
+import "babel-polyfill"; // replaced with specific polyfills where needed
 import React from "react";
 import { initGA } from "../analytics";
 import palette from "../colours";

--- a/app/package.json
+++ b/app/package.json
@@ -81,6 +81,7 @@
     "@types/base-64": "^0.1.2",
     "babel-plugin-emotion": "^9.1.0",
     "babel-plugin-source-map-support": "^2.0.1",
+    "babel-polyfill": "^6.26.0",
     "babel-regenerator-runtime": "^6.5.0",
     "base-64": "^0.1.0",
     "color": "^3.0.0",

--- a/app/webpack.common.js
+++ b/app/webpack.common.js
@@ -16,7 +16,15 @@ const nodeExternals = require("webpack-node-externals");
 
 const babelCommon = {
   presets: [
-    ["@babel/env", { targets: { browsers: ["last 2 versions"] } }],
+    [
+      "@babel/env",
+      {
+        targets: {
+          browsers: ["last 2 versions"]
+        },
+        useBuiltIns: "usage"
+      }
+    ],
     "@babel/typescript",
     "@babel/react"
   ],


### PR DESCRIPTION
This will fix some sentry bugs we've been getting, by allowing babel to polyfill things per use

Fixes https://sentry.io/the-guardian/manage-frontend-client/issues/614206024/