### PR TITLE
Single Page App support for Google Optimise

### DIFF
--- a/app/client/components/GoogleOptimiseAwaitFlagWrapper.tsx
+++ b/app/client/components/GoogleOptimiseAwaitFlagWrapper.tsx
@@ -1,24 +1,39 @@
 import React from "react";
+import { Globals } from "../../globals";
 import { applyAnyOptimiseExperiments } from "./analytics";
 
+export interface GlobalsWithExperimentFlags extends Globals {
+  experimentFlags?: {
+    [experimentFlagName: string]: true;
+  };
+}
+
+interface WindowWithGlobalsWithExperimentFlags extends Window {
+  guardian: GlobalsWithExperimentFlags;
+}
+
+declare let window: WindowWithGlobalsWithExperimentFlags;
+
 export interface AwaitOptimiseFlagProps {
-  experimentFlagName: string;
+  experimentFlagName: string | undefined;
   children: {
-    flagIsSet: JSX.Element;
+    flagIsSet: JSX.Element | undefined;
     flagIsNotSet: JSX.Element;
   };
 }
 
-export const GoogleOptimiseAwaitFlagWrapper = (
+export const GoogleOptimiseAwaitFlagWrapper: (
   props: AwaitOptimiseFlagProps
-) => {
+) => JSX.Element = (props: AwaitOptimiseFlagProps) => {
   applyAnyOptimiseExperiments(); // blocks until experiments have run (variant or original)
 
   if (
+    props.experimentFlagName &&
     typeof window !== "undefined" &&
     window.guardian &&
     window.guardian.experimentFlags &&
-    window.guardian.experimentFlags[props.experimentFlagName]
+    window.guardian.experimentFlags[props.experimentFlagName] &&
+    props.children.flagIsSet
   ) {
     return props.children.flagIsSet;
   }

--- a/app/client/components/GoogleOptimiseAwaitFlagWrapper.tsx
+++ b/app/client/components/GoogleOptimiseAwaitFlagWrapper.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { applyAnyOptimiseExperiments } from "./analytics";
+
+export interface AwaitOptimiseFlagProps {
+  experimentFlagName: string;
+  children: {
+    flagIsSet: JSX.Element;
+    flagIsNotSet: JSX.Element;
+  };
+}
+
+export const GoogleOptimiseAwaitFlagWrapper = (
+  props: AwaitOptimiseFlagProps
+) => {
+  applyAnyOptimiseExperiments(); // blocks until experiments have run (variant or original)
+
+  if (
+    typeof window !== "undefined" &&
+    window.guardian &&
+    window.guardian.experimentFlags &&
+    window.guardian.experimentFlags[props.experimentFlagName]
+  ) {
+    return props.children.flagIsSet;
+  }
+
+  return props.children.flagIsNotSet;
+};

--- a/app/client/components/analytics.tsx
+++ b/app/client/components/analytics.tsx
@@ -52,19 +52,14 @@ export class AnalyticsTracker extends React.PureComponent<{}> {
       window.ga("require", "GTM-M985W29");
       window.ga("set", "transport", "beacon");
 
-      if (MutationObserver) {
-        new MutationObserver(applyAnyOptimiseExperiments).observe(
-          document.body,
-          {
-            attributes: false,
-            characterData: false,
-            childList: true,
-            subtree: true,
-            attributeOldValue: false,
-            characterDataOldValue: false
-          }
-        );
-      }
+      new MutationObserver(applyAnyOptimiseExperiments).observe(document.body, {
+        attributes: false,
+        characterData: false,
+        childList: true,
+        subtree: true,
+        attributeOldValue: false,
+        characterDataOldValue: false
+      });
     }
   }
 

--- a/app/client/components/analytics.tsx
+++ b/app/client/components/analytics.tsx
@@ -5,6 +5,7 @@ declare global {
   interface Window {
     ga?: any;
     gaData?: any;
+    dataLayer?: any;
   }
 }
 
@@ -33,13 +34,37 @@ export const trackEvent = ({
   }
 };
 
+export const applyAnyOptimiseExperiments = () => {
+  if (typeof window !== "undefined" && window.ga && window.dataLayer) {
+    window.dataLayer.push({ event: "optimize.activate" });
+  }
+};
+
 export class AnalyticsTracker extends React.PureComponent<{}> {
   constructor(props: {}) {
     super(props);
-    if (window.ga) {
+    if (typeof window !== "undefined" && window.ga) {
+      if (window.dataLayer === undefined) {
+        window.dataLayer = [];
+      }
+
       window.ga("create", "UA-51507017-5", "auto");
-      window.ga("require", "GTM-NZGXNBL");
+      window.ga("require", "GTM-M985W29");
       window.ga("set", "transport", "beacon");
+
+      if (MutationObserver) {
+        new MutationObserver(applyAnyOptimiseExperiments).observe(
+          document.body,
+          {
+            attributes: false,
+            characterData: false,
+            childList: true,
+            subtree: true,
+            attributeOldValue: false,
+            characterDataOldValue: false
+          }
+        );
+      }
     }
   }
 
@@ -47,8 +72,14 @@ export class AnalyticsTracker extends React.PureComponent<{}> {
     return (
       <Location>
         {({ location }) => {
-          if (location && location.pathname && window.ga) {
+          if (
+            location &&
+            location.pathname &&
+            typeof window !== "undefined" &&
+            window.ga
+          ) {
             window.ga("send", "pageview", location.pathname);
+            applyAnyOptimiseExperiments();
           }
           return null; // null is a valid React node type, but void is not.
         }}

--- a/app/client/components/cancel/paidMembership/paidMembershipFlow.tsx
+++ b/app/client/components/cancel/paidMembership/paidMembershipFlow.tsx
@@ -6,6 +6,7 @@ import { minWidth } from "../../../styles/breakpoints";
 import { trackEvent } from "../../analytics";
 import { LinkButton } from "../../buttons";
 import { CheckFlowIsValid } from "../../cancellationFlowWrapper";
+import { GoogleOptimiseAwaitFlagWrapper } from "../../GoogleOptimiseAwaitFlagWrapper";
 import {
   hasMembership,
   loadMembershipData,
@@ -169,50 +170,56 @@ const getReasonsRenderer = (routeableProps: RouteableProps) => (
             >
               If you cancel your Membership you will miss out on:
             </h4>
-            {window.guardian &&
-            window.guardian.experimentFlags &&
-            window.guardian.experimentFlags.alternateMembershipBenefits ? (
-              <ul className={reasonsCss}>
-                <li className={cssBullet("100%")}>
-                  Exclusive emails from our membership editor
-                </li>
-                <li className={cssBullet("100%")} css={{ paddingTop: "5px" }}>
-                  Free access to the ad-free premium tier of the Guardian app,
-                  now featuring ‘Live’ & ‘Discover’ - two new ways to experience
-                  the Guardian, set to the pace of your day.
-                  <ul>
-                    <li css={{ display: "list-item" }}>
-                      Live: Access to every breaking news story and update, in
-                      real time
+            <GoogleOptimiseAwaitFlagWrapper experimentFlagName="alternateMembershipBenefits">
+              {{
+                flagIsSet: (
+                  <ul className={reasonsCss}>
+                    <li className={cssBullet("100%")}>
+                      Exclusive emails from our membership editor
                     </li>
-                    <li>
-                      Discover: Explore great stories you may have missed, when
-                      you have more time
+                    <li
+                      className={cssBullet("100%")}
+                      css={{ paddingTop: "5px" }}
+                    >
+                      Free access to the ad-free premium tier of the Guardian
+                      app, now featuring ‘Live’ & ‘Discover’ - two new ways to
+                      experience the Guardian, set to the pace of your day.
+                      <ul>
+                        <li css={{ display: "list-item" }}>
+                          Live: Access to every breaking news story and update,
+                          in real time
+                        </li>
+                        <li>
+                          Discover: Explore great stories you may have missed,
+                          when you have more time
+                        </li>
+                      </ul>
+                    </li>
+                    <div
+                      css={{
+                        textAlign: "center",
+                        width: "100%",
+                        margin: "10px"
+                      }}
+                    >
+                      {clickHereToFindOutMoreAboutOurNewFeatures}
+                    </div>
+                  </ul>
+                ),
+                flagIsNotSet: (
+                  <ul className={reasonsCss}>
+                    <li className={cssBullet()}>Access to events tickets</li>
+                    <li className={cssBullet()}>
+                      Exclusive emails from our membership editor
+                    </li>
+                    <li className={cssBullet()} css={{ paddingTop: "5px" }}>
+                      Free access to the premium tier of the Guardian app -{" "}
+                      {clickHereToFindOutMoreAboutOurNewFeatures}
                     </li>
                   </ul>
-                </li>
-                <div
-                  css={{
-                    textAlign: "center",
-                    width: "100%",
-                    margin: "10px"
-                  }}
-                >
-                  {clickHereToFindOutMoreAboutOurNewFeatures}
-                </div>
-              </ul>
-            ) : (
-              <ul className={reasonsCss}>
-                <li className={cssBullet()}>Access to events tickets</li>
-                <li className={cssBullet()}>
-                  Exclusive emails from our membership editor
-                </li>
-                <li className={cssBullet()} css={{ paddingTop: "5px" }}>
-                  Free access to the premium tier of the Guardian app -{" "}
-                  {clickHereToFindOutMoreAboutOurNewFeatures}
-                </li>
-              </ul>
-            )}
+                )
+              }}
+            </GoogleOptimiseAwaitFlagWrapper>
           </div>
 
           <PageContainerSection>

--- a/app/client/components/cancel/stages/genericSaveAttempt.tsx
+++ b/app/client/components/cancel/stages/genericSaveAttempt.tsx
@@ -2,13 +2,13 @@ import { navigate } from "@reach/router";
 import React, { ChangeEvent, ReactNode } from "react";
 import palette from "../../../colours";
 import { minWidth } from "../../../styles/breakpoints";
-import { css } from "../../../styles/emotion";
 import { sans } from "../../../styles/fonts";
 import { trackEvent } from "../../analytics";
 import { Button } from "../../buttons";
 import { CallCentreNumbers } from "../../callCentreNumbers";
 import { CaseCreationWrapper } from "../../caseCreationWrapper";
 import { CaseUpdateAsyncLoader, getUpdateCasePromise } from "../../caseUpdate";
+import { GoogleOptimiseAwaitFlagWrapper } from "../../GoogleOptimiseAwaitFlagWrapper";
 import { PageContainerSection } from "../../page";
 import {
   CancellationCaseIdContext,
@@ -208,16 +208,14 @@ export const GenericSaveAttempt = (props: GenericSaveAttemptProps) => (
           <WizardStep routeableProps={props}>
             <PageContainerSection>
               <h2>{props.reason.saveTitle}</h2>
-              {window.guardian &&
-              window.guardian.experimentFlags &&
-              props.reason.experimentTriggerFlag &&
-              window.guardian.experimentFlags[
-                props.reason.experimentTriggerFlag
-              ] ? (
-                props.reason.experimentSaveBody
-              ) : (
-                <p>{props.reason.saveBody}</p>
-              )}
+              <GoogleOptimiseAwaitFlagWrapper
+                experimentFlagName={props.reason.experimentTriggerFlag}
+              >
+                {{
+                  flagIsSet: props.reason.experimentSaveBody,
+                  flagIsNotSet: <p>{props.reason.saveBody}</p>
+                }}
+              </GoogleOptimiseAwaitFlagWrapper>
 
               {props.reason.skipFeedback ? (
                 undefined

--- a/app/client/components/cancel/stages/genericSaveAttempt.tsx
+++ b/app/client/components/cancel/stages/genericSaveAttempt.tsx
@@ -207,13 +207,13 @@ export const GenericSaveAttempt = (props: GenericSaveAttemptProps) => (
         >
           <WizardStep routeableProps={props}>
             <PageContainerSection>
-              <h2>{props.reason.saveTitle}</h2>
+              <h2 id="save_title">{props.reason.saveTitle}</h2>
               <GoogleOptimiseAwaitFlagWrapper
                 experimentFlagName={props.reason.experimentTriggerFlag}
               >
                 {{
                   flagIsSet: props.reason.experimentSaveBody,
-                  flagIsNotSet: <p>{props.reason.saveBody}</p>
+                  flagIsNotSet: <p id="save_body">{props.reason.saveBody}</p>
                 }}
               </GoogleOptimiseAwaitFlagWrapper>
 

--- a/app/client/components/payment/paypalDisplay.tsx
+++ b/app/client/components/payment/paypalDisplay.tsx
@@ -8,7 +8,7 @@ export interface PayPalProps {
   payPalEmail: string;
 }
 
-interface PayPalDisplayState {
+export interface PayPalDisplayState {
   shouldShowAccountName: boolean;
 }
 

--- a/app/client/components/user.tsx
+++ b/app/client/components/user.tsx
@@ -1,5 +1,5 @@
 import { navigate, Router, ServerLocation } from "@reach/router";
-import React, { ReactNode } from "react";
+import React from "react";
 import { fetchMe, MeAsyncLoader, MeResponse } from "../../shared/meResponse";
 import { injectGlobal } from "../styles/emotion";
 import { fonts } from "../styles/fonts";
@@ -46,8 +46,8 @@ export interface CancellationReason {
   reasonId: string;
   linkLabel: string;
   saveTitle: string;
-  saveBody: string | ReactNode;
-  experimentSaveBody?: string | ReactNode;
+  saveBody: string | JSX.Element;
+  experimentSaveBody?: JSX.Element;
   experimentTriggerFlag?: string;
   alternateCallUsPrefix?: string;
   alternateFeedbackIntro?: string;

--- a/app/client/components/user.tsx
+++ b/app/client/components/user.tsx
@@ -1,4 +1,4 @@
-import { Location, navigate, Router, ServerLocation } from "@reach/router";
+import { navigate, Router, ServerLocation } from "@reach/router";
 import React, { ReactNode } from "react";
 import { fetchMe, MeAsyncLoader, MeResponse } from "../../shared/meResponse";
 import { injectGlobal } from "../styles/emotion";
@@ -148,7 +148,7 @@ export const ServerUser = (url: string) => (
 
 export const BrowserUser = (
   <>
-    <User />
     <AnalyticsTracker />
+    <User />
   </>
 );

--- a/app/client/components/wizardRouterAdapter.tsx
+++ b/app/client/components/wizardRouterAdapter.tsx
@@ -1,5 +1,6 @@
 import { Router } from "@reach/router";
 import React from "react";
+import { conf } from "../../server/config";
 import palette from "../colours";
 import { Button, LinkButton } from "./buttons";
 import { PageContainer, PageContainerSection } from "./page";
@@ -35,7 +36,13 @@ const estimateTotal = (currentStep: number, child: any) => {
 
 export const ReturnToYourAccountButton = () => (
   <div css={{ marginTop: "15px" }}>
-    <a href={"https://profile." + window.guardian.domain + "/membership/edit"}>
+    <a
+      href={
+        "https://profile." +
+        (typeof window !== "undefined" ? window.guardian.domain : conf.DOMAIN) +
+        "/membership/edit"
+      }
+    >
       <Button
         text="Return to your account"
         textColor={palette.white}

--- a/app/globals.ts
+++ b/app/globals.ts
@@ -1,9 +1,6 @@
 export interface Globals {
   domain: string;
   dsn: string | null;
-  experimentFlags?: {
-    [experimentFlagName: string]: true;
-  };
 }
 
 declare global {

--- a/app/server/html.ts
+++ b/app/server/html.ts
@@ -31,14 +31,6 @@ const html: (
       ${insertGlobals(globals)}
       <link rel="shortcut icon" type="image/png" href="https://assets.guim.co.uk/images/favicons/48bc5564bb01b74cf7cd1a08ae0dd98e/32x32.ico" />
       <meta name="viewport" content="width=device-width, initial-scale=1">
-      <style>.async-hide { opacity: 0 !important} </style>
-      <script>
-        (function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;
-        h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
-        (a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;
-        })(window,document.documentElement,'async-hide','dataLayer',4000,
-        {'GTM-NZGXNBL':true});
-      </script>
     </head>
     <body style="margin:0">
       <div id="app">${body}</div>


### PR DESCRIPTION
Previously Google Optimize only worked on the first page load and only for flag based experiments, which were still 'racey' even then.

Now it uses MutationObserver to push `"optimize.activate"` `dataLayer` event on DOM changes to apply an _applicable_ experiments (typically to catch the non-engineer created experiments).

Also includes a neat `GoogleOptimiseAwaitFlagWrapper` component which eliminates the race condition by awaiting the outcome of the "optimize.activate" in the render. It uses ‘named slots projection’ pattern (children as an object map) for React children - which leads to really readable and typesafe code :)