### PR TITLE
Post demo tweaks

### DIFF
--- a/app/client/components/buttons.tsx
+++ b/app/client/components/buttons.tsx
@@ -11,6 +11,9 @@ export interface CommonButtonProps {
   disabled?: boolean;
   colour?: string;
   textColour?: string;
+  primary?: true;
+  hollow?: true;
+  hide?: boolean;
 }
 
 export interface LinkButtonProps extends CommonButtonProps {
@@ -39,28 +42,71 @@ const applyArrowStyleIfApplicable = (
   };
 };
 
+const calcBackgroundColour = (
+  disabled?: boolean,
+  colour?: string,
+  primary?: true,
+  hollow?: true
+) => {
+  if (disabled) {
+    return palette.neutral["4"];
+  } else if (primary) {
+    return palette.yellow.medium;
+  } else if (hollow) {
+    return palette.white;
+  }
+  return colour;
+};
+
+const calcTextColour = (
+  disabled?: boolean,
+  textColour?: string,
+  primary?: true,
+  hollow?: true
+) => {
+  if (disabled) {
+    return palette.white;
+  } else if (primary || hollow) {
+    return palette.neutral["1"];
+  }
+  return textColour;
+};
+
 const defaultColour = palette.neutral["2"];
 const buttonCss = ({
   disabled,
   colour = defaultColour,
   textColour = palette.white,
   left,
-  right
-}: CommonButtonProps) => ({
-  ...styles.common,
-  background: disabled ? palette.neutral["4"] : colour,
-  color: textColour,
-  ...applyArrowStyleIfApplicable(false, left, right),
-  ":hover": disabled
-    ? undefined
-    : {
-        background: Color(colour)
-          .darken(colour === defaultColour ? 0.3 : 0.1)
-          .string(),
-        ...applyArrowStyleIfApplicable(true, left, right)
-      },
-  cursor: disabled ? "not-allowed" : "pointer"
-});
+  right,
+  primary,
+  hollow,
+  hide
+}: CommonButtonProps) => {
+  const backgroundColour = calcBackgroundColour(
+    disabled,
+    colour,
+    primary,
+    hollow
+  );
+  return {
+    ...styles.common,
+    display: hide ? "none" : "inline-flex",
+    background: backgroundColour,
+    color: calcTextColour(disabled, textColour, primary, hollow),
+    border: hollow ? "1px solid" : "none",
+    ...applyArrowStyleIfApplicable(false, left, right),
+    ":hover": disabled
+      ? undefined
+      : {
+          background: Color(backgroundColour)
+            .darken(backgroundColour === defaultColour ? 0.3 : 0.1)
+            .string(),
+          ...applyArrowStyleIfApplicable(true, left, right)
+        },
+    cursor: disabled ? "not-allowed" : "pointer"
+  };
+};
 
 export const ButtonArrow = () => (
   <svg width="30" height="30" viewBox="0 0 30 30">
@@ -75,8 +121,6 @@ const styles = {
     fontSize: "16px",
     fontFamily: sans,
     borderRadius: "1000px",
-    border: "none",
-    display: "inline-flex",
     alignItems: "center",
     whiteSpace: "nowrap",
     position: "relative"

--- a/app/client/components/cancel/cancellationSummary.tsx
+++ b/app/client/components/cancel/cancellationSummary.tsx
@@ -36,12 +36,7 @@ const actuallyCancelled = (cancelType: string, subscription: Subscription) => (
     </p>
     <div css={{ textAlign: "right" }}>
       <a href={`https://support.${window.guardian.domain}`}>
-        <Button
-          text="Support The Guardian"
-          textColour={palette.neutral["1"]}
-          colour={palette.yellow.medium}
-          right
-        />
+        <Button text="Support The Guardian" primary right />
       </a>
     </div>
   </PageContainerSection>

--- a/app/client/components/cancel/stages/genericSaveAttempt.tsx
+++ b/app/client/components/cancel/stages/genericSaveAttempt.tsx
@@ -182,8 +182,6 @@ const ConfirmCancellationButton = (props: ConfirmCancellationButtonProps) => (
   >
     <Button
       text="Confirm Cancellation"
-      textColour={palette.white}
-      colour={palette.neutral["2"]}
       onClick={() => {
         if (props.onClick) {
           props.onClick();

--- a/app/client/components/footer/in_page/questionsFooter.tsx
+++ b/app/client/components/footer/in_page/questionsFooter.tsx
@@ -12,7 +12,7 @@ export class QuestionsFooter extends React.Component<{}, QuestionsFooterState> {
   public render(): JSX.Element {
     return (
       <InPageFooter title="Questions?">
-        If you have any questions about contributing to The Guardian, please{" "}
+        If you have any questions about updating your payment details, please{" "}
         <button
           onClick={this.toggleExpanded}
           css={{

--- a/app/client/components/membership.tsx
+++ b/app/client/components/membership.tsx
@@ -202,11 +202,7 @@ const renderMembershipData = (apiResponse: MembersDataApiResponse) => {
                   "/tier/change"
                 }
               >
-                <Button
-                  text="Change tier"
-                  textColour={palette.white}
-                  colour={palette.neutral["1"]}
-                />
+                <Button text="Change tier" />
               </a>
             </div>
           }

--- a/app/client/components/payment/update/confirmCardUpdate.tsx
+++ b/app/client/components/payment/update/confirmCardUpdate.tsx
@@ -47,6 +47,7 @@ class ExecuteCardUpdate extends React.Component<
       <Button
         text="Complete Payment Update"
         onClick={() => this.setState({ hasHitComplete: true })}
+        primary
         right
       />
     );
@@ -118,6 +119,7 @@ export const ConfirmCardUpdate = (props: RouteableStepProps) => (
             <WizardStep
               routeableStepProps={props}
               backButtonLevelsUp
+              hollowReturnButton
               extraFooterComponents={<QuestionsFooter />}
             >
               <h3>Please confirm your change from...</h3>

--- a/app/client/components/payment/update/paymentUpdated.tsx
+++ b/app/client/components/payment/update/paymentUpdated.tsx
@@ -3,7 +3,13 @@ import AsyncLoader from "../../asyncLoader";
 import { QuestionsFooter } from "../../footer/in_page/questionsFooter";
 import { SpreadTheWordFooter } from "../../footer/in_page/spreadTheWordFooter";
 import { GenericErrorScreen } from "../../genericErrorScreen";
-import { formatDate, Subscription, WithSubscription } from "../../user";
+import { hasMembership } from "../../membership";
+import {
+  formatDate,
+  MembersDataApiResponseContext,
+  Subscription,
+  WithSubscription
+} from "../../user";
 import { RouteableStepProps, WizardStep } from "../../wizardRouterAdapter";
 import { CardDisplay } from "../cardDisplay";
 import { StripeTokenResponseContext } from "./cardInputForm";
@@ -27,14 +33,28 @@ const ConfirmedNewPaymentDetailsRenderer = (subscription: Subscription) => {
     return (
       <>
         <CardDisplay {...subscription.card} />
-        <div>
-          <b>Next Payment:</b> {subscription.plan.currency}
-          {(subscription.nextPaymentPrice / 100.0).toFixed(2)} on{" "}
-          {formatDate(subscription.nextPaymentDate)}
-        </div>
-        <div>
-          <b>Payment Frequency:</b> {subscription.plan.interval}ly
-        </div>
+        <MembersDataApiResponseContext.Consumer>
+          {membersDataApiResponse =>
+            hasMembership(membersDataApiResponse) &&
+            membersDataApiResponse.alertText ? (
+              <div>
+                To resolve the previous payment failure we will retry the charge
+                within the next 24 hours.
+              </div>
+            ) : (
+              <>
+                <div>
+                  <b>Next Payment:</b> {subscription.plan.currency}
+                  {(subscription.nextPaymentPrice / 100.0).toFixed(2)} on{" "}
+                  {formatDate(subscription.nextPaymentDate)}
+                </div>
+                <div>
+                  <b>Payment Frequency:</b> {subscription.plan.interval}ly
+                </div>
+              </>
+            )
+          }
+        </MembersDataApiResponseContext.Consumer>
       </>
     );
   }

--- a/app/client/components/payment/update/paymentUpdated.tsx
+++ b/app/client/components/payment/update/paymentUpdated.tsx
@@ -39,8 +39,8 @@ const ConfirmedNewPaymentDetailsRenderer = (subscription: Subscription) => {
             hasMembership(membersDataApiResponse) &&
             membersDataApiResponse.alertText ? (
               <div>
-                We will take the outstanding amount from the failed payment
-                within 24 hours.
+                We will take the outstanding payment within 24 hours, using your
+                new card details.
               </div>
             ) : (
               <>

--- a/app/client/components/payment/update/paymentUpdated.tsx
+++ b/app/client/components/payment/update/paymentUpdated.tsx
@@ -86,6 +86,7 @@ export const PaymentUpdated = (props: PaymentUpdatedProps) => (
             <QuestionsFooter key="questions" />,
             <SpreadTheWordFooter key="share" />
           ]}
+          hideReturnButton
         >
           <WithSubscriptionAsyncLoader
             fetch={props.fetch}

--- a/app/client/components/payment/update/paymentUpdated.tsx
+++ b/app/client/components/payment/update/paymentUpdated.tsx
@@ -13,6 +13,7 @@ import {
 import { RouteableStepProps, WizardStep } from "../../wizardRouterAdapter";
 import { CardDisplay } from "../cardDisplay";
 import { StripeTokenResponseContext } from "./cardInputForm";
+import { Button, LinkButton } from "../../buttons";
 
 export const handleNoToken = (props: RouteableStepProps) => {
   if (props.navigate) {
@@ -69,6 +70,14 @@ const WithSubscriptionRenderer = (withSub: WithSubscription) => (
     <h2>
       Thank you. You are helping to support independent investigative journalism
     </h2>
+    <div>
+      <LinkButton to="/" text="Manage your account" primary right />
+    </div>
+    <div css={{ marginTop: "20px" }}>
+      <a href="https://www.theguardian.com">
+        <Button text="Explore The Guardian" primary right />
+      </a>
+    </div>
   </>
 );
 

--- a/app/client/components/payment/update/paymentUpdated.tsx
+++ b/app/client/components/payment/update/paymentUpdated.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import AsyncLoader from "../../asyncLoader";
+import { Button, LinkButton } from "../../buttons";
 import { QuestionsFooter } from "../../footer/in_page/questionsFooter";
 import { SpreadTheWordFooter } from "../../footer/in_page/spreadTheWordFooter";
 import { GenericErrorScreen } from "../../genericErrorScreen";
@@ -13,7 +14,6 @@ import {
 import { RouteableStepProps, WizardStep } from "../../wizardRouterAdapter";
 import { CardDisplay } from "../cardDisplay";
 import { StripeTokenResponseContext } from "./cardInputForm";
-import { Button, LinkButton } from "../../buttons";
 
 export const handleNoToken = (props: RouteableStepProps) => {
   if (props.navigate) {
@@ -39,8 +39,8 @@ const ConfirmedNewPaymentDetailsRenderer = (subscription: Subscription) => {
             hasMembership(membersDataApiResponse) &&
             membersDataApiResponse.alertText ? (
               <div>
-                To resolve the previous payment failure we will retry the charge
-                within the next 24 hours.
+                We will take the outstanding amount from the failed payment
+                within 24 hours.
               </div>
             ) : (
               <>

--- a/app/client/components/payment/update/stripeCardInputForm.tsx
+++ b/app/client/components/payment/update/stripeCardInputForm.tsx
@@ -75,6 +75,7 @@ export class StripeCardInputForm extends React.Component<
                         disabled={this.props.stripe === undefined}
                         text="Review Payment Update"
                         onClick={this.startCardUpdate(nav.navigate)}
+                        primary
                         right
                       />
                       {this.renderError()}

--- a/app/client/components/payment/update/updatePaymentFlow.tsx
+++ b/app/client/components/payment/update/updatePaymentFlow.tsx
@@ -130,6 +130,7 @@ class PaymentUpdaterStep extends React.Component<
             <WizardStep
               routeableStepProps={this.props.routeableStepProps}
               extraFooterComponents={<QuestionsFooter />}
+              hollowReturnButton
             >
               <div
                 css={{

--- a/app/client/components/payment/update/updatePaymentFlow.tsx
+++ b/app/client/components/payment/update/updatePaymentFlow.tsx
@@ -23,7 +23,7 @@ import { CurrentPaymentDetails } from "./currentPaymentDetails";
 enum PaymentMethod {
   card = "Card",
   payPal = "PayPal",
-  dd = "Direct Debit"
+  dd = "Direct Debit" // TODO handle https://github.com/guardian/members-data-api/blob/2424286f14ea5b4655cd6a56e93088d8402b776e/membership-attribute-service/app/models/AccountDetails.scala#L50-L55
 }
 
 interface PaymentMethodProps {

--- a/app/client/components/wizardRouterAdapter.tsx
+++ b/app/client/components/wizardRouterAdapter.tsx
@@ -19,12 +19,21 @@ export interface MultiRouteableProps extends RouteableStepProps {
   linkLabel: string;
 }
 
-interface RootComponentProps {
+export interface ButtonStyleModifierProps {
+  hideReturnButton?: true;
+  hollowReturnButton?: true;
+}
+
+export interface CommonProps extends ButtonStyleModifierProps {
+  backButtonLevelsUp?: true;
+  extraFooterComponents?: JSX.Element | JSX.Element[];
+}
+
+interface RootComponentProps extends CommonProps {
   routeableStepProps: RouteableStepProps;
   thisStageChildren: any;
   path: string;
-  backButtonLevelsUp?: true;
-  extraFooterComponents?: JSX.Element | JSX.Element[];
+  children: null;
 }
 
 const estimateTotal = (currentStep: number, child: any) => {
@@ -38,7 +47,7 @@ const estimateTotal = (currentStep: number, child: any) => {
   return 3; // TODO dynamically estimate total steps by recursively exploring children
 };
 
-export const ReturnToYourAccountButton = () => (
+export const ReturnToYourAccountButton = (props: ButtonStyleModifierProps) => (
   <div css={{ marginTop: "15px" }}>
     <a
       href={
@@ -47,7 +56,12 @@ export const ReturnToYourAccountButton = () => (
         "/membership/edit"
       }
     >
-      <Button text="Return to your account" left />
+      <Button
+        text="Return to your account"
+        hide={props.hideReturnButton}
+        hollow={props.hollowReturnButton}
+        left
+      />
     </a>
   </div>
 );
@@ -68,9 +82,15 @@ const RootComponent = (props: RootComponentProps) => (
       {props.thisStageChildren}
 
       {props.backButtonLevelsUp ? (
-        <LinkButton text="Back" to=".." left />
+        <LinkButton
+          hide={props.hideReturnButton}
+          text="Back"
+          to=".."
+          hollow={props.hollowReturnButton}
+          left
+        />
       ) : (
-        <ReturnToYourAccountButton />
+        <ReturnToYourAccountButton {...props} />
       )}
     </PageContainer>
     {props.extraFooterComponents}
@@ -80,20 +100,17 @@ const RootComponent = (props: RootComponentProps) => (
 const ThisStageContent = (props: WizardStepProps) => (
   <Router>
     <RootComponent
+      {...props}
+      children={null} // override passed prop from spread
       path="/"
       thisStageChildren={props.children}
-      routeableStepProps={props.routeableStepProps}
-      backButtonLevelsUp={props.backButtonLevelsUp}
-      extraFooterComponents={props.extraFooterComponents}
     />
   </Router>
 );
 
-export interface WizardStepProps {
+export interface WizardStepProps extends CommonProps {
   routeableStepProps: RouteableStepProps;
   children: any;
-  backButtonLevelsUp?: true;
-  extraFooterComponents?: JSX.Element | JSX.Element[];
 }
 
 export const WizardStep = (props: WizardStepProps) => (


### PR DESCRIPTION
1. Changing "contact us" copy 
2. Confirmation page
  - If not in payment failure- then shows next payment date etc. (as before)
  - If in payment failure- We will take the payment in the next 24 hours.  ( in place of next payment date etc.) 
3. Yellow forward buttons 
4. Hollowed out "return to your account" button
5.  Manage + explore guardian buttons on confirmation as forward 