### PR TITLE
 Added notion of experimentFlags (set on window.guardian)

### DIFF
--- a/app/client/components/cancel/paidMembership/cancellationReasons.tsx
+++ b/app/client/components/cancel/paidMembership/cancellationReasons.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { conf } from "../../../../server/config";
 import palette from "../../../colours";
 import { CancellationReason } from "../../user";
+import { SwitchToContributionPlaceholder } from "./switchToContributionPlaceholder";
 
 // Webpack doesn't like browser globals
 let domain: string;
@@ -19,6 +20,26 @@ export const membershipCancellationReasonMatrix: CancellationReason[] = [
       "We understand that financial circumstances can change from time to time",
     saveBody:
       "Making a smaller contribution to the Guardian can be an inexpensive way of keeping journalism open for everyone to read and enjoy. There are a number of flexible ways to make support us and one of our customer service specialist would be happy to hear from you.",
+    experimentSaveBody: (
+      <>
+        <div css={{ marginTop: "10px" }}>
+          Making a smaller one time or recurring contribution to the Guardian
+          can be an inexpensive way of keeping journalism open for everyone to
+          read and enjoy.{" "}
+          <span
+            css={{
+              backgroundColor: palette.yellow.medium,
+              color: palette.neutral["1"]
+            }}
+          >
+            For as little as £1 you can continue to support the Guardian - and
+            it only takes a minute.
+          </span>
+        </div>
+        <SwitchToContributionPlaceholder />
+      </>
+    ),
+    experimentTriggerFlag: "showSwitchToContributionPlaceholder",
     alternateFeedbackThankYouBody:
       "One of our customer service specialists will be in touch shortly."
   },

--- a/app/client/components/cancel/paidMembership/paidMembershipFlow.tsx
+++ b/app/client/components/cancel/paidMembership/paidMembershipFlow.tsx
@@ -1,6 +1,7 @@
 import React, { ChangeEvent, ReactNode } from "react";
 import { css } from "react-emotion";
 import { MeResponse } from "../../../../shared/meResponse";
+import { trackEvent } from "../../../analytics";
 import palette from "../../../colours";
 import { minWidth } from "../../../styles/breakpoints";
 import { LinkButton } from "../../buttons";
@@ -95,14 +96,17 @@ const childWithRouteablePropsToElement = (child: {
   </option>
 );
 
-const cssBullet = css`
-  flex-basis: 50%;
+const cssBullet = (flexBasis: string = "50%") => css`
+  flex-basis: ${flexBasis};
   flex-grow: 1;
   list-style: none;
+  list-style-position: inside;
+  text-indent: -0.6em;
+  padding-left: 20px;
   &::before {
     display: inline-block;
     content: "●";
-    margin-right: 15px;
+    margin-right: 0.6em;
   }
 `;
 
@@ -115,6 +119,25 @@ const reasonsCss = css({
     flexWrap: "wrap"
   }
 });
+
+const clickHereToFindOutMoreAboutOurNewFeatures = (
+  <a
+    css={{
+      textDecoration: "underline",
+      color: palette.blue.dark,
+      ":visited": { color: palette.blue.dark }
+    }}
+    href="https://www.theguardian.com/help/insideguardian/2018/may/15/introducing-live-and-discover-to-the-premium-tier-of-the-guardian-app"
+    onClick={() => {
+      trackEvent({
+        eventCategory: "href",
+        eventAction: "premium_features"
+      });
+    }}
+  >
+    click here to find out about our brand new features
+  </a>
+);
 
 const getReasonsRenderer = (routeableProps: RouteableProps) => (
   data: MembersDataApiResponse
@@ -146,25 +169,50 @@ const getReasonsRenderer = (routeableProps: RouteableProps) => (
             >
               If you cancel your Membership you will miss out on:
             </h4>
-            <ul className={reasonsCss}>
-              <li className={cssBullet}>Access to events tickets</li>
-              <li className={cssBullet}>
-                Exclusive emails from our membership editor
-              </li>
-              <li className={cssBullet} css={{ paddingTop: "5px" }}>
-                Free access to the premium tier of the Guardian app -{" "}
-                <a
+            {window.guardian &&
+            window.guardian.experimentFlags &&
+            window.guardian.experimentFlags.alternateMembershipBenefits ? (
+              <ul className={reasonsCss}>
+                <li className={cssBullet("100%")}>
+                  Exclusive emails from our membership editor
+                </li>
+                <li className={cssBullet("100%")} css={{ paddingTop: "5px" }}>
+                  Free access to the ad-free premium tier of the Guardian app,
+                  now featuring ‘Live’ & ‘Discover’ - two new ways to experience
+                  the Guardian, set to the pace of your day.
+                  <ul>
+                    <li css={{ display: "list-item" }}>
+                      Live: Access to every breaking news story and update, in
+                      real time
+                    </li>
+                    <li>
+                      Discover: Explore great stories you may have missed, when
+                      you have more time
+                    </li>
+                  </ul>
+                </li>
+                <div
                   css={{
-                    textDecoration: "underline",
-                    color: palette.blue.dark,
-                    ":visited": { color: palette.blue.dark }
+                    textAlign: "center",
+                    width: "100%",
+                    margin: "10px"
                   }}
-                  href="https://www.theguardian.com/help/insideguardian/2018/may/15/introducing-live-and-discover-to-the-premium-tier-of-the-guardian-app"
                 >
-                  click here to find out about our brand new features
-                </a>
-              </li>
-            </ul>
+                  {clickHereToFindOutMoreAboutOurNewFeatures}
+                </div>
+              </ul>
+            ) : (
+              <ul className={reasonsCss}>
+                <li className={cssBullet()}>Access to events tickets</li>
+                <li className={cssBullet()}>
+                  Exclusive emails from our membership editor
+                </li>
+                <li className={cssBullet()} css={{ paddingTop: "5px" }}>
+                  Free access to the premium tier of the Guardian app -{" "}
+                  {clickHereToFindOutMoreAboutOurNewFeatures}
+                </li>
+              </ul>
+            )}
           </div>
 
           <PageContainerSection>

--- a/app/client/components/cancel/paidMembership/switchToContributionPlaceholder.tsx
+++ b/app/client/components/cancel/paidMembership/switchToContributionPlaceholder.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { trackEvent } from "../../../analytics";
+import palette from "../../../colours";
+import { Button } from "../../buttons";
+
+export interface SwitchToContributionPlaceholderState {
+  shouldShowPlaceholder: boolean;
+}
+
+export class SwitchToContributionPlaceholder extends React.Component<
+  {},
+  SwitchToContributionPlaceholderState
+> {
+  public state = { shouldShowPlaceholder: false };
+
+  public render(): React.ReactNode {
+    return (
+      <div css={{ marginBottom: "30px" }}>
+        {this.state.shouldShowPlaceholder ? (
+          <div
+            css={{
+              marginLeft: "15px",
+              marginTop: "30px",
+              paddingLeft: "15px",
+              borderLeft: "1px solid " + palette.neutral["4"]
+            }}
+          >
+            Sorry this is temporarily unavailable. We're working on a fix but in
+            the meantime please contact us to set up your contribution. One of
+            our customer service specialists would be happy to arrange this for
+            you.
+          </div>
+        ) : (
+          <div css={{ textAlign: "right" }}>
+            <Button
+              text="Switch to recurring contribution"
+              textColor={palette.white}
+              color={palette.neutral["2"]}
+              onClick={() => {
+                trackEvent({
+                  eventCategory: "switch",
+                  eventAction: "attempted"
+                });
+                this.setState({ shouldShowPlaceholder: true });
+              }}
+            />
+          </div>
+        )}
+      </div>
+    );
+  }
+}

--- a/app/client/components/cancel/stages/genericSaveAttempt.tsx
+++ b/app/client/components/cancel/stages/genericSaveAttempt.tsx
@@ -203,7 +203,9 @@ export const GenericSaveAttempt = (props: GenericSaveAttemptProps) => (
           <WizardStep routeableProps={props}>
             <PageContainerSection>
               <h2>{props.reason.saveTitle}</h2>
-              {props.reason.experimentTriggerFlag &&
+              {window.guardian &&
+              window.guardian.experimentFlags &&
+              props.reason.experimentTriggerFlag &&
               window.guardian.experimentFlags[
                 props.reason.experimentTriggerFlag
               ] ? (

--- a/app/client/components/cancel/stages/genericSaveAttempt.tsx
+++ b/app/client/components/cancel/stages/genericSaveAttempt.tsx
@@ -203,7 +203,15 @@ export const GenericSaveAttempt = (props: GenericSaveAttemptProps) => (
           <WizardStep routeableProps={props}>
             <PageContainerSection>
               <h2>{props.reason.saveTitle}</h2>
-              <p>{props.reason.saveBody}</p>
+              {props.reason.experimentTriggerFlag &&
+              window.guardian.experimentFlags[
+                props.reason.experimentTriggerFlag
+              ] ? (
+                props.reason.experimentSaveBody
+              ) : (
+                <p>{props.reason.saveBody}</p>
+              )}
+
               {props.reason.skipFeedback ? (
                 undefined
               ) : (

--- a/app/client/components/page.tsx
+++ b/app/client/components/page.tsx
@@ -10,7 +10,7 @@ export const PageContainer: React.SFC<{}> = ({ children }) => {
       css={{
         maxWidth: "980px",
         margin: "1.8125rem auto 0",
-        padding: "0.625rem",
+        padding: "0 0.625rem",
 
         [minWidth.tablet]: {
           padding: "0 1.25rem"
@@ -29,7 +29,7 @@ export const PageContainerSection: React.SFC<{}> = ({ children }) => {
       css={{
         maxWidth: "calc(45rem + 1.25rem)",
         margin: "1.8125rem auto 0",
-        padding: "0.625rem",
+        padding: "0 0.625rem",
 
         [minWidth.tablet]: {
           maxWidth: "calc(45rem + 2.5rem)",

--- a/app/client/components/user.tsx
+++ b/app/client/components/user.tsx
@@ -45,6 +45,8 @@ export interface CancellationReason {
   linkLabel: string;
   saveTitle: string;
   saveBody: string | ReactNode;
+  experimentSaveBody?: string | ReactNode;
+  experimentTriggerFlag?: string;
   alternateCallUsPrefix?: string;
   alternateFeedbackIntro?: string;
   alternateFeedbackThankYouTitle?: string;

--- a/app/globals.ts
+++ b/app/globals.ts
@@ -2,7 +2,7 @@ export interface Globals {
   domain: string;
   dsn: string | null;
   experimentFlags?: {
-    showSwitchToContributionPlaceholder?: true;
+    [experimentFlagName: string]: true;
   };
 }
 

--- a/app/globals.ts
+++ b/app/globals.ts
@@ -1,6 +1,9 @@
 export interface Globals {
   domain: string;
   dsn: string | null;
+  experimentFlags?: {
+    showSwitchToContributionPlaceholder?: true;
+  };
 }
 
 declare global {


### PR DESCRIPTION
For more complicated experiments (more than just text, minor css changes) we don't want to rely on Google Optimize (generally to minimise dependency on vendor tools but also not version controlled) so introduced experimentFlags (set on window.guardian) which can be set in Google Optimize to trigger the 'advanced' changes which are actually part of the deployed codebase.