### PR TITLE
FIX signin/reauth redirect when sending the user to their comments management section

### DIFF
--- a/app/server/server.ts
+++ b/app/server/server.ts
@@ -229,7 +229,7 @@ const profileRedirectHandler: JsonHandler = (
 
 server.get(
   "/profile/user",
-  withIdentity(401),
+  withIdentity(),
   apiHandler(profileRedirectHandler)("https://members-data-api." + conf.DOMAIN)(
     "user-attributes/me"
   )


### PR DESCRIPTION
FIX: the redirect for sending the user to their comments management was behaving like an API endpoint and returning 401 when sign-in/reauth was required (poor user experience) - it now actually redirects them to sign-in/reauth first if needs be