### PR TITLE
turned off all caching (for both Fastly CDN AND browsers)

### DIFF
--- a/app/server/server.ts
+++ b/app/server/server.ts
@@ -44,7 +44,11 @@ const globals: Globals = {
 
 server.use(
   (req: express.Request, res: express.Response, next: express.NextFunction) => {
-    res.header("Cache-Control", "private");
+    // this header is VERY IMPORTANT and prevents caching (on both CDN and in browsers)
+    res.header(
+      "Cache-Control",
+      "private, no-cache, no-store, must-revalidate, max-age=0"
+    );
     res.header("Access-Control-Allow-Origin", "*." + conf.DOMAIN);
     next();
   }


### PR DESCRIPTION
https://docs.fastly.com/guides/tutorials/cache-control-tutorial#do-not-cache
> Fastly does not currently respect no-store or no-cache directives. Including either or both of these in a Cache-Control header has no effect on Fastly's caching decision, unless you alter this behaviour using custom VCL.

...and...

> The private directive does not prevent content from being cached in the browser. If you need to prevent caching by both Fastly and web browsers, we recommend combining the private directive with max-age=0 or no-store.

Given the above we need to set `Cache-Control` header to both `private` and `no-store` to prevent caching in BOTH the browser and on the CDN. The header value in this change covers all bases 😉 