### PR TITLE
Mobile tweaks/fixes

### DIFF
--- a/app/client/components/analytics.tsx
+++ b/app/client/components/analytics.tsx
@@ -73,6 +73,10 @@ export class AnalyticsTracker extends React.PureComponent<{}> {
               page: location.pathname + location.search
             });
             applyAnyOptimiseExperiments();
+            // tslint:disable-next-line:no-object-mutation
+            document.body.scrollTop = 0; // For Safari
+            // tslint:disable-next-line:no-object-mutation
+            document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
           }
           return null; // null is a valid React node type, but void is not.
         }}

--- a/app/client/components/progressBreadcrumb.tsx
+++ b/app/client/components/progressBreadcrumb.tsx
@@ -45,8 +45,9 @@ export const ProgressBreadcrumb = ({
             overflow: "hidden",
             whiteSpace: "nowrap",
             [maxWidth.mobileLandscape]: {
+              display: "block", // fixes weird bug on some mobiles (mainly Mobile Safari)
               width: isCurrentStep
-                ? "initial"
+                ? "auto"
                 : `${
                     isFirstStep ? height / 1.5 : isLastStep ? 0 : height / 2
                   }px`,
@@ -82,20 +83,29 @@ export const ProgressBreadcrumb = ({
               background
             }}
           />
-          <span
+          <div
             css={{
-              display: "table-cell", // IE :(
-              textAlign: "center", // IE :(
-              verticalAlign: "middle", // IE :(
-              paddingLeft: "5px",
-              paddingRight: isLastStep ? "5px" : `${height}px`,
-              [maxWidth.mobileLandscape]: {
-                display: isCurrentStep ? undefined : "none"
-              }
+              // having this wrapper fixes weird bug on some mobiles (mainly Mobile Safari)
+              display: "table",
+              width: "100%",
+              height: "100%"
             }}
           >
-            {label}
-          </span>
+            <span
+              css={{
+                display: "table-cell", // IE :(
+                textAlign: "center", // IE :(
+                verticalAlign: "middle", // IE :(
+                paddingLeft: "5px",
+                paddingRight: isLastStep ? "5px" : `${height}px`,
+                [maxWidth.mobileLandscape]: {
+                  display: isCurrentStep ? undefined : "none"
+                }
+              }}
+            >
+              {label}
+            </span>
+          </div>
         </div>
       );
     })}


### PR DESCRIPTION
Whilst trying to replicate the TypeError on iOS I noticed the progress breadcrumb was a bit squashed so fixed. 

Also made all page navigations scroll to the top (as they would if it wasn't a single page app) as it improves the usability.