### PR TITLE
Fix Cloudwatch logging (2nd attempt)

### DIFF
--- a/app/server/log.ts
+++ b/app/server/log.ts
@@ -14,14 +14,3 @@ export const log = winston.createLogger({
     new winston.transports.Console({ format: winston.format.simple() })
   ]
 });
-
-export const audit = winston.createLogger({
-  level: "info",
-  format: winston.format.json(),
-  transports: [
-    new winston.transports.File({
-      filename: `${location}/manage-frontend-audit.log`
-    }),
-    new winston.transports.Console({ format: winston.format.simple() })
-  ]
-});

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -101,7 +101,9 @@ Resources:
             # add user
             groupadd manage-frontend
             useradd -r -s /usr/bin/nologin -g manage-frontend manage-frontend
+            touch /var/log/manage-frontend.log
             chown -R manage-frontend:manage-frontend /etc/gu
+            chown manage-frontend:manage-frontend /var/log/manage-frontend.log
 
             # write out systemd file
             cat >/etc/systemd/system/manage-frontend.service <<EOL
@@ -125,8 +127,6 @@ Resources:
             systemctl enable manage-frontend
             systemctl start manage-frontend
             /opt/cloudwatch-logs/configure-logs application ${Stack} ${Stage} ${App} /var/log/manage-frontend.log
-            /opt/cloudwatch-logs/configure-logs audit ${Stack} ${Stage} ${App} /var/log/manage-frontend-audit.log
-
 
           - DomainEnvVariable: !FindInMap [ StageVariables, !Ref Stage, DomainEnvVariable ]
             SFCasesUrl: !FindInMap [ StageVariables, !Ref Stage, SFCasesUrl ]
@@ -146,13 +146,16 @@ Resources:
             Action:
               - sts:AssumeRole
       Policies:
-        - PolicyName: UpdateSSHKeys
+        - PolicyName: PushLogs
           PolicyDocument:
             Version: 2012-10-17
             Statement:
               - Effect: Allow
-                Action: s3:GetObject
-                Resource: arn:aws:s3:::github-public-keys/Membership-and-Subscriptions/*
+                Action:
+                - logs:CreateLogGroup
+                - logs:CreateLogStream
+                - logs:PutLogEvents
+                Resource: !GetAtt ManageFrontendLogGroup.Arn
 
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile
@@ -251,3 +254,9 @@ Resources:
           FromPort: 443
           ToPort: 443
           CidrIp: 0.0.0.0/0
+
+  ManageFrontendLogGroup:
+    Type: "AWS::Logs::LogGroup"
+    Properties:
+      LogGroupName: !Sub support-manage-frontend-${Stage}
+      RetentionInDays: 14


### PR DESCRIPTION
Reverts guardian/manage-frontend#71

Now that deployments are fixed we can re-run: https://github.com/guardian/manage-frontend/pull/70