### PR TITLE
now builds and sends 'acquisitionData' query param when linking to 'support'

### DIFF
--- a/app/client/__tests__/__snapshots__/main.tsx.snap
+++ b/app/client/__tests__/__snapshots__/main.tsx.snap
@@ -999,7 +999,7 @@ exports[`Main renders something 1`] = `
                 >
                   Support The Guardian
                 </div>
-                <a
+                <div
                   css={
                     Object {
                       "display": "inline-block",
@@ -1007,31 +1007,36 @@ exports[`Main renders something 1`] = `
                       "marginRight": "10px",
                     }
                   }
-                  href="https://support.theguardian.com/contribute?INTCMP=mma_footer_support_contribute"
                 >
-                  <button
-                    css={
-                      Object {
-                        "map": undefined,
-                        "name": "vigqs",
-                        "next": undefined,
-                        "styles": "font-size:16px;font-family:\\"Guardian Text Sans Web\\", \\"Helvetica Neue\\", Helvetica, Arial, \\"Lucida Grande\\", sans-serif;border-radius:1000px;align-items:center;white-space:nowrap;position:relative;:active{outline:none;}min-height:36px;line-height:36px;font-weight:bold;display:inline-flex;background:#ffe500;color:#121212;border:none;padding:1px 40px 0 18px;svg{fill:currentColor;height:34px;position:absolute;right:0;top:50%;transform:translate(0, -50%);transition:transform .3s, background .3s;width:40px;}:hover{background:hsl(53.89999999999998, 100%, 45%);svg{transform:translate(5px, -50%);}}cursor:pointer;@media (max-width: 319px){max-width:280px;}@media (max-width: 424px){max-width:320px;white-space:normal;line-height:16px;}",
-                      }
-                    }
-                    onMouseUp={[Function]}
+                  <a
+                    href="https://support.thegulocal.com/contribute?acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_MANAGE_MY_ACCOUNT%22%2C%22componentId%22%3A%22mma_footer_support_contribute%22%7D"
+                    onClick={[Function]}
                   >
-                    Contribute
-                    <svg
-                      viewBox="0 0 30 30"
+                    <button
+                      css={
+                        Object {
+                          "map": undefined,
+                          "name": "vigqs",
+                          "next": undefined,
+                          "styles": "font-size:16px;font-family:\\"Guardian Text Sans Web\\", \\"Helvetica Neue\\", Helvetica, Arial, \\"Lucida Grande\\", sans-serif;border-radius:1000px;align-items:center;white-space:nowrap;position:relative;:active{outline:none;}min-height:36px;line-height:36px;font-weight:bold;display:inline-flex;background:#ffe500;color:#121212;border:none;padding:1px 40px 0 18px;svg{fill:currentColor;height:34px;position:absolute;right:0;top:50%;transform:translate(0, -50%);transition:transform .3s, background .3s;width:40px;}:hover{background:hsl(53.89999999999998, 100%, 45%);svg{transform:translate(5px, -50%);}}cursor:pointer;@media (max-width: 319px){max-width:280px;}@media (max-width: 424px){max-width:320px;white-space:normal;line-height:16px;}",
+                        }
+                      }
+                      onMouseUp={[Function]}
                     >
-                      <path
-                        d="M22.8 14.6L15.2 7l-.7.7 5.5 6.6H6v1.5h14l-5.5 6.6.7.7 7.6-7.6v-.9"
-                      />
-                    </svg>
-                  </button>
-                </a>
+                      Contribute
+                      <svg
+                        viewBox="0 0 30 30"
+                      >
+                        <path
+                          d="M22.8 14.6L15.2 7l-.7.7 5.5 6.6H6v1.5h14l-5.5 6.6.7.7 7.6-7.6v-.9"
+                        />
+                      </svg>
+                    </button>
+                  </a>
+                </div>
                 <a
-                  href="https://support.theguardian.com/subscribe?INTCMP=mma_footer_support_subscribe"
+                  href="https://support.thegulocal.com/subscribe?acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_MANAGE_MY_ACCOUNT%22%2C%22componentId%22%3A%22mma_footer_support_subscribe%22%7D"
+                  onClick={[Function]}
                 >
                   <button
                     css={

--- a/app/client/__tests__/__snapshots__/main.tsx.snap
+++ b/app/client/__tests__/__snapshots__/main.tsx.snap
@@ -1009,7 +1009,7 @@ exports[`Main renders something 1`] = `
                   }
                 >
                   <a
-                    href="https://support.thegulocal.com/contribute?acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_MANAGE_MY_ACCOUNT%22%2C%22componentId%22%3A%22mma_footer_support_contribute%22%7D"
+                    href="https://support.thegulocal.com/contribute?INTCMP=mma_footer_support_contribute&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_MANAGE_MY_ACCOUNT%22%2C%22componentId%22%3A%22mma_footer_support_contribute%22%7D"
                     onClick={[Function]}
                   >
                     <button
@@ -1035,7 +1035,7 @@ exports[`Main renders something 1`] = `
                   </a>
                 </div>
                 <a
-                  href="https://support.thegulocal.com/subscribe?acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_MANAGE_MY_ACCOUNT%22%2C%22componentId%22%3A%22mma_footer_support_subscribe%22%7D"
+                  href="https://support.thegulocal.com/subscribe?INTCMP=mma_footer_support_subscribe&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_MANAGE_MY_ACCOUNT%22%2C%22componentId%22%3A%22mma_footer_support_subscribe%22%7D"
                   onClick={[Function]}
                 >
                   <button

--- a/app/client/components/footer/footer.tsx
+++ b/app/client/components/footer/footer.tsx
@@ -3,7 +3,7 @@ import { conf } from "../../../server/config";
 import palette from "../../colours";
 import { minWidth } from "../../styles/breakpoints";
 import { headline } from "../../styles/fonts";
-import { Button } from "../buttons";
+import { SupportTheGuardianButton } from "../supportTheGuardianButton";
 import { footerLinks } from "./footerlinks";
 
 let domain: string;
@@ -176,19 +176,26 @@ const Footer = () => (
                 >
                   Support The&nbsp;Guardian
                 </div>
-                <a
-                  href="https://support.theguardian.com/contribute?INTCMP=mma_footer_support_contribute"
+                <div
                   css={{
                     display: "inline-block",
                     marginRight: "10px",
                     marginBottom: "6px"
                   }}
                 >
-                  <Button text="Contribute" fontWeight="bold" primary right />
-                </a>
-                <a href="https://support.theguardian.com/subscribe?INTCMP=mma_footer_support_subscribe">
-                  <Button text="Subscribe" fontWeight="bold" primary right />
-                </a>
+                  <SupportTheGuardianButton
+                    urlSuffix="contribute"
+                    supportReferer="footer_support_contribute"
+                    alternateButtonText="Contribute"
+                    fontWeight="bold"
+                  />
+                </div>
+                <SupportTheGuardianButton
+                  urlSuffix="subscribe"
+                  supportReferer="footer_support_subscribe"
+                  alternateButtonText="Subscribe"
+                  fontWeight="bold"
+                />
               </div>
             </div>
           </div>

--- a/app/client/components/membershipFAQs.tsx
+++ b/app/client/components/membershipFAQs.tsx
@@ -3,6 +3,7 @@ import palette from "../colours";
 import { Accordion } from "./accordion";
 import { navLinks } from "./nav";
 import { PageContainerSection, PageHeaderContainer } from "./page";
+import { buildSupportHref } from "./supportTheGuardianButton";
 import { RouteableProps } from "./wizardRouterAdapter";
 
 const headerCss = {
@@ -38,7 +39,10 @@ export const MembershipFAQs = (props: RouteableProps) => (
               it. Rather than setting up a paywall, we are asking those who can
               afford it to make their contribution to our fearless, independent
               journalism.{" "}
-              <a css={linkCss} href="https://support.theguardian.com/">
+              <a
+                css={linkCss}
+                href={buildSupportHref({ supportReferer: "membership_faq" })}
+              >
                 Become a Supporter
               </a>{" "}
               if you share our belief that the open exchange of information,
@@ -85,7 +89,10 @@ export const MembershipFAQs = (props: RouteableProps) => (
               the website.{" "}
               <a
                 css={linkCss}
-                href="https://support.theguardian.com/subscribe/digital"
+                href={buildSupportHref({
+                  supportReferer: "membership_faq",
+                  urlSuffix: "subscribe/digital"
+                })}
               >
                 Sign up for Digital Pack here
               </a>
@@ -117,7 +124,10 @@ export const MembershipFAQs = (props: RouteableProps) => (
             created a{" "}
             <a
               css={linkCss}
-              href="https://support.theguardian.com/contribute?INTCMP=membership_faq"
+              href={buildSupportHref({
+                supportReferer: "membership_faq",
+                urlSuffix: "contribute"
+              })}
             >
               one-off contributions
             </a>{" "}

--- a/app/client/components/supportTheGuardianButton.tsx
+++ b/app/client/components/supportTheGuardianButton.tsx
@@ -1,12 +1,23 @@
 import React from "react";
+import url from "url";
+import { conf } from "../../server/config";
 import { trackEvent } from "./analytics";
 import { Button } from "./buttons";
-import url from "url";
 
 export interface SupportTheGuardianButtonProps {
   supportReferer: string;
   alternateButtonText?: string;
   urlSuffix?: string;
+  fontWeight?: "bold";
+}
+
+const hasWindow = typeof window !== "undefined" && window.guardian;
+
+let domain: string;
+if (hasWindow) {
+  domain = window.guardian.domain;
+} else {
+  domain = conf.DOMAIN;
 }
 
 const buildAcquisitionData = (supportReferer: string) => ({
@@ -14,19 +25,21 @@ const buildAcquisitionData = (supportReferer: string) => ({
   componentType: "ACQUISITIONS_MANAGE_MY_ACCOUNT",
   componentId: `mma_${supportReferer}`,
   referrerPageviewId:
-    window && window.guardian && window.guardian.ophan
+    hasWindow && window.guardian.ophan
       ? window.guardian.ophan.viewId
       : undefined,
-  referrerUrl: window ? window.location.href : undefined
+  referrerUrl: hasWindow ? window.location.href : undefined
 });
 
-const buildHref = (supportReferer: string, urlSuffix: string | undefined) =>
+export const buildSupportHref = (props: SupportTheGuardianButtonProps) =>
   url.format({
     protocol: "https",
-    host: `support.${window.guardian.domain}`,
-    pathname: urlSuffix || "",
+    host: `support.${domain || "theguardian.com"}`,
+    pathname: props.urlSuffix || "",
     query: {
-      acquisitionData: JSON.stringify(buildAcquisitionData(supportReferer))
+      acquisitionData: JSON.stringify(
+        buildAcquisitionData(props.supportReferer)
+      )
     }
   });
 
@@ -34,7 +47,7 @@ export const SupportTheGuardianButton = (
   props: SupportTheGuardianButtonProps
 ) => (
   <a
-    href={buildHref(props.supportReferer, props.urlSuffix)}
+    href={buildSupportHref(props)}
     onClick={() => {
       trackEvent({
         eventCategory: "href",
@@ -45,6 +58,7 @@ export const SupportTheGuardianButton = (
   >
     <Button
       text={props.alternateButtonText || "Support The Guardian"}
+      fontWeight={props.fontWeight}
       primary
       right
     />

--- a/app/client/components/supportTheGuardianButton.tsx
+++ b/app/client/components/supportTheGuardianButton.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { trackEvent } from "./analytics";
 import { Button } from "./buttons";
+import url from "url";
 
 export interface SupportTheGuardianButtonProps {
   supportReferer: string;
@@ -8,12 +9,32 @@ export interface SupportTheGuardianButtonProps {
   urlSuffix?: string;
 }
 
+const buildAcquisitionData = (supportReferer: string) => ({
+  source: "GUARDIAN_WEB",
+  componentType: "ACQUISITIONS_MANAGE_MY_ACCOUNT",
+  componentId: `mma_${supportReferer}`,
+  referrerPageviewId:
+    window && window.guardian && window.guardian.ophan
+      ? window.guardian.ophan.viewId
+      : undefined,
+  referrerUrl: window ? window.location.href : undefined
+});
+
+const buildHref = (supportReferer: string, urlSuffix: string | undefined) =>
+  url.format({
+    protocol: "https",
+    host: `support.${window.guardian.domain}`,
+    pathname: urlSuffix || "",
+    query: {
+      acquisitionData: JSON.stringify(buildAcquisitionData(supportReferer))
+    }
+  });
+
 export const SupportTheGuardianButton = (
   props: SupportTheGuardianButtonProps
 ) => (
   <a
-    href={`https://support.${window.guardian.domain}${props.urlSuffix ||
-      ""}?INTCMP=mma_${props.supportReferer}`}
+    href={buildHref(props.supportReferer, props.urlSuffix)}
     onClick={() => {
       trackEvent({
         eventCategory: "href",

--- a/app/client/components/supportTheGuardianButton.tsx
+++ b/app/client/components/supportTheGuardianButton.tsx
@@ -20,10 +20,10 @@ if (hasWindow) {
   domain = conf.DOMAIN;
 }
 
-const buildAcquisitionData = (supportReferer: string) => ({
+const buildAcquisitionData = (componentId: string) => ({
   source: "GUARDIAN_WEB",
   componentType: "ACQUISITIONS_MANAGE_MY_ACCOUNT",
-  componentId: `mma_${supportReferer}`,
+  componentId,
   referrerPageviewId:
     hasWindow && window.guardian.ophan
       ? window.guardian.ophan.viewId
@@ -37,8 +37,9 @@ export const buildSupportHref = (props: SupportTheGuardianButtonProps) =>
     host: `support.${domain || "theguardian.com"}`,
     pathname: props.urlSuffix || "",
     query: {
+      INTCMP: `mma_${props.supportReferer}`,
       acquisitionData: JSON.stringify(
-        buildAcquisitionData(props.supportReferer)
+        buildAcquisitionData(`mma_${props.supportReferer}`)
       )
     }
   });


### PR DESCRIPTION
This replaces the INTCMP as it can provide more granular information and ensures correct attribution (for example in the 'Acquisitions Slicer').

Also refactored everything that links to 'support' to use this class/function.

See the URL when hovering over the Contribute button for example...
![image](https://user-images.githubusercontent.com/19289579/55082519-bcd7fa00-5099-11e9-9ebc-1d04f705d3bf.png)
