### PR TITLE
set Cache-Control back to private (to get master back to a safe state)

### DIFF
--- a/app/server/server.ts
+++ b/app/server/server.ts
@@ -44,7 +44,7 @@ const globals: Globals = {
 
 server.use(
   (req: express.Request, res: express.Response, next: express.NextFunction) => {
-    res.header("Cache-Control", "no-cache");
+    res.header("Cache-Control", "private");
     res.header("Access-Control-Allow-Origin", "*." + conf.DOMAIN);
     next();
   }


### PR DESCRIPTION
since Fastly doesn't respect no-cache (https://docs.fastly.com/guides/tutorials/cache-control-tutorial#do-not-cache)