### PR TITLE
add ophan tracker js

### DIFF
--- a/app/client/components/analytics.tsx
+++ b/app/client/components/analytics.tsx
@@ -32,6 +32,15 @@ export const trackEvent = ({
       eventValue
     );
   }
+  if (window.guardian && window.guardian.ophan) {
+    window.guardian.ophan.record({
+      componentEvent: {
+        component: `MMA_${eventCategory.toUpperCase()}`,
+        action: `MMA_${eventAction.toUpperCase()}`,
+        value: eventLabel
+      }
+    });
+  }
 };
 
 export const applyAnyOptimiseExperiments = () => {
@@ -67,16 +76,22 @@ export class AnalyticsTracker extends React.PureComponent<{}> {
     return (
       <Location>
         {({ location }) => {
-          if (location && typeof window !== "undefined" && window.ga) {
-            window.ga("send", "pageview", {
-              location: location.href,
-              page: location.pathname + location.search
-            });
-            applyAnyOptimiseExperiments();
-            // tslint:disable-next-line:no-object-mutation
-            document.body.scrollTop = 0; // For Safari
-            // tslint:disable-next-line:no-object-mutation
-            document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
+          if (location && typeof window !== "undefined") {
+            if (window.guardian && window.guardian.ophan) {
+              // TODO call window.guardian.ophan.sendInitialEvent here once new tracker-js is deployed
+            }
+            if (window.ga) {
+              window.ga("send", "pageview", {
+                location: location.href,
+                page: location.pathname + location.search
+              });
+              // TODO add ophan pageViewId as a GA dimension
+              applyAnyOptimiseExperiments();
+              // tslint:disable-next-line:no-object-mutation
+              document.body.scrollTop = 0; // For Safari
+              // tslint:disable-next-line:no-object-mutation
+              document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
+            }
           }
           return null; // null is a valid React node type, but void is not.
         }}

--- a/app/client/components/analytics.tsx
+++ b/app/client/components/analytics.tsx
@@ -77,8 +77,12 @@ export class AnalyticsTracker extends React.PureComponent<{}> {
       <Location>
         {({ location }) => {
           if (location && typeof window !== "undefined") {
-            if (window.guardian && window.guardian.ophan) {
-              // TODO call window.guardian.ophan.sendInitialEvent here once new tracker-js is deployed
+            if (
+              window.guardian &&
+              window.guardian.ophan &&
+              window.guardian.ophan.sendInitialEvent
+            ) {
+              window.guardian.ophan.sendInitialEvent(location.href);
             }
             if (window.ga) {
               window.ga("send", "pageview", {

--- a/app/client/user.ts
+++ b/app/client/user.ts
@@ -1,7 +1,6 @@
-import * as ophan from "ophan-tracker-js/build/ophan.manage-my-account";
+import "ophan-tracker-js/build/ophan.manage-my-account";
 import Raven from "raven-js";
 import ReactDOM from "react-dom";
-import { RecordOphanComponentEvent } from "../globals";
 import { BrowserUser } from "./components/user";
 
 declare var WEBPACK_BUILD: string;
@@ -11,13 +10,6 @@ if (typeof window !== "undefined" && window.guardian && window.guardian.dsn) {
     release: WEBPACK_BUILD || "local",
     environment: window.guardian.domain
   }).install();
-}
-
-if (typeof window !== "undefined" && window.guardian) {
-  // tslint:disable-next-line:no-object-mutation
-  window.guardian.ophan = {
-    record: ophan.record as RecordOphanComponentEvent
-  };
 }
 
 const element = document.getElementById("app");

--- a/app/client/user.ts
+++ b/app/client/user.ts
@@ -1,5 +1,7 @@
+import * as ophan from "ophan-tracker-js/build/ophan.manage-my-account";
 import Raven from "raven-js";
 import ReactDOM from "react-dom";
+import { RecordOphanComponentEvent } from "../globals";
 import { BrowserUser } from "./components/user";
 
 declare var WEBPACK_BUILD: string;
@@ -9,6 +11,13 @@ if (typeof window !== "undefined" && window.guardian && window.guardian.dsn) {
     release: WEBPACK_BUILD || "local",
     environment: window.guardian.domain
   }).install();
+}
+
+if (typeof window !== "undefined" && window.guardian) {
+  // tslint:disable-next-line:no-object-mutation
+  window.guardian.ophan = {
+    record: ophan.record as RecordOphanComponentEvent
+  };
 }
 
 const element = document.getElementById("app");

--- a/app/globals.ts
+++ b/app/globals.ts
@@ -3,9 +3,9 @@ export interface Globals {
   dsn: string | null;
   supportedBrowser: boolean;
   ophan?: {
-    // viewId: string;
+    viewId: string;
     record: RecordOphanComponentEvent;
-    // sendInitialEvent: () => void;
+    sendInitialEvent: (url?: string, referer?: string) => void;
   };
 }
 

--- a/app/globals.ts
+++ b/app/globals.ts
@@ -2,6 +2,21 @@ export interface Globals {
   domain: string;
   dsn: string | null;
   supportedBrowser: boolean;
+  ophan?: {
+    // viewId: string;
+    record: RecordOphanComponentEvent;
+    // sendInitialEvent: () => void;
+  };
+}
+
+export type RecordOphanComponentEvent = (
+  payload: { componentEvent: OphanComponentEvent }
+) => void;
+
+export interface OphanComponentEvent {
+  component: string;
+  action: string;
+  value?: string;
 }
 
 declare global {

--- a/app/package.json
+++ b/app/package.json
@@ -107,6 +107,7 @@
     "helmet": "^3.12.1",
     "moment": "^2.22.2",
     "node-fetch": "^2.1.2",
+    "ophan-tracker-js": "^1.3.13",
     "raven": "^2.6.2",
     "raven-js": "^3.25.2",
     "react": "^16.4.1",

--- a/app/package.json
+++ b/app/package.json
@@ -107,7 +107,7 @@
     "helmet": "^3.12.1",
     "moment": "^2.22.2",
     "node-fetch": "^2.1.2",
-    "ophan-tracker-js": "^1.3.13",
+    "ophan-tracker-js": "^1.3.14",
     "raven": "^2.6.2",
     "raven-js": "^3.25.2",
     "react": "^16.4.1",

--- a/app/types/ophan-tracker-js.d.ts
+++ b/app/types/ophan-tracker-js.d.ts
@@ -1,0 +1,1 @@
+declare module "ophan-tracker-js/build/ophan.manage-my-account";

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -5932,6 +5932,10 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+ophan-tracker-js@^1.3.13:
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.13.tgz#715aa8655c1ec4c8e45379bae55a95b535522ff6"
+
 opn@^5.1.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.3.0.tgz#64871565c863875f052cfdf53d3e3cb5adb53b1c"


### PR DESCRIPTION
adding ophan tracking using the dedicated `ophan.manage-my-account` tracking script (which now has support for client side routing - see https://github.com/guardian/ophan/pull/2979) 