### PR TITLE
fixed returnUrl issue in redirects for /api/

### DIFF
--- a/app/server/__tests__/identity/identityMiddleware.ts
+++ b/app/server/__tests__/identity/identityMiddleware.ts
@@ -12,18 +12,19 @@ const codeReauthURL = profilePrefix + codeDomain + "/" + reauthPath;
 const requestedUrlSimple = {
   baseUrl: "baseUrl",
   path: "path",
+  header: () => "header",
   get: () => "host",
   query: {}
 };
 
 test("should replace code.dev-theguardian.com with thegulocal.com in the augmented redirect URL", () => {
   expect(
-    augmentRedirectURL(requestedUrlSimple, codeReauthURL, gulocalDomain)
+    augmentRedirectURL(requestedUrlSimple, codeReauthURL, gulocalDomain, false)
   ).toContain(profilePrefix + gulocalDomain);
 });
 
 test("augmented URL should at least contain the simple input URL", () => {
   expect(
-    augmentRedirectURL(requestedUrlSimple, codeReauthURL, codeDomain)
+    augmentRedirectURL(requestedUrlSimple, codeReauthURL, codeDomain, false)
   ).toContain(codeReauthURL);
 });


### PR DESCRIPTION
Introduced slight flaw in https://github.com/guardian/manage-frontend/pull/167, which this PR resolves.

Previously the /api/ url would be used for `?returnUrl=` rather than the page that was making the AJAX request, so now it uses the `referer` header for the `?returnUrl=` for /api/ endpoints. 

NOTE identity will not redirect to an unsafe `?returnUrl=` so no security alarm here.