### PR TITLE
redirect for use with the dotcom banner so we don't need to expose 'payment' in the URL

### DIFF
--- a/app/server/server.ts
+++ b/app/server/server.ts
@@ -156,6 +156,13 @@ server.get(
   withIdentity
 );
 
+server.use(
+  "/banner/:product",
+  (req: express.Request, res: express.Response) => {
+    res.redirect("/payment/" + req.params["product"] + "?INTCMP=BANNER");
+  }
+);
+
 // ALL OTHER ENDPOINTS CAN BE HANDLED BY CLIENT SIDE REACT ROUTING
 server.use((req: express.Request, res: express.Response) => {
   /**

--- a/app/server/server.ts
+++ b/app/server/server.ts
@@ -156,10 +156,11 @@ server.get(
   withIdentity
 );
 
+const productParamName = "product";
 server.use(
-  "/banner/:product",
+  "/banner/:" + productParamName,
   (req: express.Request, res: express.Response) => {
-    res.redirect("/payment/" + req.params["product"] + "?INTCMP=BANNER");
+    res.redirect("/payment/" + req.params[productParamName] + "?INTCMP=BANNER");
   }
 );
 


### PR DESCRIPTION
This change is to add a little brokering point for the CTA on the DOTCOM banner so we don't need to expose the purpose of the 'action required' in the URL.
See also...
https://github.com/guardian/frontend/pull/20430