### PR TITLE
combined 'Subscriptions' tab (Paper, Weekly & Digipack - not Membership or Contributions)

### DIFF
--- a/app/client/__tests__/__snapshots__/main.tsx.snap
+++ b/app/client/__tests__/__snapshots__/main.tsx.snap
@@ -234,10 +234,10 @@ exports[`Main renders something 1`] = `
           <li>
             <a
               className="emotion-1"
-              href="/digitalpack"
+              href="/subscriptions"
             >
               <span>
-                Digital Pack
+                Subscriptions
               </span>
             </a>
           </li>

--- a/app/client/__tests__/__snapshots__/main.tsx.snap
+++ b/app/client/__tests__/__snapshots__/main.tsx.snap
@@ -538,7 +538,7 @@ exports[`Main renders something 1`] = `
                         "padding": "6px 0",
                       }
                     }
-                    href="https://securedrop.thegulocal.com"
+                    href="https://thegulocal.com/securedrop"
                   >
                     Secure Drop
                   </a>

--- a/app/client/components/callCentreNumbers.tsx
+++ b/app/client/components/callCentreNumbers.tsx
@@ -11,7 +11,8 @@ const callCenterStyles = css({
   marginBottom: "10px",
   display: "flex",
   flexWrap: "wrap",
-  textAlign: "left"
+  textAlign: "left",
+  fontWeight: "normal"
 });
 
 export interface CallCentreNumbersProps {

--- a/app/client/components/cancel/caseCreationWrapper.tsx
+++ b/app/client/components/cancel/caseCreationWrapper.tsx
@@ -22,7 +22,7 @@ const getCreateCaseFunc = (
     body: JSON.stringify({
       reason,
       product: sfProduct,
-      subscriptionName: membershipData.subscription.subscriberId,
+      subscriptionName: membershipData.subscription.subscriptionId,
       gaData: "" + JSON.stringify(window.gaData)
     }),
     headers: { "Content-Type": "application/json" }

--- a/app/client/components/cancel/stages/executeCancellation.tsx
+++ b/app/client/components/cancel/stages/executeCancellation.tsx
@@ -99,11 +99,11 @@ export const ExecuteCancellation = (
                 hasProduct(productDetail) ? (
                   <PerformCancelAsyncLoader
                     fetch={getCancelFunc(
-                      productDetail.subscription.subscriberId,
+                      productDetail.subscription.subscriptionId,
                       reason,
                       createProductDetailFetcher(
                         props.productType,
-                        productDetail.subscription.subscriberId
+                        productDetail.subscription.subscriptionId
                       )
                     )}
                     render={getCaseUpdatingCancellationSummary(

--- a/app/client/components/flowStartMultipleProductDetailHandler.tsx
+++ b/app/client/components/flowStartMultipleProductDetailHandler.tsx
@@ -11,7 +11,10 @@ import {
   sortByJoinDate,
   Subscription
 } from "../../shared/productResponse";
-import { createProductDetailFetcher } from "../../shared/productTypes";
+import {
+  createProductDetailFetcher,
+  hasProductPageProperties
+} from "../../shared/productTypes";
 import palette from "../colours";
 import { Button } from "./buttons";
 import { CheckFlowIsValid } from "./checkFlowIsValid";
@@ -80,7 +83,7 @@ const getProductDetailSelector = (
                     ...commonFlexCSS
                   }}
                 >
-                  {props.productType.productPage &&
+                  {hasProductPageProperties(props.productType) &&
                   props.productType.productPage.tierRowLabel ? (
                     <span>
                       <strong>Tier: </strong> {productDetail.tier}{" "}

--- a/app/client/components/flowStartMultipleProductDetailHandler.tsx
+++ b/app/client/components/flowStartMultipleProductDetailHandler.tsx
@@ -69,7 +69,7 @@ const getProductDetailSelector = (
           </PageContainer>
           {activeList.map((productDetail, listIndex) => (
             <div
-              key={productDetail.subscription.subscriberId}
+              key={productDetail.subscription.subscriptionId}
               css={{
                 padding: "10px",
                 background:

--- a/app/client/components/footer/in_page/questionsFooter.tsx
+++ b/app/client/components/footer/in_page/questionsFooter.tsx
@@ -1,37 +1,10 @@
 import React from "react";
-import { CallCentreNumbers } from "../../callCentreNumbers";
+import { InlineContactUs } from "../../inlineContactUs";
 import { InPageFooter } from "./inPageFooter";
 
-export interface QuestionsFooterState {
-  expanded: boolean;
-}
-
-export class QuestionsFooter extends React.Component<{}, QuestionsFooterState> {
-  public state = { expanded: false };
-
-  public render(): JSX.Element {
-    return (
-      <InPageFooter title="Questions?">
-        If you have any questions about updating your payment details, please{" "}
-        <button
-          onClick={this.toggleExpanded}
-          css={{
-            cursor: "pointer",
-            textDecoration: "underline",
-            border: "none",
-            fontSize: "inherit",
-            fontFamily: "inherit",
-            padding: 0,
-            background: "none"
-          }}
-        >
-          contact us
-        </button>
-        {this.state.expanded ? <CallCentreNumbers prefixText="" /> : undefined}
-      </InPageFooter>
-    );
-  }
-
-  private toggleExpanded = () =>
-    this.setState(prevState => ({ expanded: !prevState.expanded }));
-}
+export const QuestionsFooter = () => (
+  <InPageFooter title="Questions?">
+    If you have any questions about updating your payment details, please{" "}
+    <InlineContactUs />
+  </InPageFooter>
+);

--- a/app/client/components/inlineContactUs.tsx
+++ b/app/client/components/inlineContactUs.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { CallCentreNumbers } from "./callCentreNumbers";
+
+export interface InlineContactUsState {
+  expanded: boolean;
+}
+
+export class InlineContactUs extends React.Component<{}, InlineContactUsState> {
+  public state = { expanded: false };
+
+  public render(): JSX.Element {
+    return (
+      <>
+        <button
+          onClick={this.toggleExpanded}
+          css={{
+            cursor: "pointer",
+            textDecoration: "underline",
+            border: "none",
+            fontSize: "inherit",
+            fontWeight: "inherit",
+            fontFamily: "inherit",
+            padding: 0,
+            background: "none",
+            marginBottom: "10px"
+          }}
+        >
+          contact us
+        </button>
+        {this.state.expanded && <CallCentreNumbers prefixText="" />}
+      </>
+    );
+  }
+  private toggleExpanded = () =>
+    this.setState(prevState => ({ expanded: !prevState.expanded }));
+}

--- a/app/client/components/nav.tsx
+++ b/app/client/components/nav.tsx
@@ -74,7 +74,7 @@ export interface NavLinks {
   publicProfile: NavItem;
   accountDetails: NavItem;
   membership: NavItem;
-  digitalPack: NavItem;
+  subscriptions: NavItem;
   contributions: NavItem;
   emailPrefs: NavItem;
 }
@@ -93,9 +93,9 @@ export const navLinks: NavLinks = {
     link: "/membership",
     local: true
   },
-  digitalPack: {
-    title: "Digital Pack",
-    link: "/digitalpack",
+  subscriptions: {
+    title: "Subscriptions",
+    link: "/subscriptions",
     local: true
   },
   contributions: {

--- a/app/client/components/noProduct.tsx
+++ b/app/client/components/noProduct.tsx
@@ -1,5 +1,9 @@
 import React from "react";
-import { ProductType, WithProductType } from "../../shared/productTypes";
+import {
+  hasProductPageProperties,
+  ProductType,
+  WithProductType
+} from "../../shared/productTypes";
 import { SupportTheGuardianButton } from "./supportTheGuardianButton";
 
 export interface NoProductProps extends WithProductType<ProductType> {
@@ -10,7 +14,7 @@ export interface NoProductProps extends WithProductType<ProductType> {
 export const NoProduct = (props: NoProductProps) => (
   <div>
     <h2>You do not currently have a {props.productType.friendlyName}.</h2>
-    {props.inTab && props.productType.productPage ? (
+    {props.inTab && hasProductPageProperties(props.productType) ? (
       <p>{props.productType.productPage.noProductInTabCopy}</p>
     ) : (
       undefined

--- a/app/client/components/payment/update/confirmPaymentUpdate.tsx
+++ b/app/client/components/payment/update/confirmPaymentUpdate.tsx
@@ -140,7 +140,9 @@ export const ConfirmPaymentUpdate = (props: RouteableStepProps) => (
                   <div css={{ marginTop: "20px", textAlign: "right" }}>
                     <ExecutePaymentUpdate
                       {...props}
-                      subscriptionName={productDetail.subscription.subscriberId}
+                      subscriptionName={
+                        productDetail.subscription.subscriptionId
+                      }
                       newPaymentMethodDetail={newPaymentMethodDetail}
                     />
                   </div>

--- a/app/client/components/payment/update/paymentUpdated.tsx
+++ b/app/client/components/payment/update/paymentUpdated.tsx
@@ -102,24 +102,13 @@ const WithSubscriptionRenderer = (
         journalism.
       </h2>
       <div>
-        {productType.alternateManagementUrl ? (
-          <a href={productType.alternateManagementUrl}>
-            <Button
-              text={"Manage your " + productType.friendlyName}
-              maxWidthIfWrapping="230px"
-              primary
-              right
-            />
-          </a>
-        ) : (
-          <LinkButton
-            to={"/" + productType.urlPart}
-            text={"Manage your " + productType.friendlyName}
-            maxWidthIfWrapping="230px"
-            primary
-            right
-          />
-        )}
+        <LinkButton
+          to={"/" + productType.urlPart}
+          text={"Manage your " + productType.friendlyName}
+          maxWidthIfWrapping="230px"
+          primary
+          right
+        />
       </div>
       <div css={{ marginTop: "20px" }}>
         <a href="https://www.theguardian.com">

--- a/app/client/components/payment/update/paymentUpdated.tsx
+++ b/app/client/components/payment/update/paymentUpdated.tsx
@@ -102,8 +102,8 @@ const WithSubscriptionRenderer = (
         journalism.
       </h2>
       <div>
-        {productType.alternateReturnToAccountDestination ? (
-          <a href={productType.alternateReturnToAccountDestination}>
+        {productType.alternateManagementUrl ? (
+          <a href={productType.alternateManagementUrl}>
             <Button
               text={"Manage your " + productType.friendlyName}
               maxWidthIfWrapping="230px"

--- a/app/client/components/payment/update/paymentUpdated.tsx
+++ b/app/client/components/payment/update/paymentUpdated.tsx
@@ -143,7 +143,7 @@ export const PaymentUpdated = (props: RouteableStepProps) => (
               <WithSubscriptionAsyncLoader
                 fetch={createProductDetailFetcher(
                   props.productType,
-                  previousProductDetail.subscription.subscriberId
+                  previousProductDetail.subscription.subscriptionId
                 )}
                 render={WithSubscriptionRenderer(
                   props.productType,

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -24,6 +24,7 @@ import { maxWidth, minWidth } from "../styles/breakpoints";
 import { headline } from "../styles/fonts";
 import { Button, LinkButton } from "./buttons";
 import { getCancellationSummary } from "./cancel/cancellationSummary";
+import { InlineContactUs } from "./inlineContactUs";
 import { MembershipLinks } from "./membershipLinks";
 import { NoProduct } from "./noProduct";
 import { PageContainer, PageHeaderContainer } from "./page";
@@ -182,6 +183,9 @@ const getProductDetailRenderer = (
   const productType = originalProductType.mapSoCalledToSpecific
     ? originalProductType.mapSoCalledToSpecific(productDetail)
     : originalProductType;
+  const alternateManagementCtaLabel =
+    productType.alternateManagementCtaLabel &&
+    productType.alternateManagementCtaLabel(productDetail);
   return (
     <div
       key={productDetail.subscription.subscriberId}
@@ -326,6 +330,20 @@ const getProductDetailRenderer = (
             ) : (
               undefined
             )}
+            {productType.alternateManagementUrl &&
+              alternateManagementCtaLabel &&
+              (productDetailListLength > 1 ? (
+                <div css={{ fontWeight: "bold" }}>
+                  {alternateManagementCtaLabel}, please <InlineContactUs />
+                </div>
+              ) : (
+                <a href={productType.alternateManagementUrl}>
+                  <Button
+                    text={alternateManagementCtaLabel + " click here"}
+                    right
+                  />
+                </a>
+              ))}
           </PageContainer>
         </>
       )}

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -16,7 +16,7 @@ import {
 } from "../../shared/productResponse";
 import {
   createProductDetailFetcher,
-  ProductTypeWithProductPage
+  ProductTypeWithProductPageProperties
 } from "../../shared/productTypes";
 import palette from "../colours";
 import { maxWidth, minWidth } from "../styles/breakpoints";
@@ -141,7 +141,7 @@ const getPaymentMethodRow = (
 
 const getPaymentPart = (
   productDetail: ProductDetail,
-  productType: ProductTypeWithProductPage
+  productType: ProductTypeWithProductPageProperties
 ) => {
   if (productDetail.isPaidTier) {
     return (
@@ -173,9 +173,9 @@ const getPaymentPart = (
   }
 };
 
-const getProductRenderer = (productType: ProductTypeWithProductPage) => (
-  apiResponse: MembersDataApiResponse[]
-) => {
+const getProductRenderer = (
+  productType: ProductTypeWithProductPageProperties
+) => (apiResponse: MembersDataApiResponse[]) => {
   const productDetailList = apiResponse.filter(hasProduct).sort(sortByJoinDate);
   return (
     <>
@@ -313,7 +313,7 @@ const getProductRenderer = (productType: ProductTypeWithProductPage) => (
                       productDetail.subscription.start || productDetail.joinDate
                     )}
                   />
-                  {productType.productPage.showTrialRemainingIfApplicable &&
+                  {productType.showTrialRemainingIfApplicable &&
                   productDetail.subscription.trialLength > 0 ? (
                     <ProductDetailRow
                       label={"Trial remaining"}
@@ -369,7 +369,7 @@ const headerCss = css({
 
 export interface RouteableProductPropsWithProductPage
   extends RouteableProductProps {
-  productType: ProductTypeWithProductPage;
+  productType: ProductTypeWithProductPageProperties;
 }
 
 export const ProductPage = (props: RouteableProductPropsWithProductPage) => (

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -258,9 +258,9 @@ const getProductDetailRenderer = (
             undefined
           )}
           <PageContainer>
-            {productPageProperties.showSubscriberId ? (
+            {productPageProperties.showSubscriptionId ? (
               <ProductDetailRow
-                label={"Subscriber ID"}
+                label={"Subscription ID"}
                 data={productDetail.subscription.subscriberId}
               />
             ) : (

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -208,7 +208,7 @@ const getProductDetailRenderer = (
                   {listIndex + 1}
                 </h2>
               ) : (
-                <h2>{productDetail.tier}</h2>
+                <h2>{productType.alternateTierValue || productDetail.tier}</h2>
               )}
             </PageContainer>
           ) : (
@@ -274,7 +274,7 @@ const getProductDetailRenderer = (
                   productPageProperties.tierChangeable ? (
                     <div css={wrappingContainerCSS}>
                       <div css={{ marginRight: "15px" }}>
-                        {productDetail.tier}
+                        {productType.alternateTierValue || productDetail.tier}
                       </div>
                       {/*TODO add a !=="Patron" condition around the Change tier button once we have a direct journey to cancellation*/}
                       <a
@@ -288,7 +288,7 @@ const getProductDetailRenderer = (
                       </a>
                     </div>
                   ) : (
-                    productDetail.tier
+                    productType.alternateTierValue || productDetail.tier
                   )
                 }
               />

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -188,7 +188,7 @@ const getProductDetailRenderer = (
     productType.alternateManagementCtaLabel(productDetail);
   return (
     <div
-      key={productDetail.subscription.subscriberId}
+      key={productDetail.subscription.subscriptionId}
       css={{
         background:
           productDetailListLength > 1 && (listIndex + 1) % 2 !== 0
@@ -261,7 +261,7 @@ const getProductDetailRenderer = (
             {productPageProperties.showSubscriptionId ? (
               <ProductDetailRow
                 label={"Subscription ID"}
-                data={productDetail.subscription.subscriberId}
+                data={productDetail.subscription.subscriptionId}
               />
             ) : (
               undefined

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -333,12 +333,15 @@ const getProductDetailRenderer = (
               alternateManagementCtaLabel &&
               (productDetailListLength > 1 ? (
                 <div css={{ fontWeight: "bold" }}>
-                  {alternateManagementCtaLabel}, please <InlineContactUs />
+                  To {alternateManagementCtaLabel}, please <InlineContactUs />
                 </div>
               ) : (
                 <a href={productType.alternateManagementUrl}>
                   <Button
-                    text={alternateManagementCtaLabel + " click here"}
+                    text={
+                      alternateManagementCtaLabel.substr(0, 1).toUpperCase() +
+                      alternateManagementCtaLabel.substr(1)
+                    }
                     right
                   />
                 </a>

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -186,14 +186,13 @@ const getProductDetailRenderer = (
   const alternateManagementCtaLabel =
     productType.alternateManagementCtaLabel &&
     productType.alternateManagementCtaLabel(productDetail);
+  const shouldShowShadedBackground =
+    productDetailListLength > 1 && (listIndex + 1) % 2 !== 0;
   return (
     <div
       key={productDetail.subscription.subscriptionId}
       css={{
-        background:
-          productDetailListLength > 1 && (listIndex + 1) % 2 !== 0
-            ? palette.neutral["7"]
-            : undefined,
+        background: shouldShowShadedBackground && palette.neutral["7"],
         padding: "5px 0 20px"
       }}
     >

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -180,8 +180,8 @@ const getProductDetailRenderer = (
   productPageProperties: ProductPageProperties,
   productDetailListLength: number
 ) => (productDetail: ProductDetail, listIndex: number) => {
-  const productType = originalProductType.mapSoCalledToSpecific
-    ? originalProductType.mapSoCalledToSpecific(productDetail)
+  const productType = originalProductType.mapGroupedToSpecific
+    ? originalProductType.mapGroupedToSpecific(productDetail)
     : originalProductType;
   const alternateManagementCtaLabel =
     productType.alternateManagementCtaLabel &&

--- a/app/client/components/redirectOnMeResponse.tsx
+++ b/app/client/components/redirectOnMeResponse.tsx
@@ -23,10 +23,8 @@ export const RedirectOnMeResponse = (props: RouteableProps) => (
           startRedirect(navLinks.membership);
         } else if (me.contentAccess.recurringContributor) {
           startRedirect(navLinks.contributions);
-        } else if (me.contentAccess.digitalPack) {
-          startRedirect(navLinks.digitalPack);
         } else {
-          startRedirect(navLinks.membership);
+          startRedirect(navLinks.subscriptions);
         }
         return null; // official way to render nothing, while awaiting redirect to take effect
       }}

--- a/app/client/components/updatableAmount.tsx
+++ b/app/client/components/updatableAmount.tsx
@@ -5,7 +5,7 @@ import {
 } from "../../shared/productResponse";
 import {
   ProductType,
-  ProductTypeWithProductPage,
+  ProductTypeWithProductPageProperties,
   WithProductType
 } from "../../shared/productTypes";
 import palette from "../colours";
@@ -101,7 +101,7 @@ const getAmountUpdater = (
   });
 
 export type UpdatableAmountProps = WithSubscription &
-  WithProductType<ProductTypeWithProductPage>;
+  WithProductType<ProductTypeWithProductPageProperties>;
 
 export interface UpdatableAmountState {
   inEditMode: boolean;

--- a/app/client/components/updatableAmount.tsx
+++ b/app/client/components/updatableAmount.tsx
@@ -101,7 +101,7 @@ const getAmountUpdater = (
   });
 
 export type UpdatableAmountProps = WithSubscription &
-  WithProductType<ProductTypeWithProductPageProperties>;
+  WithProductType<ProductType>;
 
 export interface UpdatableAmountState {
   inEditMode: boolean;
@@ -271,7 +271,7 @@ export class UpdatableAmount extends React.Component<
         {this.state.currentAmount.toFixed(2)}{" "}
         {this.props.subscription.plan.currencyISO}
       </span>
-      {this.props.productType.productPage.updateAmountMdaEndpoint ? (
+      {this.props.productType.updateAmountMdaEndpoint ? (
         <>
           <Button
             text="Change amount"

--- a/app/client/components/updatableAmount.tsx
+++ b/app/client/components/updatableAmount.tsx
@@ -161,7 +161,7 @@ export class UpdatableAmount extends React.Component<
       fetch={getAmountUpdater(
         this.state.newAmount,
         this.props.productType,
-        this.props.subscription.subscriberId
+        this.props.subscription.subscriptionId
       )}
       readerOnOK={(resp: Response) => resp.text()}
       render={() => {

--- a/app/client/components/user.tsx
+++ b/app/client/components/user.tsx
@@ -46,7 +46,15 @@ const User = () => (
             productType={productType}
           />
         ))}
-
+      {Object.values(ProductTypes)
+        .filter(hasProductPageRedirect)
+        .map((productType: ProductTypeWithProductPageRedirect) => (
+          <Redirect
+            key={productType.urlPart}
+            from={"/" + productType.urlPart}
+            to={"/" + productType.productPage}
+          />
+        ))}
       {Object.values(ProductTypes)
         .filter(hasCancellationFlow)
         .map((productType: ProductTypeWithCancellationFlow) => (

--- a/app/client/components/user.tsx
+++ b/app/client/components/user.tsx
@@ -77,26 +77,31 @@ const User = () => (
           </CancellationFlow>
         ))}
 
-      {Object.values(ProductTypes).map((productType: ProductType) => (
-        <PaymentUpdateFlow
-          key={productType.urlPart}
-          path={"/payment/" + productType.urlPart}
-          productType={productType}
-          currentStep={1}
-        >
-          <ConfirmPaymentUpdate
-            path="confirm"
+      {Object.values(ProductTypes)
+        .filter(
+          // i.e. don't create payment update flow for grouped product types
+          (productType: ProductType) => !productType.mapSoCalledToSpecific
+        )
+        .map((productType: ProductType) => (
+          <PaymentUpdateFlow
+            key={productType.urlPart}
+            path={"/payment/" + productType.urlPart}
             productType={productType}
-            currentStep={2}
+            currentStep={1}
           >
-            <PaymentUpdated
-              path="updated"
+            <ConfirmPaymentUpdate
+              path="confirm"
               productType={productType}
-              currentStep={3}
-            />
-          </ConfirmPaymentUpdate>
-        </PaymentUpdateFlow>
-      ))}
+              currentStep={2}
+            >
+              <PaymentUpdated
+                path="updated"
+                productType={productType}
+                currentStep={3}
+              />
+            </ConfirmPaymentUpdate>
+          </PaymentUpdateFlow>
+        ))}
 
       <MembershipFAQs path="/help" />
 

--- a/app/client/components/user.tsx
+++ b/app/client/components/user.tsx
@@ -1,12 +1,16 @@
-import { Router, ServerLocation } from "@reach/router";
+import { Redirect, Router, ServerLocation } from "@reach/router";
 import React from "react";
 import {
   hasCancellationFlow,
-  hasProductPage,
+  hasProductPageRedirect,
   ProductType,
   ProductTypes,
   ProductTypeWithCancellationFlow,
-  ProductTypeWithProductPage
+  ProductTypeWithProductPageProperties
+} from "../../shared/productTypes";
+import {
+  hasProductPageProperties,
+  ProductTypeWithProductPageRedirect
 } from "../../shared/productTypes";
 import { injectGlobal } from "../styles/emotion";
 import { fonts } from "../styles/fonts";
@@ -34,8 +38,8 @@ const User = () => (
       <RedirectOnMeResponse path="/" />
 
       {Object.values(ProductTypes)
-        .filter(hasProductPage)
-        .map((productType: ProductTypeWithProductPage) => (
+        .filter(hasProductPageProperties)
+        .map((productType: ProductTypeWithProductPageProperties) => (
           <ProductPage
             key={productType.urlPart}
             path={"/" + productType.urlPart}

--- a/app/client/components/user.tsx
+++ b/app/client/components/user.tsx
@@ -6,7 +6,8 @@ import {
   ProductType,
   ProductTypes,
   ProductTypeWithCancellationFlow,
-  ProductTypeWithProductPageProperties
+  ProductTypeWithProductPageProperties,
+  shouldCreatePaymentUpdateFlow
 } from "../../shared/productTypes";
 import {
   hasProductPageProperties,
@@ -86,10 +87,7 @@ const User = () => (
         ))}
 
       {Object.values(ProductTypes)
-        .filter(
-          // i.e. don't create payment update flow for grouped product types
-          (productType: ProductType) => !productType.mapGroupedToSpecific
-        )
+        .filter(shouldCreatePaymentUpdateFlow)
         .map((productType: ProductType) => (
           <PaymentUpdateFlow
             key={productType.urlPart}

--- a/app/client/components/user.tsx
+++ b/app/client/components/user.tsx
@@ -88,7 +88,7 @@ const User = () => (
       {Object.values(ProductTypes)
         .filter(
           // i.e. don't create payment update flow for grouped product types
-          (productType: ProductType) => !productType.mapSoCalledToSpecific
+          (productType: ProductType) => !productType.mapGroupedToSpecific
         )
         .map((productType: ProductType) => (
           <PaymentUpdateFlow

--- a/app/client/components/userNav.tsx
+++ b/app/client/components/userNav.tsx
@@ -144,8 +144,8 @@ export class UserNav extends React.Component {
       link: "/contributions"
     },
     {
-      title: "Digital Pack",
-      link: "/digitalpack",
+      title: "Subscriptions",
+      link: "/subscriptions",
       border: true
     },
     {

--- a/app/client/components/wizardRouterAdapter.tsx
+++ b/app/client/components/wizardRouterAdapter.tsx
@@ -53,8 +53,8 @@ const estimateTotal = (currentStep: number, child: any) => {
 export const ReturnToYourProductButton = (
   props: WithProductType<ProductType>
 ) =>
-  props.productType.alternateReturnToAccountDestination ? (
-    <a href={props.productType.alternateReturnToAccountDestination}>
+  props.productType.alternateManagementUrl ? (
+    <a href={props.productType.alternateManagementUrl}>
       <Button text="Return to your account" hollow left />
     </a>
   ) : (

--- a/app/client/components/wizardRouterAdapter.tsx
+++ b/app/client/components/wizardRouterAdapter.tsx
@@ -52,19 +52,14 @@ const estimateTotal = (currentStep: number, child: any) => {
 
 export const ReturnToYourProductButton = (
   props: WithProductType<ProductType>
-) =>
-  props.productType.alternateManagementUrl ? (
-    <a href={props.productType.alternateManagementUrl}>
-      <Button text="Return to your account" hollow left />
-    </a>
-  ) : (
-    <LinkButton
-      text="Return to your account"
-      to={"/" + props.productType.urlPart}
-      hollow
-      left
-    />
-  );
+) => (
+  <LinkButton
+    text="Return to your account"
+    to={"/" + props.productType.urlPart}
+    hollow
+    left
+  />
+);
 
 const RootComponent = (props: RootComponentProps) => (
   <>

--- a/app/package.json
+++ b/app/package.json
@@ -20,7 +20,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn fix && GIT_DIR=../.git && (yarn bundle-check-client & yarn type-check)"
+      "pre-commit": "yarn fix && GIT_DIR=../.git && yarn type-check && yarn bundle-check-client"
     }
   },
   "cloudformation": "../cfn.yaml",

--- a/app/server/server.ts
+++ b/app/server/server.ts
@@ -9,7 +9,12 @@ import { parse } from "url";
 import { ServerUser } from "../client/components/user";
 import { Globals } from "../globals";
 import { MDA_TEST_USER_HEADER } from "../shared/productResponse";
-import { ProductType, ProductTypes } from "../shared/productTypes";
+import {
+  hasProductPageProperties,
+  hasProductPageRedirect,
+  ProductType,
+  ProductTypes
+} from "../shared/productTypes";
 import { conf, Environments } from "./config";
 import { renderStylesToString } from "./emotion-server";
 import html from "./html";
@@ -196,7 +201,7 @@ Object.values(ProductTypes).forEach((productType: ProductType) => {
   );
 
   if (
-    productType.productPage &&
+    hasProductPageProperties(productType) &&
     productType.productPage.updateAmountMdaEndpoint
   ) {
     server.post(
@@ -208,6 +213,14 @@ Object.values(ProductTypes).forEach((productType: ProductType) => {
         false,
         "subscriptionName"
       )
+    );
+  }
+  if (productType.productPage && hasProductPageRedirect(productType)) {
+    server.get(
+      "/" + productType.urlPart,
+      (req: express.Request, res: express.Response) => {
+        res.redirect("/" + productType.productPage);
+      }
     );
   }
 });

--- a/app/server/server.ts
+++ b/app/server/server.ts
@@ -212,7 +212,7 @@ Object.values(ProductTypes).forEach((productType: ProductType) => {
       )
     );
   }
-  if (productType.productPage && hasProductPageRedirect(productType)) {
+  if (hasProductPageRedirect(productType)) {
     server.get(
       "/" + productType.urlPart,
       (req: express.Request, res: express.Response) => {

--- a/app/server/server.ts
+++ b/app/server/server.ts
@@ -200,15 +200,12 @@ Object.values(ProductTypes).forEach((productType: ProductType) => {
     }
   );
 
-  if (
-    hasProductPageProperties(productType) &&
-    productType.productPage.updateAmountMdaEndpoint
-  ) {
+  if (productType.updateAmountMdaEndpoint) {
     server.post(
       "/api/update/amount/" + productType.urlPart + "/:subscriptionName",
       membersDataApiHandler(
         "user-attributes/me/" +
-          productType.productPage.updateAmountMdaEndpoint +
+          productType.updateAmountMdaEndpoint +
           "/:subscriptionName",
         false,
         "subscriptionName"

--- a/app/shared/__tests__/productTypes.ts
+++ b/app/shared/__tests__/productTypes.ts
@@ -1,0 +1,15 @@
+import {
+  hasProductPageProperties,
+  hasProductPageRedirect,
+  ProductTypes
+} from "../productTypes";
+
+test("should identify a product page definition which has real properties (i.e. is an object)", () => {
+  expect(hasProductPageProperties(ProductTypes.membership)).toBeTruthy();
+  expect(hasProductPageProperties(ProductTypes.digipack)).toBeFalsy();
+});
+
+test("should identify a product page definition which is a redirect (i.e. is a string)", () => {
+  expect(hasProductPageRedirect(ProductTypes.membership)).toBeFalsy();
+  expect(hasProductPageRedirect(ProductTypes.digipack)).toBeTruthy();
+});

--- a/app/shared/meResponse.ts
+++ b/app/shared/meResponse.ts
@@ -10,6 +10,7 @@ export interface MeResponse {
     recurringContributor: boolean;
     digitalPack: boolean;
     paperSubscriber: boolean;
+    weeklySubscriber: boolean;
   };
   alertAvailableFor?: string;
 }

--- a/app/shared/meResponse.ts
+++ b/app/shared/meResponse.ts
@@ -10,7 +10,7 @@ export interface MeResponse {
     recurringContributor: boolean;
     digitalPack: boolean;
     paperSubscriber: boolean;
-    weeklySubscriber: boolean;
+    guardianWeeklySubscriber: boolean;
   };
   alertAvailableFor?: string;
 }

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -76,7 +76,7 @@ export interface SubscriptionPlanWithAmount extends SubscriptionPlan {
 }
 
 export interface Subscription {
-  subscriberId: string;
+  subscriptionId: string;
   start?: string;
   end: string;
   cancelledAt: boolean;

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -86,6 +86,7 @@ export interface Subscription {
   card?: Card;
   payPalEmail?: string;
   mandate?: DirectDebitDetails;
+  autoRenew: boolean;
   plan: SubscriptionPlanWithAmount;
   trialLength: number;
 }

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -10,7 +10,7 @@ import { membershipCancellationReasons } from "../client/components/cancel/membe
 import { MeValidator } from "../client/components/checkFlowIsValid";
 import { NavItem, navLinks } from "../client/components/nav";
 import { MeResponse } from "./meResponse";
-import { formatDate, Subscription } from "./productResponse";
+import { formatDate, ProductDetail, Subscription } from "./productResponse";
 
 export type ProductFriendlyName =
   | "membership"
@@ -60,7 +60,6 @@ export interface ProductPageProperties {
   title: ProductTitle;
   navLink: NavItem;
   noProductInTabCopy: string;
-  updateAmountMdaEndpoint?: string;
   tierRowLabel?: string; // no label means row is not displayed;
   tierChangeable?: true;
   showSubscriberId?: true;
@@ -77,6 +76,8 @@ export interface ProductType {
   productPage?: ProductPageProperties | ProductUrlPart; // undefined 'productPage' means no product page
   cancellation?: CancellationFlowProperties; // undefined 'cancellation' means no cancellation flow
   showTrialRemainingIfApplicable?: true;
+  mapSoCalledToSpecific?: (productDetail: ProductDetail) => ProductType;
+  updateAmountMdaEndpoint?: string;
 }
 
 export interface ProductTypeWithCancellationFlow extends ProductType {
@@ -171,12 +172,12 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
     urlPart: "contributions",
     validator: (me: MeResponse) => me.contentAccess.recurringContributor,
     noProductSupportUrlSuffix: "/contribute",
+    updateAmountMdaEndpoint: "contribution-update-amount",
     productPage: {
       title: "Contributions",
       navLink: navLinks.contributions,
       noProductInTabCopy:
-        "To manage your existing membership or subscription, please select from the tabs above.",
-      updateAmountMdaEndpoint: "contribution-update-amount"
+        "To manage your existing membership or subscription, please select from the tabs above."
     },
     cancellation: {
       linkOnProductPage: true,
@@ -264,6 +265,16 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
         "To manage your existing membership or contribution, please select from the tabs above.",
       tierRowLabel: "Subscription product",
       showSubscriberId: true
+    },
+    mapSoCalledToSpecific: (productDetail: ProductDetail) => {
+      if (productDetail.tier === "Digital Pack") {
+        return ProductTypes.digipack;
+      } else if (productDetail.tier.startsWith("Newspaper")) {
+        return ProductTypes.newspaper;
+      } else if (productDetail.tier.startsWith("Guardian Weekly")) {
+        return ProductTypes.guardianweekly;
+      }
+      return ProductTypes.soCalledSubscriptions; // This should never happen!
     }
   }
 };

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -240,7 +240,8 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
     alternateManagementCtaLabel: (productDetail: ProductDetail) =>
       productDetail.tier === "Newspaper Delivery"
         ? "To manage your holiday stops"
-        : undefined
+        : undefined,
+    productPage: "subscriptions"
   },
   guardianweekly: {
     friendlyName: "Guardian Weekly",
@@ -248,7 +249,8 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
     urlPart: "guardianweekly",
     validator: (me: MeResponse) => me.contentAccess.weeklySubscriber,
     alternateManagementUrl: domainSpecificSubsManageURL,
-    alternateManagementCtaLabel: () => "To renew your Guardian Weekly"
+    alternateManagementCtaLabel: () => "To renew your Guardian Weekly",
+    productPage: "subscriptions"
   },
   digipack: {
     friendlyName: "digital pack",

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -62,7 +62,7 @@ export interface ProductPageProperties {
   noProductInTabCopy: string;
   tierRowLabel?: string; // no label means row is not displayed;
   tierChangeable?: true;
-  showSubscriberId?: true;
+  showSubscriptionId?: true;
 }
 
 export interface ProductType {
@@ -274,7 +274,7 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
       noProductInTabCopy:
         "To manage your existing membership or contribution, please select from the tabs above.",
       tierRowLabel: "Subscription product",
-      showSubscriberId: true
+      showSubscriptionId: true
     },
     mapSoCalledToSpecific: (productDetail: ProductDetail) => {
       if (productDetail.tier === "Digital Pack") {

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -71,7 +71,10 @@ export interface ProductType {
   urlPart: ProductUrlPart;
   validator: MeValidator;
   includeGuardianInTitles?: true;
-  alternateReturnToAccountDestination?: string;
+  alternateManagementUrl?: string;
+  alternateManagementCtaLabel?: (
+    productDetail: ProductDetail
+  ) => string | undefined;
   noProductSupportUrlSuffix?: string;
   productPage?: ProductPageProperties | ProductUrlPart; // undefined 'productPage' means no product page
   cancellation?: CancellationFlowProperties; // undefined 'cancellation' means no cancellation flow
@@ -233,14 +236,19 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
     urlPart: "paper",
     validator: (me: MeResponse) => me.contentAccess.paperSubscriber,
     includeGuardianInTitles: true,
-    alternateReturnToAccountDestination: domainSpecificSubsManageURL
+    alternateManagementUrl: domainSpecificSubsManageURL,
+    alternateManagementCtaLabel: (productDetail: ProductDetail) =>
+      productDetail.tier === "Newspaper Delivery"
+        ? "To manage your holiday stops"
+        : undefined
   },
   guardianweekly: {
     friendlyName: "Guardian Weekly",
     allProductsProductTypeFilterString: "Weekly",
     urlPart: "guardianweekly",
     validator: (me: MeResponse) => me.contentAccess.weeklySubscriber,
-    alternateReturnToAccountDestination: domainSpecificSubsManageURL
+    alternateManagementUrl: domainSpecificSubsManageURL,
+    alternateManagementCtaLabel: () => "To renew your Guardian Weekly"
   },
   digipack: {
     friendlyName: "digital pack",

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -113,6 +113,9 @@ export interface WithProductType<ProductTypeVariant extends ProductType> {
   productType: ProductTypeVariant;
 }
 
+export const shouldCreatePaymentUpdateFlow = (productType: ProductType) =>
+  !productType.mapGroupedToSpecific;
+
 export const createProductDetailFetcher = (
   productType: ProductType,
   subscriptionName?: string

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -242,7 +242,7 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
     alternateManagementUrl: domainSpecificSubsManageURL,
     alternateManagementCtaLabel: (productDetail: ProductDetail) =>
       productDetail.tier === "Newspaper Delivery"
-        ? "To manage your holiday stops"
+        ? "manage your holiday stops"
         : undefined,
     productPage: "subscriptions"
   },
@@ -255,7 +255,7 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
     alternateManagementCtaLabel: (productDetail: ProductDetail) =>
       productDetail.subscription.autoRenew
         ? undefined
-        : "To renew your one-off Guardian Weekly subscription",
+        : "renew your one-off Guardian Weekly subscription",
     productPage: "subscriptions"
   },
   digipack: {

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -34,7 +34,7 @@ export type AllProductsProductTypeFilterString =
   | "Contribution"
   | "Membership"
   | "Digipack"
-  | "SoCalledSubscription";
+  | "ContentSubscription";
 
 export interface CancellationFlowProperties {
   reasons: CancellationReason[];
@@ -79,7 +79,7 @@ export interface ProductType {
   productPage?: ProductPageProperties | ProductUrlPart; // undefined 'productPage' means no product page
   cancellation?: CancellationFlowProperties; // undefined 'cancellation' means no cancellation flow
   showTrialRemainingIfApplicable?: true;
-  mapSoCalledToSpecific?: (productDetail: ProductDetail) => ProductType;
+  mapGroupedToSpecific?: (productDetail: ProductDetail) => ProductType;
   updateAmountMdaEndpoint?: string;
 }
 
@@ -261,9 +261,9 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
     showTrialRemainingIfApplicable: true,
     productPage: "subscriptions"
   },
-  soCalledSubscriptions: {
+  contentSubscriptions: {
     friendlyName: "subscription",
-    allProductsProductTypeFilterString: "SoCalledSubscription",
+    allProductsProductTypeFilterString: "ContentSubscription",
     urlPart: "subscriptions",
     validator: (me: MeResponse) =>
       me.contentAccess.digitalPack ||
@@ -277,7 +277,7 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
       tierRowLabel: "Subscription product",
       showSubscriptionId: true
     },
-    mapSoCalledToSpecific: (productDetail: ProductDetail) => {
+    mapGroupedToSpecific: (productDetail: ProductDetail) => {
       if (productDetail.tier === "Digital Pack") {
         return ProductTypes.digipack;
       } else if (productDetail.tier.startsWith("Newspaper")) {
@@ -285,7 +285,7 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
       } else if (productDetail.tier.startsWith("Guardian Weekly")) {
         return ProductTypes.guardianweekly;
       }
-      return ProductTypes.soCalledSubscriptions; // This should never happen!
+      return ProductTypes.contentSubscriptions; // This should never happen!
     }
   }
 };

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -71,6 +71,7 @@ export interface ProductType {
   urlPart: ProductUrlPart;
   validator: MeValidator;
   includeGuardianInTitles?: true;
+  alternateTierValue?: string;
   alternateManagementUrl?: string;
   alternateManagementCtaLabel?: (
     productDetail: ProductDetail
@@ -251,6 +252,7 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
     allProductsProductTypeFilterString: "Weekly",
     urlPart: "guardianweekly",
     validator: (me: MeResponse) => me.contentAccess.guardianWeeklySubscriber,
+    alternateTierValue: "Guardian Weekly",
     alternateManagementUrl: domainSpecificSubsManageURL,
     alternateManagementCtaLabel: (productDetail: ProductDetail) =>
       productDetail.subscription.autoRenew

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -16,8 +16,8 @@ export type ProductFriendlyName =
   | "membership"
   | "recurring contribution" // TODO use payment frequency instead of 'recurring' e.g. monthly annual etc
   | "newspaper subscription"
-  | "digital pack"
-  | "Guardian Weekly"
+  | "digital pack subscription"
+  | "Guardian Weekly subscription"
   | "subscription";
 export type ProductUrlPart =
   | "membership"
@@ -244,16 +244,17 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
     productPage: "subscriptions"
   },
   guardianweekly: {
-    friendlyName: "Guardian Weekly",
+    friendlyName: "Guardian Weekly subscription",
     allProductsProductTypeFilterString: "Weekly",
     urlPart: "guardianweekly",
-    validator: (me: MeResponse) => me.contentAccess.weeklySubscriber,
+    validator: (me: MeResponse) => me.contentAccess.guardianWeeklySubscriber,
     alternateManagementUrl: domainSpecificSubsManageURL,
-    alternateManagementCtaLabel: () => "To renew your Guardian Weekly",
+    alternateManagementCtaLabel: () =>
+      "To renew your Guardian Weekly subscription",
     productPage: "subscriptions"
   },
   digipack: {
-    friendlyName: "digital pack",
+    friendlyName: "digital pack subscription",
     allProductsProductTypeFilterString: "Digipack",
     urlPart: "digitalpack",
     validator: (me: MeResponse) => me.contentAccess.digitalPack,
@@ -267,7 +268,7 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
     validator: (me: MeResponse) =>
       me.contentAccess.digitalPack ||
       me.contentAccess.paperSubscriber ||
-      me.contentAccess.weeklySubscriber,
+      me.contentAccess.guardianWeeklySubscriber,
     productPage: {
       title: "Subscriptions",
       navLink: navLinks.subscriptions,

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -249,8 +249,10 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
     urlPart: "guardianweekly",
     validator: (me: MeResponse) => me.contentAccess.guardianWeeklySubscriber,
     alternateManagementUrl: domainSpecificSubsManageURL,
-    alternateManagementCtaLabel: () =>
-      "To renew your Guardian Weekly subscription",
+    alternateManagementCtaLabel: (productDetail: ProductDetail) =>
+      productDetail.subscription.autoRenew
+        ? undefined
+        : "To renew your one-off Guardian Weekly subscription",
     productPage: "subscriptions"
   },
   digipack: {

--- a/app/webpack.common.js
+++ b/app/webpack.common.js
@@ -12,7 +12,7 @@ const assetsPluginInstance = new AssetsPlugin({
 const definePlugin = new webpack.DefinePlugin({
   WEBPACK_BUILD: process.env.TEAMCITY_BUILD
     ? `'${process.env.TEAMCITY_BUILD}'`
-    : "'NO BUILD SET'",
+    : `'DEV_${new Date().getTime()}'`,
   GIT_COMMIT_HASH: process.env.BUILD_VCS_NUMBER
     ? `'${process.env.BUILD_VCS_NUMBER}'`
     : `'${new GitRevisionPlugin().commithash()}'`


### PR DESCRIPTION
### Combined paper, weekly and digipack into new Subscriptions tab
Created a grouped product type ('ContentSubscription' - see https://github.com/guardian/members-data-api/pull/366) which allows paper, weekly and digipack subscriptions to be displayed together in one tab.
Also relies on https://github.com/guardian/members-data-api/pull/367

Corresponding tab labels and global nav changes on the main website : https://github.com/guardian/frontend/pull/20991 (which should be deployed after this change)


#### Details
- Mapped grouped product types back to the specific product where appropriate
- Disabled payment update flow for the grouped subscriptions
- Ensured that payment flows, etc for ContentSubscriptions always return back to /subscriptions
- Added functionality to display 'contact us' link when more than one subscription of paper or weekly is held, otherwise added link to `https://subscribe.theguardian.com/manage`

![image](https://user-images.githubusercontent.com/15648334/51926523-62982100-23e9-11e9-9609-0d6c13978de8.png)


#### Messaging and links:
|  |  | Screenshot |
| --- | --- | --- |
| Paper | One subscription |![image](https://user-images.githubusercontent.com/15648334/51925744-a4c06300-23e7-11e9-9057-8494b0ef309d.png) ![image](https://user-images.githubusercontent.com/15648334/51916339-ff03f880-23d4-11e9-9ada-48beca7a5256.png) <br /> _Goes to `https://subscribe.theguardian.com/manage`_|
|  Paper |More than one subscription |![image](https://user-images.githubusercontent.com/15648334/51915484-2063e500-23d3-11e9-9c9c-e670ecf5f89d.png)|
|  Weekly |One subscription |![image](https://user-images.githubusercontent.com/15648334/51918365-5906bd00-23d9-11e9-9990-5a564ed37fd0.png) ![image](https://user-images.githubusercontent.com/15648334/51918332-43919300-23d9-11e9-9af2-ca1c344caa52.png) _Goes to `https://subscribe.theguardian.com/manage`_|
| Weekly |More than one subscription | ![image](https://user-images.githubusercontent.com/15648334/51915542-47221b80-23d3-11e9-9cb5-bb7d8352ec3b.png)|