### PR TITLE
Add functionality to AB test user journeys on manage.

### DIFF
--- a/app/client/components/analytics.tsx
+++ b/app/client/components/analytics.tsx
@@ -60,7 +60,8 @@ export const trackEvent = ({
           ]
         },
         action: "VIEW",
-        value: eventValue !== undefined ? `${eventValue}` : undefined
+        value: eventValue !== undefined ? `${eventValue}` : undefined,
+        abTest: window.guardian.abTest
       }
     });
   }
@@ -78,11 +79,23 @@ export class AnalyticsTracker extends React.PureComponent<{}> {
   constructor(props: {}) {
     super(props);
     if (typeof window !== "undefined" && window.ga) {
-      this.INTCMP = parse(window.location.href, true).query.INTCMP;
+      const queryParams = parse(window.location.href, true).query;
+
+      this.INTCMP = queryParams.INTCMP;
 
       if (window.guardian) {
         // tslint:disable-next-line:no-object-mutation
         window.guardian.INTCMP = this.INTCMP;
+
+        const abName = queryParams.abName;
+        const abVariant = queryParams.abVariant;
+
+        if (abName && abVariant) {
+          window.guardian.abTest = {
+            name: abName,
+            variant: abVariant
+          };
+        }
       }
 
       if (window.dataLayer === undefined) {

--- a/app/server/identity/identityMiddleware.ts
+++ b/app/server/identity/identityMiddleware.ts
@@ -54,13 +54,17 @@ export const augmentRedirectURL = (
     // since they can be utilised to facilitate sign-in by identity frontend.
     "encryptedEmail",
     "autoSignInToken",
-    // By passing these profile to, can measure the sign in rates across test segments.
+    // By passing these to profile, can measure the sign in rates across test segments.
     "abName",
     "abVariant"
   ];
 
-  const queryParametersToForward = Object.entries(req.query).filter(
-    ([name, _]) => queryParametersNamesToForward.includes(name)
+  const queryParametersToForward = queryParametersNamesToForward.reduce(
+    (params, name) => {
+      const value = req.query[name];
+      return value ? { ...params, [name]: value } : params;
+    },
+    {}
   );
 
   return url.format({

--- a/app/shared/globals.ts
+++ b/app/shared/globals.ts
@@ -1,4 +1,4 @@
-import { OphanComponentEvent } from "./ophanTypes";
+import { AbTest, OphanComponentEvent } from "./ophanTypes";
 
 export interface Globals {
   domain: string;
@@ -11,6 +11,7 @@ export interface Globals {
     record: (payload: { componentEvent: OphanComponentEvent }) => void;
     sendInitialEvent: (url?: string, referer?: string) => void;
   };
+  abTest?: AbTest;
 }
 
 declare global {

--- a/app/shared/ophanTypes.ts
+++ b/app/shared/ophanTypes.ts
@@ -66,8 +66,14 @@ export interface OphanComponent {
   labels?: string[];
 }
 
+export interface AbTest {
+  name: string;
+  variant: string;
+}
+
 export interface OphanComponentEvent {
   component: OphanComponent;
   action: OphanAction;
   value?: string;
+  abTest?: AbTest;
 }


### PR DESCRIPTION
When a user lands on manage from an external link, store the information of the ab test they were in (if applicable) so that it can be included on all component events sent by manage. Additionally, include the ab test data as query parameters if the user if kicked to manage (so that sign-in success can be measured across test variants).

With this PR, there are now 5 query parameters that are getting included (if present) if the user gets redirected to profile. So additionally this PR handles the inclusion of those query parameters in a more general manner.