### PR TITLE
temporarily disable DirectDebit payment methods alone from triggering the yellow resubscribe thrasher

### DIFF
--- a/app/client/components/resubscribeThrasher.tsx
+++ b/app/client/components/resubscribeThrasher.tsx
@@ -40,7 +40,7 @@ const getThrasher = (props: ResubscribeThrasherProps) => (
       )
   )
     ? []
-    : existingPaymentOptions;
+    : existingPaymentOptions.filter(option => option.paymentType === "Card");
 
   if (eligiblePaymentOptionsIfNoActiveExistingContribution.length) {
     trackEvent({


### PR DESCRIPTION
As discussed with @jacobwinch, until reuse of direct debit is implemented in `support-workers` and then enabled via support-admin-console (and thus support-frontend), filter only on 'Card' when deciding whether to show the yellow  resubscribe thrasher (see https://github.com/guardian/manage-frontend/pull/210) - to avoid promising people that they can use existing payment method when in reality they could not.

_We expect to revert this in 3 or 4 weeks when we get round to implementing the underlying functionality._ 