### PR TITLE
fixed annoying outline around buttons when clicked

### DIFF
--- a/app/client/__tests__/__snapshots__/main.tsx.snap
+++ b/app/client/__tests__/__snapshots__/main.tsx.snap
@@ -1035,6 +1035,9 @@ exports[`Main renders something 1`] = `
                   <button
                     css={
                       Object {
+                        ":active": Object {
+                          "outline": "none",
+                        },
                         ":hover": Object {
                           "background": "hsl(53.89999999999998, 100%, 45%)",
                           "svg": Object {
@@ -1076,6 +1079,7 @@ exports[`Main renders something 1`] = `
                         "whiteSpace": "nowrap",
                       }
                     }
+                    onMouseUp={[Function]}
                   >
                     Contribute
                     <svg
@@ -1093,6 +1097,9 @@ exports[`Main renders something 1`] = `
                   <button
                     css={
                       Object {
+                        ":active": Object {
+                          "outline": "none",
+                        },
                         ":hover": Object {
                           "background": "hsl(53.89999999999998, 100%, 45%)",
                           "svg": Object {
@@ -1134,6 +1141,7 @@ exports[`Main renders something 1`] = `
                         "whiteSpace": "nowrap",
                       }
                     }
+                    onMouseUp={[Function]}
                   >
                     Subscribe
                     <svg

--- a/app/client/components/buttons.tsx
+++ b/app/client/components/buttons.tsx
@@ -139,7 +139,10 @@ const styles = {
     borderRadius: "1000px",
     alignItems: "center",
     whiteSpace: "nowrap",
-    position: "relative"
+    position: "relative",
+    ":active": {
+      outline: "none"
+    }
   },
   leftHover: {
     svg: { transform: "translate(-5px, -50%) rotate(180deg)" }
@@ -187,6 +190,9 @@ export const Button = (props: ButtonProps) => (
     onClick={props.onClick}
     css={buttonCss(props)}
     disabled={props.disabled}
+    onMouseUp={(event: React.MouseEvent<HTMLButtonElement>) =>
+      (event.target as HTMLButtonElement).blur()
+    }
   >
     {props.text}
     <ButtonArrow />


### PR DESCRIPTION
Buttons used to have the focus highlight wrapping them once clicked, which was ugly/distracting for a short period of time until the desired action happened. Now only shows for actual focus (for keyboard navigation accessibility).

for example...
![image](https://user-images.githubusercontent.com/19289579/49802246-44e10080-fd44-11e8-9dce-7074cdab9dcc.png)

