### PR TITLE
Digipack tab parity

### DIFF
--- a/app/client/__tests__/__snapshots__/main.tsx.snap
+++ b/app/client/__tests__/__snapshots__/main.tsx.snap
@@ -234,7 +234,7 @@ exports[`Main renders something 1`] = `
           <li>
             <a
               className="emotion-1"
-              href="https://profile.thegulocal.com/digitalpack/edit"
+              href="/digitalpack"
             >
               <span>
                 Digital Pack

--- a/app/client/components/nav.tsx
+++ b/app/client/components/nav.tsx
@@ -95,7 +95,8 @@ export const navLinks: NavLinks = {
   },
   digitalPack: {
     title: "Digital Pack",
-    link: "/digitalpack/edit"
+    link: "/digitalpack",
+    local: true
   },
   contributions: {
     title: "Contributions",

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -261,6 +261,14 @@ const getProductRenderer = (productType: ProductTypeWithProductPage) => (
                   undefined
                 )}
                 <PageContainer>
+                  {productType.productPage.showSubscriberId ? (
+                    <ProductDetailRow
+                      label={"Subscriber ID"}
+                      data={productDetail.subscription.subscriberId}
+                    />
+                  ) : (
+                    undefined
+                  )}
                   {productType.productPage.tierRowLabel ? (
                     <>
                       {productDetail.regNumber ? (

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -313,6 +313,17 @@ const getProductRenderer = (productType: ProductTypeWithProductPage) => (
                       productDetail.subscription.start || productDetail.joinDate
                     )}
                   />
+                  {productType.productPage.showTrialRemainingIfApplicable &&
+                  productDetail.subscription.trialLength > 0 ? (
+                    <ProductDetailRow
+                      label={"Trial remaining"}
+                      data={`${productDetail.subscription.trialLength} day${
+                        productDetail.subscription.trialLength !== 1 ? "s" : ""
+                      }`}
+                    />
+                  ) : (
+                    undefined
+                  )}
                   {getPaymentPart(productDetail, productType)}
                   {productType.cancellation &&
                   productType.cancellation.linkOnProductPage ? (

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -383,7 +383,9 @@ export const ProductPage = (props: RouteableProductPropsWithProductPage) => (
       fetch={createProductDetailFetcher(props.productType)}
       render={getProductRenderer(props.productType)}
       readerOnOK={annotateMdaResponseWithTestUserFromHeaders}
-      loadingMessage={`Loading your ${props.productType.urlPart} details...`}
+      loadingMessage={`Loading your ${
+        props.productType.friendlyName
+      } details...`}
     />
     <PageContainer>
       <MembershipLinks /> {/*TODO need to have contributions FAQ*/}

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -274,21 +274,25 @@ const getProductRenderer = (productType: ProductTypeWithProductPage) => (
                       <ProductDetailRow
                         label={productType.productPage.tierRowLabel}
                         data={
-                          <div css={wrappingContainerCSS}>
-                            <div css={{ marginRight: "15px" }}>
-                              {productDetail.tier}
+                          productType.productPage.tierChangeable ? (
+                            <div css={wrappingContainerCSS}>
+                              <div css={{ marginRight: "15px" }}>
+                                {productDetail.tier}
+                              </div>
+                              {/*TODO add a !=="Patron" condition around the Change tier button once we have a direct journey to cancellation*/}
+                              <a
+                                href={
+                                  "https://membership." +
+                                  window.guardian.domain +
+                                  "/tier/change"
+                                }
+                              >
+                                <Button text="Change tier" right />
+                              </a>
                             </div>
-                            {/*TODO add a !=="Patron" condition around the Change tier button once we have a direct journey to cancellation*/}
-                            <a
-                              href={
-                                "https://membership." +
-                                window.guardian.domain +
-                                "/tier/change"
-                              }
-                            >
-                              <Button text="Change tier" right />
-                            </a>
-                          </div>
+                          ) : (
+                            productDetail.tier
+                          )
                         }
                       />
                     </>

--- a/app/client/components/userNav.tsx
+++ b/app/client/components/userNav.tsx
@@ -120,7 +120,7 @@ export class UserNav extends React.Component {
   public userNavItems: UserNavItem[] = [
     {
       title: "Comments & replies",
-      link: `/profile/user` // note this hits a redirect/proxy endpoint
+      link: "/profile/user" // note this hits a redirect/proxy endpoint
     },
     {
       title: "Public profile",
@@ -137,15 +137,15 @@ export class UserNav extends React.Component {
     },
     {
       title: "Membership",
-      link: `/membership`
+      link: "/membership"
     },
     {
       title: "Contributions",
-      link: `/contributions`
+      link: "/contributions"
     },
     {
       title: "Digital Pack",
-      link: `/digitalpack`,
+      link: "/digitalpack",
       border: true
     },
     {

--- a/app/client/components/userNav.tsx
+++ b/app/client/components/userNav.tsx
@@ -145,7 +145,7 @@ export class UserNav extends React.Component {
     },
     {
       title: "Digital Pack",
-      link: `${profileHostName}/digitalpack/edit`,
+      link: `/digitalpack`,
       border: true
     },
     {

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -83,6 +83,7 @@ export interface Subscription {
   payPalEmail?: string;
   mandate?: DirectDebitDetails;
   plan: SubscriptionPlan;
+  trialLength: number;
 }
 
 export interface WithSubscription {

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -23,7 +23,7 @@ export type ProductUrlPart =
   | "paper"
   | "digitalpack";
 export type SfProduct = "Membership" | "Contribution";
-export type ProductTitle = "Membership" | "Contributions";
+export type ProductTitle = "Membership" | "Contributions" | "Digital Pack";
 export type AllProductsProductTypeFilterString =
   | "Weekly"
   | "Paper"
@@ -56,7 +56,8 @@ export interface ProductPageProperties {
   navLink: NavItem;
   noProductInTabCopy: string;
   updateAmountMdaEndpoint?: string;
-  tierRowLabel?: string; // no label means row is not displayed
+  tierRowLabel?: string; // no label means row is not displayed;
+  tierChangeable?: true;
 }
 
 export interface ProductType {
@@ -117,7 +118,8 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
       navLink: navLinks.membership,
       noProductInTabCopy:
         "To manage your existing contribution or subscription, please select from the tabs above.",
-      tierRowLabel: "Membership tier"
+      tierRowLabel: "Membership tier",
+      tierChangeable: true
     },
     includeGuardianInTitles: true,
     cancellation: {
@@ -222,6 +224,13 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
       typeof window !== "undefined" && window.guardian && window.guardian.domain
         ? window.guardian.domain
         : "theguardian.com"
-    }/digitalpack/edit`
+    }/digitalpack/edit`,
+    productPage: {
+      title: "Digital Pack",
+      navLink: navLinks.digitalPack,
+      noProductInTabCopy:
+        "To manage your existing membership or contribution, please select from the tabs above.",
+      tierRowLabel: "Subscription product"
+    }
   }
 };

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -58,6 +58,7 @@ export interface ProductPageProperties {
   updateAmountMdaEndpoint?: string;
   tierRowLabel?: string; // no label means row is not displayed;
   tierChangeable?: true;
+  showSubscriberId?: true;
 }
 
 export interface ProductType {
@@ -230,7 +231,8 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
       navLink: navLinks.digitalPack,
       noProductInTabCopy:
         "To manage your existing membership or contribution, please select from the tabs above.",
-      tierRowLabel: "Subscription product"
+      tierRowLabel: "Subscription product",
+      showSubscriberId: true
     }
   }
 };

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -59,6 +59,7 @@ export interface ProductPageProperties {
   tierRowLabel?: string; // no label means row is not displayed;
   tierChangeable?: true;
   showSubscriberId?: true;
+  showTrialRemainingIfApplicable?: true;
 }
 
 export interface ProductType {
@@ -232,7 +233,8 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
       noProductInTabCopy:
         "To manage your existing membership or contribution, please select from the tabs above.",
       tierRowLabel: "Subscription product",
-      showSubscriberId: true
+      showSubscriberId: true,
+      showTrialRemainingIfApplicable: true
     }
   }
 };


### PR DESCRIPTION
Replicated the digipack tab from profile.theguardian.com. This required adding the following additional rows to the existing productPage implementation in `manage-frontend`:

- subscriber ID
- trial remaining
- subscription product

Global navigation and tabs within `manage-frontend` now point to the new tab.

_Changes to `frontend` to redirect traffic will follow soon._

![image](https://user-images.githubusercontent.com/15648334/51263227-bea38400-19ab-11e9-9290-9c760fb0eb6f.png)
