### PR TITLE
move package.json to static on build

### DIFF
--- a/app/webpack.common.js
+++ b/app/webpack.common.js
@@ -21,7 +21,7 @@ const copyPlugin = new CopyWebpackPlugin([
   },
   {
     from: path.resolve(__dirname, "package.json"),
-    to: path.resolve(__dirname, "dist", "package.json")
+    to: path.resolve(__dirname, "dist", "static", "package.json")
   }
 ]);
 


### PR DESCRIPTION
Should allow Browserlist-useragent to find it and display errors correctly.