### PR TITLE
Revert "temporarily disable DirectDebit payment methods alone from triggering the yellow resubscribe thrasher"

### DIFF
--- a/app/client/components/resubscribeThrasher.tsx
+++ b/app/client/components/resubscribeThrasher.tsx
@@ -49,7 +49,7 @@ const getThrasher = (props: ResubscribeThrasherProps) => (
       )
   )
     ? []
-    : existingPaymentOptions.filter(option => option.paymentType === "Card");
+    : existingPaymentOptions;
 
   if (eligiblePaymentOptionsIfNoActiveExistingContribution.length) {
     trackEvent({


### PR DESCRIPTION
## Release AFTER https://github.com/guardian/support-frontend/pull/1772 
Now that re-use of existing direct debit is implemented in `support-workers` (see https://github.com/guardian/support-frontend/pull/1772) we can now revert https://github.com/guardian/manage-frontend/pull/211, so the existing direct debit details will trigger the yellow re-subscribe thrasher on manage.theguardian.com.