### PR TITLE
refactored out the fallback to old 'plan' field in the event of no plans (e.g. Friends)

### DIFF
--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -9,7 +9,7 @@ import {
   annotateMdaResponseWithTestUserFromHeaders,
   augmentInterval,
   formatDate,
-  getFuturePlanIfStartsBeforeXDaysFromToday,
+  getFuturePlanIfVisible,
   getMainPlan,
   hasProduct,
   isPaidSubscriptionPlan,
@@ -157,9 +157,7 @@ const getPaymentPart = (
   productType: ProductType
 ) => {
   const mainPlan = getMainPlan(productDetail.subscription);
-  const futurePlan = getFuturePlanIfStartsBeforeXDaysFromToday(
-    productDetail.subscription
-  );
+  const futurePlan = getFuturePlanIfVisible(productDetail.subscription);
   if (isPaidSubscriptionPlan(mainPlan)) {
     const mainPlanInterval = augmentInterval(mainPlan.interval);
     return (

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -66,8 +66,8 @@ export interface DirectDebitDetails {
 }
 
 export interface SubscriptionPlan {
-  name?: string;
-  start: string;
+  name: string | null;
+  start?: string;
   shouldBeVisible: boolean;
 }
 
@@ -83,6 +83,7 @@ export const augmentInterval = (interval: string) =>
 export interface PaidSubscriptionPlan
   extends SubscriptionPlan,
     CurrencyAndIntervalDetail {
+  start: string;
   end: string;
   chargedThrough?: string;
   amount: number;
@@ -108,7 +109,6 @@ export interface Subscription {
   payPalEmail?: string;
   mandate?: DirectDebitDetails;
   autoRenew: boolean;
-  plan: SubscriptionPlan;
   currentPlans: SubscriptionPlan[];
   futurePlans: SubscriptionPlan[];
   trialLength: number;
@@ -118,7 +118,9 @@ export interface WithSubscription {
   subscription: Subscription;
 }
 
-export const getMainPlan = (subscription: Subscription) => {
+export const getMainPlan: (subscription: Subscription) => SubscriptionPlan = (
+  subscription: Subscription
+) => {
   if (subscription.currentPlans.length > 0) {
     if (subscription.currentPlans.length > 1) {
       Raven.captureException(
@@ -130,7 +132,11 @@ export const getMainPlan = (subscription: Subscription) => {
     // fallback to use the first future plan (contributions for example are always future plans)
     return subscription.futurePlans[0];
   }
-  return subscription.plan;
+  return {
+    name: null,
+    start: subscription.start,
+    shouldBeVisible: true
+  };
 };
 
 export const getFuturePlanIfStartsBeforeXDaysFromToday = (

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -139,9 +139,7 @@ export const getMainPlan: (subscription: Subscription) => SubscriptionPlan = (
   };
 };
 
-export const getFuturePlanIfStartsBeforeXDaysFromToday = (
-  subscription: Subscription
-) => {
+export const getFuturePlanIfVisible = (subscription: Subscription) => {
   const indexToFetch = subscription.currentPlans.length === 0 ? 1 : 0; // if main plan is using the first future plan use the 2nd future plan
   return subscription.futurePlans
     .filter(isPaidSubscriptionPlan)


### PR DESCRIPTION
## This is a proper FIX for the TEMP FIX https://github.com/guardian/manage-frontend/pull/202

The rate plan on Friend memberships ends the day after start date and thus `currentPlans` AND `futurePlans` arrays are empty, which needs to be handled.

The temporary FIX https://github.com/guardian/manage-frontend/pull/202 simply fell back to the old `plan` field in this scenario, however we want to remove that field soon and so this PR is a proper fix which builds a basic plan object to return so all the rendering works.