### PR TITLE
added email address (under Name field) when creating Stripe token 

### DIFF
--- a/app/client/components/payment/update/cardInputForm.tsx
+++ b/app/client/components/payment/update/cardInputForm.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import {
-  CardNumberElement,
   Elements,
   injectStripe,
   ReactStripeElements,
@@ -16,6 +15,7 @@ const InjectedStripeCardInputForm = injectStripe(StripeCardInputForm);
 
 export interface CardInputFormProps {
   stripeApiKey: string;
+  userEmail?: string;
   stripeTokenUpdater: (
     stripeTokenResponse: ReactStripeElements.PatchedTokenResponse
   ) => void;

--- a/app/client/components/payment/update/stripeCardInputForm.tsx
+++ b/app/client/components/payment/update/stripeCardInputForm.tsx
@@ -14,6 +14,7 @@ export interface StripeCardInputFormProps
   stripeTokenUpdater: (
     stripeTokenResponse: ReactStripeElements.PatchedTokenResponse
   ) => void;
+  userEmail?: string;
 }
 
 export interface StripeCardInputFormState {
@@ -123,7 +124,9 @@ export class StripeCardInputForm extends React.Component<
   private startCardUpdate = (navigate: NavigateFn) => async () => {
     this.setInProgress(true);
     if (this.props.stripe) {
-      const tokenResponse = await this.props.stripe.createToken(); // may need to add token options for product switch
+      const tokenResponse = await this.props.stripe.createToken(
+        { name: this.props.userEmail } // may need to add more token options for product switch
+      );
       if (tokenResponse.token && tokenResponse.token.card) {
         this.props.stripeTokenUpdater(tokenResponse);
         navigate("confirm");

--- a/app/client/components/payment/update/updatePaymentFlow.tsx
+++ b/app/client/components/payment/update/updatePaymentFlow.tsx
@@ -1,4 +1,5 @@
 import { NavigateFn } from "@reach/router";
+import { get as getCookie } from "es-cookie";
 import React from "react";
 import { ReactStripeElements } from "react-stripe-elements";
 import { ProductType, ProductTypes } from "../../../../shared/productTypes";
@@ -14,7 +15,6 @@ import {
   MembershipAsyncLoader,
   MembershipData
 } from "../../membership";
-import { PageContainer } from "../../page";
 import { MembersDataApiResponseContext, Subscription } from "../../user";
 import { RouteableStepProps, WizardStep } from "../../wizardRouterAdapter";
 import { CardInputForm, StripeTokenResponseContext } from "./cardInputForm";
@@ -103,6 +103,10 @@ interface PaymentUpdaterStepState {
   selectedPaymentMethod: PaymentMethod;
 }
 
+const getSignInEmailFromCookie = () => {
+  return getCookie("GU_SIGNIN_EMAIL");
+};
+
 class PaymentUpdaterStep extends React.Component<
   PaymentUpdaterStepProps,
   PaymentUpdaterStepState
@@ -178,6 +182,7 @@ class PaymentUpdaterStep extends React.Component<
           <CardInputForm
             stripeApiKey={subscription.card.stripePublicKeyForUpdate}
             stripeTokenUpdater={this.stripeTokenUpdater}
+            userEmail={subscription.card.email || getSignInEmailFromCookie()}
           />
         ) : (
           <GenericErrorScreen loggingMessage="No existing card information to update from" />

--- a/app/client/components/user.tsx
+++ b/app/client/components/user.tsx
@@ -26,6 +26,7 @@ import { RedirectOnMeResponse } from "./redirectOnMeResponse";
 
 export interface Card extends CardProps {
   stripePublicKeyForUpdate: string;
+  email?: string;
 }
 
 export interface Subscription {


### PR DESCRIPTION
(for parity with current payment update mechanism).

This doesn't appear to be essential for the transaction to be successful, however for consistency and if anyone is using it in reports or indeed if the card becomes detached it could be useful.

This allows for the value to come from members-data-api (PR to follow) but falls back to value of GU_SIGNIN_EMAIL cookie.