### PR TITLE
correctly handle no payment method and alert if not a free sub

### DIFF
--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -42,6 +42,7 @@ export const sortByJoinDate = (a: ProductDetail, b: ProductDetail) =>
 
 export interface ProductDetail extends WithSubscription {
   isTestUser: boolean; // THIS IS NOT PART OF THE RESPONSE (but inferred from a header)
+  isPaidTier: boolean;
   regNumber?: string;
   tier: string;
   joinDate: string;


### PR DESCRIPTION
_Missing_ payment details were being treated as 'free' in the payment update flow and the user was therefore presented with a 'Support The Guardian' messaging accordingly, which is wrong. Missing payment details are now handled correctly with a new Sentry error if this ever occurs (which it shouldn't happen anymore based on below).

However due to the internals of `members-data-api` (fixed in https://github.com/guardian/membership-common/pull/593 and https://github.com/guardian/members-data-api/pull/378) previously the payment details weren't being exposed at all and thus `manage-frontend` didn't know what form to display.