### PR TITLE
Polyfill more browsers and add fetch

### DIFF
--- a/app/client/components/main.tsx
+++ b/app/client/components/main.tsx
@@ -1,4 +1,3 @@
-import "babel-polyfill"; // replaced with specific polyfills where needed
 import React from "react";
 import { initGA } from "../analytics";
 import palette from "../colours";

--- a/app/package.json
+++ b/app/package.json
@@ -98,6 +98,7 @@
     "source-map-support": "^0.5.6",
     "stylis-pxtorem": "^0.0.2",
     "webpack-node-externals": "^1.7.2",
+    "whatwg-fetch": "^2.0.4",
     "winston": "^3.0.0"
   },
   "license": "UNLICENSED"

--- a/app/package.json
+++ b/app/package.json
@@ -76,12 +76,11 @@
     "webpack-merge": "^4.1.2"
   },
   "dependencies": {
+    "@babel/polyfill": "^7.0.0-beta.55",
     "@reach/router": "^1.1.1",
     "@types/base-64": "^0.1.2",
     "babel-plugin-emotion": "^9.1.0",
     "babel-plugin-source-map-support": "^2.0.1",
-    "babel-polyfill": "^6.26.0",
-    "babel-regenerator-runtime": "^6.5.0",
     "base-64": "^0.1.0",
     "color": "^3.0.0",
     "emotion": "^9.1.3",

--- a/app/webpack.common.js
+++ b/app/webpack.common.js
@@ -19,7 +19,7 @@ const babelCommon = {
       "@babel/env",
       {
         targets: {
-          browsers: ["last 2 versions", "safari >= 7"]
+          browsers: ["last 2 versions", "safari >= 7", "iOS >= 9"]
         },
         useBuiltIns: "usage"
       }
@@ -76,8 +76,8 @@ const server = merge(common, {
 
 const client = merge(common, {
   entry: {
-    csr: ["./client/csr"],
-    user: ["./client/user"]
+    csr: ["whatwg-fetch", "./client/csr"],
+    user: ["whatwg-fetch", "./client/user"]
   },
   output: {
     path: path.resolve(__dirname, "dist", "static"),

--- a/app/webpack.common.js
+++ b/app/webpack.common.js
@@ -19,7 +19,7 @@ const babelCommon = {
       "@babel/env",
       {
         targets: {
-          browsers: ["last 2 versions"]
+          browsers: ["last 2 versions", "safari >= 7"]
         },
         useBuiltIns: "usage"
       }
@@ -76,8 +76,8 @@ const server = merge(common, {
 
 const client = merge(common, {
   entry: {
-    csr: ["babel-regenerator-runtime", "./client/csr"],
-    user: ["babel-regenerator-runtime", "./client/user"]
+    csr: ["./client/csr"],
+    user: ["./client/user"]
   },
   output: {
     path: path.resolve(__dirname, "dist", "static"),


### PR DESCRIPTION
https://babeljs.io/docs/en/next/babel-preset-env.html#usebuiltins - Allows babel to replace old usages via babel-polyfill at compile-time.

[`whatwg-fetch`](https://github.com/github/fetch) is included as fetch is not considered to be a part of core JS, and is therefore not available to babel-polyfill