### PR TITLE
Guardian weekly payment flow

### DIFF
--- a/app/client/components/flowStartMultipleProductDetailHandler.tsx
+++ b/app/client/components/flowStartMultipleProductDetailHandler.tsx
@@ -107,7 +107,7 @@ const getProductDetailSelector = (
                           &nbsp;
                           {productDetail.subscription.plan.currency}
                           {(
-                            productDetail.subscription.nextPaymentPrice / 100.0
+                            productDetail.subscription.plan.amount / 100.0
                           ).toFixed(2)}{" "}
                           {productDetail.subscription.plan.interval}ly
                         </span>
@@ -117,10 +117,12 @@ const getProductDetailSelector = (
                       " FREE"
                     )}
                   </div>
-                  <span>
-                    <strong>Next payment date:</strong>{" "}
-                    {formatDate(productDetail.subscription.nextPaymentDate)}
-                  </span>
+                  {productDetail.subscription.nextPaymentDate && (
+                    <span>
+                      <strong>Next payment date:</strong>{" "}
+                      {formatDate(productDetail.subscription.nextPaymentDate)}
+                    </span>
+                  )}
                 </div>
                 {productDetail.alertText ? (
                   <div css={{ color: palette.red.dark }}>

--- a/app/client/components/flowStartMultipleProductDetailHandler.tsx
+++ b/app/client/components/flowStartMultipleProductDetailHandler.tsx
@@ -8,7 +8,7 @@ import {
   MembersDataApiResponse,
   MembersDatApiAsyncLoader,
   ProductDetail,
-  sortByStartDate,
+  sortByJoinDate,
   Subscription
 } from "../../shared/productResponse";
 import { createProductDetailFetcher } from "../../shared/productTypes";
@@ -48,7 +48,7 @@ const getProductDetailSelector = (
   const activeList = data
     .filter(hasProduct)
     .filter(_ => !_.subscription.cancelledAt)
-    .sort(sortByStartDate);
+    .sort(sortByJoinDate);
   if (activeList.length > 0) {
     const first = activeList[0];
     if (activeList.length === 1 && hasProduct(first)) {

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -146,10 +146,12 @@ const getPaymentPart = (
   if (productDetail.isPaidTier) {
     return (
       <>
-        <ProductDetailRow
-          label={"Next payment date"}
-          data={formatDate(productDetail.subscription.nextPaymentDate)}
-        />
+        {productDetail.subscription.nextPaymentDate && (
+          <ProductDetailRow
+            label={"Next payment date"}
+            data={formatDate(productDetail.subscription.nextPaymentDate)}
+          />
+        )}
         <ProductDetailRow
           label={
             productDetail.subscription.plan.interval.charAt(0).toUpperCase() +

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -12,7 +12,7 @@ import {
   MembersDataApiResponse,
   MembersDatApiAsyncLoader,
   ProductDetail,
-  sortByStartDate
+  sortByJoinDate
 } from "../../shared/productResponse";
 import {
   createProductDetailFetcher,
@@ -174,9 +174,7 @@ const getPaymentPart = (
 const getProductRenderer = (productType: ProductTypeWithProductPage) => (
   apiResponse: MembersDataApiResponse[]
 ) => {
-  const productDetailList = apiResponse
-    .filter(hasProduct)
-    .sort(sortByStartDate);
+  const productDetailList = apiResponse.filter(hasProduct).sort(sortByJoinDate);
   return (
     <>
       {productDetailList.length > 1 ? (

--- a/app/client/components/updatableAmount.tsx
+++ b/app/client/components/updatableAmount.tsx
@@ -116,7 +116,7 @@ export class UpdatableAmount extends React.Component<
   UpdatableAmountProps,
   UpdatableAmountState
 > {
-  public initialAmount = this.props.subscription.nextPaymentPrice / 100.0;
+  public initialAmount = this.props.subscription.plan.amount / 100.0;
   public state = {
     inEditMode: false,
     isApplyingUpdate: false,

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -36,8 +36,8 @@ export const alertTextWithoutCTA = (productDetail: ProductDetail) =>
     ? productDetail.alertText.replace(/Please check .*/g, "")
     : undefined;
 
-export const sortByStartDate = (a: ProductDetail, b: ProductDetail) =>
-  b.subscription.start.localeCompare(a.subscription.start);
+export const sortByJoinDate = (a: ProductDetail, b: ProductDetail) =>
+  b.joinDate.localeCompare(a.joinDate);
 
 export interface ProductDetail extends WithSubscription {
   isTestUser: boolean; // THIS IS NOT PART OF THE RESPONSE (but inferred from a header)

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -71,18 +71,22 @@ export interface SubscriptionPlan {
   interval: string;
 }
 
+export interface SubscriptionPlanWithAmount extends SubscriptionPlan {
+  amount: number;
+}
+
 export interface Subscription {
   subscriberId: string;
-  start: string;
+  start?: string;
   end: string;
   cancelledAt: boolean;
-  nextPaymentDate: string;
-  nextPaymentPrice: number;
+  nextPaymentDate?: string;
+  nextPaymentPrice?: number;
   paymentMethod?: string;
   card?: Card;
   payPalEmail?: string;
   mandate?: DirectDebitDetails;
-  plan: SubscriptionPlan;
+  plan: SubscriptionPlanWithAmount;
   trialLength: number;
 }
 

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -16,12 +16,14 @@ export type ProductFriendlyName =
   | "membership"
   | "recurring contribution" // TODO use payment frequency instead of 'recurring' e.g. monthly annual etc
   | "newspaper subscription"
-  | "digital pack";
+  | "digital pack"
+  | "Guardian Weekly";
 export type ProductUrlPart =
   | "membership"
   | "contributions"
   | "paper"
-  | "digitalpack";
+  | "digitalpack"
+  | "guardianweekly";
 export type SfProduct = "Membership" | "Contribution";
 export type ProductTitle = "Membership" | "Contributions" | "Digital Pack";
 export type AllProductsProductTypeFilterString =
@@ -108,6 +110,12 @@ export const createProductDetailFetcher = (
       mode: "same-origin"
     }
   );
+
+const domainSpecificSubsManageURL = `https://subscribe.${
+  typeof window !== "undefined" && window.guardian && window.guardian.domain
+    ? window.guardian.domain
+    : "theguardian.com"
+}/manage`;
 
 export const ProductTypes: { [productKey: string]: ProductType } = {
   membership: {
@@ -205,28 +213,26 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
       swapFeedbackAndContactUs: true
     }
   },
-  print: {
+  newspaper: {
     friendlyName: "newspaper subscription",
     allProductsProductTypeFilterString: "Paper",
     urlPart: "paper",
     validator: (me: MeResponse) => me.contentAccess.paperSubscriber,
     includeGuardianInTitles: true,
-    alternateReturnToAccountDestination: `https://subscribe.${
-      typeof window !== "undefined" && window.guardian && window.guardian.domain
-        ? window.guardian.domain
-        : "theguardian.com"
-    }/manage`
+    alternateReturnToAccountDestination: domainSpecificSubsManageURL
+  },
+  guardianweekly: {
+    friendlyName: "Guardian Weekly",
+    allProductsProductTypeFilterString: "Weekly",
+    urlPart: "guardianweekly",
+    validator: (me: MeResponse) => true, // TODO: change to me.contentAccess.weeklySubscriber once exposed by members-data-api
+    alternateReturnToAccountDestination: domainSpecificSubsManageURL
   },
   digipack: {
     friendlyName: "digital pack",
     allProductsProductTypeFilterString: "Digipack",
     urlPart: "digitalpack",
     validator: (me: MeResponse) => me.contentAccess.digitalPack,
-    alternateReturnToAccountDestination: `https://profile.${
-      typeof window !== "undefined" && window.guardian && window.guardian.domain
-        ? window.guardian.domain
-        : "theguardian.com"
-    }/digitalpack/edit`,
     productPage: {
       title: "Digital Pack",
       navLink: navLinks.digitalPack,


### PR DESCRIPTION
Added configuration to enable payment update flow for Guardian Weekly and correctly handled the fact that the start date, next payment date and next payment price can be null.

### Example of single Weekly
![image](https://user-images.githubusercontent.com/15648334/51397825-efb1bf00-1b39-11e9-901d-86a9f9d950a1.png)

### Example of multiple Weeklys
![image](https://user-images.githubusercontent.com/15648334/51397682-a3667f00-1b39-11e9-86fd-407ec7f82d2a.png)
