### PR TITLE
Add a proper 'No Membership' screen

### DIFF
--- a/app/client/__tests__/__snapshots__/main.tsx.snap
+++ b/app/client/__tests__/__snapshots__/main.tsx.snap
@@ -214,7 +214,7 @@ exports[`Main renders something 1`] = `
           <li>
             <a
               className="emotion-1"
-              href="https://profile.thegulocal.com/membership/edit"
+              href="/membership"
             >
               <span>
                 Membership

--- a/app/client/components/cancel/cancellationSummary.tsx
+++ b/app/client/components/cancel/cancellationSummary.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import palette from "../../colours";
-import { trackEvent } from "../analytics";
-import { Button } from "../buttons";
 import { GenericErrorScreen } from "../genericErrorScreen";
 import { PageContainerSection } from "../page";
+import { SupportTheGuardianButton } from "../supportTheGuardianButton";
 import { formatDate, Subscription } from "../user";
 
 const actuallyCancelled = (cancelType: string, subscription: Subscription) => (
@@ -36,17 +35,7 @@ const actuallyCancelled = (cancelType: string, subscription: Subscription) => (
       consider either a contribution or a subscription.
     </p>
     <div css={{ textAlign: "right" }}>
-      <a
-        href={`https://support.${window.guardian.domain}`}
-        onClick={() => {
-          trackEvent({
-            eventCategory: "href",
-            eventAction: "support_the_guardian"
-          });
-        }}
-      >
-        <Button text="Support The Guardian" primary right />
-      </a>
+      <SupportTheGuardianButton supportReferer="cancellation_summary" />
     </div>
   </PageContainerSection>
 );

--- a/app/client/components/cancel/membership/membershipCancellationFlow.tsx
+++ b/app/client/components/cancel/membership/membershipCancellationFlow.tsx
@@ -22,6 +22,7 @@ import {
   WizardStep
 } from "../../wizardRouterAdapter";
 import { CancellationSummary } from "../cancellationSummary";
+import { NoMembership } from "./noMembership";
 
 interface ReasonPickerProps {
   options: ReactNode[];
@@ -163,6 +164,7 @@ const getReasonsRenderer = (routeableStepProps: RouteableStepProps) => (
             <h4
               css={{
                 textAlign: "center",
+                marginTop: "0",
                 marginBottom: "10px"
               }}
             >
@@ -250,7 +252,7 @@ const getReasonsRenderer = (routeableStepProps: RouteableStepProps) => (
 
   return (
     <>
-      <h2>No Membership</h2>
+      <NoMembership />
       <ReturnToYourAccountButton />
     </>
   );

--- a/app/client/components/cancel/membership/noMembership.tsx
+++ b/app/client/components/cancel/membership/noMembership.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { SupportTheGuardianButton } from "../../supportTheGuardianButton";
+
+export const NoMembership = () => (
+  <div>
+    <h2>You do not currently have a membership.</h2>
+    <p>
+      If you are interested in supporting our journalism in other ways, please
+      consider either a contribution or a subscription.
+    </p>
+    <div css={{ textAlign: "right" }}>
+      <SupportTheGuardianButton supportReferer="no_membership_screen" />
+    </div>
+  </div>
+);

--- a/app/client/components/cancellationFlowWrapper.tsx
+++ b/app/client/components/cancellationFlowWrapper.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { fetchMe, MeAsyncLoader, MeResponse } from "../../shared/meResponse";
 import { ProductType } from "../../shared/productTypes";
-import { GenericErrorScreen } from "./genericErrorScreen";
+import { PageContainer } from "./page";
 
 const renderChildrenIfValidated = (props: CheckFlowIsValidProps) => (
   me: MeResponse
@@ -9,7 +9,7 @@ const renderChildrenIfValidated = (props: CheckFlowIsValidProps) => (
   props.validator(me) ? (
     <>{props.children}</>
   ) : (
-    <GenericErrorScreen loggingMessage="Direct navigation in cancellation flow without having the corresponding product" />
+    <PageContainer>{props.invalidComponentRenderer}</PageContainer>
   );
 
 export type MeValidator = (me: MeResponse) => boolean;

--- a/app/client/components/membership.tsx
+++ b/app/client/components/membership.tsx
@@ -6,6 +6,7 @@ import { serif } from "../styles/fonts";
 import AsyncLoader from "./asyncLoader";
 import { Button, LinkButton } from "./buttons";
 import { CancellationSummary } from "./cancel/cancellationSummary";
+import { NoMembership } from "./cancel/membership/noMembership";
 import { MembershipLinks } from "./membershipLinks";
 import { PageContainer, PageHeaderContainer } from "./page";
 import { CardDisplay } from "./payment/cardDisplay";
@@ -215,7 +216,7 @@ const renderMembershipData = (apiResponse: MembersDataApiResponse) => {
       </div>
     );
   }
-  return <h2>No Membership</h2>;
+  return <NoMembership />;
 };
 
 const headerCss = css({

--- a/app/client/components/notFound.tsx
+++ b/app/client/components/notFound.tsx
@@ -1,4 +1,9 @@
 import { RouteComponentProps } from "@reach/router";
 import React from "react";
+import { PageContainer } from "./page";
 
-export const NotFound = (props: RouteComponentProps) => <h1>Not Found</h1>;
+export const NotFound = (props: RouteComponentProps) => (
+  <PageContainer>
+    <h1>Not Found</h1>
+  </PageContainer>
+);

--- a/app/client/components/payment/update/updatePaymentFlow.tsx
+++ b/app/client/components/payment/update/updatePaymentFlow.tsx
@@ -5,6 +5,7 @@ import { ReactStripeElements } from "react-stripe-elements";
 import { ProductType, ProductTypes } from "../../../../shared/productTypes";
 import palette from "../../../colours";
 import { minWidth } from "../../../styles/breakpoints";
+import { NoMembership } from "../../cancel/membership/noMembership";
 import { CheckFlowIsValid } from "../../cancellationFlowWrapper";
 import { QuestionsFooter } from "../../footer/in_page/questionsFooter";
 import { GenericErrorScreen } from "../../genericErrorScreen";
@@ -203,7 +204,7 @@ const getPaymentUpdateRenderer = (routeableStepProps: RouteableStepProps) => (
   hasMembership(data) ? (
     <PaymentUpdaterStep routeableStepProps={routeableStepProps} data={data} />
   ) : (
-    <GenericErrorScreen loggingMessage="No membership to update payment for" />
+    <NoMembership />
   );
 
 const createUpdatePaymentFlow = (productType: ProductType) => (

--- a/app/client/components/redirectOnMeResponse.tsx
+++ b/app/client/components/redirectOnMeResponse.tsx
@@ -18,7 +18,7 @@ export const RedirectOnMeResponse = (props: RouteableProps) => (
         } else if (me.contentAccess.digitalPack) {
           navigate(qualifyLink(navLinks.digiPack), replace);
         } else {
-          navigate("https://" + window.guardian.domain, replace);
+          navigate(qualifyLink(navLinks.membership), replace);
         }
         return null; // official way to render nothing
       }}

--- a/app/client/components/supportTheGuardianButton.tsx
+++ b/app/client/components/supportTheGuardianButton.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { trackEvent } from "./analytics";
+import { Button } from "./buttons";
+
+export interface SupportTheGuardianButtonProps {
+  supportReferer: string;
+}
+
+export const SupportTheGuardianButton = (
+  props: SupportTheGuardianButtonProps
+) => (
+  <a
+    href={`https://support.${window.guardian.domain}`}
+    onClick={() => {
+      trackEvent({
+        eventCategory: "href",
+        eventAction: "support_the_guardian",
+        eventLabel: "support_from_" + props.supportReferer
+      });
+    }}
+  >
+    <Button text="Support The Guardian" primary right />
+  </a>
+);

--- a/app/client/components/userNav.tsx
+++ b/app/client/components/userNav.tsx
@@ -112,7 +112,7 @@ export class UserNav extends React.Component {
   public userNavItems: UserNavItem[] = [
     {
       title: "Comments & replies",
-      link: `/profile/user`
+      link: `/profile/user` // note this hits a redirect/proxy endpoint
     },
     {
       title: "Public profile",
@@ -129,7 +129,7 @@ export class UserNav extends React.Component {
     },
     {
       title: "Membership",
-      link: `${profileHostName}/membership/edit`
+      link: `/membership`
     },
     {
       title: "Contributions",

--- a/app/client/components/wizardRouterAdapter.tsx
+++ b/app/client/components/wizardRouterAdapter.tsx
@@ -49,13 +49,7 @@ const estimateTotal = (currentStep: number, child: any) => {
 
 export const ReturnToYourAccountButton = (props: ButtonStyleModifierProps) => (
   <div css={{ marginTop: "15px" }}>
-    <a
-      href={
-        "https://profile." +
-        (typeof window !== "undefined" ? window.guardian.domain : conf.DOMAIN) +
-        "/membership/edit"
-      }
-    >
+    <a href="/membership">
       <Button
         text="Return to your account"
         hide={props.hideReturnButton}

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+import { NoMembership } from "../client/components/cancel/membership/noMembership";
 import { MeValidator } from "../client/components/cancellationFlowWrapper";
 import { MeResponse } from "./meResponse";
 
@@ -6,15 +8,18 @@ export type ProductName = "membership" | "recurring contribution";
 export interface ProductType {
   productName: ProductName;
   validator: MeValidator;
+  invalidComponentRenderer: JSX.Element;
 }
 
 export const ProductTypes: { [productKey: string]: ProductType } = {
   membership: {
     productName: "membership",
-    validator: (me: MeResponse) => me.contentAccess.member
+    validator: (me: MeResponse) => me.contentAccess.member,
+    invalidComponentRenderer: <NoMembership />
   },
   contributions: {
     productName: "recurring contribution",
-    validator: (me: MeResponse) => me.contentAccess.recurringContributor
+    validator: (me: MeResponse) => me.contentAccess.recurringContributor,
+    invalidComponentRenderer: <h2>You do not have a Recurring Contribution.</h2>
   }
 };


### PR DESCRIPTION
Previously if uses clicked external links directly into membership cancellation flow (e.g. membership help, delete you account instructions etc.) they would see a misleading generic error screen. Now they see a nice clear message and button to 'Support The Guardian'...
![image](https://user-images.githubusercontent.com/19289579/46011702-a63af100-c0be-11e8-8329-b0e23730802c.png)

Similarly, visitors to the membership tab (who didn't have a membership) used to see basic 'No Membership' heading, whereas the component is now nicely reused...
![image](https://user-images.githubusercontent.com/19289579/46011722-b5ba3a00-c0be-11e8-9f3c-340363995756.png)
