### PR TITLE
forward the INTCMP query param to identity (for signin/reauth) a…

### DIFF
--- a/app/server/identity/identityMiddleware.ts
+++ b/app/server/identity/identityMiddleware.ts
@@ -18,6 +18,9 @@ export const withIdentity: express.RequestHandler = (
 
   const user = getUser(cookies);
 
+  const intcmp = req.query.INTCMP;
+  const intcmpUrlInfix = intcmp ? `INTCMP=${intcmp}&` : "";
+
   if (
     user === IdentityError.NotLoggedIn ||
     user === IdentityError.CouldNotParse
@@ -26,7 +29,9 @@ export const withIdentity: express.RequestHandler = (
 
     // somehow the redirect url is automatically encoded
     res.redirect(
-      `https://profile.${conf.DOMAIN}/signin?returnUrl=${returnUrl}`
+      `https://profile.${
+        conf.DOMAIN
+      }/signin?${intcmpUrlInfix}returnUrl=${returnUrl}`
     );
     return;
   }
@@ -35,7 +40,9 @@ export const withIdentity: express.RequestHandler = (
 
     // somehow the redirect url is automatically encoded
     res.redirect(
-      `https://profile.${conf.DOMAIN}/reauthenticate?returnUrl=${returnUrl}`
+      `https://profile.${
+        conf.DOMAIN
+      }/reauthenticate?${intcmpUrlInfix}returnUrl=${returnUrl}`
     );
     return;
   }


### PR DESCRIPTION
forward the INTCMP query param to identity (for signin/reauth) as a top level query arg (i.e. not just inside the returnUrl)