### PR TITLE
temporarily hardcoded the route for the contributions tab

### DIFF
--- a/app/client/components/user.tsx
+++ b/app/client/components/user.tsx
@@ -78,8 +78,9 @@ const User = () => (
         </ConfirmCardUpdate>
       </PaymentUpdateFlow>
 
+      {/*TODO change this to use navLinks once we fully migrate contributions tab*/}
       <ProductPage
-        path={navLinks.contributions.link}
+        path="/contributions"
         productType={ProductTypes.contributions}
       />
       <ContributionsCancellationFlow // TODO replace with generic CancellationFlow


### PR DESCRIPTION
just temporarily hardcoded the route for the contributions tab to ensure all flows lead back there (as per TODO will remove once we fully migrate contributions tab)