### PR TITLE
PROUT: removed CODE checkpoint since it only fires after the PR is merged

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -1,9 +1,5 @@
 {
   "checkpoints": {
-    "CODE": {
-      "url": "https://manage.code.dev-theguardian.com/_prout",
-      "overdue": "1H"
-    },
     "PROD": {
       "url": "https://manage.theguardian.com/_prout",
       "overdue": "15M"


### PR DESCRIPTION
...therefore isn't much use (may reinstate in future if there is another way to trigger PROUT on pushes prior to PR merge)

**_Follows closely on from https://github.com/guardian/manage-frontend/pull/172_**