### PR TITLE
Prevent payment method update in unsafe scenarios and allow users with no payment method to add card

### DIFF
--- a/app/client/components/payment/update/confirmPaymentUpdate.tsx
+++ b/app/client/components/payment/update/confirmPaymentUpdate.tsx
@@ -39,6 +39,12 @@ class ExecutePaymentUpdate extends React.Component<
     hasHitComplete: false
   };
 
+  private paymentMethodChangeType: string =
+    this.props.productDetail.subscription.paymentMethod ===
+    PaymentMethod.resetRequired
+      ? "reset"
+      : "update";
+
   public render(): React.ReactNode {
     return this.state.hasHitComplete ? (
       <PaymentUpdateAsyncLoader
@@ -60,12 +66,6 @@ class ExecutePaymentUpdate extends React.Component<
       />
     );
   }
-
-  private paymentMethodChangeType: string =
-    this.props.productDetail.subscription.paymentMethod ===
-    PaymentMethod.resetRequired
-      ? "reset"
-      : "update";
 
   private executePaymentUpdate: () => Promise<Response> = async () =>
     await fetch(
@@ -89,9 +89,9 @@ class ExecutePaymentUpdate extends React.Component<
     ) {
       trackEvent({
         eventCategory: "payment",
-        eventAction:
-          this.props.newPaymentMethodDetail.name +
-          `_${this.paymentMethodChangeType}_success`,
+        eventAction: `${this.props.newPaymentMethodDetail.name}_${
+          this.paymentMethodChangeType
+        }_success`,
         product: {
           productType: this.props.productType,
           productDetail: this.props.productDetail
@@ -108,9 +108,9 @@ class ExecutePaymentUpdate extends React.Component<
   private PaymentUpdateFailed = () => {
     trackEvent({
       eventCategory: "payment",
-      eventAction:
-        this.props.newPaymentMethodDetail.name +
-        `_${this.paymentMethodChangeType}_failed`,
+      eventAction: `${this.props.newPaymentMethodDetail.name}_${
+        this.paymentMethodChangeType
+      }_failed`,
       product: {
         productType: this.props.productType,
         productDetail: this.props.productDetail

--- a/app/client/components/payment/update/confirmPaymentUpdate.tsx
+++ b/app/client/components/payment/update/confirmPaymentUpdate.tsx
@@ -18,7 +18,7 @@ import {
   PaymentUpdateAsyncLoader
 } from "./newPaymentMethodDetail";
 import { handleNoNewPaymentDetails } from "./paymentUpdated";
-import { labelPaymentStepProps } from "./updatePaymentFlow";
+import { labelPaymentStepProps, PaymentMethod } from "./updatePaymentFlow";
 
 export const CONFIRM_BUTTON_TEXT = "Complete payment update";
 
@@ -61,6 +61,12 @@ class ExecutePaymentUpdate extends React.Component<
     );
   }
 
+  private paymentMethodChangeType: string =
+    this.props.productDetail.subscription.paymentMethod ===
+    PaymentMethod.resetRequired
+      ? "reset"
+      : "update";
+
   private executePaymentUpdate: () => Promise<Response> = async () =>
     await fetch(
       `/api/payment/${this.props.newPaymentMethodDetail.apiUrlPart}/${
@@ -83,7 +89,9 @@ class ExecutePaymentUpdate extends React.Component<
     ) {
       trackEvent({
         eventCategory: "payment",
-        eventAction: this.props.newPaymentMethodDetail.name + "_update_success",
+        eventAction:
+          this.props.newPaymentMethodDetail.name +
+          `_${this.paymentMethodChangeType}_success`,
         product: {
           productType: this.props.productType,
           productDetail: this.props.productDetail
@@ -100,7 +108,9 @@ class ExecutePaymentUpdate extends React.Component<
   private PaymentUpdateFailed = () => {
     trackEvent({
       eventCategory: "payment",
-      eventAction: this.props.newPaymentMethodDetail.name + "_update_failed",
+      eventAction:
+        this.props.newPaymentMethodDetail.name +
+        `_${this.paymentMethodChangeType}_failed`,
       product: {
         productType: this.props.productType,
         productDetail: this.props.productDetail

--- a/app/client/components/payment/update/currentPaymentDetails.tsx
+++ b/app/client/components/payment/update/currentPaymentDetails.tsx
@@ -12,5 +12,5 @@ export const CurrentPaymentDetails = (subscription: Subscription) => {
   } else if (subscription.mandate) {
     return <DirectDebitDisplay {...subscription.mandate} />;
   }
-  return <span>Other Payment Method</span>; // Direct Debit ???
+  return <span>No Payment Method</span>;
 };

--- a/app/client/components/payment/update/updatePaymentFlow.tsx
+++ b/app/client/components/payment/update/updatePaymentFlow.tsx
@@ -25,7 +25,7 @@ import {
   NewPaymentMethodDetail
 } from "./newPaymentMethodDetail";
 
-enum PaymentMethod {
+export enum PaymentMethod {
   card = "Card",
   payPal = "PayPal",
   dd = "Direct Debit",

--- a/app/client/components/payment/update/updatePaymentFlow.tsx
+++ b/app/client/components/payment/update/updatePaymentFlow.tsx
@@ -29,6 +29,7 @@ enum PaymentMethod {
   card = "Card",
   payPal = "PayPal",
   dd = "Direct Debit",
+  resetRequired = "ResetRequired",
   free = "FREE",
   unknown = "Unknown"
 }
@@ -99,7 +100,9 @@ const PaymentMethodBar = (props: PaymentMethodProps) => (
 const subscriptionToPaymentMethod: (sub: Subscription) => PaymentMethod = (
   subscription: Subscription
 ) => {
-  if (subscription.paymentMethod === "Card" && subscription.card) {
+  if (!subscription.safeToUpdatePaymentMethod) {
+    return PaymentMethod.unknown;
+  } else if (subscription.paymentMethod === "Card" && subscription.card) {
     return PaymentMethod.card;
   } else if (
     subscription.paymentMethod === "PayPal" &&
@@ -111,6 +114,8 @@ const subscriptionToPaymentMethod: (sub: Subscription) => PaymentMethod = (
     subscription.mandate
   ) {
     return PaymentMethod.dd;
+  } else if (subscription.paymentMethod === "ResetRequired") {
+    return PaymentMethod.resetRequired;
   } else if (subscription.paymentMethod === undefined) {
     return PaymentMethod.free;
   }
@@ -211,6 +216,16 @@ class PaymentUpdaterStep extends React.Component<
 
   private getInputForm = (subscription: Subscription, isTestUser: boolean) => {
     switch (this.state.selectedPaymentMethod) {
+      case PaymentMethod.resetRequired:
+        return subscription.stripePublicKeyForCardAddition ? (
+          <CardInputForm
+            stripeApiKey={subscription.stripePublicKeyForCardAddition}
+            newPaymentMethodDetailUpdater={this.newPaymentMethodDetailUpdater}
+            userEmail={getSignInEmailFromCookie()}
+          />
+        ) : (
+          <GenericErrorScreen loggingMessage="No Stripe key provided to enable adding a payment method" />
+        );
       case PaymentMethod.card:
         return subscription.card &&
           subscription.card.stripePublicKeyForUpdate ? (
@@ -249,8 +264,7 @@ class PaymentUpdaterStep extends React.Component<
       default:
         return (
           <span>
-            Updating {this.state.selectedPaymentMethod} is not currently
-            possible online.
+            It is not currently possible to update your payment method online.
           </span>
         );
     }

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -135,6 +135,13 @@ const getPaymentMethodRow = (
         )}
       />
     );
+  } else if (productDetail.subscription.stripePublicKeyForCardAddition) {
+    return (
+      <ProductDetailRow
+        label="Payment method"
+        data={addUpdateButton(<span>No Payment Method</span>)}
+      />
+    );
   } else {
     Raven.captureException("Unknown payment method");
   }

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -83,6 +83,8 @@ export interface Subscription {
   nextPaymentDate?: string;
   nextPaymentPrice?: number;
   paymentMethod?: string;
+  stripePublicKeyForCardAddition?: string;
+  safeToUpdatePaymentMethod: boolean;
   card?: Card;
   payPalEmail?: string;
   mandate?: DirectDebitDetails;


### PR DESCRIPTION
When a payment method is not correctly linked to a Zuora account _and_ the prerequisites for auto-cancellation are not met, it's possible for users to build up 'debts' whilst continuing to receive their subscription benefits. Currently many users in this bad state are unable to add a new payment method to fix the situation (which means that we cannot recover them easily). For other users, it _is_ possible to add a new payment method, but if they choose to do so this will inadvertently cause the payment for several invoices to be collected at once.

This PR allows us to use the updated response added by https://github.com/guardian/members-data-api/pull/370 to prevent unsafe payment method updates.

It also allows users without a correctly linked payment method to add a new payment card in safe scenarios (which enables us to start collecting their payments again 💰) 

## Screenshots

**Adding a payment method when there isn't one already linked / set up correctly**

![image](https://user-images.githubusercontent.com/19384074/52956335-d7c29a80-3386-11e9-9cee-042a00e6e5d1.png)

![image](https://user-images.githubusercontent.com/19384074/52956369-eb6e0100-3386-11e9-9910-2df50486758f.png)

![image](https://user-images.githubusercontent.com/19384074/52956386-f6289600-3386-11e9-99b7-5c60f017fc93.png)

![image](https://user-images.githubusercontent.com/19384074/52956413-050f4880-3387-11e9-9b35-d904115584ef.png)

**Restricting payment method update**

Payment method update is deemed unsafe:

![image](https://user-images.githubusercontent.com/19384074/52956573-6a633980-3387-11e9-8df4-9ef9494867f8.png)
