### PR TITLE
IE11: fixed the outrageous placement of the footer, roundel and tabs

### DIFF
--- a/app/client/__tests__/__snapshots__/main.tsx.snap
+++ b/app/client/__tests__/__snapshots__/main.tsx.snap
@@ -106,6 +106,7 @@ exports[`Main renders something 1`] = `
 
 .emotion-12 {
   width: 56px;
+  height: 56px;
 }
 
 <div
@@ -325,7 +326,8 @@ exports[`Main renders something 1`] = `
   <div
     css={
       Object {
-        "flex": "1",
+        "flexGrow": "1",
+        "flexShrink": "0",
       }
     }
   >

--- a/app/client/components/main.tsx
+++ b/app/client/components/main.tsx
@@ -21,7 +21,8 @@ export class Main extends React.PureComponent<{}> {
         <Header />
         <div
           css={{
-            flex: "1"
+            flexGrow: "1",
+            flexShrink: "0"
           }}
         >
           <main

--- a/app/client/components/nav.tsx
+++ b/app/client/components/nav.tsx
@@ -17,7 +17,6 @@ const navCss = css({
   background: "#fafafa",
   tableLayout: "fixed",
   gridTemplateColumns: "repeat(auto-fit, minmax(40%, 1fr))",
-  gridColumnGap: "0.125rem",
   display: "grid",
 
   [minWidth.desktop]: {
@@ -53,7 +52,9 @@ const navItemCss = (local: boolean | undefined) =>
     }`,
     borderTop: `0.1875rem solid ${palette.neutral["6"]}`,
     display: "table-cell",
-    width: "100%"
+    width: "100%",
+    minWidth: "155px", // gross hack to make IE11 work
+    borderRight: "0.125rem solid " + palette.white
   });
 
 export interface NavItem {

--- a/app/client/components/roundel.tsx
+++ b/app/client/components/roundel.tsx
@@ -13,7 +13,8 @@ const Roundel: React.SFC<{ size: number }> = ({ size }) => (
       xmlns="http://www.w3.org/2000/svg"
       className={
         css({
-          width: `${size}px`
+          width: `${size}px`,
+          height: `${size}px`
         }) /* emotion css property not recognised properly on <svg> tag */
       }
     >


### PR DESCRIPTION
fixed the outrageous placement of the footer, roundel and tabs (caused by IE11's numerous flexbox implementation bugs)

**Before**
![image](https://user-images.githubusercontent.com/19289579/46162009-f791de80-c27e-11e8-8098-d16940b0782e.png)

**After**
![image](https://user-images.githubusercontent.com/19289579/46162195-7d158e80-c27f-11e8-98d1-420c5269438f.png)


