### PR TITLE
Restyle 'action required' mini banner (plus slight copy tweaks)

### DIFF
--- a/app/client/components/cancel/membership/noMembership.tsx
+++ b/app/client/components/cancel/membership/noMembership.tsx
@@ -5,11 +5,9 @@ export const NoMembership = () => (
   <div>
     <h2>You do not currently have a membership.</h2>
     <p>
-      If you are interested in supporting our journalism in other ways, please
-      consider either a contribution or a subscription.
+      Please support our journalism by making either a contribution or a
+      subscription.
     </p>
-    <div css={{ textAlign: "right" }}>
-      <SupportTheGuardianButton supportReferer="no_membership_screen" />
-    </div>
+    <SupportTheGuardianButton supportReferer="no_membership_screen" />
   </div>
 );

--- a/app/client/components/membershipLinks.tsx
+++ b/app/client/components/membershipLinks.tsx
@@ -51,7 +51,7 @@ export const MembershipLinks = () => (
     <ul
       css={{
         fontSize: "0.875rem",
-        marginTop: "2rem",
+        marginTop: "3rem",
         marginLeft: "1.5625rem",
         padding: 0,
 

--- a/app/client/components/payment/paypalDisplay.tsx
+++ b/app/client/components/payment/paypalDisplay.tsx
@@ -1,8 +1,7 @@
 import React from "react";
-import palette from "../../colours";
 import { minWidth } from "../../styles/breakpoints";
 import { Button } from "../buttons";
-import { spaceBetweenCSS } from "../membership";
+import { wrappingContainerCSS } from "../membership";
 
 export interface PayPalProps {
   payPalEmail: string;
@@ -21,7 +20,7 @@ export class PayPalDisplay extends React.Component<
   public render(): React.ReactNode {
     return (
       <div>
-        <div css={spaceBetweenCSS}>
+        <div css={wrappingContainerCSS}>
           <span css={{ marginRight: "15px", display: "inline-block" }}>
             You are paying with PayPal. Please login to PayPal to change your
             payment details.


### PR DESCRIPTION
Trying to reduce the drop off rate when on the membership tab and in payment failure, by bringing the mini-banner style inline with the DOTCOM banner (see https://github.com/guardian/frontend/pull/20256) AND adding a CTA directly in the mini-banner to avoid confusion and hopefully drive up navigations into the payment update flow.

Also sneaked in some slight copy and alignment tweaks on the No Membership screen.

**After**
![image](https://user-images.githubusercontent.com/19289579/46143819-0e224080-c253-11e8-84c0-bee0ca21b526.png)

