### PR TITLE
explicitly mark proxy calls as same-origin

### DIFF
--- a/app/client/components/cancel/stages/executeCancellation.tsx
+++ b/app/client/components/cancel/stages/executeCancellation.tsx
@@ -20,6 +20,7 @@ const getCancelFunc = (
   await fetch("/api/cancel/" + cancelApiUrlSuffix, {
     credentials: "include",
     method: "POST",
+    mode: "same-origin",
     body: JSON.stringify({ reason }),
     headers: { "Content-Type": "application/json" }
   }); // response is either empty or 404 - neither is useful so fetch subscription to determine cancellation result...

--- a/app/client/components/caseCreationWrapper.tsx
+++ b/app/client/components/caseCreationWrapper.tsx
@@ -15,6 +15,7 @@ const getCreateCaseFunc = (
   await fetch("/api/case", {
     credentials: "include",
     method: "POST",
+    mode: "same-origin",
     body: JSON.stringify({
       reason,
       product: sfProduct,

--- a/app/client/components/caseUpdate.tsx
+++ b/app/client/components/caseUpdate.tsx
@@ -10,6 +10,7 @@ export const getUpdateCasePromise = (caseId: string, body: object) =>
   fetch("/api/case/" + caseId, {
     credentials: "include",
     method: "PATCH",
+    mode: "same-origin",
     body: JSON.stringify(body),
     headers: { "Content-Type": "application/json" }
   });

--- a/app/client/components/membership.tsx
+++ b/app/client/components/membership.tsx
@@ -30,10 +30,13 @@ export function hasMembership(
 
 export class MembershipAsyncLoader extends AsyncLoader<
   MembersDataApiResponse
-  > { }
+> {}
 
 export const loadMembershipData: () => Promise<Response> = async () =>
-  await fetch("/api/me/membership", { credentials: "include" });
+  await fetch("/api/me/membership", {
+    credentials: "include",
+    mode: "same-origin"
+  });
 
 interface MembershipRowProps {
   label: string;
@@ -146,8 +149,8 @@ const renderMembershipData = (apiResponse: MembersDataApiResponse) => {
         {data.regNumber ? (
           <MembershipRow label={"Membership number"} data={data.regNumber} />
         ) : (
-            undefined
-          )}
+          undefined
+        )}
         <MembershipRow
           label={"Membership tier"}
           data={


### PR DESCRIPTION
As all our client calls are to same origin, this explicitly marks them as such.

May help with the "Access-Control-Allow-Origin" issues we're seeing on Mobile safari