### PR TITLE
FIX: gaData was being omitted from the post body if the user had GA blocked

### DIFF
--- a/app/client/components/caseCreationWrapper.tsx
+++ b/app/client/components/caseCreationWrapper.tsx
@@ -19,7 +19,7 @@ const getCreateCaseFunc = (
       reason,
       product: sfProduct,
       subscriptionName: membershipData.subscription.subscriberId,
-      gaData: JSON.stringify(window.gaData)
+      gaData: "" + JSON.stringify(window.gaData)
     }),
     headers: { "Content-Type": "application/json" }
   });


### PR DESCRIPTION
…this fix makes it return "undefined" string in this case, so that 'gaData' key is ALWAYS present in post body to avoid 400 errors