### PR TITLE
Make 'My account' button keyboard and screen-reader accessible

### DIFF
--- a/app/client/__tests__/__snapshots__/main.tsx.snap
+++ b/app/client/__tests__/__snapshots__/main.tsx.snap
@@ -41,45 +41,42 @@ exports[`Main renders something 1`] = `
       }
     >
       <nav
-        css={
-          Object {
-            "fontSize": "16px",
-            "position": "relative",
-            "transform": "translateY(-1px)",
-          }
-        }
+        onKeyDown={[Function]}
       >
-        <span
+        <button
+          aria-expanded={false}
           css={
             Object {
               "map": undefined,
-              "name": "c8vi01",
+              "name": "1puykvp",
               "next": undefined,
-              "styles": "display:flex;align-items:center;justify-content:space-between;cursor:pointer;::after{content:'';display:block;width:5px;height:5px;border:1px solid currentColor;border-left:transparent;border-top:transparent;margin-left:5px;transform:translateY(-2px) rotate(45deg);}:hover{color:#ffe500;::after{transform:translateY(0px) rotate(45deg);transition-property:transform;transition-duration:250ms;transition-timing-function:ease-in-out;}}color:#ffffff;",
+              "styles": "display:flex;align-items:center;justify-content:space-between;cursor:pointer;border:0;background:none;text-align:left;font-family:inherit;font-size:16px;padding:10px 1px 10px 0;position:relative;transform:translateY(-1px);::after{content:'';display:block;width:5px;height:5px;border:1px solid currentColor;border-left:transparent;border-top:transparent;margin-left:5px;transform:translateY(-2px) rotate(45deg);}:hover, :focus{color:#ffe500;::after{transform:translateY(0px) rotate(45deg);transition-property:transform;transition-duration:250ms;transition-timing-function:ease-in-out;}}color:#ffffff;",
             }
           }
           onClick={[Function]}
+          type="button"
         >
           My account
-        </span>
+        </button>
         <ul
           css={
             Object {
               "map": undefined,
-              "name": "1v0t73g",
+              "name": "1dp5ejy",
               "next": undefined,
-              "styles": "display:none;background:#ffffff;position:absolute;left:0;top:2.2rem;z-index:1071;list-style:none;line-height:1.375rem;box-shadow:0 0 0 0.0625rem rgba(0,0,0,0.1);border-radius:0.1875rem;margin:0;padding:0.375rem 0;overflow:hidden; li{padding:0;margin:0;}",
+              "styles": "display:none;background:#ffffff;position:absolute;top:3.05rem;z-index:1071;list-style:none;line-height:1.375rem;box-shadow:0 0 0 0.0625rem rgba(0,0,0,0.1);border-radius:0.1875rem;margin:0;padding:0.375rem 0;overflow:hidden; li{padding:0;margin:0;}",
             }
           }
+          role="tablist"
         >
           <li>
             <a
               css={
                 Object {
                   "map": undefined,
-                  "name": "ipwub6",
+                  "name": "1cruahm",
                   "next": undefined,
-                  "styles": "padding:7px 20px 15px 30px;text-decoration:none;color:currentColor;white-space:nowrap;position:relative;margin-top:-1px;display:flex;align-items:center;:hover{background-color:#ececec;text-decoration:none;}",
+                  "styles": "padding:7px 20px 15px 30px;text-decoration:none;color:currentColor;white-space:nowrap;position:relative;margin-top:-1px;display:flex;align-items:center;:hover, :focus{background-color:#ececec;text-decoration:none;}:focus{outline:0;}",
                 }
               }
               href="/profile/user"
@@ -94,9 +91,9 @@ exports[`Main renders something 1`] = `
               css={
                 Object {
                   "map": undefined,
-                  "name": "ipwub6",
+                  "name": "1cruahm",
                   "next": undefined,
-                  "styles": "padding:7px 20px 15px 30px;text-decoration:none;color:currentColor;white-space:nowrap;position:relative;margin-top:-1px;display:flex;align-items:center;:hover{background-color:#ececec;text-decoration:none;}",
+                  "styles": "padding:7px 20px 15px 30px;text-decoration:none;color:currentColor;white-space:nowrap;position:relative;margin-top:-1px;display:flex;align-items:center;:hover, :focus{background-color:#ececec;text-decoration:none;}:focus{outline:0;}",
                 }
               }
               href="https://profile.thegulocal.com/public/edit"
@@ -111,9 +108,9 @@ exports[`Main renders something 1`] = `
               css={
                 Object {
                   "map": undefined,
-                  "name": "ipwub6",
+                  "name": "1cruahm",
                   "next": undefined,
-                  "styles": "padding:7px 20px 15px 30px;text-decoration:none;color:currentColor;white-space:nowrap;position:relative;margin-top:-1px;display:flex;align-items:center;:hover{background-color:#ececec;text-decoration:none;}",
+                  "styles": "padding:7px 20px 15px 30px;text-decoration:none;color:currentColor;white-space:nowrap;position:relative;margin-top:-1px;display:flex;align-items:center;:hover, :focus{background-color:#ececec;text-decoration:none;}:focus{outline:0;}",
                 }
               }
               href="https://profile.thegulocal.com/account/edit"
@@ -128,9 +125,9 @@ exports[`Main renders something 1`] = `
               css={
                 Object {
                   "map": undefined,
-                  "name": "ipwub6",
+                  "name": "1cruahm",
                   "next": undefined,
-                  "styles": "padding:7px 20px 15px 30px;text-decoration:none;color:currentColor;white-space:nowrap;position:relative;margin-top:-1px;display:flex;align-items:center;:hover{background-color:#ececec;text-decoration:none;}",
+                  "styles": "padding:7px 20px 15px 30px;text-decoration:none;color:currentColor;white-space:nowrap;position:relative;margin-top:-1px;display:flex;align-items:center;:hover, :focus{background-color:#ececec;text-decoration:none;}:focus{outline:0;}",
                 }
               }
               href="https://profile.thegulocal.com/email-prefs"
@@ -155,9 +152,9 @@ exports[`Main renders something 1`] = `
               css={
                 Object {
                   "map": undefined,
-                  "name": "ipwub6",
+                  "name": "1cruahm",
                   "next": undefined,
-                  "styles": "padding:7px 20px 15px 30px;text-decoration:none;color:currentColor;white-space:nowrap;position:relative;margin-top:-1px;display:flex;align-items:center;:hover{background-color:#ececec;text-decoration:none;}",
+                  "styles": "padding:7px 20px 15px 30px;text-decoration:none;color:currentColor;white-space:nowrap;position:relative;margin-top:-1px;display:flex;align-items:center;:hover, :focus{background-color:#ececec;text-decoration:none;}:focus{outline:0;}",
                 }
               }
               href="/membership"
@@ -172,9 +169,9 @@ exports[`Main renders something 1`] = `
               css={
                 Object {
                   "map": undefined,
-                  "name": "ipwub6",
+                  "name": "1cruahm",
                   "next": undefined,
-                  "styles": "padding:7px 20px 15px 30px;text-decoration:none;color:currentColor;white-space:nowrap;position:relative;margin-top:-1px;display:flex;align-items:center;:hover{background-color:#ececec;text-decoration:none;}",
+                  "styles": "padding:7px 20px 15px 30px;text-decoration:none;color:currentColor;white-space:nowrap;position:relative;margin-top:-1px;display:flex;align-items:center;:hover, :focus{background-color:#ececec;text-decoration:none;}:focus{outline:0;}",
                 }
               }
               href="/contributions"
@@ -189,9 +186,9 @@ exports[`Main renders something 1`] = `
               css={
                 Object {
                   "map": undefined,
-                  "name": "ipwub6",
+                  "name": "1cruahm",
                   "next": undefined,
-                  "styles": "padding:7px 20px 15px 30px;text-decoration:none;color:currentColor;white-space:nowrap;position:relative;margin-top:-1px;display:flex;align-items:center;:hover{background-color:#ececec;text-decoration:none;}",
+                  "styles": "padding:7px 20px 15px 30px;text-decoration:none;color:currentColor;white-space:nowrap;position:relative;margin-top:-1px;display:flex;align-items:center;:hover, :focus{background-color:#ececec;text-decoration:none;}:focus{outline:0;}",
                 }
               }
               href="/subscriptions"
@@ -216,9 +213,9 @@ exports[`Main renders something 1`] = `
               css={
                 Object {
                   "map": undefined,
-                  "name": "ipwub6",
+                  "name": "1cruahm",
                   "next": undefined,
-                  "styles": "padding:7px 20px 15px 30px;text-decoration:none;color:currentColor;white-space:nowrap;position:relative;margin-top:-1px;display:flex;align-items:center;:hover{background-color:#ececec;text-decoration:none;}",
+                  "styles": "padding:7px 20px 15px 30px;text-decoration:none;color:currentColor;white-space:nowrap;position:relative;margin-top:-1px;display:flex;align-items:center;:hover, :focus{background-color:#ececec;text-decoration:none;}:focus{outline:0;}",
                 }
               }
               href="https://profile.thegulocal.com/signout"
@@ -278,6 +275,7 @@ exports[`Main renders something 1`] = `
           }
         }
         href="https://www.theguardian.com"
+        title="The Guardian - Back to home"
       >
         <svg
           css={

--- a/app/client/components/roundel.tsx
+++ b/app/client/components/roundel.tsx
@@ -12,6 +12,7 @@ export const Roundel = (props: RoundelProps) => (
       alignSelf: "flex-start"
     }}
     href="https://www.theguardian.com"
+    title="The Guardian - Back to home"
   >
     <svg
       viewBox="0 0 56 56"

--- a/app/client/components/userNav.tsx
+++ b/app/client/components/userNav.tsx
@@ -9,8 +9,7 @@ const userNavMenuCss = (showMenu: boolean) =>
     display: `${showMenu ? "block" : "none"}`,
     background: palette.white,
     position: "absolute",
-    left: 0,
-    top: "2.2rem",
+    top: "3.05rem",
     zIndex: 1071,
     listStyle: "none",
     lineHeight: "1.375rem",
@@ -19,7 +18,6 @@ const userNavMenuCss = (showMenu: boolean) =>
     margin: 0,
     padding: "0.375rem 0",
     overflow: "hidden",
-
     " li": {
       padding: 0,
       margin: 0
@@ -35,10 +33,12 @@ const userNavItemCss = css({
   marginTop: "-1px",
   display: "flex",
   alignItems: "center",
-
-  ":hover": {
+  ":hover, :focus": {
     backgroundColor: palette.neutral["6"],
     textDecoration: "none"
+  },
+  ":focus": {
+    outline: 0
   }
 });
 
@@ -49,6 +49,43 @@ const userNavBorderCss = css({
   display: "block",
   margin: "0 0 0 1.875rem"
 });
+
+const userNavButtonCss = (showMenu: boolean) =>
+  css({
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    cursor: "pointer",
+    border: "0",
+    background: "none",
+    textAlign: "left",
+    fontFamily: "inherit",
+    fontSize: "16px",
+    padding: "10px 1px 10px 0",
+    position: "relative",
+    transform: "translateY(-1px)",
+    "::after": {
+      content: "''",
+      display: "block",
+      width: "5px",
+      height: "5px",
+      border: "1px solid currentColor",
+      borderLeft: "transparent",
+      borderTop: "transparent",
+      marginLeft: "5px",
+      transform: `translateY(${showMenu ? 0 : -2}px) rotate(45deg)`
+    },
+    ":hover, :focus": {
+      color: palette.yellow.medium,
+      "::after": {
+        transform: "translateY(0px) rotate(45deg)",
+        transitionProperty: "transform",
+        transitionDuration: "250ms",
+        transitionTimingFunction: "ease-in-out"
+      }
+    },
+    color: showMenu ? palette.yellow.medium : palette.white
+  });
 
 const signOutIcon = (
   <svg width="100%" height="100%" viewBox="0 0 20 22" fill="none">
@@ -127,53 +164,22 @@ export class UserNav extends React.Component {
     }
   ];
 
+  private buttonElement = React.createRef<HTMLButtonElement>();
+
   public render(): JSX.Element {
     return (
-      <nav
-        css={{
-          position: "relative",
-          transform: "translateY(-1px)",
-          fontSize: "16px"
-        }}
-      >
-        <span
-          css={css({
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            cursor: "pointer",
-
-            "::after": {
-              content: "''",
-              display: "block",
-              width: "5px",
-              height: "5px",
-              border: "1px solid currentColor",
-              borderLeft: "transparent",
-              borderTop: "transparent",
-              marginLeft: "5px",
-              transform: `translateY(${
-                this.state.showMenu ? 0 : -2
-              }px) rotate(45deg)`
-            },
-
-            ":hover": {
-              color: palette.yellow.medium,
-              "::after": {
-                transform: "translateY(0px) rotate(45deg)",
-                transitionProperty: "transform",
-                transitionDuration: "250ms",
-                transitionTimingFunction: "ease-in-out"
-              }
-            },
-            color: this.state.showMenu ? palette.yellow.medium : palette.white
-          })}
+      <nav onKeyDown={this.handleKeyDown}>
+        <button
+          css={userNavButtonCss(this.state.showMenu)}
+          type="button"
+          aria-expanded={this.state.showMenu}
           onClick={() => this.setState({ showMenu: !this.state.showMenu })}
+          ref={this.buttonElement}
         >
           My account
-        </span>
+        </button>
 
-        <ul css={userNavMenuCss(this.state.showMenu)}>
+        <ul role="tablist" css={userNavMenuCss(this.state.showMenu)}>
           {this.userNavItems.map((item: UserNavItem) => (
             <React.Fragment key={item.title}>
               <li>
@@ -216,6 +222,15 @@ export class UserNav extends React.Component {
     const thisInDOM = findDOMNode(this);
     if (thisInDOM && event.target && !thisInDOM.contains(event.target)) {
       this.setState({ showMenu: false });
+    }
+  };
+
+  private handleKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    if (event.keyCode === 27 && this.state.showMenu) {
+      this.setState({ showMenu: false });
+      if (this.buttonElement.current) {
+        this.buttonElement.current.focus();
+      }
     }
   };
 }


### PR DESCRIPTION
The 'My account' button was not accessible by keyboard, so users of keyboard navigation and/or screen readers were unable to access the menu. 

The 'My Account button' and dropdown menu now meet the following accessibility requirements:
- Button is accessible by Tab key
- Menu opens/closes with Enter/Space keys
- Menu closes when Escape key is pressed and focus returns to 'My Account' button
- Menu closes when user clicks outside the menu

A mixture of semantic HTML markup and ARIA roles were used to achieve this.

The roundel was also updated with a friendly text description to match Frontend and help screen reader users (previously the URL was read out).

![image](https://user-images.githubusercontent.com/15648334/54292891-e1ff3f80-45a6-11e9-85f5-9bc4a75d91b5.png)
