### PR TITLE
prevented double-counting of initial page view in Ophan

### DIFF
--- a/app/client/components/analytics.tsx
+++ b/app/client/components/analytics.tsx
@@ -82,7 +82,12 @@ export class AnalyticsTracker extends React.PureComponent<{}> {
               window.guardian.ophan &&
               window.guardian.ophan.sendInitialEvent
             ) {
-              window.guardian.ophan.sendInitialEvent(location.href);
+              if (window.guardian.spaTransition) {
+                window.guardian.ophan.sendInitialEvent(location.href);
+              } else {
+                // tslint:disable-next-line:no-object-mutation
+                window.guardian.spaTransition = true;
+              }
             }
             if (window.ga) {
               window.ga("send", "pageview", {

--- a/app/globals.ts
+++ b/app/globals.ts
@@ -2,6 +2,7 @@ export interface Globals {
   domain: string;
   dsn: string | null;
   supportedBrowser: boolean;
+  spaTransition?: true;
   ophan?: {
     viewId: string;
     record: RecordOphanComponentEvent;


### PR DESCRIPTION
When checking the 5XX alert email (not related, and resolved itself) I noticed the first page was being double counted after my hasty change last Friday (https://github.com/guardian/manage-frontend/pull/165)

The double counting is because an initial event is sent when the Ophan tracking script loads the page and then again with the usual 'page change'