### PR TITLE
changed to new cert for CODE (which is referenced by new Fastly CODE configuration)

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -42,7 +42,7 @@ Mappings:
       MaxInstances: 2
       MinInstances: 1
       InstanceType: t2.small
-      CertificateARN: arn:aws:acm:eu-west-1:865473395570:certificate/f44a80e1-7c25-422e-987d-f50d88093aec
+      CertificateARN: arn:aws:acm:eu-west-1:865473395570:certificate/2c2a72a2-a0d6-4ffa-b8a1-8a7916000515
       DomainEnvVariable: code.dev-theguardian.com
       SFCasesUrl: https://gm3ysthjh6.execute-api.eu-west-1.amazonaws.com/CODE
     PROD:


### PR DESCRIPTION
changed to new cert (which is referenced in Fastly) which follows the naming convention for PROD (and other apps CODE certs)