### PR TITLE
Unsupported browsers banner

### DIFF
--- a/app/.browserslistrc
+++ b/app/.browserslistrc
@@ -1,0 +1,8 @@
+>0.25%
+chrome >= 49
+firefox >= 46
+ie >= 11
+edge >= 13
+safari >= 8
+opera >= 27
+iOS >= 9

--- a/app/.browserslistrc
+++ b/app/.browserslistrc
@@ -1,8 +1,0 @@
->0.25%
-chrome >= 49
-firefox >= 46
-ie >= 11
-edge >= 13
-safari >= 8
-opera >= 27
-iOS >= 9

--- a/app/globals.ts
+++ b/app/globals.ts
@@ -1,6 +1,7 @@
 export interface Globals {
   domain: string;
   dsn: string | null;
+  supportedBrowser: boolean;
   experimentFlags?: {
     [experimentFlagName: string]: true;
   };

--- a/app/package.json
+++ b/app/package.json
@@ -24,6 +24,16 @@
   "buildDir": "dist",
   "projectName": "support:manage-frontend",
   "main": "./dist/server",
+  "browserslist": [
+    ">0.25%",
+    "chrome >= 49",
+    "firefox >= 46",
+    "ie >= 11",
+    "edge >= 13",
+    "safari >= 8",
+    "opera >= 27",
+    "iOS >= 9"
+  ],
   "devDependencies": {
     "@babel/cli": "^7.0.0-rc.1",
     "@babel/core": "^7.0.0-rc.1",
@@ -83,6 +93,7 @@
     "babel-plugin-emotion": "^9.1.0",
     "babel-plugin-source-map-support": "^2.0.1",
     "base-64": "^0.1.0",
+    "browserslist-useragent": "^2.0.1",
     "color": "^3.0.0",
     "emotion": "^9.1.3",
     "emotion-server": "^9.1.3",

--- a/app/server/html.ts
+++ b/app/server/html.ts
@@ -41,6 +41,11 @@ const html: (
       </script>
     </head>
     <body style="margin:0">
+        ${
+          globals.supportedBrowser
+            ? ""
+            : '<p style="text-align: center; margin: 0; padding: 10px; background-color: #ff4e36; color: #fff">Your browser isn\'t actively supported by theguardian.com, for more information, see <a href="https://www.theguardian.com/help/recommended-browsers" style="color: #FFF; text-decoration: underline">our help page</a></p>'
+        }
       <div id="app">${body}</div>
       </body>
       <script>

--- a/app/server/server.ts
+++ b/app/server/server.ts
@@ -1,4 +1,5 @@
 import bodyParser from "body-parser";
+import { matchesUA } from "browserslist-useragent";
 import express from "express";
 import helmet from "helmet";
 import fetch from "node-fetch";
@@ -32,7 +33,8 @@ if (conf.ENVIRONMENT === Environments.PRODUCTION && !conf.CLIENT_DSN) {
 
 const globals: Globals = {
   domain: conf.DOMAIN,
-  dsn: clientDSN
+  dsn: clientDSN,
+  supportedBrowser: true
 };
 
 server.use(
@@ -155,7 +157,11 @@ server.use((req: express.Request, res: express.Response) => {
   const body = renderStylesToString(renderToString(ServerUser(req.url)));
   const title = "My Account | The Guardian";
   const src = "/static/user.js";
-
+  Object.assign(globals, {
+    supportedBrowser: matchesUA(req.headers["user-agent"], {
+      env: "development"
+    })
+  });
   res.send(
     html({
       body,

--- a/app/types/browserslist-useragent.d.ts
+++ b/app/types/browserslist-useragent.d.ts
@@ -1,0 +1,1 @@
+declare module "browserslist-useragent";

--- a/app/webpack.common.js
+++ b/app/webpack.common.js
@@ -26,9 +26,6 @@ const babelCommon = {
     [
       "@babel/env",
       {
-        targets: {
-          browsers: ["last 2 versions", "safari >= 7", "iOS >= 9"]
-        },
         useBuiltIns: "usage"
       }
     ],
@@ -72,7 +69,13 @@ const server = merge(common, {
         options: {
           plugins: [...babelCommon.plugins, "babel-plugin-source-map-support"],
           presets: [
-            ["@babel/env", { targets: { node: "10.7.0" } }],
+            [
+              "@babel/env",
+              {
+                targets: { node: "10.7.0" },
+                ignoreBrowserslistConfig: true
+              }
+            ],
             "@babel/typescript",
             "@babel/react"
           ]


### PR DESCRIPTION
Checks a user's UA against a browserlist - The same one that's used to transpile in babel-preset-env and shows a banner if they're not supported.

![banner](https://user-images.githubusercontent.com/2104095/44798045-76c0c380-aba8-11e8-8591-4822fa832359.png)


Requires a looking at by UX