### PR TITLE
Contributions Tab (parity with profile)

### DIFF
--- a/app/client/__tests__/__snapshots__/main.tsx.snap
+++ b/app/client/__tests__/__snapshots__/main.tsx.snap
@@ -225,7 +225,7 @@ exports[`Main renders something 1`] = `
           <li>
             <a
               className="emotion-1"
-              href="https://profile.thegulocal.com/contribution/recurring/edit"
+              href="/contributions"
             >
               <span>
                 Contributions

--- a/app/client/__tests__/components/updatableAmount.ts
+++ b/app/client/__tests__/components/updatableAmount.ts
@@ -1,0 +1,63 @@
+import { pleaseCheck, validateValue } from "../../components/updatableAmount";
+
+const monthlyPounds = {
+  currency: "£",
+  currencyISO: "GBP",
+  interval: "month"
+};
+const monthlyNZD = {
+  currency: "$",
+  currencyISO: "NZD",
+  interval: "month"
+};
+const annualPounds = {
+  currency: "£",
+  currencyISO: "GBP",
+  interval: "year"
+};
+const annualNZD = {
+  currency: "$",
+  currencyISO: "NZD",
+  interval: "year"
+};
+
+test("should reject invalid number", () => {
+  expect(validateValue(0, parseFloat("invalid"), monthlyPounds)).toContain(
+    "valid number"
+  );
+});
+
+test("should reject no change in value", () => {
+  expect(validateValue(5, 5, monthlyPounds)).toContain(
+    "enter a different amount"
+  );
+});
+
+test("should reject below minimum for currency and interval", () => {
+  const expectedStrContain = "or more";
+  expect(validateValue(5, 1, monthlyPounds)).toContain(expectedStrContain);
+  expect(validateValue(5, 2, monthlyPounds)).toBeUndefined();
+  expect(validateValue(20, 2, annualPounds)).toContain(expectedStrContain);
+  expect(validateValue(20, 10, annualPounds)).toBeUndefined();
+  expect(validateValue(15, 1, monthlyNZD)).toContain(expectedStrContain);
+  expect(validateValue(15, 10, monthlyNZD)).toBeUndefined();
+  expect(validateValue(20, 1, annualNZD)).toContain(expectedStrContain);
+  expect(validateValue(20, 10, annualNZD)).toBeUndefined();
+});
+
+test("should reject above maximum for currency and interval", () => {
+  const expectedStrContain = "cannot accept contributions over";
+  expect(validateValue(5, 9999, monthlyPounds)).toContain(expectedStrContain);
+  expect(validateValue(5, 10, monthlyPounds)).toBeUndefined();
+  expect(validateValue(20, 9999, annualPounds)).toContain(expectedStrContain);
+  expect(validateValue(20, 100, annualPounds)).toBeUndefined();
+  expect(validateValue(15, 9999, monthlyNZD)).toContain(expectedStrContain);
+  expect(validateValue(15, 150, monthlyNZD)).toBeUndefined();
+  expect(validateValue(20, 9999, annualNZD)).toContain(expectedStrContain);
+  expect(validateValue(20, 150, annualNZD)).toBeUndefined();
+});
+
+test("should warn about more than 10x increase", () => {
+  expect(validateValue(5, 60, monthlyPounds)).toContain(pleaseCheck);
+  expect(validateValue(5, 10, monthlyPounds)).toBeUndefined();
+});

--- a/app/client/colours.ts
+++ b/app/client/colours.ts
@@ -15,6 +15,10 @@ const palette = {
     medium: "#0084c6",
     dark: "#005689"
   },
+  green: {
+    dark: "#236925",
+    medium: "#3db540"
+  },
   gold: {
     light: "#eacca0",
     medium: "#ab8958",

--- a/app/client/components/nav.tsx
+++ b/app/client/components/nav.tsx
@@ -67,7 +67,7 @@ export interface NavLinks {
   publicProfile: NavItem;
   accountDetails: NavItem;
   membership: NavItem;
-  digiPack: NavItem;
+  digitalPack: NavItem;
   contributions: NavItem;
   emailPrefs: NavItem;
 }
@@ -86,7 +86,7 @@ export const navLinks: NavLinks = {
     link: "/membership",
     local: true
   },
-  digiPack: {
+  digitalPack: {
     title: "Digital Pack",
     link: "/digitalpack/edit"
   },

--- a/app/client/components/nav.tsx
+++ b/app/client/components/nav.tsx
@@ -92,7 +92,8 @@ export const navLinks: NavLinks = {
   },
   contributions: {
     title: "Contributions",
-    link: "/contribution/recurring/edit"
+    link: "/contributions",
+    local: true
   },
   emailPrefs: {
     title: "Emails & marketing",

--- a/app/client/components/payment/update/stripeCardInputForm.tsx
+++ b/app/client/components/payment/update/stripeCardInputForm.tsx
@@ -1,9 +1,8 @@
 import { NavigateFn } from "@reach/router";
 import React from "react";
 import { ReactStripeElements } from "react-stripe-elements";
-import palette from "../../../colours";
 import { maxWidth } from "../../../styles/breakpoints";
-import { sans } from "../../../styles/fonts";
+import { validationWarningCSS } from "../../../styles/fonts";
 import { Button } from "../../buttons";
 import { GenericErrorScreen } from "../../genericErrorScreen";
 import { Spinner } from "../../spinner";
@@ -21,7 +20,6 @@ export interface StripeCardInputFormProps
 
 export interface StripeCardInputFormState {
   isGeneratingToken: boolean;
-  isValid: boolean;
   error: {
     code?: string;
     message?: string;
@@ -36,7 +34,6 @@ export class StripeCardInputForm extends React.Component<
 > {
   public state: StripeCardInputFormState = {
     isGeneratingToken: false,
-    isValid: false,
     error: {},
     readyElements: []
   };
@@ -140,9 +137,7 @@ export class StripeCardInputForm extends React.Component<
       return (
         <p
           css={{
-            color: palette.red.medium,
-            fontFamily: sans,
-            fontSize: "0.8rem",
+            ...validationWarningCSS,
             marginTop: "5px"
           }}
         >

--- a/app/client/components/payment/update/updatePaymentFlow.tsx
+++ b/app/client/components/payment/update/updatePaymentFlow.tsx
@@ -83,7 +83,7 @@ const PaymentMethodRadioButton = (props: PaymentMethodRadioButtonProps) => (
       value={props.paymentMethod}
       checked={props.value === props.paymentMethod}
       onChange={(changeEvent: any) =>
-        props.updatePaymentMethod(changeEvent.target.value)
+        props.updatePaymentMethod(changeEvent.target.newAmount)
       }
     />
     {props.paymentMethod}

--- a/app/client/components/payment/update/updatePaymentFlow.tsx
+++ b/app/client/components/payment/update/updatePaymentFlow.tsx
@@ -83,7 +83,7 @@ const PaymentMethodRadioButton = (props: PaymentMethodRadioButtonProps) => (
       value={props.paymentMethod}
       checked={props.value === props.paymentMethod}
       onChange={(changeEvent: any) =>
-        props.updatePaymentMethod(changeEvent.target.newAmount)
+        props.updatePaymentMethod(changeEvent.target.value)
       }
     />
     {props.paymentMethod}

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -25,6 +25,7 @@ import { PageContainer, PageHeaderContainer } from "./page";
 import { CardDisplay } from "./payment/cardDisplay";
 import { DirectDebitDisplay } from "./payment/directDebitDisplay";
 import { PayPalDisplay } from "./payment/paypalDisplay";
+import { UpdatableAmount } from "./updatableAmount";
 import { RouteableProductProps } from "./wizardRouterAdapter";
 
 interface ProductRowProps {
@@ -126,7 +127,7 @@ const getPaymentMethodRow = (
   return undefined;
 };
 
-const getPaymentPart = (data: ProductDetail, updatePaymentPath: string) => {
+const getPaymentPart = (data: ProductDetail, productType: ProductType) => {
   if (data.isPaidTier) {
     return (
       <>
@@ -141,11 +142,16 @@ const getPaymentPart = (data: ProductDetail, updatePaymentPath: string) => {
             "ly payment"
           }
           data={
-            data.subscription.plan.currency +
-            (data.subscription.nextPaymentPrice / 100.0).toFixed(2)
+            <UpdatableAmount
+              subscription={data.subscription}
+              productType={productType}
+            />
           }
         />
-        {getPaymentMethodRow(data.subscription, updatePaymentPath)}
+        {getPaymentMethodRow(
+          data.subscription,
+          "/payment/" + productType.urlPart
+        )}
       </>
     );
   } else {
@@ -205,33 +211,35 @@ const getProductRenderer = (productType: ProductType) => (
           undefined
         )}
         <PageContainer>
-          {data.regNumber ? (
-            <ProductDetailRow
-              label={"Registration number"}
-              data={data.regNumber}
-            />
-          ) : (
-            undefined
-          )}
           {productType.tierRowLabel ? (
-            <ProductDetailRow
-              label={productType.tierRowLabel}
-              data={
-                <div css={wrappingContainerCSS}>
-                  <div css={{ marginRight: "15px" }}>{data.tier}</div>
-                  {/*TODO add a !=="Patron" condition around the Change tier button once we have a direct journey to cancellation*/}
-                  <a
-                    href={
-                      "https://membership." +
-                      window.guardian.domain +
-                      "/tier/change"
-                    }
-                  >
-                    <Button text="Change tier" right />
-                  </a>
-                </div>
-              }
-            />
+            <>
+              {data.regNumber ? (
+                <ProductDetailRow
+                  label={"Registration number"}
+                  data={data.regNumber}
+                />
+              ) : (
+                undefined
+              )}
+              <ProductDetailRow
+                label={productType.tierRowLabel}
+                data={
+                  <div css={wrappingContainerCSS}>
+                    <div css={{ marginRight: "15px" }}>{data.tier}</div>
+                    {/*TODO add a !=="Patron" condition around the Change tier button once we have a direct journey to cancellation*/}
+                    <a
+                      href={
+                        "https://membership." +
+                        window.guardian.domain +
+                        "/tier/change"
+                      }
+                    >
+                      <Button text="Change tier" right />
+                    </a>
+                  </div>
+                }
+              />
+            </>
           ) : (
             undefined
           )}
@@ -239,7 +247,7 @@ const getProductRenderer = (productType: ProductType) => (
             label={"Start date"}
             data={formatDate(data.subscription.start || data.joinDate)}
           />
-          {getPaymentPart(data, "/payment/" + productType.urlPart)}
+          {getPaymentPart(data, productType)}
           {productType.cancelLinkOnProductPage ? (
             <Link
               css={{

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -1,3 +1,4 @@
+import { Link } from "@reach/router";
 import { css } from "emotion";
 import Raven from "raven-js";
 import React from "react";
@@ -239,6 +240,20 @@ const getProductRenderer = (productType: ProductType) => (
             data={formatDate(data.subscription.start || data.joinDate)}
           />
           {getPaymentPart(data, "/payment/" + productType.urlPart)}
+          {productType.cancelLinkOnProductPage ? (
+            <Link
+              css={{
+                textDecoration: "underline",
+                color: palette.neutral["1"],
+                ":visited": { color: palette.neutral["1"] }
+              }}
+              to={"/cancel/" + productType.urlPart}
+            >
+              {"Cancel your " + productType.friendlyName}
+            </Link>
+          ) : (
+            undefined
+          )}
         </PageContainer>
       </div>
     );

--- a/app/client/components/redirectOnMeResponse.tsx
+++ b/app/client/components/redirectOnMeResponse.tsx
@@ -1,26 +1,34 @@
 import { navigate } from "@reach/router";
 import React from "react";
 import { fetchMe, MeAsyncLoader, MeResponse } from "../../shared/meResponse";
-import { navLinks, qualifyLink } from "./nav";
+import { NavItem, navLinks, qualifyLink } from "./nav";
 import { PageContainer } from "./page";
 import { RouteableProps } from "./wizardRouterAdapter";
+
+export const startRedirect = (navLink: NavItem) => {
+  const qualifiedLink = qualifyLink(navLink);
+  if (navLink.local) {
+    navigate(qualifiedLink, { replace: true });
+  } else {
+    window.location.replace(qualifiedLink);
+  }
+};
 
 export const RedirectOnMeResponse = (props: RouteableProps) => (
   <PageContainer>
     <MeAsyncLoader
       fetch={fetchMe}
       render={(me: MeResponse) => {
-        const replace = { replace: true };
         if (me.contentAccess.member) {
-          navigate(qualifyLink(navLinks.membership), replace);
+          startRedirect(navLinks.membership);
         } else if (me.contentAccess.recurringContributor) {
-          navigate(qualifyLink(navLinks.contributions), replace);
+          startRedirect(navLinks.contributions);
         } else if (me.contentAccess.digitalPack) {
-          navigate(qualifyLink(navLinks.digiPack), replace);
+          startRedirect(navLinks.digitalPack);
         } else {
-          navigate(qualifyLink(navLinks.membership), replace);
+          startRedirect(navLinks.membership);
         }
-        return null; // official way to render nothing
+        return null; // official way to render nothing, while awaiting redirect to take effect
       }}
       loadingMessage={"Checking your products..."}
     />

--- a/app/client/components/updatableAmount.tsx
+++ b/app/client/components/updatableAmount.tsx
@@ -47,7 +47,7 @@ const validateValue = (
   if (newValue === currentAmount) {
     return `Your current contribution is ${
       subscription.plan.currency
-    }${currentAmount.toFixed(2)} per ${
+    }${currentAmount.toFixed(2)} a ${
       subscription.plan.interval
     }. Please enter a different amount.`;
   }
@@ -58,7 +58,7 @@ const validateValue = (
   if (newValue < minAmount) {
     return `Please enter an amount of ${
       subscription.plan.currency
-    }${minAmount} or more per ${subscription.plan.interval}`;
+    }${minAmount} or more a ${subscription.plan.interval}`;
   }
   const maxAmount = calculateMinOrMaxAmount(
     MinOrMax.maximum,
@@ -67,12 +67,12 @@ const validateValue = (
   if (newValue > maxAmount) {
     return `Thank you but we cannot accept contributions over ${
       subscription.plan.currency
-    }${maxAmount} per ${subscription.plan.interval}`;
+    }${maxAmount} a ${subscription.plan.interval}`;
   }
   if (newValue > 10 * currentAmount) {
     return `Your current contribution is ${
       subscription.plan.currency
-    }${currentAmount.toFixed(2)} per ${
+    }${currentAmount.toFixed(2)} a ${
       subscription.plan.interval
     }. ${pleaseCheck}`;
   }

--- a/app/client/components/updatableAmount.tsx
+++ b/app/client/components/updatableAmount.tsx
@@ -36,9 +36,9 @@ const calculateMinOrMaxAmount = (
   return minOrMax === MinOrMax.minimum ? 10 : 2000; // annual
 };
 
-const pleaseCheck = "Please check the amount you've entered.";
+export const pleaseCheck = "Please check the amount you've entered.";
 
-const validateValue = (
+export const validateValue = (
   currentAmount: number,
   newValue: number,
   subscriptionPlan: SubscriptionPlan

--- a/app/client/components/updatableAmount.tsx
+++ b/app/client/components/updatableAmount.tsx
@@ -1,0 +1,287 @@
+import React, { ChangeEvent } from "react";
+import {
+  Subscription,
+  SubscriptionPlan,
+  WithSubscription
+} from "../../shared/productResponse";
+import { ProductType, WithProductType } from "../../shared/productTypes";
+import palette from "../colours";
+import { minWidth } from "../styles/breakpoints";
+import { validationWarningCSS } from "../styles/fonts";
+import AsyncLoader from "./asyncLoader";
+import { Button } from "./buttons";
+import { wrappingContainerCSS } from "./productPage";
+
+enum MinOrMax {
+  minimum,
+  maximum
+}
+
+// min & max values based on https://github.com/guardian/support-frontend/blob/5aa237d/assets/helpers/contributions.js
+const calculateMinOrMaxAmount = (
+  minOrMax: MinOrMax,
+  plan: SubscriptionPlan
+) => {
+  if (plan.interval.toLowerCase() === "month") {
+    if (plan.currencyISO === "NZD" || plan.currencyISO === "AUD") {
+      return minOrMax === MinOrMax.minimum ? 10 : 200;
+    }
+    if (plan.currencyISO === "CAD") {
+      return minOrMax === MinOrMax.minimum ? 5 : 166;
+    }
+    return minOrMax === MinOrMax.minimum ? 2 : 166; // monthly default
+  }
+  return minOrMax === MinOrMax.minimum ? 10 : 2000; // annual
+};
+
+const pleaseCheck = "Please check the amount you've entered.";
+
+const validateValue = (
+  currentAmount: number,
+  newValue: number,
+  subscription: Subscription
+) => {
+  if (isNaN(newValue)) {
+    return "Please enter a valid number";
+  }
+  if (newValue === currentAmount) {
+    return `Your current contribution is ${
+      subscription.plan.currency
+    }${currentAmount.toFixed(2)} per ${
+      subscription.plan.interval
+    }. Please enter a different amount.`;
+  }
+  const minAmount = calculateMinOrMaxAmount(
+    MinOrMax.minimum,
+    subscription.plan
+  );
+  if (newValue < minAmount) {
+    return `Please enter an amount of ${
+      subscription.plan.currency
+    }${minAmount} or more per ${subscription.plan.interval}`;
+  }
+  const maxAmount = calculateMinOrMaxAmount(
+    MinOrMax.maximum,
+    subscription.plan
+  );
+  if (newValue > maxAmount) {
+    return `Thank you but we cannot accept contributions over ${
+      subscription.plan.currency
+    }${maxAmount} per ${subscription.plan.interval}`;
+  }
+  if (newValue > 10 * currentAmount) {
+    return `Your current contribution is ${
+      subscription.plan.currency
+    }${currentAmount.toFixed(2)} per ${
+      subscription.plan.interval
+    }. ${pleaseCheck}`;
+  }
+};
+
+const amountValidationWarningCSS = {
+  ...validationWarningCSS,
+  minHeight: "2rem",
+  padding: "5px 15px",
+  width: "100%"
+};
+
+class UpdateAmountLoader extends AsyncLoader<string> {}
+
+const getAmountUpdater = (
+  newAmount: number,
+  productType: ProductType
+) => async () =>
+  await fetch(`/api/update/amount/${productType.urlPart}`, {
+    credentials: "include",
+    method: "POST",
+    mode: "same-origin",
+    body: JSON.stringify({ newPaymentAmount: newAmount })
+  });
+
+export type UpdatableAmountProps = WithSubscription & WithProductType;
+
+export interface UpdatableAmountState {
+  inEditMode: boolean;
+  isApplyingUpdate: boolean;
+  currentAmount: number;
+  newAmount: number;
+  validationMessage?: string;
+}
+
+// tslint:disable-next-line:max-classes-per-file
+export class UpdatableAmount extends React.Component<
+  UpdatableAmountProps,
+  UpdatableAmountState
+> {
+  public initialAmount = this.props.subscription.nextPaymentPrice / 100.0;
+  public state = {
+    inEditMode: false,
+    isApplyingUpdate: false,
+    currentAmount: this.initialAmount,
+    newAmount: this.initialAmount,
+    validationMessage: ""
+  };
+
+  public render(): React.ReactNode {
+    return (
+      <div css={wrappingContainerCSS}>
+        {this.state.isApplyingUpdate ? (
+          <UpdateAmountLoader
+            fetch={getAmountUpdater(
+              this.state.newAmount,
+              this.props.productType
+            )}
+            readerOnOK={(resp: Response) => resp.text()}
+            render={() => {
+              this.setState({
+                isApplyingUpdate: false,
+                inEditMode: false,
+                currentAmount: this.state.newAmount
+              });
+              return null;
+            }}
+            loadingMessage={"Updating..."}
+            errorRender={() => {
+              this.setState({
+                isApplyingUpdate: false,
+                validationMessage:
+                  "Updating failed this time. Please try again later..."
+              });
+              return null;
+            }}
+            spinnerScale={0.7}
+            inline
+          />
+        ) : (
+          <>
+            <span css={{ width: "12px" }}>
+              {this.props.subscription.plan.currency}
+            </span>
+            {this.state.inEditMode ? (
+              <>
+                <input
+                  css={{
+                    fontSize: "inherit",
+                    fontFamily: "inherit",
+                    width: "70px",
+                    marginLeft: "3px",
+                    marginRight: "3px",
+                    height: "32px",
+                    border: "1px black solid"
+                  }}
+                  type="number"
+                  step="0.01"
+                  defaultValue={this.state.newAmount.toFixed(2)}
+                  onChange={this.handleChange}
+                  autoFocus
+                />
+                <span
+                  css={{
+                    marginRight: "10px"
+                  }}
+                >
+                  {this.props.subscription.plan.currencyISO}
+                </span>
+                <div
+                  css={{
+                    ...amountValidationWarningCSS,
+                    display: "block",
+                    [minWidth.mobileLandscape]: {
+                      display: "none"
+                    }
+                  }}
+                >
+                  {this.state.validationMessage || " "}
+                </div>
+                <div>
+                  <Button
+                    text="Confirm"
+                    onClick={() => this.setState({ isApplyingUpdate: true })}
+                    disabled={
+                      this.state.validationMessage !== undefined &&
+                      !this.state.validationMessage.endsWith(pleaseCheck)
+                    }
+                  />{" "}
+                  <Button
+                    text="Back"
+                    onClick={() => this.setState({ inEditMode: false })}
+                  />
+                </div>
+                <div
+                  css={{
+                    ...amountValidationWarningCSS,
+                    display: "none",
+                    [minWidth.mobileLandscape]: {
+                      display: "block"
+                    }
+                  }}
+                >
+                  {this.state.validationMessage || <>&nbsp;</>}
+                </div>
+              </>
+            ) : (
+              <>
+                <span
+                  css={{
+                    marginRight: "15px"
+                  }}
+                >
+                  {this.state.currentAmount.toFixed(2)}{" "}
+                  {this.props.subscription.plan.currencyISO}
+                </span>
+                {this.props.productType.updateAmountMdaEndpoint ? (
+                  <>
+                    <Button
+                      text="Change amount"
+                      onClick={() => {
+                        // tslint:disable-next-line:no-object-mutation
+                        this.initialAmount = this.state.currentAmount; // effectively clears any previous success message
+                        this.setState({
+                          inEditMode: true,
+                          validationMessage: validateValue(
+                            this.initialAmount,
+                            this.state.newAmount,
+                            this.props.subscription
+                          )
+                        });
+                      }}
+                    />
+                    {this.initialAmount !== this.state.currentAmount ? (
+                      <div
+                        css={{
+                          ...amountValidationWarningCSS,
+                          paddingLeft: "0",
+                          fontWeight: "bold",
+                          color: palette.green.dark
+                        }}
+                      >
+                        Your contribution amount was updated successfully. Thank
+                        you.
+                      </div>
+                    ) : (
+                      undefined
+                    )}
+                  </>
+                ) : (
+                  undefined
+                )}
+              </>
+            )}
+          </>
+        )}
+      </div>
+    );
+  }
+
+  private handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const newValue: number = parseFloat(event.target.value);
+    this.setState({
+      newAmount: newValue,
+      validationMessage: validateValue(
+        this.state.currentAmount,
+        newValue,
+        this.props.subscription
+      )
+    });
+  };
+}

--- a/app/client/components/userNav.tsx
+++ b/app/client/components/userNav.tsx
@@ -133,7 +133,7 @@ export class UserNav extends React.Component {
     },
     {
       title: "Contributions",
-      link: `/contribtions`
+      link: `/contributions`
     },
     {
       title: "Digital Pack",

--- a/app/client/components/userNav.tsx
+++ b/app/client/components/userNav.tsx
@@ -133,7 +133,7 @@ export class UserNav extends React.Component {
     },
     {
       title: "Contributions",
-      link: `${profileHostName}/contribution/recurring/edit`
+      link: `/contribtions`
     },
     {
       title: "Digital Pack",

--- a/app/client/styles/fonts.ts
+++ b/app/client/styles/fonts.ts
@@ -1,3 +1,5 @@
+import palette from "../colours";
+
 export const fonts = `
 @font-face {
 	font-family: "GH Guardian Headline";
@@ -328,3 +330,9 @@ export const fonts = `
 export const sans = `"Guardian Text Sans Web", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif`;
 export const serif = `"GuardianTextEgyptian", Georgia, serif`;
 export const headline = `GH Guardian Headline, ${serif}`;
+
+export const validationWarningCSS = {
+  color: palette.red.medium,
+  fontFamily: sans,
+  fontSize: "0.8rem"
+};

--- a/app/server/server.ts
+++ b/app/server/server.ts
@@ -160,6 +160,22 @@ Object.values(ProductTypes).forEach((productType: ProductType) => {
         })()
     )
   );
+
+  server.use(
+    "/banner/" + productType.urlPart,
+    (req: express.Request, res: express.Response) => {
+      res.redirect("/payment/" + productType.urlPart + "?INTCMP=BANNER");
+    }
+  );
+
+  if (productType.updateAmountMdaEndpoint) {
+    server.post(
+      "/api/update/amount/" + productType.urlPart,
+      membersDataApiHandler(
+        "user-attributes/me/" + productType.updateAmountMdaEndpoint
+      )
+    );
+  }
 });
 
 server.post("/api/case", sfCasesApiHandler("case"));
@@ -183,14 +199,6 @@ server.get(
     "user-attributes/me"
   ),
   withIdentity
-);
-
-const productParamName = "product";
-server.use(
-  "/banner/:" + productParamName,
-  (req: express.Request, res: express.Response) => {
-    res.redirect("/payment/" + req.params[productParamName] + "?INTCMP=BANNER");
-  }
 );
 
 // ALL OTHER ENDPOINTS CAN BE HANDLED BY CLIENT SIDE REACT ROUTING

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -43,6 +43,13 @@ export interface DirectDebitDetails {
   accountName: string;
 }
 
+export interface SubscriptionPlan {
+  amount: number;
+  currency: string;
+  currencyISO: string;
+  interval: string;
+}
+
 export interface Subscription {
   subscriberId: string;
   start: string;
@@ -54,11 +61,7 @@ export interface Subscription {
   card?: Card;
   payPalEmail?: string;
   account?: DirectDebitDetails;
-  plan: {
-    amount: number;
-    currency: string;
-    interval: string;
-  };
+  plan: SubscriptionPlan;
 }
 
 export interface WithSubscription {

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -44,7 +44,6 @@ export interface DirectDebitDetails {
 }
 
 export interface SubscriptionPlan {
-  amount: number;
   currency: string;
   currencyISO: string;
   interval: string;

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -25,6 +25,7 @@ export interface ProductType {
   validator: MeValidator;
   sfProduct: SfProduct;
   noProductInTabCopy: string;
+  updateAmountMdaEndpoint?: string;
   cancelLinkOnProductPage?: true;
   cancellationReasons: CancellationReason[];
   cancellationStartPageBody: JSX.Element;
@@ -96,6 +97,7 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
     productPageTitle: "Contributions",
     noProductInTabCopy:
       "To manage your existing membership or subscription, please select from the tabs above.",
+    updateAmountMdaEndpoint: "contribution-update-amount",
     cancelLinkOnProductPage: true,
     cancellationReasons: contributionsCancellationReasons,
     cancellationStartPageBody: contributionsCancellationFlowStart,

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -25,6 +25,7 @@ export interface ProductType {
   validator: MeValidator;
   sfProduct: SfProduct;
   noProductInTabCopy: string;
+  cancelLinkOnProductPage?: true;
   cancellationReasons: CancellationReason[];
   cancellationStartPageBody: JSX.Element;
   cancellationSaveTitlePrefix?: string;
@@ -95,6 +96,7 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
     productPageTitle: "Contributions",
     noProductInTabCopy:
       "To manage your existing membership or subscription, please select from the tabs above.",
+    cancelLinkOnProductPage: true,
     cancellationReasons: contributionsCancellationReasons,
     cancellationStartPageBody: contributionsCancellationFlowStart,
     cancellationSaveTitlePrefix: "Reason: ",


### PR DESCRIPTION
Replicates and improves upon the contributions tab from profile.
![image](https://user-images.githubusercontent.com/19289579/47149018-31786280-d2ca-11e8-917c-c9c76d266e40.png)

## Key Feature : Amount Updater
NOW uses the bounds from https://github.com/guardian/support-frontend/blob/5aa237d/assets/helpers/contributions.js which differ based on currency and  frequency (monthly vs annual) and also has an improved 'sense check' where you are asked to double check if you increase your contribution by x10 (indicative of an accidental extra key press).

![image](https://user-images.githubusercontent.com/19289579/47149653-21fa1900-d2cc-11e8-9e6f-0f7c26ff1ae9.png)

![image](https://user-images.githubusercontent.com/19289579/47149244-e3b02a00-d2ca-11e8-9494-b5c8a783b3ab.png)

![image](https://user-images.githubusercontent.com/19289579/47149221-ced39680-d2ca-11e8-8047-9308e42e4ac5.png)

![image](https://user-images.githubusercontent.com/19289579/47149258-edd22880-d2ca-11e8-8457-2b0692b89856.png)

![image](https://user-images.githubusercontent.com/19289579/47149726-540b7b00-d2cc-11e8-9705-7203dfc2662a.png)

![image](https://user-images.githubusercontent.com/19289579/47149268-faef1780-d2ca-11e8-9378-87c5f9cb5fb6.png)

![image](https://user-images.githubusercontent.com/19289579/47149885-c9774b80-d2cc-11e8-81c8-b17feca2a370.png)

![image](https://user-images.githubusercontent.com/19289579/47149283-05a9ac80-d2cb-11e8-8e49-67f0d2a11dd7.png)

...or, if it fails...

![image](https://user-images.githubusercontent.com/19289579/47149928-e744b080-d2cc-11e8-9f18-978fc4d36512.png)