### PR TITLE
added missing return statement (corrects PR139)

### DIFF
--- a/app/server/identity/identityMiddleware.ts
+++ b/app/server/identity/identityMiddleware.ts
@@ -44,6 +44,7 @@ export const withIdentity: express.RequestHandler = (
   if (user === IdentityError.Expired) {
     log.info("User session expired.");
     res.redirect(getAuthRedirectUrl("reauthenticate"));
+    return;
   }
 
   // tslint:disable-next-line:no-object-mutation


### PR DESCRIPTION
there was a missing return statement in https://github.com/guardian/manage-frontend/pull/139 which caused a NodeError where it was continuing to try send the normal response after already redirecting (fortunately didn't make it to PROD).