### PR TITLE
Update securedrop link

### DIFF
--- a/app/client/components/footer/footerlinks.tsx
+++ b/app/client/components/footer/footerlinks.tsx
@@ -28,7 +28,7 @@ export const footerLinks: FooterLink[][] = [
     },
     {
       title: "Secure Drop",
-      link: `https://securedrop.${domain}`
+      link: `https://${domain}/securedrop`
     },
     {
       title: "Work for us",


### PR DESCRIPTION
Securedrop is moving onto theguardian.com. This PR updates the footer link accordingly