### PR TITLE
improve display of physical subs

### DIFF
--- a/app/client/components/flowStartMultipleProductDetailHandler.tsx
+++ b/app/client/components/flowStartMultipleProductDetailHandler.tsx
@@ -93,12 +93,8 @@ const getProductDetailSelector = (
                     undefined
                   )}
                   <span>
-                    <strong>
-                      {productDetail.subscription.start ? "Start " : "Join "}Date:
-                    </strong>{" "}
-                    {formatDate(
-                      productDetail.subscription.start || productDetail.joinDate
-                    )}{" "}
+                    <strong>Join Date:</strong>{" "}
+                    {formatDate(productDetail.joinDate)}{" "}
                   </span>
                   <div
                     css={css({

--- a/app/client/components/flowStartMultipleProductDetailHandler.tsx
+++ b/app/client/components/flowStartMultipleProductDetailHandler.tsx
@@ -5,7 +5,9 @@ import {
   alertTextWithoutCTA,
   annotateMdaResponseWithTestUserFromHeaders,
   formatDate,
+  getMainPlan,
   hasProduct,
+  isPaidSubscriptionPlan,
   MembersDataApiResponse,
   MembersDatApiAsyncLoader,
   ProductDetail,
@@ -43,6 +45,23 @@ const commonFlexCSS = css({
     marginRight: "10px"
   }
 });
+
+const getPaymentPart = (productDetail: ProductDetail) => {
+  const mainPlan = getMainPlan(productDetail.subscription);
+  if (isPaidSubscriptionPlan(mainPlan)) {
+    return (
+      <>
+        <span>
+          &nbsp;
+          {mainPlan.currency}
+          {(mainPlan.amount / 100.0).toFixed(2)} {mainPlan.interval}ly
+        </span>
+        <PaymentTypeRenderer {...productDetail.subscription} />
+      </>
+    );
+  }
+  return " FREE";
+};
 
 const getProductDetailSelector = (
   props: FlowStartMultipleProductDetailHandlerProps,
@@ -103,21 +122,7 @@ const getProductDetailSelector = (
                     })}
                   >
                     <strong>Payment:</strong>
-                    {productDetail.isPaidTier ? (
-                      <>
-                        <span>
-                          &nbsp;
-                          {productDetail.subscription.plan.currency}
-                          {(
-                            productDetail.subscription.plan.amount / 100.0
-                          ).toFixed(2)}{" "}
-                          {productDetail.subscription.plan.interval}ly
-                        </span>
-                        <PaymentTypeRenderer {...productDetail.subscription} />
-                      </>
-                    ) : (
-                      " FREE"
-                    )}
+                    {getPaymentPart(productDetail)}
                   </div>
                   {productDetail.subscription.nextPaymentDate &&
                     !productDetail.alertText && (

--- a/app/client/components/flowStartMultipleProductDetailHandler.tsx
+++ b/app/client/components/flowStartMultipleProductDetailHandler.tsx
@@ -39,13 +39,15 @@ const PaymentTypeRenderer = (subscription: Subscription) => {
   return null;
 };
 
-const commonFlexCSS = css({
-  alignItems: "center",
-  flexWrap: "wrap",
-  "span, div": {
-    marginRight: "10px"
-  }
-});
+const flexCSS = (display: "inline-flex" | "flex") =>
+  css({
+    display,
+    alignItems: "center",
+    flexWrap: "wrap",
+    "span, div": {
+      marginRight: "10px"
+    }
+  });
 
 const getPaymentPart = (productDetail: ProductDetail) => {
   const mainPlan = getMainPlan(productDetail.subscription);
@@ -99,12 +101,14 @@ const getProductDetailSelector = (
               }}
             >
               <PageContainer noVerticalMargin>
-                <div
-                  css={css({
-                    display: "flex",
-                    ...commonFlexCSS
-                  })}
-                >
+                {props.productType.displayPlanName && (
+                  <i>
+                    {props.productType
+                      .displayPlanName(getMainPlan(productDetail.subscription))
+                      .trim()}
+                  </i>
+                )}
+                <div css={flexCSS("flex")}>
                   {hasProductPageProperties(props.productType) &&
                   props.productType.productPage.tierRowLabel ? (
                     <span>
@@ -117,12 +121,7 @@ const getProductDetailSelector = (
                     <strong>Join Date:</strong>{" "}
                     {formatDate(productDetail.joinDate)}{" "}
                   </span>
-                  <div
-                    css={css({
-                      display: "inline-flex",
-                      ...commonFlexCSS
-                    })}
-                  >
+                  <div css={flexCSS("inline-flex")}>
                     <strong>Payment:</strong>
                     {getPaymentPart(productDetail)}
                   </div>

--- a/app/client/components/flowStartMultipleProductDetailHandler.tsx
+++ b/app/client/components/flowStartMultipleProductDetailHandler.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import {
   alertTextWithoutCTA,
   annotateMdaResponseWithTestUserFromHeaders,
+  augmentInterval,
   formatDate,
   getMainPlan,
   hasProduct,
@@ -54,7 +55,8 @@ const getPaymentPart = (productDetail: ProductDetail) => {
         <span>
           &nbsp;
           {mainPlan.currency}
-          {(mainPlan.amount / 100.0).toFixed(2)} {mainPlan.interval}ly
+          {(mainPlan.amount / 100.0).toFixed(2)}{" "}
+          {augmentInterval(mainPlan.interval)}
         </span>
         <PaymentTypeRenderer {...productDetail.subscription} />
       </>

--- a/app/client/components/flowStartMultipleProductDetailHandler.tsx
+++ b/app/client/components/flowStartMultipleProductDetailHandler.tsx
@@ -101,12 +101,8 @@ const getProductDetailSelector = (
               }}
             >
               <PageContainer noVerticalMargin>
-                {props.productType.displayPlanName && (
-                  <i>
-                    {props.productType
-                      .displayPlanName(getMainPlan(productDetail.subscription))
-                      .trim()}
-                  </i>
+                {getMainPlan(productDetail.subscription).name && (
+                  <i>({getMainPlan(productDetail.subscription).name})</i>
                 )}
                 <div css={flexCSS("flex")}>
                   {hasProductPageProperties(props.productType) &&

--- a/app/client/components/flowStartMultipleProductDetailHandler.tsx
+++ b/app/client/components/flowStartMultipleProductDetailHandler.tsx
@@ -93,7 +93,9 @@ const getProductDetailSelector = (
                     undefined
                   )}
                   <span>
-                    <strong>Start Date:</strong>{" "}
+                    <strong>
+                      {productDetail.subscription.start ? "Start " : "Join "}Date:
+                    </strong>{" "}
                     {formatDate(
                       productDetail.subscription.start || productDetail.joinDate
                     )}{" "}

--- a/app/client/components/flowStartMultipleProductDetailHandler.tsx
+++ b/app/client/components/flowStartMultipleProductDetailHandler.tsx
@@ -119,12 +119,13 @@ const getProductDetailSelector = (
                       " FREE"
                     )}
                   </div>
-                  {productDetail.subscription.nextPaymentDate && (
-                    <span>
-                      <strong>Next payment date:</strong>{" "}
-                      {formatDate(productDetail.subscription.nextPaymentDate)}
-                    </span>
-                  )}
+                  {productDetail.subscription.nextPaymentDate &&
+                    !productDetail.alertText && (
+                      <span>
+                        <strong>Next payment date:</strong>{" "}
+                        {formatDate(productDetail.subscription.nextPaymentDate)}
+                      </span>
+                    )}
                 </div>
                 {productDetail.alertText ? (
                   <div css={{ color: palette.red.dark }}>

--- a/app/client/components/flowStartMultipleProductDetailHandler.tsx
+++ b/app/client/components/flowStartMultipleProductDetailHandler.tsx
@@ -110,17 +110,29 @@ const getProductDetailSelector = (
                 )}
                 <div css={flexCSS("flex")}>
                   {hasProductPageProperties(props.productType) &&
-                  props.productType.productPage.tierRowLabel ? (
+                    props.productType.productPage.tierRowLabel && (
+                      <span>
+                        <strong>Tier: </strong> {productDetail.tier}{" "}
+                      </span>
+                    )}
+                  {((hasProductPageProperties(props.productType) &&
+                    props.productType.productPage.forceShowJoinDateOnly) ||
+                    !productDetail.subscription.start) && (
                     <span>
-                      <strong>Tier: </strong> {productDetail.tier}{" "}
+                      <strong>Join Date:</strong>{" "}
+                      {formatDate(productDetail.joinDate)}{" "}
                     </span>
-                  ) : (
-                    undefined
                   )}
-                  <span>
-                    <strong>Join Date:</strong>{" "}
-                    {formatDate(productDetail.joinDate)}{" "}
-                  </span>
+                  {productDetail.subscription.start &&
+                    !(
+                      hasProductPageProperties(props.productType) &&
+                      props.productType.productPage.forceShowJoinDateOnly
+                    ) && (
+                      <span>
+                        <strong>Start Date:</strong>{" "}
+                        {formatDate(productDetail.subscription.start)}{" "}
+                      </span>
+                    )}
                   <div css={flexCSS("inline-flex")}>
                     <strong>Payment:</strong>
                     {getPaymentPart(productDetail)}
@@ -133,12 +145,10 @@ const getProductDetailSelector = (
                       </span>
                     )}
                 </div>
-                {productDetail.alertText ? (
+                {productDetail.alertText && (
                   <div css={{ color: palette.red.dark }}>
                     <strong>{alertTextWithoutCTA(productDetail)}</strong>
                   </div>
-                ) : (
-                  undefined
                 )}
                 <div css={{ marginTop: "10px" }}>
                   <Button

--- a/app/client/components/payment/update/paymentUpdated.tsx
+++ b/app/client/components/payment/update/paymentUpdated.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+  augmentInterval,
   formatDate,
   getMainPlan,
   hasProduct,
@@ -77,7 +78,7 @@ const ConfirmedNewPaymentDetailsRenderer = ({
                 </div>
               )}
             <div>
-              <b>Payment Frequency:</b> {mainPlan.interval}ly
+              <b>Payment Frequency:</b> {augmentInterval(mainPlan.interval)}
             </div>
           </>
         )}

--- a/app/client/components/payment/update/paymentUpdated.tsx
+++ b/app/client/components/payment/update/paymentUpdated.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import {
   formatDate,
+  getMainPlan,
   hasProduct,
+  isPaidSubscriptionPlan,
   MembersDataApiResponseContext,
   ProductDetail,
   Subscription,
@@ -53,7 +55,11 @@ const ConfirmedNewPaymentDetailsRenderer = ({
   newPaymentMethodDetail,
   previousProductDetail
 }: ConfirmedNewPaymentDetailsRendererProps) => {
-  if (newPaymentMethodDetail.subHasExpectedPaymentType(subscription)) {
+  const mainPlan = getMainPlan(subscription);
+  if (
+    newPaymentMethodDetail.subHasExpectedPaymentType(subscription) &&
+    isPaidSubscriptionPlan(mainPlan)
+  ) {
     return (
       <>
         {newPaymentMethodDetail.render(subscription)}
@@ -62,17 +68,16 @@ const ConfirmedNewPaymentDetailsRenderer = ({
           <div>{newPaymentMethodDetail.paymentFailureRecoveryMessage}</div>
         ) : (
           <>
-            {subscription.nextPaymentPrice && subscription.nextPaymentDate ? (
-              <div>
-                <b>Next Payment:</b> {subscription.plan.currency}
-                {(subscription.nextPaymentPrice / 100.0).toFixed(2)} on{" "}
-                {formatDate(subscription.nextPaymentDate)}
-              </div>
-            ) : (
-              undefined
-            )}
+            {subscription.nextPaymentPrice &&
+              subscription.nextPaymentDate && (
+                <div>
+                  <b>Next Payment:</b> {mainPlan.currency}
+                  {(subscription.nextPaymentPrice / 100.0).toFixed(2)} on{" "}
+                  {formatDate(subscription.nextPaymentDate)}
+                </div>
+              )}
             <div>
-              <b>Payment Frequency:</b> {subscription.plan.interval}ly
+              <b>Payment Frequency:</b> {mainPlan.interval}ly
             </div>
           </>
         )}

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -155,12 +155,13 @@ const getPaymentPart = (
   if (productDetail.isPaidTier) {
     return (
       <>
-        {productDetail.subscription.nextPaymentDate && (
-          <ProductDetailRow
-            label={"Next payment date"}
-            data={formatDate(productDetail.subscription.nextPaymentDate)}
-          />
-        )}
+        {productDetail.subscription.nextPaymentDate &&
+          !productDetail.alertText && (
+            <ProductDetailRow
+              label={"Next payment date"}
+              data={formatDate(productDetail.subscription.nextPaymentDate)}
+            />
+          )}
         <ProductDetailRow
           label={
             productDetail.subscription.plan.interval.charAt(0).toUpperCase() +

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -246,7 +246,16 @@ const getProductDetailRenderer = (
                   {listIndex + 1}
                 </h2>
               ) : (
-                <h2>{productType.alternateTierValue || productDetail.tier}</h2>
+                <h2>
+                  {productType.alternateTierValue || productDetail.tier}
+                  {productType.displayPlanName && (
+                    <i>
+                      {productType.displayPlanName(
+                        getMainPlan(productDetail.subscription)
+                      )}
+                    </i>
+                  )}
+                </h2>
               )}
             </PageContainer>
           ) : (
@@ -309,25 +318,34 @@ const getProductDetailRenderer = (
               <ProductDetailRow
                 label={productPageProperties.tierRowLabel}
                 data={
-                  productPageProperties.tierChangeable ? (
-                    <div css={wrappingContainerCSS}>
-                      <div css={{ marginRight: "15px" }}>
-                        {productType.alternateTierValue || productDetail.tier}
+                  <>
+                    {productPageProperties.tierChangeable ? (
+                      <div css={wrappingContainerCSS}>
+                        <div css={{ marginRight: "15px" }}>
+                          {productType.alternateTierValue || productDetail.tier}
+                        </div>
+                        {/*TODO add a !=="Patron" condition around the Change tier button once we have a direct journey to cancellation*/}
+                        <a
+                          href={
+                            "https://membership." +
+                            window.guardian.domain +
+                            "/tier/change"
+                          }
+                        >
+                          <Button text="Change tier" right />
+                        </a>
                       </div>
-                      {/*TODO add a !=="Patron" condition around the Change tier button once we have a direct journey to cancellation*/}
-                      <a
-                        href={
-                          "https://membership." +
-                          window.guardian.domain +
-                          "/tier/change"
-                        }
-                      >
-                        <Button text="Change tier" right />
-                      </a>
-                    </div>
-                  ) : (
-                    productType.alternateTierValue || productDetail.tier
-                  )
+                    ) : (
+                      productType.alternateTierValue || productDetail.tier
+                    )}
+                    {productType.displayPlanName && (
+                      <i>
+                        {productType.displayPlanName(
+                          getMainPlan(productDetail.subscription)
+                        )}
+                      </i>
+                    )}
+                  </>
                 }
               />
             ) : (

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -304,14 +304,18 @@ const getProductDetailRenderer = (
             ) : (
               undefined
             )}
-            <ProductDetailRow
-              label={
-                productDetail.subscription.start ? "Start date" : "Join date"
-              }
-              data={formatDate(
-                productDetail.subscription.start || productDetail.joinDate
-              )}
-            />
+            {productDetail.joinDate !== productDetail.subscription.start && (
+              <ProductDetailRow
+                label={"Join date"}
+                data={formatDate(productDetail.joinDate)}
+              />
+            )}
+            {productDetail.subscription.start && (
+              <ProductDetailRow
+                label={"Start date"}
+                data={formatDate(productDetail.subscription.start)}
+              />
+            )}
             {productType.showTrialRemainingIfApplicable &&
             productDetail.subscription.trialLength > 0 ? (
               <ProductDetailRow

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -305,7 +305,9 @@ const getProductDetailRenderer = (
               undefined
             )}
             <ProductDetailRow
-              label={"Start date"}
+              label={
+                productDetail.subscription.start ? "Start date" : "Join date"
+              }
               data={formatDate(
                 productDetail.subscription.start || productDetail.joinDate
               )}

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -7,6 +7,7 @@ import React from "react";
 import {
   alertTextWithoutCTA,
   annotateMdaResponseWithTestUserFromHeaders,
+  augmentInterval,
   formatDate,
   getFuturePlanIfStartsBeforeXDaysFromToday,
   getMainPlan,
@@ -160,6 +161,7 @@ const getPaymentPart = (
     productDetail.subscription
   );
   if (isPaidSubscriptionPlan(mainPlan)) {
+    const mainPlanInterval = augmentInterval(mainPlan.interval);
     return (
       <>
         {productDetail.subscription.nextPaymentDate &&
@@ -172,9 +174,9 @@ const getPaymentPart = (
         {}
         <ProductDetailRow
           label={
-            mainPlan.interval.charAt(0).toUpperCase() +
-            mainPlan.interval.substr(1) +
-            "ly payment"
+            mainPlanInterval.charAt(0).toUpperCase() +
+            mainPlanInterval.substr(1) +
+            " payment"
           }
           data={
             <>
@@ -191,7 +193,9 @@ const getPaymentPart = (
                     {(futurePlan.amount / 100.0).toFixed(2)}{" "}
                     {futurePlan.currencyISO}{" "}
                     {futurePlan.interval !== mainPlan.interval && (
-                      <strong>{`${futurePlan.interval}ly `}</strong>
+                      <strong>
+                        {augmentInterval(futurePlan.interval) + " "}
+                      </strong>
                     )}
                     starting {formatDate(futurePlan.start)}
                   </div>

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -312,84 +312,81 @@ const getProductDetailRenderer = (
               undefined
             )}
             {productPageProperties.tierRowLabel &&
-            (productDetailListLength === 1 ||
-              productPageProperties.tierChangeable) ? (
-              <ProductDetailRow
-                label={productPageProperties.tierRowLabel}
-                data={
-                  <>
-                    {productPageProperties.tierChangeable ? (
-                      <div css={wrappingContainerCSS}>
-                        <div css={{ marginRight: "15px" }}>
-                          {productType.alternateTierValue || productDetail.tier}
+              (productDetailListLength === 1 ||
+                productPageProperties.tierChangeable) && (
+                <ProductDetailRow
+                  label={productPageProperties.tierRowLabel}
+                  data={
+                    <>
+                      {productPageProperties.tierChangeable ? (
+                        <div css={wrappingContainerCSS}>
+                          <div css={{ marginRight: "15px" }}>
+                            {productType.alternateTierValue ||
+                              productDetail.tier}
+                          </div>
+                          {/*TODO add a !=="Patron" condition around the Change tier button once we have a direct journey to cancellation*/}
+                          <a
+                            href={
+                              "https://membership." +
+                              window.guardian.domain +
+                              "/tier/change"
+                            }
+                          >
+                            <Button text="Change tier" right />
+                          </a>
                         </div>
-                        {/*TODO add a !=="Patron" condition around the Change tier button once we have a direct journey to cancellation*/}
-                        <a
-                          href={
-                            "https://membership." +
-                            window.guardian.domain +
-                            "/tier/change"
-                          }
-                        >
-                          <Button text="Change tier" right />
-                        </a>
-                      </div>
-                    ) : (
-                      productType.alternateTierValue || productDetail.tier
-                    )}
-                    {productType.displayPlanName && (
-                      <i>
-                        {productType.displayPlanName(
-                          getMainPlan(productDetail.subscription)
-                        )}
-                      </i>
-                    )}
-                  </>
-                }
-              />
-            ) : (
-              undefined
-            )}
-            {productDetail.joinDate !== productDetail.subscription.start && (
+                      ) : (
+                        productType.alternateTierValue || productDetail.tier
+                      )}
+                      {productType.displayPlanName && (
+                        <i>
+                          {productType.displayPlanName(
+                            getMainPlan(productDetail.subscription)
+                          )}
+                        </i>
+                      )}
+                    </>
+                  }
+                />
+              )}
+            {(productPageProperties.forceShowJoinDateOnly ||
+              !productDetail.subscription.start) && (
               <ProductDetailRow
                 label={"Join date"}
                 data={formatDate(productDetail.joinDate)}
               />
             )}
-            {productDetail.subscription.start && (
-              <ProductDetailRow
-                label={"Start date"}
-                data={formatDate(productDetail.subscription.start)}
-              />
-            )}
+            {productDetail.subscription.start &&
+              !productPageProperties.forceShowJoinDateOnly && (
+                <ProductDetailRow
+                  label={"Start date"}
+                  data={formatDate(productDetail.subscription.start)}
+                />
+              )}
             {productType.showTrialRemainingIfApplicable &&
-            productDetail.subscription.trialLength > 0 ? (
-              <ProductDetailRow
-                label={"Trial remaining"}
-                data={`${productDetail.subscription.trialLength} day${
-                  productDetail.subscription.trialLength !== 1 ? "s" : ""
-                }`}
-              />
-            ) : (
-              undefined
-            )}
+              productDetail.subscription.trialLength > 0 && (
+                <ProductDetailRow
+                  label={"Trial remaining"}
+                  data={`${productDetail.subscription.trialLength} day${
+                    productDetail.subscription.trialLength !== 1 ? "s" : ""
+                  }`}
+                />
+              )}
             {getPaymentPart(productDetail, productType)}
             {productType.cancellation &&
-            productType.cancellation.linkOnProductPage ? (
-              <Link
-                css={{
-                  textDecoration: "underline",
-                  color: palette.neutral["1"],
-                  ":visited": { color: palette.neutral["1"] }
-                }}
-                to={"/cancel/" + productType.urlPart}
-                state={productDetail}
-              >
-                {"Cancel this " + productType.friendlyName}
-              </Link>
-            ) : (
-              undefined
-            )}
+              productType.cancellation.linkOnProductPage && (
+                <Link
+                  css={{
+                    textDecoration: "underline",
+                    color: palette.neutral["1"],
+                    ":visited": { color: palette.neutral["1"] }
+                  }}
+                  to={"/cancel/" + productType.urlPart}
+                  state={productDetail}
+                >
+                  {"Cancel this " + productType.friendlyName}
+                </Link>
+              )}
             {productType.alternateManagementUrl &&
               alternateManagementCtaLabel &&
               (productDetailListLength > 1 ? (

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -223,6 +223,7 @@ const getProductDetailRenderer = (
     productType.alternateManagementCtaLabel(productDetail);
   const shouldShowShadedBackground =
     productDetailListLength > 1 && (listIndex + 1) % 2 !== 0;
+  const mainPlan = getMainPlan(productDetail.subscription);
   return (
     <div
       key={productDetail.subscription.subscriptionId}
@@ -237,7 +238,7 @@ const getProductDetailRenderer = (
         getCancellationSummary(productType)(productDetail.subscription)
       ) : (
         <>
-          {productDetailListLength > 1 ? (
+          {productDetailListLength > 1 && (
             <PageContainer noVerticalMargin>
               {productType.productPage === productPageProperties ? (
                 <h2>
@@ -247,20 +248,12 @@ const getProductDetailRenderer = (
               ) : (
                 <h2>
                   {productType.alternateTierValue || productDetail.tier}
-                  {productType.displayPlanName && (
-                    <i>
-                      {productType.displayPlanName(
-                        getMainPlan(productDetail.subscription)
-                      )}
-                    </i>
-                  )}
+                  {mainPlan.name && <i>&nbsp;({mainPlan.name})</i>}
                 </h2>
               )}
             </PageContainer>
-          ) : (
-            undefined
           )}
-          {productDetail.alertText ? (
+          {productDetail.alertText && (
             <div
               css={{
                 backgroundColor: palette.red.dark,
@@ -299,17 +292,13 @@ const getProductDetailRenderer = (
                 />
               </PageContainer>
             </div>
-          ) : (
-            undefined
           )}
           <PageContainer>
-            {productPageProperties.showSubscriptionId ? (
+            {productPageProperties.showSubscriptionId && (
               <ProductDetailRow
                 label={"Subscription ID"}
                 data={productDetail.subscription.subscriptionId}
               />
-            ) : (
-              undefined
             )}
             {productPageProperties.tierRowLabel &&
               (productDetailListLength === 1 ||
@@ -338,11 +327,9 @@ const getProductDetailRenderer = (
                       ) : (
                         productType.alternateTierValue || productDetail.tier
                       )}
-                      {productType.displayPlanName && (
+                      {getMainPlan(productDetail.subscription).name && (
                         <i>
-                          {productType.displayPlanName(
-                            getMainPlan(productDetail.subscription)
-                          )}
+                          &nbsp;({getMainPlan(productDetail.subscription).name})
                         </i>
                       )}
                     </>
@@ -417,15 +404,13 @@ const getProductRenderer = (
   const productDetailList = apiResponse.filter(hasProduct).sort(sortByJoinDate);
   return (
     <>
-      {productDetailList.length > 1 ? (
+      {productDetailList.length > 1 && (
         <PageContainer>
           <h3>
             You have <strong>{toWords(productDetailList.length)}</strong>{" "}
             concurrent {productType.friendlyName}s:
           </h3>
         </PageContainer>
-      ) : (
-        undefined
       )}
       {productDetailList.length > 0 ? (
         productDetailList.map(

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -186,7 +186,6 @@ const getPaymentPart = (
                 productType={productType}
               />
               {futurePlan &&
-                futurePlan.productRatePlanId !== mainPlan.productRatePlanId &&
                 futurePlan.amount !== mainPlan.amount && (
                   <div css={{ fontStyle: "italic" }}>
                     {futurePlan.currency}{" "}

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -70,7 +70,7 @@ export interface SubscriptionPlan {
   productName: string;
   name: string;
   start: string;
-  startsBeforeXDaysFromToday: boolean;
+  shouldBeVisible: boolean;
 }
 
 export interface CurrencyAndIntervalDetail {
@@ -138,5 +138,5 @@ export const getFuturePlanIfStartsBeforeXDaysFromToday = (
   const indexToFetch = subscription.currentPlans.length === 0 ? 1 : 0; // if main plan is using the first future plan use the 2nd future plan
   return subscription.futurePlans
     .filter(isPaidSubscriptionPlan)
-    .filter(plan => plan.startsBeforeXDaysFromToday)[indexToFetch];
+    .filter(plan => plan.shouldBeVisible)[indexToFetch];
 };

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -66,8 +66,6 @@ export interface DirectDebitDetails {
 }
 
 export interface SubscriptionPlan {
-  productRatePlanId: string;
-  productName: string;
   name: string;
   start: string;
   shouldBeVisible: boolean;

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -66,7 +66,7 @@ export interface DirectDebitDetails {
 }
 
 export interface SubscriptionPlan {
-  name: string;
+  name?: string;
   start: string;
   shouldBeVisible: boolean;
 }

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -79,6 +79,9 @@ export interface CurrencyAndIntervalDetail {
   interval: string;
 }
 
+export const augmentInterval = (interval: string) =>
+  interval === "6 weeks" ? "One-off" : `${interval}ly`;
+
 export interface PaidSubscriptionPlan
   extends SubscriptionPlan,
     CurrencyAndIntervalDetail {

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -69,6 +69,7 @@ export interface ProductPageProperties {
   tierRowLabel?: string; // no label means row is not displayed;
   tierChangeable?: true;
   showSubscriptionId?: true;
+  forceShowJoinDateOnly?: true;
 }
 
 export interface ProductType {
@@ -170,7 +171,8 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
       noProductInTabCopy:
         "To manage your existing contribution or subscription, please select from the tabs above.",
       tierRowLabel: "Membership tier",
-      tierChangeable: true
+      tierChangeable: true,
+      forceShowJoinDateOnly: true
     },
     includeGuardianInTitles: true,
     cancellation: {

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -11,12 +11,7 @@ import { MeValidator } from "../client/components/checkFlowIsValid";
 import { NavItem, navLinks } from "../client/components/nav";
 import { MeResponse } from "./meResponse";
 import { OphanProduct } from "./ophanTypes";
-import {
-  formatDate,
-  ProductDetail,
-  Subscription,
-  SubscriptionPlan
-} from "./productResponse";
+import { formatDate, ProductDetail, Subscription } from "./productResponse";
 
 export type ProductFriendlyName =
   | "membership"
@@ -82,7 +77,6 @@ export interface ProductType {
   ) => OphanProduct | undefined;
   includeGuardianInTitles?: true;
   alternateTierValue?: string;
-  displayPlanName?: (plan: SubscriptionPlan) => string;
   alternateManagementUrl?: string;
   alternateManagementCtaLabel?: (
     productDetail: ProductDetail
@@ -258,8 +252,6 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
     validator: (me: MeResponse) => me.contentAccess.paperSubscriber,
     getOphanProductType: () => "PRINT_SUBSCRIPTION",
     includeGuardianInTitles: true,
-    displayPlanName: (plan: SubscriptionPlan) =>
-      ` (${plan.name.replace("+", " plus Digital Pack")})`,
     alternateManagementUrl: domainSpecificSubsManageURL,
     alternateManagementCtaLabel: (productDetail: ProductDetail) =>
       productDetail.tier === "Newspaper Delivery"
@@ -274,10 +266,6 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
     validator: (me: MeResponse) => me.contentAccess.guardianWeeklySubscriber,
     getOphanProductType: () => "PRINT_SUBSCRIPTION", // TODO create a GUARDIAN_WEEKLY Product in Ophan data model
     alternateTierValue: "Guardian Weekly",
-    displayPlanName: (plan: SubscriptionPlan) =>
-      plan.name.indexOf("Six for Six") !== -1
-        ? " (currently on '6 for 6')"
-        : "",
     alternateManagementUrl: domainSpecificSubsManageURL,
     alternateManagementCtaLabel: (productDetail: ProductDetail) =>
       productDetail.subscription.autoRenew

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -11,7 +11,12 @@ import { MeValidator } from "../client/components/checkFlowIsValid";
 import { NavItem, navLinks } from "../client/components/nav";
 import { MeResponse } from "./meResponse";
 import { OphanProduct } from "./ophanTypes";
-import { formatDate, ProductDetail, Subscription } from "./productResponse";
+import {
+  formatDate,
+  ProductDetail,
+  Subscription,
+  SubscriptionPlan
+} from "./productResponse";
 
 export type ProductFriendlyName =
   | "membership"
@@ -76,6 +81,7 @@ export interface ProductType {
   ) => OphanProduct | undefined;
   includeGuardianInTitles?: true;
   alternateTierValue?: string;
+  displayPlanName?: (plan: SubscriptionPlan) => string;
   alternateManagementUrl?: string;
   alternateManagementCtaLabel?: (
     productDetail: ProductDetail
@@ -250,6 +256,8 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
     validator: (me: MeResponse) => me.contentAccess.paperSubscriber,
     getOphanProductType: () => "PRINT_SUBSCRIPTION",
     includeGuardianInTitles: true,
+    displayPlanName: (plan: SubscriptionPlan) =>
+      ` (${plan.name.replace("+", " plus Digital Pack")})`,
     alternateManagementUrl: domainSpecificSubsManageURL,
     alternateManagementCtaLabel: (productDetail: ProductDetail) =>
       productDetail.tier === "Newspaper Delivery"
@@ -264,6 +272,10 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
     validator: (me: MeResponse) => me.contentAccess.guardianWeeklySubscriber,
     getOphanProductType: () => "PRINT_SUBSCRIPTION", // TODO create a GUARDIAN_WEEKLY Product in Ophan data model
     alternateTierValue: "Guardian Weekly",
+    displayPlanName: (plan: SubscriptionPlan) =>
+      plan.name.indexOf("Six for Six") !== -1
+        ? " (currently on '6 for 6')"
+        : "",
     alternateManagementUrl: domainSpecificSubsManageURL,
     alternateManagementCtaLabel: (productDetail: ProductDetail) =>
       productDetail.subscription.autoRenew


### PR DESCRIPTION
## _**Must be released after https://github.com/guardian/members-data-api/pull/371**_

Various improvements with the main underlying goal of ensuring is price rise is displayed correctly (once the API says it can be displayed, see https://github.com/guardian/members-data-api/pull/371).

### Now displays Join Date OR Start Date depending on product type 
_(rather than using join date as potentially misleading fallback or indeed showing both)_
![image](https://user-images.githubusercontent.com/19289579/53430654-daf10280-39e6-11e9-8bf4-d6791656fa65.png)
![image](https://user-images.githubusercontent.com/19289579/53430583-b09f4500-39e6-11e9-9861-b930b2f443c9.png)


### Price rises now display (if appropriate)
_(i.e. if `shouldBeVisible` is true - see https://github.com/guardian/members-data-api/pull/371)_
![image](https://user-images.githubusercontent.com/19289579/53177596-3c306480-35e8-11e9-98d5-8fe8ba819ee5.png)

Including in the "Six for Six" scenario...
![image](https://user-images.githubusercontent.com/19289579/53431613-ca418c00-39e8-11e9-853c-007575f529ec.png)

### Type of physical subscription now shown for Paper and Guardian Weekly

![image](https://user-images.githubusercontent.com/19289579/53431088-bfd2c280-39e7-11e9-84d6-8100f8ea0373.png)

![image](https://user-images.githubusercontent.com/19289579/53431124-ceb97500-39e7-11e9-8293-749a7a379990.png)

![image](https://user-images.githubusercontent.com/19289579/53431140-d711b000-39e7-11e9-9f35-0fb681007899.png)

