### PR TITLE
Tweaks to IDAPI integration ready for their PR.

### DIFF
--- a/app/server/identity/identityMiddleware.ts
+++ b/app/server/identity/identityMiddleware.ts
@@ -1,6 +1,10 @@
 import express from "express";
 import fetch from "node-fetch";
 import url, { UrlWithParsedQuery } from "url";
+import {
+  getScopeFromRequestPathOrEmptyString,
+  X_GU_ID_FORWARDED_SCOPE
+} from "../../shared/identity";
 import { conf } from "../config";
 import { handleIdapiRelatedError, idapiConfigPromise } from "../idapiConfig";
 
@@ -135,13 +139,6 @@ const redirectOrCustomStatusCode = (
 export const getCookiesOrEmptyString = (req: express.Request) =>
   req.header("cookie") || "";
 
-const getScopeFromRequestPathOrEmptyString = (requestPath: string) => {
-  if (requestPath.indexOf("/payment/") !== -1) {
-    return "payment-flow";
-  }
-  return "";
-};
-
 export const withIdentity: (statusCode?: number) => express.RequestHandler = (
   statusCode?: number
 ) => (
@@ -169,7 +166,7 @@ export const withIdentity: (statusCode?: number) => express.RequestHandler = (
             headers: {
               "X-GU-ID-Client-Access-Token":
                 "Bearer " + idapiConfig.accessToken,
-              "X-GU-ID-FORWARDED-SCOPE": getScopeFromRequestPathOrEmptyString(
+              [X_GU_ID_FORWARDED_SCOPE]: getScopeFromRequestPathOrEmptyString(
                 req.path
               ),
               Cookie: getCookiesOrEmptyString(req)

--- a/app/server/identity/identityMiddleware.ts
+++ b/app/server/identity/identityMiddleware.ts
@@ -5,7 +5,8 @@ import { conf } from "../config";
 import { handleIdapiRelatedError, idapiConfigPromise } from "../idapiConfig";
 
 interface RedirectResponseBody {
-  status: string;
+  status?: string; // TODO remove after https://github.com/guardian/identity/pull/1527
+  signInStatus?: string;
   redirect?: {
     url: string;
   };
@@ -192,8 +193,8 @@ export const withIdentity: (statusCode?: number) => express.RequestHandler = (
                 statusCode
               );
             } else if (
-              redirectResponseBody.status === "ok" ||
-              redirectResponseBody.status === "signedIn"
+              redirectResponseBody.status === "ok" || // TODO remove after https://github.com/guardian/identity/pull/1527
+              redirectResponseBody.signInStatus === "signedInRecently"
             ) {
               // If the request to manage contains sign-in token query parameters,
               // but they are not needed because the user is already signed in,

--- a/app/server/server.ts
+++ b/app/server/server.ts
@@ -8,6 +8,7 @@ import { renderToString } from "react-dom/server";
 import { parse } from "url";
 import { ServerUser } from "../client/components/user";
 import { Globals } from "../shared/globals";
+import { X_GU_ID_FORWARDED_SCOPE } from "../shared/identity";
 import { MDA_TEST_USER_HEADER } from "../shared/productResponse";
 import {
   hasProductPageRedirect,
@@ -118,7 +119,8 @@ const apiHandler = (jsonHandler: JsonHandler) => (
     body: Buffer.isBuffer(req.body) ? req.body : undefined,
     headers: {
       "Content-Type": "application/json",
-      Cookie: getCookiesOrEmptyString(req)
+      Cookie: getCookiesOrEmptyString(req),
+      [X_GU_ID_FORWARDED_SCOPE]: req.header(X_GU_ID_FORWARDED_SCOPE) || ""
     }
   })
     .then(intermediateResponse => {

--- a/app/server/server.ts
+++ b/app/server/server.ts
@@ -17,6 +17,7 @@ import {
 import { conf, Environments } from "./config";
 import html from "./html";
 import {
+  augmentRedirectURL,
   getCookiesOrEmptyString,
   withIdentity
 } from "./identity/identityMiddleware";
@@ -128,6 +129,15 @@ const apiHandler = (jsonHandler: JsonHandler) => (
           intermediateResponse.headers.get(headerName) || undefined
         )
       );
+      const idapiRedirect = intermediateResponse.headers.get(
+        "X-GU-IDAPI-Redirect"
+      );
+      if (intermediateResponse.status === 401 && idapiRedirect) {
+        res.header(
+          "Location",
+          augmentRedirectURL(req, idapiRedirect, conf.DOMAIN, true)
+        );
+      }
       return intermediateResponse.text();
     })
     .then(_ => jsonHandler(res, _))

--- a/app/shared/identity.ts
+++ b/app/shared/identity.ts
@@ -1,0 +1,8 @@
+export const X_GU_ID_FORWARDED_SCOPE = "X-GU-ID-FORWARDED-SCOPE";
+
+export const getScopeFromRequestPathOrEmptyString = (requestPath: string) => {
+  if (requestPath.indexOf("/payment/") !== -1) {
+    return "payment-flow";
+  }
+  return "";
+};

--- a/app/shared/meResponse.ts
+++ b/app/shared/meResponse.ts
@@ -1,4 +1,8 @@
 import AsyncLoader from "../client/components/asyncLoader";
+import {
+  getScopeFromRequestPathOrEmptyString,
+  X_GU_ID_FORWARDED_SCOPE
+} from "./identity";
 
 export interface MeResponse {
   userId: string;
@@ -16,6 +20,13 @@ export interface MeResponse {
 }
 
 export const fetchMe: () => Promise<Response> = async () =>
-  await fetch("/api/me", { credentials: "include" });
+  await fetch("/api/me", {
+    credentials: "include",
+    headers: {
+      [X_GU_ID_FORWARDED_SCOPE]: getScopeFromRequestPathOrEmptyString(
+        window.location.href
+      )
+    }
+  });
 
 export class MeAsyncLoader extends AsyncLoader<MeResponse> {}

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -9,6 +9,10 @@ import { membershipCancellationFlowStart } from "../client/components/cancel/mem
 import { membershipCancellationReasons } from "../client/components/cancel/membership/membershipCancellationReasons";
 import { MeValidator } from "../client/components/checkFlowIsValid";
 import { NavItem, navLinks } from "../client/components/nav";
+import {
+  getScopeFromRequestPathOrEmptyString,
+  X_GU_ID_FORWARDED_SCOPE
+} from "./identity";
 import { MeResponse } from "./meResponse";
 import { OphanProduct } from "./ophanTypes";
 import { formatDate, ProductDetail, Subscription } from "./productResponse";
@@ -133,7 +137,12 @@ export const createProductDetailFetcher = (
         : `?productType=${productType.allProductsProductTypeFilterString}`),
     {
       credentials: "include",
-      mode: "same-origin"
+      mode: "same-origin",
+      headers: {
+        [X_GU_ID_FORWARDED_SCOPE]: getScopeFromRequestPathOrEmptyString(
+          window.location.href
+        )
+      }
     }
   );
 


### PR DESCRIPTION
_Follows on from https://github.com/guardian/manage-frontend/pull/213 ✅_

Some tweaks following changes to https://github.com/guardian/identity/pull/1527 

ALSO in preparation for https://github.com/guardian/members-data-api/pull/384 ensure the new `X-GU-IDAPI-Redirect` header from members-data-api which now accompanies 401s, is used to build the `Location` header for the final 401 response which will trigger a client-side redirect to signin/reauth AND that `X_GU_ID_FORWARDED_SCOPE` header is passed on to `members-data-api` when used in a scoped context.