### PR TITLE
tweaked the wording of the 'switch to contribution' placeholder

### DIFF
--- a/app/client/components/cancel/cancellationSummary.tsx
+++ b/app/client/components/cancel/cancellationSummary.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import palette from "../../colours";
+import { trackEvent } from "../analytics";
 import { Button } from "../buttons";
 import { GenericErrorScreen } from "../genericErrorScreen";
 import { PageContainerSection } from "../page";
@@ -35,7 +36,15 @@ const actuallyCancelled = (cancelType: string, subscription: Subscription) => (
       consider either a contribution or a subscription.
     </p>
     <div css={{ textAlign: "right" }}>
-      <a href={`https://support.${window.guardian.domain}`}>
+      <a
+        href={`https://support.${window.guardian.domain}`}
+        onClick={() => {
+          trackEvent({
+            eventCategory: "href",
+            eventAction: "support_the_guardian"
+          });
+        }}
+      >
         <Button text="Support The Guardian" primary right />
       </a>
     </div>

--- a/app/client/components/cancel/membership/cancellationReasons.tsx
+++ b/app/client/components/cancel/membership/cancellationReasons.tsx
@@ -32,7 +32,7 @@ export const membershipCancellationReasonMatrix: CancellationReason[] = [
               color: palette.neutral["1"]
             }}
           >
-            For as little as £1 you can continue to support the Guardian - and
+            For as little as £2 you can continue to support the Guardian - and
             it only takes a minute.
           </span>
         </div>

--- a/app/client/components/cancel/membership/switchToContributionPlaceholder.tsx
+++ b/app/client/components/cancel/membership/switchToContributionPlaceholder.tsx
@@ -26,9 +26,9 @@ export class SwitchToContributionPlaceholder extends React.Component<
             }}
           >
             Sorry this is temporarily unavailable. We're working on a fix but in
-            the meantime please contact us to set up your contribution. One of
-            our customer service specialists would be happy to arrange this for
-            you.
+            the meantime you can complete the cancellation below, then please
+            follow the yellow "Support The Guardian" button on the cancellation
+            confirmation page.
           </div>
         ) : (
           <div css={{ textAlign: "right" }}>


### PR DESCRIPTION
 tweaked the wording of the 'switch to contribution' placeholder and added an event should they then go on click the "Support The Guardian" button. Once deployed its ready to start the experiment.