### PR TITLE
Added one hour re-authenticate requirement to the whole of manage.theguardian.com (to match profile)

### DIFF
--- a/app/server/__tests__/identity/identity.ts
+++ b/app/server/__tests__/identity/identity.ts
@@ -8,7 +8,7 @@ import {
 
 const createFakeCookie = (
   epochTimestampPart: number,
-  prefixParts: string[] = []
+  ...prefixParts: string[]
 ) =>
   encode(
     // base64
@@ -43,7 +43,7 @@ test("non-expired SC_GU_U cookie", () => {
 test("reauth required based on SC_GU_LA cookie", () => {
   const reAuthScGuLaCookie = createFakeCookie(
     new Date().getTime() - ONE_HOUR * 2, // last logged in 2 hours ago
-    ["la"]
+    "LA"
   );
 
   expect(checkScGuLaExpiry(reAuthScGuLaCookie)).toBe(IdentityError.Expired);
@@ -52,7 +52,7 @@ test("reauth required based on SC_GU_LA cookie", () => {
 test("no reauth required based on SC_GU_LA cookie", () => {
   const freshSignInScGuLaCookie = createFakeCookie(
     new Date().getTime(), // signed in just now
-    ["la"]
+    "LA"
   );
 
   expect(checkScGuLaExpiry(freshSignInScGuLaCookie)).toBeUndefined();

--- a/app/server/__tests__/identity/identity.ts
+++ b/app/server/__tests__/identity/identity.ts
@@ -1,0 +1,59 @@
+import { encode } from "base-64";
+import {
+  checkScGuLaExpiry,
+  checkScGuUExpiry,
+  IdentityError,
+  ONE_HOUR
+} from "../../identity/identity";
+
+const createFakeCookie = (
+  epochTimestampPart: number,
+  prefixParts: string[] = []
+) =>
+  encode(
+    // base64
+    JSON.stringify([...prefixParts, "identityID", epochTimestampPart])
+  );
+
+test("unparseable cookies", () => {
+  const unparseableCookie = "garbage";
+
+  expect(checkScGuUExpiry(unparseableCookie)).toBe(IdentityError.CouldNotParse);
+  expect(checkScGuLaExpiry(unparseableCookie)).toBe(
+    IdentityError.CouldNotParse
+  );
+});
+
+test("expired SC_GU_U cookie", () => {
+  const expiredScGuUCookie = createFakeCookie(
+    new Date().getTime() // expiring now
+  );
+
+  expect(checkScGuUExpiry(expiredScGuUCookie)).toBe(IdentityError.Expired);
+});
+
+test("non-expired SC_GU_U cookie", () => {
+  const expiredScGuUCookie = createFakeCookie(
+    new Date().getTime() + ONE_HOUR * 3 // expiring 3hours from now,
+  );
+
+  expect(checkScGuUExpiry(expiredScGuUCookie)).toBeUndefined();
+});
+
+test("reauth required based on SC_GU_LA cookie", () => {
+  const reAuthScGuLaCookie = createFakeCookie(
+    new Date().getTime() - ONE_HOUR * 2, // last logged in 2 hours ago
+    ["la"]
+  );
+
+  expect(checkScGuLaExpiry(reAuthScGuLaCookie)).toBe(IdentityError.Expired);
+});
+
+test("no reauth required based on SC_GU_LA cookie", () => {
+  const freshSignInScGuLaCookie = createFakeCookie(
+    new Date().getTime(), // signed in just now
+    ["la"]
+  );
+
+  expect(checkScGuLaExpiry(freshSignInScGuLaCookie)).toBeUndefined();
+});

--- a/app/server/identity/identity.ts
+++ b/app/server/identity/identity.ts
@@ -1,12 +1,12 @@
 import { decode } from "base-64";
 import { parse as parseCookie } from "es-cookie";
 
-const ONE_HOUR = 3600000;
+export const ONE_HOUR = 3600000;
 
 export interface IdentityUser {
   readonly GU_U: string;
   readonly SC_GU_U: string;
-  expiry: number;
+  readonly SC_GU_LA: string;
 }
 
 export enum IdentityError {
@@ -15,8 +15,9 @@ export enum IdentityError {
   NotLoggedIn
 }
 const keys = {
-  GU: "GU_U",
-  SC: "SC_GU_U"
+  GU_U: "GU_U",
+  SC_GU_U: "SC_GU_U",
+  SC_GU_LA: "SC_GU_LA"
 };
 
 export function isUser(x: any): x is IdentityUser {
@@ -31,45 +32,28 @@ export const getUser: (
   }
 
   const cookieJar = parseCookie(cookies);
-  const GU_U = cookieJar[keys.GU];
-  const SC_GU_U = cookieJar[keys.SC];
+  const GU_U = cookieJar[keys.GU_U];
+  const SC_GU_U = cookieJar[keys.SC_GU_U];
+  const SC_GU_LA = cookieJar[keys.SC_GU_LA];
 
-  if (GU_U == null || SC_GU_U == null) {
+  if (GU_U == null || SC_GU_U == null || SC_GU_LA == null) {
     return IdentityError.NotLoggedIn;
   }
 
-  const [encodedToken] = SC_GU_U.split(".");
-  const cookieString = safely(() => decode(encodedToken));
-  if (cookieString == null) {
-    return IdentityError.CouldNotParse;
-  }
-  const parsed = safely(() => JSON.parse(cookieString));
-  if (parsed == null) {
-    return IdentityError.CouldNotParse;
-  }
-  if (!(Array.isArray(parsed) && parsed.length === 2)) {
-    return IdentityError.CouldNotParse;
+  const scGuUExpiryError = checkScGuUExpiry(SC_GU_U);
+  if (scGuUExpiryError !== undefined) {
+    return scGuUExpiryError;
   }
 
-  const [id, expires] = parsed;
-  if (expires == null) {
-    return IdentityError.CouldNotParse;
-  }
-
-  const expiry = safely(() => parseInt(expires, 10));
-  if (expiry == null) {
-    return IdentityError.CouldNotParse;
-  }
-
-  const remaining = expiry - new Date().getTime();
-  if (remaining < ONE_HOUR) {
-    return IdentityError.Expired;
+  const scGuLaExpiryError = checkScGuLaExpiry(SC_GU_LA);
+  if (scGuLaExpiryError !== undefined) {
+    return scGuLaExpiryError;
   }
 
   return {
     GU_U,
     SC_GU_U,
-    expiry
+    SC_GU_LA
   };
 };
 
@@ -78,5 +62,64 @@ const safely: <T>(f: () => T) => T | null = f => {
     return f();
   } catch (e) {
     return null;
+  }
+};
+
+export const checkScGuUExpiry: (
+  SC_GU_U: string
+) => IdentityError | undefined = (SC_GU_U: string) => {
+  const scGuGuStr = safely(() => decode(SC_GU_U.split(".", 1)[0]));
+  if (scGuGuStr == null) {
+    return IdentityError.CouldNotParse;
+  }
+  const scGuGuParsed = safely(() => JSON.parse(scGuGuStr));
+  if (
+    scGuGuParsed == null ||
+    !Array.isArray(scGuGuParsed) ||
+    scGuGuParsed.length !== 2
+  ) {
+    return IdentityError.CouldNotParse;
+  }
+  const [identityID, expires] = scGuGuParsed;
+  if (expires == null) {
+    return IdentityError.CouldNotParse;
+  }
+  const expiry = safely(() => parseInt(expires, 10));
+  if (expiry == null) {
+    return IdentityError.CouldNotParse;
+  }
+  const remaining = expiry - new Date().getTime();
+  if (remaining < ONE_HOUR) {
+    return IdentityError.Expired;
+  }
+};
+
+export const checkScGuLaExpiry: (
+  SC_GU_LA: string
+) => IdentityError | undefined = (SC_GU_LA: string) => {
+  const scGuLaStr = safely(() => decode(SC_GU_LA.split(".")[0]));
+  if (scGuLaStr == null) {
+    return IdentityError.CouldNotParse;
+  }
+  const scGuLaParsed = safely(() => JSON.parse(scGuLaStr));
+  if (
+    scGuLaParsed == null ||
+    !Array.isArray(scGuLaParsed) ||
+    scGuLaParsed.length !== 3
+  ) {
+    return IdentityError.CouldNotParse;
+  }
+  const [la, id, lastAuthTimestampStr] = scGuLaParsed;
+  if (lastAuthTimestampStr == null) {
+    return IdentityError.CouldNotParse;
+  }
+  const lastAuthTimestamp = safely(() => parseInt(lastAuthTimestampStr, 10));
+  if (lastAuthTimestamp == null) {
+    return IdentityError.CouldNotParse;
+  }
+
+  const reauthDeadline = lastAuthTimestamp + ONE_HOUR;
+  if (reauthDeadline < new Date().getTime()) {
+    return IdentityError.Expired;
   }
 };

--- a/app/server/identity/identityMiddleware.ts
+++ b/app/server/identity/identityMiddleware.ts
@@ -4,9 +4,6 @@ import { conf } from "../config";
 import { log } from "../log";
 import { getUser, IdentityError } from "./identity";
 
-const GU_U = "GU_U";
-const SC_GU_U = "SC_GU_U";
-
 export const withIdentity: express.RequestHandler = (
   req: express.Request,
   res: express.Response,

--- a/app/server/server.ts
+++ b/app/server/server.ts
@@ -55,9 +55,7 @@ server.get("/_healthcheck", (req: express.Request, res: express.Response) => {
   res.send("OK");
 });
 
-// server.use(bodyParser.json());
 server.use(bodyParser.raw({ type: "*/*" })); // parses all bodys to a raw 'Buffer'
-server.use("/api/membership", withIdentity);
 server.use("/", withIdentity);
 
 server.use("/static", express.static(__dirname + "/static"));


### PR DESCRIPTION
The MMA pages of profile.theguardian.com have a one hour re-authenticate requirement. This PR adds the same to all of manage.theguardian.com (before we release the payment update functionality).

For profile behaviour, see...
https://github.com/guardian/frontend/blob/f033cc8dc41ebbc96be63425a0a14cd734647443/identity/app/services/AuthenticationService.scala#L49-L55