### PR TITLE
resubscribe thrasher (aka existing payment methods)

### DIFF
--- a/app/client/__tests__/__snapshots__/main.tsx.snap
+++ b/app/client/__tests__/__snapshots__/main.tsx.snap
@@ -1009,7 +1009,7 @@ exports[`Main renders something 1`] = `
                   }
                 >
                   <a
-                    href="https://support.thegulocal.com/contribute?INTCMP=mma_footer_support_contribute&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_MANAGE_MY_ACCOUNT%22%2C%22componentId%22%3A%22mma_footer_support_contribute%22%7D"
+                    href="https://support.thegulocal.com/contribute?INTCMP=mma_footer_support_contribute&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_MANAGE_MY_ACCOUNT%22%2C%22componentId%22%3A%22mma_footer_support_contribute%22%7D&displayExistingPaymentOptions=true"
                     onClick={[Function]}
                   >
                     <button
@@ -1035,7 +1035,7 @@ exports[`Main renders something 1`] = `
                   </a>
                 </div>
                 <a
-                  href="https://support.thegulocal.com/subscribe?INTCMP=mma_footer_support_subscribe&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_MANAGE_MY_ACCOUNT%22%2C%22componentId%22%3A%22mma_footer_support_subscribe%22%7D"
+                  href="https://support.thegulocal.com/subscribe?INTCMP=mma_footer_support_subscribe&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_MANAGE_MY_ACCOUNT%22%2C%22componentId%22%3A%22mma_footer_support_subscribe%22%7D&displayExistingPaymentOptions=true"
                   onClick={[Function]}
                 >
                   <button

--- a/app/client/components/cancel/cancellationSummary.tsx
+++ b/app/client/components/cancel/cancellationSummary.tsx
@@ -2,7 +2,8 @@ import React from "react";
 import { Subscription } from "../../../shared/productResponse";
 import { ProductType } from "../../../shared/productTypes";
 import { GenericErrorScreen } from "../genericErrorScreen";
-import { PageContainerSection } from "../page";
+import { PageContainer } from "../page";
+import { ResubscribeThrasher } from "../resubscribeThrasher";
 import { SupportTheGuardianButton } from "../supportTheGuardianButton";
 import { CancellationReasonContext } from "./cancellationContexts";
 
@@ -10,55 +11,65 @@ const actuallyCancelled = (
   productType: ProductType,
   subscription: Subscription
 ) => (
-  <PageContainerSection>
-    <h3>Your {productType.friendlyName} is cancelled.</h3>
-    {productType.cancellation ? (
-      <p>{productType.cancellation.summaryMainPara(subscription)}</p>
-    ) : (
-      undefined
-    )}
-    <CancellationReasonContext.Consumer>
-      {reason =>
-        !productType.cancellation ||
-        !productType.cancellation.onlyShowSupportSectionIfAlternateText ||
-        productType.cancellation.summaryReasonSpecificPara(reason) ? (
-          <>
-            <p>
-              {productType.cancellation &&
-              productType.cancellation.summaryReasonSpecificPara &&
-              productType.cancellation.summaryReasonSpecificPara(reason)
-                ? productType.cancellation.summaryReasonSpecificPara(reason)
-                : "If you are interested in supporting our journalism in other ways, " +
-                  "please consider either a contribution or a subscription."}
-            </p>
-            <div css={{ marginBottom: "30px" }}>
-              <SupportTheGuardianButton
-                urlSuffix={
-                  productType.cancellation &&
-                  productType.cancellation.alternateSupportButtonUrlSuffix
-                    ? productType.cancellation.alternateSupportButtonUrlSuffix(
-                        reason
-                      )
-                    : undefined
-                }
-                alternateButtonText={
-                  productType.cancellation &&
-                  productType.cancellation.alternateSupportButtonText
-                    ? productType.cancellation.alternateSupportButtonText(
-                        reason
-                      )
-                    : undefined
-                }
-                supportReferer={productType.urlPart + "_cancellation_summary"}
-              />
-            </div>
-          </>
-        ) : (
-          undefined
-        )
-      }
-    </CancellationReasonContext.Consumer>
-  </PageContainerSection>
+  <>
+    <PageContainer>
+      <h3>Your {productType.friendlyName} is cancelled.</h3>
+      {productType.cancellation ? (
+        <p>{productType.cancellation.summaryMainPara(subscription)}</p>
+      ) : (
+        undefined
+      )}
+    </PageContainer>
+    <ResubscribeThrasher
+      usageContext={`${productType.urlPart}_cancellation_summary`}
+    >
+      <PageContainer>
+        <CancellationReasonContext.Consumer>
+          {reason =>
+            !productType.cancellation ||
+            !productType.cancellation.onlyShowSupportSectionIfAlternateText ||
+            productType.cancellation.summaryReasonSpecificPara(reason) ? (
+              <>
+                <p>
+                  {productType.cancellation &&
+                  productType.cancellation.summaryReasonSpecificPara &&
+                  productType.cancellation.summaryReasonSpecificPara(reason)
+                    ? productType.cancellation.summaryReasonSpecificPara(reason)
+                    : "If you are interested in supporting our journalism in other ways, " +
+                      "please consider either a contribution or a subscription."}
+                </p>
+                <div css={{ marginBottom: "30px" }}>
+                  <SupportTheGuardianButton
+                    urlSuffix={
+                      productType.cancellation &&
+                      productType.cancellation.alternateSupportButtonUrlSuffix
+                        ? productType.cancellation.alternateSupportButtonUrlSuffix(
+                            reason
+                          )
+                        : undefined
+                    }
+                    alternateButtonText={
+                      productType.cancellation &&
+                      productType.cancellation.alternateSupportButtonText
+                        ? productType.cancellation.alternateSupportButtonText(
+                            reason
+                          )
+                        : undefined
+                    }
+                    supportReferer={
+                      productType.urlPart + "_cancellation_summary"
+                    }
+                  />
+                </div>
+              </>
+            ) : (
+              undefined
+            )
+          }
+        </CancellationReasonContext.Consumer>
+      </PageContainer>
+    </ResubscribeThrasher>
+  </>
 );
 
 export const isCancelled = (subscription: Subscription) =>

--- a/app/client/components/checkFlowIsValid.tsx
+++ b/app/client/components/checkFlowIsValid.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { fetchMe, MeAsyncLoader, MeResponse } from "../../shared/meResponse";
 import { ProductType } from "../../shared/productTypes";
 import { NoProduct } from "./noProduct";
-import { PageContainer } from "./page";
 
 const renderChildrenIfValidated = (props: CheckFlowIsValidProps) => (
   me: MeResponse
@@ -10,13 +9,11 @@ const renderChildrenIfValidated = (props: CheckFlowIsValidProps) => (
   props.validator(me) ? (
     <>{props.children}</>
   ) : (
-    <PageContainer>
-      <NoProduct
-        inTab={false}
-        supportRefererSuffix={props.supportRefererSuffix}
-        productType={props}
-      />
-    </PageContainer>
+    <NoProduct
+      inTab={false}
+      supportRefererSuffix={props.supportRefererSuffix}
+      productType={props}
+    />
   );
 
 export type MeValidator = (me: MeResponse) => boolean;

--- a/app/client/components/flowStartMultipleProductDetailHandler.tsx
+++ b/app/client/components/flowStartMultipleProductDetailHandler.tsx
@@ -173,13 +173,11 @@ const getProductDetailSelector = (
     }
   }
   return (
-    <PageContainer>
-      <NoProduct
-        inTab={false}
-        supportRefererSuffix={supportRefererSuffix}
-        productType={props.productType}
-      />
-    </PageContainer>
+    <NoProduct
+      inTab={false}
+      supportRefererSuffix={supportRefererSuffix}
+      productType={props.productType}
+    />
   );
 };
 

--- a/app/client/components/noProduct.tsx
+++ b/app/client/components/noProduct.tsx
@@ -4,6 +4,8 @@ import {
   ProductType,
   WithProductType
 } from "../../shared/productTypes";
+import { PageContainer } from "./page";
+import { ResubscribeThrasher } from "./resubscribeThrasher";
 import { SupportTheGuardianButton } from "./supportTheGuardianButton";
 
 export interface NoProductProps extends WithProductType<ProductType> {
@@ -13,21 +15,30 @@ export interface NoProductProps extends WithProductType<ProductType> {
 
 export const NoProduct = (props: NoProductProps) => (
   <div>
-    <h2>You do not currently have a {props.productType.friendlyName}.</h2>
-    {props.inTab && hasProductPageProperties(props.productType) ? (
-      <p>{props.productType.productPage.noProductInTabCopy}</p>
-    ) : (
-      undefined
-    )}
-    <p>
-      Please support our journalism by making either a contribution or a
-      subscription.
-    </p>
-    <SupportTheGuardianButton
-      supportReferer={`${props.productType.urlPart}_${
+    <PageContainer>
+      <h2>You do not currently have a {props.productType.friendlyName}.</h2>
+      {props.inTab &&
+        hasProductPageProperties(props.productType) && (
+          <p>{props.productType.productPage.noProductInTabCopy}</p>
+        )}
+    </PageContainer>
+    <ResubscribeThrasher
+      usageContext={`${props.productType.urlPart}_${
         props.supportRefererSuffix
       }`}
-      urlSuffix={props.productType.noProductSupportUrlSuffix}
-    />
+    >
+      <PageContainer>
+        <p>
+          Please support our journalism by making either a contribution or a
+          subscription.
+        </p>
+        <SupportTheGuardianButton
+          supportReferer={`${props.productType.urlPart}_${
+            props.supportRefererSuffix
+          }`}
+          urlSuffix={props.productType.noProductSupportUrlSuffix}
+        />
+      </PageContainer>
+    </ResubscribeThrasher>
   </div>
 );

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -18,11 +18,11 @@ import {
   ProductDetail,
   sortByJoinDate
 } from "../../shared/productResponse";
+import { ProductPageProperties, ProductType } from "../../shared/productTypes";
 import {
   createProductDetailFetcher,
   ProductTypeWithProductPageProperties
 } from "../../shared/productTypes";
-import { ProductPageProperties, ProductType } from "../../shared/productTypes";
 import palette from "../colours";
 import { maxWidth, minWidth } from "../styles/breakpoints";
 import { headline } from "../styles/fonts";
@@ -416,13 +416,11 @@ const getProductRenderer = (
           )
         )
       ) : (
-        <PageContainer>
-          <NoProduct
-            inTab={true}
-            supportRefererSuffix={"product_page"}
-            productType={productType}
-          />
-        </PageContainer>
+        <NoProduct
+          inTab={true}
+          supportRefererSuffix={"product_page"}
+          productType={productType}
+        />
       )}
     </>
   );

--- a/app/client/components/resubscribeThrasher.tsx
+++ b/app/client/components/resubscribeThrasher.tsx
@@ -1,0 +1,103 @@
+import React, { ReactNode } from "react";
+import palette from "../colours";
+import { minWidth } from "../styles/breakpoints";
+import { trackEvent } from "./analytics";
+import AsyncLoader from "./asyncLoader";
+import { PageContainer } from "./page";
+import { SupportTheGuardianButton } from "./supportTheGuardianButton";
+
+const fetchExistingPaymentOptions = () =>
+  fetch("/api/existing-payment-options", {
+    credentials: "include",
+    mode: "same-origin"
+  });
+
+interface ExistingPaymentSubscriptionInfo {
+  name: string;
+  isCancelled: boolean;
+  isActive: boolean;
+}
+
+interface ExistingPaymentOption {
+  paymentType: "Card" | "DirectDebit";
+  billingAccountId: string;
+  subscriptions: ExistingPaymentSubscriptionInfo[];
+  card?: string;
+  mandate?: string;
+}
+
+class ExistingPaymentOptionsAsyncLoader extends AsyncLoader<
+  ExistingPaymentOption[]
+> {}
+
+const getThrasher = (props: ResubscribeThrasherProps) => (
+  existingPaymentOptions: ExistingPaymentOption[]
+) => {
+  const eligiblePaymentOptionsIfNoActiveExistingContribution = existingPaymentOptions.find(
+    option =>
+      !!option.subscriptions.find(
+        sub => sub.isActive && sub.name.indexOf("Contribution") !== -1
+      )
+  )
+    ? []
+    : existingPaymentOptions;
+
+  if (eligiblePaymentOptionsIfNoActiveExistingContribution.length) {
+    trackEvent({
+      eventCategory: "impression",
+      eventAction: "resubscribe_thrasher",
+      eventLabel: props.usageContext
+    });
+    return (
+      <div
+        css={{
+          backgroundColor: palette.yellow.medium,
+          padding: "10px 15px 15px",
+          margin: "30px 0"
+        }}
+      >
+        <PageContainer noVerticalMargin>
+          <h2 css={{ fontWeight: "bold", margin: "0" }}>
+            Have you considered a monthly or annual contribution?
+          </h2>
+          <p
+            css={{
+              br: {
+                display: "none",
+                [minWidth.tablet]: {
+                  display: "inline"
+                }
+              }
+            }}
+          >
+            Support The Guardian with a recurring contribution of your choice.
+            You can use your existing payment details so setting it up only
+            takes a minute.
+          </p>
+          <SupportTheGuardianButton
+            supportReferer={`resubscribe_thrasher_${props.usageContext}`}
+            alternateButtonText="Make a recurring contribution"
+            urlSuffix="contribute"
+            fontWeight="bold"
+            height="42px"
+            notPrimary
+          />
+        </PageContainer>
+      </div>
+    );
+  }
+  return props.children;
+};
+
+export interface ResubscribeThrasherProps {
+  children: ReactNode;
+  usageContext: string;
+}
+
+export const ResubscribeThrasher = (props: ResubscribeThrasherProps) => (
+  <ExistingPaymentOptionsAsyncLoader
+    fetch={fetchExistingPaymentOptions}
+    render={getThrasher(props)}
+    loadingMessage={"Loading..."}
+  />
+);

--- a/app/client/components/supportTheGuardianButton.tsx
+++ b/app/client/components/supportTheGuardianButton.tsx
@@ -9,6 +9,8 @@ export interface SupportTheGuardianButtonProps {
   alternateButtonText?: string;
   urlSuffix?: string;
   fontWeight?: "bold";
+  height?: string;
+  notPrimary?: true;
 }
 
 const hasWindow = typeof window !== "undefined" && window.guardian;
@@ -61,7 +63,8 @@ export const SupportTheGuardianButton = (
     <Button
       text={props.alternateButtonText || "Support The Guardian"}
       fontWeight={props.fontWeight}
-      primary
+      height={props.height}
+      primary={props.notPrimary ? undefined : true}
       right
     />
   </a>

--- a/app/client/components/supportTheGuardianButton.tsx
+++ b/app/client/components/supportTheGuardianButton.tsx
@@ -40,7 +40,8 @@ export const buildSupportHref = (props: SupportTheGuardianButtonProps) =>
       INTCMP: `mma_${props.supportReferer}`,
       acquisitionData: JSON.stringify(
         buildAcquisitionData(`mma_${props.supportReferer}`)
-      )
+      ),
+      displayExistingPaymentOptions: true
     }
   });
 

--- a/app/server/server.ts
+++ b/app/server/server.ts
@@ -148,6 +148,11 @@ const sfCasesApiHandler = proxyApiHandler(conf.SF_CASES_URL);
 server.get("/api/me", membersDataApiHandler("user-attributes/me"));
 
 server.get(
+  "/api/existing-payment-options",
+  membersDataApiHandler("user-attributes/me/existing-payment-options")
+);
+
+server.get(
   "/api/me/mma/:subscriptionName?",
   membersDataApiHandler(
     "user-attributes/me/mma/:subscriptionName",


### PR DESCRIPTION
Following the launch of https://github.com/guardian/support-frontend/pull/1673 it's now time to start sending some traffic there  🚀 

This change adds a bright yellow 'thrasher' in-place of the lightweight Support The Guardian messaging that is used in the cancellation summary and 'no product' page... to encourage re-subscribe, providing...
- The user has eligible payment methods (based on existing-payment-methods response from `members-data-api` - see https://github.com/guardian/members-data-api/pull/376)
- The user doesn't already have an active recurring contribution (inferred from the subscriptions listed in the existing-payment-methods response)

... otherwise it will fall back to using the lightweight Support The Guardian messaging.

_NOTE: the 'displayExistingPaymentOptions=true' query param is now appended to ALL links to 'support', even outside of this new thrasher - to up the likelihood that the existing options are used - and thus reduce friction at checkout - see https://github.com/guardian/support-frontend/pull/1673 for me details on the effect of that query param_

### Screenshot
![image](https://user-images.githubusercontent.com/19289579/55159469-fcb1e680-5158-11e9-86e6-ec8ce3741c80.png)
