### PR TITLE
cache /static assets PLUS Fastly gzip assets

### DIFF
--- a/app/server/server.ts
+++ b/app/server/server.ts
@@ -51,6 +51,10 @@ const globals: Globals = {
   supportedBrowser: true
 };
 
+server.use(helmet());
+
+server.use("/static", express.static(__dirname + "/static"));
+
 server.use(
   (req: express.Request, res: express.Response, next: express.NextFunction) => {
     // this header is VERY IMPORTANT and prevents caching (on both CDN and in browsers)
@@ -62,8 +66,6 @@ server.use(
     next();
   }
 );
-
-server.use(helmet());
 
 server.get(
   "/_healthcheck",
@@ -80,8 +82,6 @@ server.get("/_prout", (req: express.Request, res: express.Response) => {
 
 server.use(bodyParser.raw({ type: "*/*" })); // parses all bodys to a raw 'Buffer'
 server.use("/api/", withIdentity(401));
-
-server.use("/static", express.static(__dirname + "/static"));
 
 type JsonHandler = (res: express.Response, jsonString: string) => void;
 


### PR DESCRIPTION
**will re-base once https://github.com/guardian/manage-frontend/pull/182 is merged** 

_Following some inspection of the client-side bundle (kicked off in https://github.com/guardian/manage-frontend/pull/182) noticed that we were NOT gzipping the client-side JS bundle._

Since its possible to configure Fastly to gzip JS assets (and others), this PR is just to make all `/static` assets cacheable (which includes the client-side JS bundle - `user.js`) which is a prerequisite for the following Fastly config changes...
![image](https://user-images.githubusercontent.com/19289579/51558188-c44f0d00-1e76-11e9-837b-a02c69323fc7.png)
...this leads to the following size/speed improvements for the client-side JS bundle download ( `user.js`)...
  - 524KB ➡️148KB 🎉 
  - 1330ms ➡️341ms ⏱ 

## Lighthouse
**This has lead to a significant improvement to the Lighthouse stats (audit tab in Chrome dev tools).** It's worth stating these are just simulated estimates and some of the poor figures are mainly down to the calls to `members-data-api` which happen as as soon as page is loaded (client-side react initiates AJAX fetch straight after hydrate upon the server-side-rendered page). With that said there are still is significant further improvements that can be made in future PRs. 

### Before (CODE)
![image](https://user-images.githubusercontent.com/19289579/51558869-6d4a3780-1e78-11e9-8174-6463850f3913.png)

### After (CODE)
![image](https://user-images.githubusercontent.com/19289579/51562557-0e89bb80-1e82-11e9-8fd7-b2ea1b96dab8.png)
