### PR TITLE
Update the AMI as part of the CFN update

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -8,17 +8,12 @@ deployments:
     app: manage-frontend
     parameters:
       templatePath: cloudformation/cfn.yaml
-  manage-frontend:
-    type: autoscaling
-    dependencies: [manage-frontend-cloudformation, manage-frontend-ami]
-    parameters:
-      bucket: membership-dist
-  manage-frontend-ami:
-    app: manage-frontend
-    type: ami-cloudformation-parameter
-    dependencies: [manage-frontend-cloudformation]
-    parameters:
       amiTags:
         Recipe: xenial-membership
         AmigoStage: PROD
       amiEncrypted: true
+  manage-frontend:
+    type: autoscaling
+    dependencies: [manage-frontend-cloudformation]
+    parameters:
+      bucket: membership-dist


### PR DESCRIPTION
Prior to this we were attempting to update the launch config with an old AMI id (i.e. the one specified in the CFN template) during the first CFN update, and then updating the launch config again to use the correct (latest) AMI. 

As well as being inefficient, this method completely stopped working this morning as the AMI referenced in CFN no longer exists (presumably due to https://github.com/guardian/amigo/pull/196).