### PR TITLE
update gulocal cert reference for new 2020 cert

### DIFF
--- a/nginx/manage-frontend.conf
+++ b/nginx/manage-frontend.conf
@@ -12,8 +12,8 @@ server {
     server_name manage.thegulocal.com;
 
     ssl on;
-    ssl_certificate wildcard-thegulocal-com-exp2019-01-09.crt; ## Supplied by https://github.com/guardian/identity-platform#setup-nginx-for-local-development
-    ssl_certificate_key wildcard-thegulocal-com-exp2019-01-09.key; ## ditto
+    ssl_certificate STAR_thegulocal_com_exp2020-01-09.crt; ## Supplied by https://github.com/guardian/identity-platform#setup-nginx-for-local-development
+    ssl_certificate_key STAR_thegulocal_com_exp2020-01-09.key; ## ditto
 
     ssl_session_timeout 5m;
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15648334/50981379-c4542200-14f2-11e9-9bd2-e19983bef4e6.png)

Much like https://github.com/guardian/members-data-api/pull/360

1. If you haven't already fetch the certs, download them (see hangouts chat message from Rupert on how/where to fetch).
2. Navigate to `./nginx` and run `./setup.sh`
3. `sudo nginx -s reload`