### PR TITLE
holiday-stop-api integration

### DIFF
--- a/app/server/awsIntegration.ts
+++ b/app/server/awsIntegration.ts
@@ -1,0 +1,61 @@
+import * as AWS from "aws-sdk";
+import { GetObjectRequest } from "aws-sdk/clients/s3";
+import Raven from "raven";
+import { conf } from "./config";
+import { log } from "./log";
+
+const REGION = "eu-west-1";
+
+const PROFILE = "membership";
+
+const CREDENTIAL_PROVIDER = new AWS.CredentialProviderChain([
+  () => new AWS.SharedIniFileCredentials({ profile: PROFILE }),
+  ...AWS.CredentialProviderChain.defaultProviders
+]);
+
+export const S3 = new AWS.S3({
+  region: REGION,
+  credentialProvider: CREDENTIAL_PROVIDER
+});
+
+export const handleAwsRelatedError = (message: string, detail?: any) => {
+  log.error(message, detail);
+  Raven.captureMessage(message);
+};
+
+export const s3ConfigPromise = <ConfigInterface>(
+  configPathPart: string,
+  ...fields: string[]
+) =>
+  (async () => {
+    const configPath: GetObjectRequest = {
+      Bucket: "gu-reader-revenue-private",
+      Key: `manage-frontend/${conf.STAGE}/${configPathPart}-${conf.STAGE}.json`
+    };
+
+    const s3PromiseResult = await S3.getObject(configPath).promise();
+
+    if (s3PromiseResult.Body) {
+      try {
+        const parsed = JSON.parse(s3PromiseResult.Body.toString());
+        if (
+          fields.filter(field => parsed.hasOwnProperty(field)).length ===
+          fields.length
+        ) {
+          return parsed as ConfigInterface;
+        }
+        handleAwsRelatedError(
+          `${configPathPart} config missing ${fields
+            .map(field => `'${field}'`)
+            .join(" and/or ")} properties`
+        );
+      } catch (err) {
+        handleAwsRelatedError(`could not parse ${configPathPart} config`, err);
+      }
+    }
+
+    handleAwsRelatedError(
+      `error fetching ${configPathPart} config from S3`,
+      s3PromiseResult
+    );
+  })();

--- a/app/server/holidayStopApiConfig.ts
+++ b/app/server/holidayStopApiConfig.ts
@@ -1,10 +1,19 @@
 import { s3ConfigPromise } from "./awsIntegration";
 
-export interface HolidayStopApiConfig {
+export interface HolidayStopApiEnvConfig {
   host: string;
   apiKey: string;
 }
 
+export interface HolidayStopApisConfig {
+  normalMode: HolidayStopApiEnvConfig;
+  testMode: HolidayStopApiEnvConfig;
+}
+
 export const holidayStopApiConfigPromise: Promise<
-  HolidayStopApiConfig | undefined
-> = s3ConfigPromise<HolidayStopApiConfig>("holiday-stop-api", "host", "apiKey");
+  HolidayStopApisConfig | undefined
+> = s3ConfigPromise<HolidayStopApisConfig>(
+  "holiday-stop-api",
+  "normalMode",
+  "testMode"
+);

--- a/app/server/holidayStopApiConfig.ts
+++ b/app/server/holidayStopApiConfig.ts
@@ -1,0 +1,10 @@
+import { s3ConfigPromise } from "./awsIntegration";
+
+export interface HolidayStopApiConfig {
+  host: string;
+  apiKey: string;
+}
+
+export const holidayStopApiConfigPromise: Promise<
+  HolidayStopApiConfig | undefined
+> = s3ConfigPromise<HolidayStopApiConfig>("holiday-stop-api", "host", "apiKey");

--- a/app/server/holidayStopApiHandlers.ts
+++ b/app/server/holidayStopApiHandlers.ts
@@ -1,0 +1,60 @@
+import express from "express";
+import fetch from "node-fetch";
+import url from "url";
+import { HolidayStopsApiProductNamePrefix } from "../shared/productTypes";
+import { holidayStopApiConfigPromise } from "./holidayStopApiConfig";
+import { log } from "./log";
+
+export const getHolidayStopApiHandler = (
+  holidayStopsApiProductNamePrefix?: HolidayStopsApiProductNamePrefix
+) => (
+  { params, method, body, query }: express.Request,
+  res: express.Response
+) =>
+  holidayStopApiConfigPromise
+    .then(hsrConfig => {
+      if (hsrConfig && res.locals.identity && res.locals.identity.userId) {
+        fetch(
+          url.format({
+            protocol: "https",
+            host: hsrConfig.host,
+            pathname:
+              (params && params.subscriptionName
+                ? params.subscriptionName === "potential"
+                  ? "/potential"
+                  : `/hsr/${params.subscriptionName}`
+                : "/hsr") +
+              (params && params.subscriptionName && params.sfId
+                ? `/${params.sfId}`
+                : ""),
+            query
+          }),
+          {
+            method,
+            headers: {
+              "x-api-key": hsrConfig.apiKey,
+              "x-identity-id": res.locals.identity.userId,
+              ...(holidayStopsApiProductNamePrefix
+                ? { "x-product-name-prefix": holidayStopsApiProductNamePrefix }
+                : {})
+            },
+            body: method !== "GET" ? body : undefined
+          }
+        )
+          .then(intermediateResponse => {
+            res.status(intermediateResponse.status);
+            return intermediateResponse.json();
+          })
+          .then(responseBodyJSON => res.json(responseBodyJSON))
+          .catch(e => {
+            log.error(e);
+            res.status(500).send();
+          });
+      } else {
+        throw new Error("could not get holiday-stop-api config");
+      }
+    })
+    .catch(e => {
+      log.error(e);
+      res.status(500).send();
+    });

--- a/app/server/idapiConfig.ts
+++ b/app/server/idapiConfig.ts
@@ -1,7 +1,4 @@
-import * as AWS from "aws-sdk";
-import { GetObjectRequest } from "aws-sdk/clients/s3";
-import Raven from "raven";
-import { conf } from "./config";
+import { s3ConfigPromise } from "./awsIntegration";
 import { log } from "./log";
 
 export interface IdapiConfig {
@@ -9,53 +6,12 @@ export interface IdapiConfig {
   accessToken: string;
 }
 
-// tslint:disable-next-line:no-object-mutation
-process.env.AWS_PROFILE = "membership"; // TODO do this with CredentialProviderChain
-
-const s3 = new AWS.S3({
-  region: "eu-west-1"
-  // credentialProvider: new AWS.CredentialProviderChain([
-  //   ...AWS.CredentialProviderChain.defaultProviders,
-  //   () => new AWS.SharedIniFileCredentials({ profile: "membership" })
-  // ])
-});
-
-export const handleIdapiRelatedError = (message: string, detail?: any) => {
-  log.error(message, detail);
-  Raven.captureMessage(message);
-};
-
 export const idapiConfigPromise: Promise<
   IdapiConfig | undefined
-> = (async () => {
-  const idapiConfigPath: GetObjectRequest = {
-    Bucket: "gu-reader-revenue-private",
-    Key: `manage-frontend/${conf.STAGE}/idapi-${conf.STAGE}.json`
-  };
+> = s3ConfigPromise<IdapiConfig>("idapi", "host", "accessToken");
 
-  const s3PromiseResult = await s3.getObject(idapiConfigPath).promise();
-
-  if (s3PromiseResult.Body) {
-    try {
-      const parsed = JSON.parse(s3PromiseResult.Body.toString());
-      if (
-        parsed.hasOwnProperty("host") &&
-        parsed.hasOwnProperty("accessToken")
-      ) {
-        const idapiConfig = parsed as IdapiConfig;
-        log.info("IDAPI: using " + idapiConfig.host);
-        return idapiConfig;
-      }
-      handleIdapiRelatedError(
-        "IDAPI config missing 'host' and/or 'accessToken' properties"
-      );
-    } catch (err) {
-      handleIdapiRelatedError("could not parse IDAPI config", err);
-    }
+idapiConfigPromise.then(idapiConfig => {
+  if (idapiConfig) {
+    log.info("IDAPI: using " + idapiConfig.host);
   }
-
-  handleIdapiRelatedError(
-    "error fetching IDAPI config from S3",
-    s3PromiseResult
-  );
-})();
+});

--- a/app/server/middleware/identityMiddleware.ts
+++ b/app/server/middleware/identityMiddleware.ts
@@ -8,7 +8,7 @@ import {
 import { conf } from "../config";
 import { handleIdapiRelatedError, idapiConfigPromise } from "../idapiConfig";
 
-interface RedirectResponseBody {
+interface RedirectResponseBody extends IdentityDetails {
   signInStatus: string;
   redirect?: {
     url: string;
@@ -203,6 +203,8 @@ export const withIdentity: (statusCode?: number) => express.RequestHandler = (
                   updateManageUrl(req, useRefererHeaderForManageUrl)
                 );
               } else {
+                // tslint:disable-next-line:no-object-mutation
+                Object.assign(res.locals, { identity: redirectResponseBody });
                 next();
               }
             } else {

--- a/app/server/middleware/identityMiddleware.ts
+++ b/app/server/middleware/identityMiddleware.ts
@@ -5,8 +5,9 @@ import {
   getScopeFromRequestPathOrEmptyString,
   X_GU_ID_FORWARDED_SCOPE
 } from "../../shared/identity";
+import { handleAwsRelatedError } from "../awsIntegration";
 import { conf } from "../config";
-import { handleIdapiRelatedError, idapiConfigPromise } from "../idapiConfig";
+import { idapiConfigPromise } from "../idapiConfig";
 
 interface RedirectResponseBody extends IdentityDetails {
   signInStatus: string;
@@ -146,7 +147,7 @@ export const withIdentity: (statusCode?: number) => express.RequestHandler = (
   next: express.NextFunction
 ) => {
   const errorHandler = (message: string, detail?: any) => {
-    handleIdapiRelatedError(message, detail);
+    handleAwsRelatedError(message, detail);
     res.sendStatus(500); // TODO maybe server side render a pretty response
   };
 

--- a/app/server/routes/products.ts
+++ b/app/server/routes/products.ts
@@ -1,13 +1,10 @@
-import { 
-  Request,
-  Response,
-  Router 
-} from 'express';
+import { Request, Response, Router } from "express";
 import {
   hasProductPageRedirect,
   ProductType,
   ProductTypes
 } from "../../shared/productTypes";
+import { getHolidayStopApiHandler } from "../holidayStopApiHandlers";
 import { membersDataApiHandler } from "../middleware/apiMiddleware";
 
 const routeProvider = (apiPathPrefix: string) => {
@@ -23,26 +20,35 @@ const routeProvider = (apiPathPrefix: string) => {
 
     if (productType.updateAmountMdaEndpoint) {
       router.post(
-        `${apiPathPrefix}update/amount/` + productType.urlPart + "/:subscriptionName",
+        `${apiPathPrefix}update/amount/` +
+          productType.urlPart +
+          "/:subscriptionName",
         membersDataApiHandler(
           "user-attributes/me/" +
-          productType.updateAmountMdaEndpoint +
-          "/:subscriptionName",
+            productType.updateAmountMdaEndpoint +
+            "/:subscriptionName",
           false,
           "subscriptionName"
         )
       );
     }
     if (hasProductPageRedirect(productType)) {
-      router.get(
-        "/" + productType.urlPart,
-        (req: Request, res: Response) => {
-          res.redirect("/" + productType.productPage);
-        }
+      router.get("/" + productType.urlPart, (req: Request, res: Response) => {
+        res.redirect("/" + productType.productPage);
+      });
+    }
+    if (productType.holidayStopsApiProductNamePrefix) {
+      router.use(
+        `${apiPathPrefix}holidays/${
+          productType.urlPart
+        }/:subscriptionName?/:sfId?`,
+        getHolidayStopApiHandler(productType.holidayStopsApiProductNamePrefix)
       );
     }
   });
+
+  router.get(`${apiPathPrefix}holidays/`, getHolidayStopApiHandler());
   return router;
-}
+};
 
 export default routeProvider;

--- a/app/server/routes/profile.ts
+++ b/app/server/routes/profile.ts
@@ -1,24 +1,18 @@
 import { Response, Router } from "express";
 import { conf } from "../config";
-import { apiHandler, JsonHandler } from "../middleware/apiMiddleware";
 import { withIdentity } from "../middleware/identityMiddleware";
 
 const router = Router();
 
-const profileRedirectHandler: JsonHandler = (
-  res: Response,
-  meJsonString: string
-) => {
-  const userId = JSON.parse(meJsonString).userId;
-  res.redirect(`https://profile.${conf.DOMAIN}/user/id/${userId}`);
-};
-
 router.get(
   "/user",
   withIdentity(),
-  apiHandler(profileRedirectHandler)("https://members-data-api." + conf.DOMAIN)(
-    "user-attributes/me"
-  )
+  (_, res: Response) =>
+    res.locals.identity && res.locals.identity.userId
+      ? res.redirect(
+          `https://profile.${conf.DOMAIN}/user/id/${res.locals.identity.userId}`
+        )
+      : res.status(500).send()
 );
 
 export default router;

--- a/app/server/server.ts
+++ b/app/server/server.ts
@@ -1,9 +1,5 @@
 import bodyParser from "body-parser";
-import {
-  default as express,
-  NextFunction,
-  Response
-} from "express";
+import { default as express, NextFunction, Response } from "express";
 import helmet from "helmet";
 import Raven from "raven";
 import { conf } from "./config";
@@ -32,23 +28,21 @@ server.use(helmet());
 
 server.use("/static", express.static(__dirname + "/static"));
 
-server.use(
-  (_, res: Response, next: NextFunction) => {
-    // this header is VERY IMPORTANT and prevents caching (on both CDN and in browsers)
-    res.header(
-      "Cache-Control",
-      "private, no-cache, no-store, must-revalidate, max-age=0"
-    );
-    res.header("Access-Control-Allow-Origin", "*." + conf.DOMAIN);
-    next();
-  }
-);
+server.use((_, res: Response, next: NextFunction) => {
+  // this header is VERY IMPORTANT and prevents caching (on both CDN and in browsers)
+  res.header(
+    "Cache-Control",
+    "private, no-cache, no-store, must-revalidate, max-age=0"
+  );
+  res.header("Access-Control-Allow-Origin", "*." + conf.DOMAIN);
+  next();
+});
 
 server.use(bodyParser.raw({ type: "*/*" })); // parses all bodys to a raw 'Buffer'
 
 server.use(routes.core);
-server.use("/api/", routes.api);
 server.use("/profile/", routes.profile);
+server.use("/api/", routes.api);
 server.use(routes.productsProvider("/api/"));
 // ALL OTHER ENDPOINTS CAN BE HANDLED BY CLIENT SIDE REACT ROUTING
 server.use(routes.frontend);

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -38,6 +38,7 @@ export type AllProductsProductTypeFilterString =
   | "Membership"
   | "Digipack"
   | "ContentSubscription";
+export type HolidayStopsApiProductNamePrefix = "Guardian Weekly";
 
 export interface CancellationFlowProperties {
   reasons: CancellationReason[];
@@ -88,6 +89,7 @@ export interface ProductType {
   showTrialRemainingIfApplicable?: true;
   mapGroupedToSpecific?: (productDetail: ProductDetail) => ProductType;
   updateAmountMdaEndpoint?: string;
+  holidayStopsApiProductNamePrefix?: HolidayStopsApiProductNamePrefix;
 }
 
 export interface ProductTypeWithCancellationFlow extends ProductType {
@@ -273,6 +275,7 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
       productDetail.subscription.autoRenew
         ? undefined
         : "renew your one-off Guardian Weekly subscription",
+    holidayStopsApiProductNamePrefix: "Guardian Weekly",
     productPage: "subscriptions"
   },
   digipack: {

--- a/app/types/express-with-identity.d.ts
+++ b/app/types/express-with-identity.d.ts
@@ -1,0 +1,12 @@
+interface IdentityDetails {
+  userId?: string;
+  displayName?: string;
+}
+
+declare namespace Express {
+  export interface Response {
+    locals: {
+      identity: IdentityDetails;
+    };
+  }
+}


### PR DESCRIPTION
#### Integrate the `holiday-stop-api` (see https://github.com/guardian/support-service-lambdas/pull/302).

The API sits behind an API Gateway, which requires...

- an `x-api-key` header, the value for which is fetched from a new config file along with the `host` (this differs obviously for each stage). Loading another config file from S3 warranted some refactoring/abstraction of this mechanism, so it's now much cleaner (and along the way found a way to use the `AWS.CredentialProviderChain` rather than overriding `AWS_PROFILE` environment variable, which is lovely - see https://github.com/guardian/dotcom-rendering/issues/575 for more info).
- and an `x-identity-id` header, the value for which was already coming back from the IDAPI call it makes before every request (due to `withIdentity()`) but this needed exposing to subsequent request handler, which is now achieved via `res.locals.identity.userId` - which required some refactoring (during which I was able to eliminate an API call in the `profileRedirectHandler` which is used for the 'Comments & replies' link in the global navigation).

... the integration also has the notion of `normalMode` and `testMode` and the correct instance of the `holiday-stop-lambda` is called based on the value in the...
- `X-Gu-Membership-Test-User` this is somewhat coincidentally the same header as comes back from members-data-api elsewhere in manage, but should be sent for all interactions with the holiday-stop-api

The URL structure in manage differs slightly from the API itself (as it does for other APIs manage interacts with like `members-data-api`)

| Method | manage | holiday-stop-api | Description |
| --- | --- | --- | --- |
| GET | `/api/holidays /{PRODUCT_URL_PART} /potential?startDate={yyyy-MM-dd}&endDate={yyyy-MM-dd}` | `/{STAGE}/potential?startDate={yyyy-MM-dd}&endDate={yyyy-MM-dd}`  (with `x-product-name-prefix` header set)  | returns an array of dates for each issue impacted between the dates for the given product |
| GET | `/api/holidays` | `/{STAGE}/hsr` | returns all holiday stops (past & present) for the user |
| GET | `/api/holidays /{PRODUCT_URL_PART}` | `/{STAGE}/hsr` (with `x-product-name-prefix` header set) | returns all holiday stops (past & present) but including a calculated 'first available date' based on the type of product |
| GET | `/api/holidays /{PRODUCT_URL_PART} /{SUBSCRIPTION_NAME}` | `/{STAGE}/hsr /{SUBSCRIPTION_NAME}` (with `x-product-name-prefix` header set) | returns all holiday stops (past & present) for the user filtered on the specified subscription also including a calculated 'first available date' based on the type of product |
| POST | `/api/holidays /{PRODUCT_URL_PART}` | `/{STAGE}/hsr` | creates a new all holiday stop, example body `{ "start": "2023-06-10", "end": "2024-06-14", "subscriptionName": "A-S00071783" }`|
| DELETE | `/api/holidays /{PRODUCT_URL_PART} /{SUBSCRIPTION_NAME} /{SF_ID}` | `/{STAGE}/hsr /{SUBSCRIPTION_NAME} /{SF_ID}` | deletes the holiday stop request from SalesForce (with Id matching `{SF_ID}`) |

NOTE: `{PRODUCT_URL_PART}` can only be `guardianweekly` at this time based on the definitions in `productTypes.ts` (where this is mapped to `Guardian Weekly` for the `x-product-name-prefix` header)