### PR TITLE
cleaned up last few instances where 'X_GU_ID_FORWARDED_SCOPE' header wasn't being passed

### DIFF
--- a/app/client/components/payment/update/confirmPaymentUpdate.tsx
+++ b/app/client/components/payment/update/confirmPaymentUpdate.tsx
@@ -1,10 +1,14 @@
 import Raven from "raven-js";
 import React from "react";
 import {
+  getScopeFromRequestPathOrEmptyString,
+  X_GU_ID_FORWARDED_SCOPE
+} from "../../../../shared/identity";
+import { hasProduct } from "../../../../shared/productResponse";
+import {
   MembersDataApiResponseContext,
   ProductDetail
 } from "../../../../shared/productResponse";
-import { hasProduct } from "../../../../shared/productResponse";
 import { trackEvent } from "../../analytics";
 import { Button } from "../../buttons";
 import { CallCentreNumbers } from "../../callCentreNumbers";
@@ -78,7 +82,12 @@ class ExecutePaymentUpdate extends React.Component<
         body: JSON.stringify(
           this.props.newPaymentMethodDetail.detailToPayloadObject()
         ),
-        headers: { "Content-Type": "application/json" }
+        headers: {
+          "Content-Type": "application/json",
+          [X_GU_ID_FORWARDED_SCOPE]: getScopeFromRequestPathOrEmptyString(
+            window.location.href
+          )
+        }
       }
     );
 

--- a/app/client/components/resubscribeThrasher.tsx
+++ b/app/client/components/resubscribeThrasher.tsx
@@ -1,4 +1,8 @@
 import React, { ReactNode } from "react";
+import {
+  getScopeFromRequestPathOrEmptyString,
+  X_GU_ID_FORWARDED_SCOPE
+} from "../../shared/identity";
 import palette from "../colours";
 import { minWidth } from "../styles/breakpoints";
 import { trackEvent } from "./analytics";
@@ -9,7 +13,12 @@ import { SupportTheGuardianButton } from "./supportTheGuardianButton";
 const fetchExistingPaymentOptions = () =>
   fetch("/api/existing-payment-options", {
     credentials: "include",
-    mode: "same-origin"
+    mode: "same-origin",
+    headers: {
+      [X_GU_ID_FORWARDED_SCOPE]: getScopeFromRequestPathOrEmptyString(
+        window.location.href
+      )
+    }
   });
 
 interface ExistingPaymentSubscriptionInfo {

--- a/app/server/identity/identityMiddleware.ts
+++ b/app/server/identity/identityMiddleware.ts
@@ -165,9 +165,9 @@ export const withIdentity: (statusCode?: number) => express.RequestHandler = (
             headers: {
               "X-GU-ID-Client-Access-Token":
                 "Bearer " + idapiConfig.accessToken,
-              [X_GU_ID_FORWARDED_SCOPE]: getScopeFromRequestPathOrEmptyString(
-                req.path
-              ),
+              [X_GU_ID_FORWARDED_SCOPE]:
+                req.header(X_GU_ID_FORWARDED_SCOPE) ||
+                getScopeFromRequestPathOrEmptyString(req.path),
               Cookie: getCookiesOrEmptyString(req)
             }
           }


### PR DESCRIPTION
The 'X_GU_ID_FORWARDED_SCOPE' header is integral to the 'auto sign-in tokens' (aka magic links) for the payment update flow (following CC Expiry, Direct Debit Mandate Failure and Payment Failure emails), see...

- https://github.com/guardian/identity/pull/1527
- https://github.com/guardian/members-data-api/pull/384
- https://github.com/guardian/identity-processes/pull/23

While end-to-end testing there were a few outstanding cases uncovered, where this header wasn't being passed when it should.