### PR TITLE
Include autoSignInToken query parameter in identity redirects

### DIFF
--- a/app/server/identity/identityMiddleware.ts
+++ b/app/server/identity/identityMiddleware.ts
@@ -52,11 +52,14 @@ export const augmentRedirectURL = (
     query: {
       ...parsedSimpleURL.query,
       ...(req.query.INTCMP && { INTCMP: req.query.INTCMP }), // if undefined then this param is omitted
-      // Some links in payment failure emails include the user's (encrypted) email as a query parameter.
-      // If present, include as a query parameter in the identity redirect url,
-      // since the data can be utilised to facilitate sign-in.
+      // Some links in payment failure emails include the user's (encrypted) email as a query parameter
+      // and/or an auto sign-in token. If present, include these in the identity redirect url,
+      // since they can be utilised to facilitate sign-in by identity frontend.
       ...(req.query.encryptedEmail && {
         encryptedEmail: req.query.encryptedEmail
+      }),
+      ...(req.query.autoSignInToken && {
+          autoSignInToken: req.query.autoSignInToken
       }),
       returnUrl // this is automatically URL encoded
     }


### PR DESCRIPTION
Follows on from #177.

The work identity have been doing recently means that am auto sign-in token will soon be included in payment failure links in emails.

For payment failure links that send the user to the manage website, include the auto sign-in token in redirects to identity frontend so that the data can be utilised to facilitate user sign-in.

I've tested this locally by entering into the browser the url:

```
https://manage.thegulocal.com/payment/contributions?autoSignInToken=<auto-sign-in-token>
```