### PR TITLE
add prout 

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -1,0 +1,12 @@
+{
+  "checkpoints": {
+    "CODE": {
+      "url": "https://manage.code.dev-theguardian.com/_prout",
+      "overdue": "1H"
+    },
+    "PROD": {
+      "url": "https://manage.theguardian.com/_prout",
+      "overdue": "15M"
+    }
+  }
+}

--- a/app/package.json
+++ b/app/package.json
@@ -69,6 +69,7 @@
     "copy-node-modules": "^1.0.4",
     "copy-webpack-plugin": "^4.5.2",
     "dom-testing-library": "^2.3.2",
+    "git-revision-webpack-plugin": "^3.0.3",
     "husky": "^0.14.3",
     "jest": "^23.0.0",
     "jest-emotion": "^9.1.3",

--- a/app/server/server.ts
+++ b/app/server/server.ts
@@ -73,6 +73,11 @@ server.get(
   }
 );
 
+declare var GIT_COMMIT_HASH: string;
+server.get("/_prout", (req: express.Request, res: express.Response) => {
+  res.send(`<pre>${GIT_COMMIT_HASH}</pre>`);
+});
+
 server.use(bodyParser.raw({ type: "*/*" })); // parses all bodys to a raw 'Buffer'
 server.use("/api/", withIdentity(401));
 

--- a/app/webpack.common.js
+++ b/app/webpack.common.js
@@ -3,6 +3,7 @@ const merge = require("webpack-merge");
 const AssetsPlugin = require("assets-webpack-plugin");
 const webpack = require("webpack");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
+const GitRevisionPlugin = require("git-revision-webpack-plugin");
 
 const assetsPluginInstance = new AssetsPlugin({
   path: path.resolve(__dirname, "./dist/")
@@ -11,7 +12,10 @@ const assetsPluginInstance = new AssetsPlugin({
 const definePlugin = new webpack.DefinePlugin({
   WEBPACK_BUILD: process.env.TEAMCITY_BUILD
     ? `'${process.env.TEAMCITY_BUILD}'`
-    : "'NO BUILD SET'"
+    : "'NO BUILD SET'",
+  GIT_COMMIT_HASH: process.env.BUILD_VCS_NUMBER
+    ? `'${process.env.BUILD_VCS_NUMBER}'`
+    : `'${new GitRevisionPlugin().commithash()}'`
 });
 
 const copyPlugin = new CopyWebpackPlugin([

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -3773,6 +3773,10 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+git-revision-webpack-plugin@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/git-revision-webpack-plugin/-/git-revision-webpack-plugin-3.0.3.tgz#f909949d7851d1039ed530518f73f5d46594e66f"
+
 glob-base@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"


### PR DESCRIPTION
Adding [PROUT](https://github.com/guardian/prout) for this repo, so we can turn on continuous deployment.

- added prout configuration file (including CODE, to highlight changes which haven't been deployed to CODE first) 
- new `/_prout` endpoint which serves up the git commit hash of the build
- Gave @prout-bot write access to this repo... ![image](https://user-images.githubusercontent.com/19289579/51054383-99da9580-15d4-11e9-90d4-cdc34f3b88f6.png)
- Added webhooks... ![image](https://user-images.githubusercontent.com/19289579/51054319-6e57ab00-15d4-11e9-9924-189a592ddd96.png)
- Added post-deploy hooks... ![image](https://user-images.githubusercontent.com/19289579/51054801-d2c73a00-15d5-11e9-94c6-dbf2ad284e31.png)
- Turned on riff-raff continuous deployment... ![image](https://user-images.githubusercontent.com/19289579/51109624-abe35080-17ed-11e9-83d1-f3b232b07edb.png)


