### PR TITLE
expose initial INTCMP query arg as GA dimension and in Ophan component event action

### DIFF
--- a/app/client/components/GoogleOptimiseAwaitFlagWrapper.tsx
+++ b/app/client/components/GoogleOptimiseAwaitFlagWrapper.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Globals } from "../../globals";
+import { Globals } from "../../shared/globals";
 import { applyAnyOptimiseExperiments } from "./analytics";
 
 export interface GlobalsWithExperimentFlags extends Globals {

--- a/app/client/components/payment/update/confirmPaymentUpdate.tsx
+++ b/app/client/components/payment/update/confirmPaymentUpdate.tsx
@@ -1,6 +1,9 @@
 import Raven from "raven-js";
 import React from "react";
-import { MembersDataApiResponseContext } from "../../../../shared/productResponse";
+import {
+  MembersDataApiResponseContext,
+  ProductDetail
+} from "../../../../shared/productResponse";
 import { hasProduct } from "../../../../shared/productResponse";
 import { trackEvent } from "../../analytics";
 import { Button } from "../../buttons";
@@ -21,7 +24,7 @@ export const CONFIRM_BUTTON_TEXT = "Complete payment update";
 
 interface ExecutePaymentUpdateProps extends RouteableStepProps {
   newPaymentMethodDetail: NewPaymentMethodDetail;
-  subscriptionName: string;
+  productDetail: ProductDetail;
 }
 
 interface ExecutePaymentUpdateState {
@@ -61,7 +64,7 @@ class ExecutePaymentUpdate extends React.Component<
   private executePaymentUpdate: () => Promise<Response> = async () =>
     await fetch(
       `/api/payment/${this.props.newPaymentMethodDetail.apiUrlPart}/${
-        this.props.subscriptionName
+        this.props.productDetail.subscription.subscriptionId
       }`,
       {
         credentials: "include",
@@ -81,6 +84,10 @@ class ExecutePaymentUpdate extends React.Component<
       trackEvent({
         eventCategory: "payment",
         eventAction: this.props.newPaymentMethodDetail.name + "_update_success",
+        product: {
+          productType: this.props.productType,
+          productDetail: this.props.productDetail
+        },
         eventLabel: this.props.productType.urlPart
       });
       this.props.navigate("updated", { replace: true });
@@ -94,6 +101,10 @@ class ExecutePaymentUpdate extends React.Component<
     trackEvent({
       eventCategory: "payment",
       eventAction: this.props.newPaymentMethodDetail.name + "_update_failed",
+      product: {
+        productType: this.props.productType,
+        productDetail: this.props.productDetail
+      },
       eventLabel: this.props.productType.urlPart
     });
 
@@ -140,9 +151,7 @@ export const ConfirmPaymentUpdate = (props: RouteableStepProps) => (
                   <div css={{ marginTop: "20px", textAlign: "right" }}>
                     <ExecutePaymentUpdate
                       {...props}
-                      subscriptionName={
-                        productDetail.subscription.subscriptionId
-                      }
+                      productDetail={productDetail}
                       newPaymentMethodDetail={newPaymentMethodDetail}
                     />
                   </div>

--- a/app/globals.ts
+++ b/app/globals.ts
@@ -3,6 +3,7 @@ export interface Globals {
   dsn: string | null;
   supportedBrowser: boolean;
   spaTransition?: true;
+  INTCMP?: string;
   ophan?: {
     viewId: string;
     record: RecordOphanComponentEvent;

--- a/app/package.json
+++ b/app/package.json
@@ -72,6 +72,7 @@
     "@types/react-dom": "^16.0.5",
     "@types/react-stripe-elements": "^1.1.7",
     "@types/react-test-renderer": "^16.0.1",
+    "@types/url-parse": "^1.4.2",
     "@types/webpack": "^4.4.9",
     "@types/webpack-merge": "^4.1.3",
     "@types/webpack-node-externals": "^1.6.3",
@@ -129,6 +130,7 @@
     "react-stripe-elements": "^2.0.1",
     "source-map-support": "^0.5.6",
     "stylis-pxtorem": "^0.0.2",
+    "url-parse": "^1.4.4",
     "webpack-node-externals": "^1.7.2",
     "winston": "^3.0.0"
   },

--- a/app/server/html.ts
+++ b/app/server/html.ts
@@ -1,4 +1,4 @@
-import { Globals } from "../globals";
+import { Globals } from "../shared/globals";
 
 declare var WEBPACK_BUILD: string;
 

--- a/app/server/server.ts
+++ b/app/server/server.ts
@@ -7,7 +7,7 @@ import Raven from "raven";
 import { renderToString } from "react-dom/server";
 import { parse } from "url";
 import { ServerUser } from "../client/components/user";
-import { Globals } from "../globals";
+import { Globals } from "../shared/globals";
 import { MDA_TEST_USER_HEADER } from "../shared/productResponse";
 import {
   hasProductPageProperties,

--- a/app/shared/globals.ts
+++ b/app/shared/globals.ts
@@ -1,3 +1,5 @@
+import { OphanComponentEvent } from "./ophanTypes";
+
 export interface Globals {
   domain: string;
   dsn: string | null;
@@ -6,19 +8,9 @@ export interface Globals {
   INTCMP?: string;
   ophan?: {
     viewId: string;
-    record: RecordOphanComponentEvent;
+    record: (payload: { componentEvent: OphanComponentEvent }) => void;
     sendInitialEvent: (url?: string, referer?: string) => void;
   };
-}
-
-export type RecordOphanComponentEvent = (
-  payload: { componentEvent: OphanComponentEvent }
-) => void;
-
-export interface OphanComponentEvent {
-  component: string;
-  action: string;
-  value?: string;
 }
 
 declare global {

--- a/app/shared/ophanTypes.ts
+++ b/app/shared/ophanTypes.ts
@@ -1,0 +1,73 @@
+export type OphanProduct =
+  | "CONTRIBUTION"
+  | "RECURRING_CONTRIBUTION"
+  | "MEMBERSHIP_SUPPORTER"
+  | "MEMBERSHIP_PATRON"
+  | "MEMBERSHIP_PARTNER"
+  | "DIGITAL_SUBSCRIPTION"
+  | "PAPER_SUBSCRIPTION_EVERYDAY"
+  | "PAPER_SUBSCRIPTION_SIXDAY"
+  | "PAPER_SUBSCRIPTION_WEEKEND"
+  | "PAPER_SUBSCRIPTION_SUNDAY"
+  | "PRINT_SUBSCRIPTION"
+  | "APP_PREMIUM_TIER";
+
+export type OphanAction =
+  | "INSERT"
+  | "VIEW"
+  | "EXPAND"
+  | "LIKE"
+  | "DISLIKE"
+  | "SUBSCRIBE"
+  | "ANSWER"
+  | "VOTE"
+  | "CLICK";
+
+export type OphanComponentType =
+  | "READERS_QUESTIONS_ATOM"
+  | "QANDA_ATOM"
+  | "PROFILE_ATOM"
+  | "GUIDE_ATOM"
+  | "TIMELINE_ATOM"
+  | "NEWSLETTER_SUBSCRIPTION"
+  | "SURVEYS_QUESTIONS"
+  | "ACQUISITIONS_ENGAGEMENT_BANNER"
+  | "ACQUISITIONS_THANK_YOU_EPIC"
+  | "ACQUISITIONS_EPIC"
+  | "ACQUISITIONS_HEADER"
+  | "ACQUISITIONS_INTERACTIVE_SLICE"
+  | "ACQUISITIONS_NUGGET"
+  | "ACQUISITIONS_FOOTER"
+  | "ACQUISITIONS_STANDFIRST"
+  | "ACQUISITIONS_EDITORIAL_LINK"
+  | "ACQUISITIONS_MANAGE_MY_ACCOUNT"
+  | "ACQUISITIONS_THRASHER"
+  | "ACQUISITIONS_BUTTON"
+  | "APP_ADVERT"
+  | "APP_AUDIO"
+  | "ACQUISITIONS_OTHER"
+  | "APP_BUTTON"
+  | "APP_CROSSWORDS"
+  | "APP_ENGAGEMENT_BANNER"
+  | "APP_CARD"
+  | "APP_EPIC"
+  | "APP_LINK"
+  | "APP_NAVIGATION_ITEM"
+  | "APP_GALLERY"
+  | "APP_SCREEN"
+  | "APP_THRASHER"
+  | "APP_VIDEO";
+
+export interface OphanComponent {
+  componentType: OphanComponentType;
+  id?: string;
+  products?: OphanProduct[];
+  campaignCode?: string;
+  labels?: string[];
+}
+
+export interface OphanComponentEvent {
+  component: OphanComponent;
+  action: OphanAction;
+  value?: string;
+}

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -10,6 +10,7 @@ import { membershipCancellationReasons } from "../client/components/cancel/membe
 import { MeValidator } from "../client/components/checkFlowIsValid";
 import { NavItem, navLinks } from "../client/components/nav";
 import { MeResponse } from "./meResponse";
+import { OphanProduct } from "./ophanTypes";
 import { formatDate, ProductDetail, Subscription } from "./productResponse";
 
 export type ProductFriendlyName =
@@ -70,6 +71,9 @@ export interface ProductType {
   allProductsProductTypeFilterString: AllProductsProductTypeFilterString;
   urlPart: ProductUrlPart;
   validator: MeValidator;
+  getOphanProductType?: (
+    productDetail: ProductDetail
+  ) => OphanProduct | undefined;
   includeGuardianInTitles?: true;
   alternateTierValue?: string;
   alternateManagementUrl?: string;
@@ -144,6 +148,16 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
     allProductsProductTypeFilterString: "Membership",
     urlPart: "membership",
     validator: (me: MeResponse) => me.contentAccess.member,
+    getOphanProductType: (productDetail: ProductDetail) => {
+      switch (productDetail.tier) {
+        case "Supporter":
+          return "MEMBERSHIP_SUPPORTER";
+        case "Partner":
+          return "MEMBERSHIP_PARTNER";
+        case "Patron":
+          return "MEMBERSHIP_PATRON";
+      }
+    },
     productPage: {
       title: "Membership",
       navLink: navLinks.membership,
@@ -178,6 +192,7 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
     allProductsProductTypeFilterString: "Contribution",
     urlPart: "contributions",
     validator: (me: MeResponse) => me.contentAccess.recurringContributor,
+    getOphanProductType: () => "RECURRING_CONTRIBUTION",
     noProductSupportUrlSuffix: "/contribute",
     updateAmountMdaEndpoint: "contribution-update-amount",
     productPage: {
@@ -239,6 +254,7 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
     allProductsProductTypeFilterString: "Paper",
     urlPart: "paper",
     validator: (me: MeResponse) => me.contentAccess.paperSubscriber,
+    getOphanProductType: () => "PRINT_SUBSCRIPTION",
     includeGuardianInTitles: true,
     alternateManagementUrl: domainSpecificSubsManageURL,
     alternateManagementCtaLabel: (productDetail: ProductDetail) =>
@@ -252,6 +268,7 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
     allProductsProductTypeFilterString: "Weekly",
     urlPart: "guardianweekly",
     validator: (me: MeResponse) => me.contentAccess.guardianWeeklySubscriber,
+    getOphanProductType: () => "PRINT_SUBSCRIPTION", // TODO create a GUARDIAN_WEEKLY Product in Ophan data model
     alternateTierValue: "Guardian Weekly",
     alternateManagementUrl: domainSpecificSubsManageURL,
     alternateManagementCtaLabel: (productDetail: ProductDetail) =>
@@ -265,6 +282,7 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
     allProductsProductTypeFilterString: "Digipack",
     urlPart: "digitalpack",
     validator: (me: MeResponse) => me.contentAccess.digitalPack,
+    getOphanProductType: () => "DIGITAL_SUBSCRIPTION",
     showTrialRemainingIfApplicable: true,
     productPage: "subscriptions"
   },

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -976,6 +976,11 @@
   dependencies:
     source-map "^0.6.1"
 
+"@types/url-parse@^1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@types/url-parse/-/url-parse-1.4.2.tgz#e18928ac9a11b693266d0f37720c2a9611d8c85b"
+  integrity sha512-Z25Ef2iI0lkiBAoe8qATRHQWy+BWFWuWasD6HB5prsWx2QjLmB/ngXv8v9dePw2jDwdSvET4/6J5HxmeqhslmQ==
+
 "@types/webpack-merge@^4.1.3":
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/@types/webpack-merge/-/webpack-merge-4.1.3.tgz#e6af0f2a0f20a86ac83d7da84a2e454063121ad4"
@@ -8017,6 +8022,14 @@ url-parse-lax@^1.0.0:
 url-parse@^1.1.8, url-parse@~1.4.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.1.tgz#4dec9dad3dc8585f862fed461d2e19bbf623df30"
+  dependencies:
+    querystringify "^2.0.0"
+    requires-port "^1.0.0"
+
+url-parse@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.4.tgz#cac1556e95faa0303691fec5cf9d5a1bc34648f8"
+  integrity sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==
   dependencies:
     querystringify "^2.0.0"
     requires-port "^1.0.0"


### PR DESCRIPTION
To help D&I correlate payment update success/failure events (and theoretically other things) back to email campaigns (`CCX`, `PF1`, `PF2` etc. - denoted in the **`INTCMP`** query parameter) the initial  INTCMP value is now exposed as both...

- a GA dimension (already a defined dimension in GA - with index 12)
- in the `campaignCode` of the Ophan component event (which required refactoring in order to send these events with the correct structure)

### TODO
- [x] Confirm with D&I that this is sufficient and makes things easy for them