### PR TITLE
Migrate manage site to t3 instance types

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -41,7 +41,7 @@ Mappings:
     CODE:
       MaxInstances: 2
       MinInstances: 1
-      InstanceType: t2.small
+      InstanceType: t3.small
       CertificateARN: arn:aws:acm:eu-west-1:865473395570:certificate/2c2a72a2-a0d6-4ffa-b8a1-8a7916000515
       ApiDomainEnvVariable: code.dev-guardianapis.com
       DomainEnvVariable: code.dev-theguardian.com

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -49,7 +49,7 @@ Mappings:
     PROD:
       MaxInstances: 6
       MinInstances: 3
-      InstanceType: t2.small
+      InstanceType: t3.small
       CertificateARN: arn:aws:acm:eu-west-1:865473395570:certificate/d2e4911c-c78d-469b-ab53-8c507aa41576
       ApiDomainEnvVariable: guardianapis.com
       DomainEnvVariable: theguardian.com


### PR DESCRIPTION
Migrate manage site to t3 instance types in preparation for AWS reservations.