### PR TITLE
Use nextPaymentPrice where available as this includes discounts etc. …

### DIFF
--- a/app/client/components/flowStartMultipleProductDetailHandler.tsx
+++ b/app/client/components/flowStartMultipleProductDetailHandler.tsx
@@ -57,7 +57,10 @@ const getPaymentPart = (productDetail: ProductDetail) => {
         <span>
           &nbsp;
           {mainPlan.currency}
-          {(mainPlan.amount / 100.0).toFixed(2)}{" "}
+          {(
+            (productDetail.subscription.nextPaymentPrice || mainPlan.amount) /
+            100.0
+          ).toFixed(2)}{" "}
           {augmentInterval(mainPlan.interval)}
         </span>
         <PaymentTypeRenderer {...productDetail.subscription} />

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -171,15 +171,12 @@ const getPaymentPart = (
           )}
         {}
         <ProductDetailRow
-          label={
-            mainPlanInterval.charAt(0).toUpperCase() +
-            mainPlanInterval.substr(1) +
-            " payment"
-          }
+          label={`Next ${mainPlanInterval} payment`}
           data={
             <>
               <UpdatableAmount
                 mainPlan={mainPlan}
+                nextPaymentPrice={productDetail.subscription.nextPaymentPrice}
                 subscriptionId={productDetail.subscription.subscriptionId}
                 productType={productType}
               />

--- a/app/client/components/updatableAmount.tsx
+++ b/app/client/components/updatableAmount.tsx
@@ -104,6 +104,7 @@ const getAmountUpdater = (
 
 export type UpdatableAmountProps = WithProductType<ProductType> & {
   mainPlan: PaidSubscriptionPlan;
+  nextPaymentPrice: number | null;
   subscriptionId: string;
 };
 
@@ -120,7 +121,8 @@ export class UpdatableAmount extends React.Component<
   UpdatableAmountProps,
   UpdatableAmountState
 > {
-  public initialAmount = this.props.mainPlan.amount / 100.0;
+  public initialAmount =
+    (this.props.nextPaymentPrice || this.props.mainPlan.amount) / 100.0;
   public state = {
     inEditMode: false,
     isApplyingUpdate: false,

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -100,8 +100,8 @@ export interface Subscription {
   start?: string;
   end: string;
   cancelledAt: boolean;
-  nextPaymentDate?: string;
-  nextPaymentPrice?: number;
+  nextPaymentDate: string | null;
+  nextPaymentPrice: number | null;
   paymentMethod?: string;
   stripePublicKeyForCardAddition?: string;
   safeToUpdatePaymentMethod: boolean;


### PR DESCRIPTION
Since the move to use plans (https://github.com/guardian/manage-frontend/pull/196) for pricing, inadvertently  any discounted subs have been showing with full price 😢 

This change now make use of `nextPaymentPrice` wherever available (sometimes `null` - although will try and improve this in a change to https://github.com/guardian/members-data-api).

This price rise display from https://github.com/guardian/manage-frontend/pull/196 continues to work.

The labelling of the row has changed slightly to make it explicit the price shown is the 'Next' price, and is usually preceded by the next payment date to reinforce this idea...
![image](https://user-images.githubusercontent.com/19289579/54359446-94dca580-465a-11e9-8460-eb6a19ce9492.png)
