### PR TITLE
Use improved amigo node role (node baked into the AMI)

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -89,10 +89,6 @@ Resources:
           - |+
             #!/bin/bash -ev
 
-            # get and install node
-            wget -nv https://nodejs.org/dist/v10.7.0/node-v10.7.0-linux-x64.tar.xz -P /tmp
-            tar -xf /tmp/node-v10.7.0-linux-x64.tar.xz  --directory /usr/local/
-
             # get runnable tar from S3
             aws --region ${AWS::Region} s3 cp s3://membership-dist/${Stack}/${Stage}/${App}/manage-frontend.tgz /tmp
             mkdir /etc/gu
@@ -108,7 +104,7 @@ Resources:
             # write out systemd file
             cat >/etc/systemd/system/manage-frontend.service <<EOL
             [Service]
-            ExecStart=/usr/local/node-v10.7.0-linux-x64/bin/node /etc/gu/dist/server.js
+            ExecStart=node /etc/gu/dist/server.js
             Restart=always
             StandardOutput=syslog
             StandardError=syslog

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -104,7 +104,7 @@ Resources:
             # write out systemd file
             cat >/etc/systemd/system/manage-frontend.service <<EOL
             [Service]
-            ExecStart=node /etc/gu/dist/server.js
+            ExecStart=/usr/bin/node /etc/gu/dist/server.js
             Restart=always
             StandardOutput=syslog
             StandardError=syslog

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -9,7 +9,7 @@ deployments:
     parameters:
       templatePath: cloudformation/cfn.yaml
       amiTags:
-        Recipe: xenial-membership
+        Recipe: manage-frontend
         AmigoStage: PROD
       amiEncrypted: true
   manage-frontend:


### PR DESCRIPTION
Following https://github.com/guardian/amigo/pull/221, this PR now changes to use a dedicated 'manage-frontend' recipe in AMIgo, which specifies the exact Node version, which is now baked into the AMI. This allows us to remove the Node download/unpack step from instance start-up, which will **improve startup time** AND **improve stability**.