### PR TITLE
upgrade to latest ophan tracker-js (where ophan pageViewId issue is fixed)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -107,7 +107,7 @@
     "helmet": "^3.12.1",
     "moment": "^2.22.2",
     "node-fetch": "^2.1.2",
-    "ophan-tracker-js": "^1.3.14",
+    "ophan-tracker-js": "^1.3.16",
     "raven": "^2.6.2",
     "raven-js": "^3.25.2",
     "react": "^16.4.1",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -5932,9 +5932,9 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-ophan-tracker-js@^1.3.14:
-  version "1.3.14"
-  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.14.tgz#9a303eacb94f3e6b7904727a4aa2b5486813de47"
+ophan-tracker-js@^1.3.16:
+  version "1.3.16"
+  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.16.tgz#0f4c14924d44eced7fa311cb6a9318a20325a680"
 
 opn@^5.1.0:
   version "5.3.0"


### PR DESCRIPTION
makes use of https://github.com/guardian/ophan/pull/3076