### PR TITLE
consent banner

### DIFF
--- a/app/client/colours.ts
+++ b/app/client/colours.ts
@@ -34,7 +34,7 @@ const palette = {
   yellow: {
     light: "#fff8e5",
     medium: "#ffe500",
-    dark: "#edd600"
+    dark: "#ffbb50"
   },
   neutral: {
     "1": "#121212",

--- a/app/client/components/analytics.tsx
+++ b/app/client/components/analytics.tsx
@@ -24,14 +24,11 @@ export interface Event {
   eventValue?: number;
 }
 
-export const trackEvent = ({
-  eventCategory,
-  eventAction,
-  product,
-  eventLabel,
-  eventValue
-}: Event) => {
-  if (window.ga) {
+export const trackEvent = (
+  { eventCategory, eventAction, product, eventLabel, eventValue }: Event,
+  alsoTrackInGA = true
+) => {
+  if (alsoTrackInGA && window.ga) {
     window.ga(
       "send",
       "event",
@@ -66,6 +63,8 @@ export const trackEvent = ({
     });
   }
 };
+
+export const trackEventInOphanOnly = (event: Event) => trackEvent(event, false);
 
 export const applyAnyOptimiseExperiments = () => {
   if (typeof window !== "undefined" && window.ga && window.dataLayer) {

--- a/app/client/components/buttons.tsx
+++ b/app/client/components/buttons.tsx
@@ -19,6 +19,8 @@ export interface CommonButtonProps {
   primary?: true;
   hollow?: true;
   hide?: boolean;
+  hoverColour?: string;
+  leftTick?: true;
 }
 
 export interface LinkButtonProps extends CommonButtonProps {
@@ -30,15 +32,20 @@ export interface ButtonProps extends CommonButtonProps {
   onClick?: () => void;
 }
 
-const applyArrowStyleIfApplicable = (
+const applyIconStyleIfApplicable = (
   hover: boolean,
   left?: true,
-  right?: true
+  right?: true,
+  leftTick?: true
 ) => {
   if (left) {
     return hover ? styles.leftHover : styles.left;
   } else if (right) {
     return hover ? styles.rightHover : styles.right;
+  } else if (leftTick) {
+    return {
+      padding: "4px 21px 3px 16px"
+    };
   }
   return {
     padding: "1px 18px 0 18px",
@@ -90,7 +97,9 @@ const buttonCss = ({
   right,
   primary,
   hollow,
-  hide
+  hide,
+  hoverColour,
+  leftTick
 }: CommonButtonProps) => {
   const backgroundColour = calcBackgroundColour(
     disabled,
@@ -115,14 +124,16 @@ const buttonCss = ({
     background: backgroundColour,
     color: calcTextColour(disabled, textColour, primary, hollow),
     border: hollow ? "1px solid" : "none",
-    ...applyArrowStyleIfApplicable(false, left, right),
+    ...applyIconStyleIfApplicable(false, left, right, leftTick),
     ":hover": disabled
       ? undefined
       : {
-          background: Color(backgroundColour)
-            .darken(backgroundColour === defaultColour ? 0.3 : 0.1)
-            .string(),
-          ...applyArrowStyleIfApplicable(true, left, right)
+          background:
+            hoverColour ||
+            Color(backgroundColour)
+              .darken(backgroundColour === defaultColour ? 0.3 : 0.1)
+              .string(),
+          ...applyIconStyleIfApplicable(true, left, right, leftTick)
         },
     cursor: disabled ? "not-allowed" : "pointer",
     [maxWidth.mobile]: {
@@ -136,9 +147,18 @@ const buttonCss = ({
   });
 };
 
-export const ButtonArrow = () => (
+export const ArrowIcon = () => (
   <svg viewBox="0 0 30 30">
     <path d="M22.8 14.6L15.2 7l-.7.7 5.5 6.6H6v1.5h14l-5.5 6.6.7.7 7.6-7.6v-.9" />
+  </svg>
+);
+
+export const TickIcon = () => (
+  <svg
+    viewBox="0 0 10.79 8.608"
+    css={{ height: "auto", width: "21px", marginRight: "10px" }}
+  >
+    <path d="M2.99 6.58L10.24 0l.55.53-7.8 8.08h-.26L0 4.79l.55-.55 2.44 2.33z" />
   </svg>
 );
 
@@ -184,7 +204,7 @@ export const LinkButton = (props: LinkButtonProps) => (
     state={props.state}
   >
     {props.text}
-    <ButtonArrow />
+    <ArrowIcon />
   </Link>
 );
 
@@ -197,7 +217,8 @@ export const Button = (props: ButtonProps) => (
       (event.target as HTMLButtonElement).blur()
     }
   >
+    {props.leftTick && <TickIcon />}
     {props.text}
-    <ButtonArrow />
+    {(props.left || props.right) && <ArrowIcon />}
   </button>
 );

--- a/app/client/components/consent/consentsBanner.tsx
+++ b/app/client/components/consent/consentsBanner.tsx
@@ -1,0 +1,128 @@
+import { RouteComponentProps } from "@reach/router";
+import React from "react";
+import palette from "../../colours";
+import { maxWidth } from "../../styles/breakpoints";
+import { sans } from "../../styles/fonts";
+import { Button } from "../buttons";
+import { PageContainer } from "../page";
+import { Roundel } from "../roundel";
+
+const CONSENT_COOKIE_NAME = "GU_TK";
+const CONSENT_COOKIE_DAYS_TO_LIVE = 30 * 18;
+
+const documentIsAvailable = typeof document !== "undefined" && document;
+
+const requiresConsents = () =>
+  documentIsAvailable &&
+  !document.cookie
+    .split(";")
+    .find(keyValue => keyValue.trim().startsWith(CONSENT_COOKIE_NAME + "="));
+
+export interface ConsentsBannerState {
+  requiresConsents: boolean;
+}
+
+export class ConsentsBanner extends React.Component<
+  RouteComponentProps,
+  ConsentsBannerState
+> {
+  public state = {
+    requiresConsents: false
+  };
+
+  public componentDidMount = () => this.updateStateWithConsents();
+
+  public render = () =>
+    documentIsAvailable && this.state.requiresConsents ? (
+      <div
+        css={{
+          zIndex: 99,
+          position: "fixed",
+          bottom: 0,
+          width: "100%",
+          padding: ".375rem 0 1.5rem",
+          background: palette.neutral["2"],
+          color: palette.white
+        }}
+      >
+        <PageContainer noVerticalMargin>
+          <div
+            css={{
+              maxWidth: "620px",
+              fontSize: "17px",
+              position: "relative",
+              a: {
+                textDecoration: "underline",
+                color: palette.white,
+                ":visited": { color: palette.white }
+              }
+            }}
+          >
+            <div
+              css={{
+                position: "absolute",
+                left: "-80px",
+                [maxWidth.leftCol]: {
+                  display: "none"
+                }
+              }}
+            >
+              <Roundel
+                size={36}
+                fillG={palette.neutral["2"]}
+                fillMain={palette.white}
+              />
+            </div>
+            <h2 css={{ margin: 0, fontWeight: 700 }}>Your privacy</h2>
+            <p>
+              We use cookies to improve your experience on our site and to show
+              you personalised advertising.
+            </p>
+            <p>
+              To find out more, read our{" "}
+              <a href="https://www.theguardian.com/help/privacy-policy">
+                privacy policy
+              </a>
+              {" and "}
+              <a href="https://www.theguardian.com/info/cookies">
+                cookie policy
+              </a>.
+            </p>
+            <Button
+              text="I'm OK with that"
+              onClick={this.writeConsents}
+              hoverColour={palette.yellow.dark}
+              fontWeight="bold"
+              leftTick
+              primary
+            />
+            <a
+              href="https://profile.theguardian.com/privacy-settings"
+              css={{ marginLeft: "10px", fontWeight: "bold", fontFamily: sans }}
+            >
+              My options
+            </a>
+          </div>
+        </PageContainer>
+      </div>
+    ) : null;
+
+  private updateStateWithConsents = () =>
+    this.setState({ requiresConsents: requiresConsents() });
+
+  private writeConsents = () => {
+    const newGuTkCookieValue = `1.${Date.now()}`;
+
+    const expires = new Date();
+    expires.setDate(expires.getDate() + CONSENT_COOKIE_DAYS_TO_LIVE);
+
+    // tslint:disable-next-line:no-object-mutation
+    document.cookie =
+      `${CONSENT_COOKIE_NAME}=${newGuTkCookieValue}; path=/; secure;` +
+      `expires=${expires.toUTCString()};domain=.${window.guardian.domain}`;
+
+    this.updateStateWithConsents();
+  };
+}
+
+export const SuppressConsentBanner = (props: RouteComponentProps) => null;

--- a/app/client/components/consent/consentsBanner.tsx
+++ b/app/client/components/consent/consentsBanner.tsx
@@ -3,12 +3,15 @@ import React from "react";
 import palette from "../../colours";
 import { maxWidth } from "../../styles/breakpoints";
 import { sans } from "../../styles/fonts";
+import { trackEventInOphanOnly } from "../analytics";
 import { Button } from "../buttons";
 import { PageContainer } from "../page";
 import { Roundel } from "../roundel";
 
 const CONSENT_COOKIE_NAME = "GU_TK";
 const CONSENT_COOKIE_DAYS_TO_LIVE = 30 * 18;
+
+const CONSENTS_BANNER_OPHAN_EVENT_CATEGORY = "consents_banner";
 
 const documentIsAvailable = typeof document !== "undefined" && document;
 
@@ -45,6 +48,10 @@ export class ConsentsBanner extends React.Component<
           color: palette.white
         }}
       >
+        {trackEventInOphanOnly({
+          eventCategory: CONSENTS_BANNER_OPHAN_EVENT_CATEGORY,
+          eventAction: "impression"
+        })}
         <PageContainer noVerticalMargin>
           <div
             css={{
@@ -90,7 +97,14 @@ export class ConsentsBanner extends React.Component<
             </p>
             <Button
               text="I'm OK with that"
-              onClick={this.writeConsents}
+              onClick={() => {
+                this.writeConsents();
+                trackEventInOphanOnly({
+                  eventCategory: CONSENTS_BANNER_OPHAN_EVENT_CATEGORY,
+                  eventAction: "click",
+                  eventLabel: "im_ok_with_that"
+                });
+              }}
               hoverColour={palette.yellow.dark}
               fontWeight="bold"
               leftTick
@@ -99,6 +113,13 @@ export class ConsentsBanner extends React.Component<
             <a
               href="https://profile.theguardian.com/privacy-settings"
               css={{ marginLeft: "10px", fontWeight: "bold", fontFamily: sans }}
+              onClick={() =>
+                trackEventInOphanOnly({
+                  eventCategory: CONSENTS_BANNER_OPHAN_EVENT_CATEGORY,
+                  eventAction: "click",
+                  eventLabel: "my_options"
+                })
+              }
             >
               My options
             </a>

--- a/app/client/components/user.tsx
+++ b/app/client/components/user.tsx
@@ -21,6 +21,10 @@ import { CancellationFlow } from "./cancel/cancellationFlow";
 import { CancellationReason } from "./cancel/cancellationReason";
 import { ExecuteCancellation } from "./cancel/stages/executeCancellation";
 import { GenericSaveAttempt } from "./cancel/stages/genericSaveAttempt";
+import {
+  ConsentsBanner,
+  SuppressConsentBanner
+} from "./consent/consentsBanner";
 import { Main } from "./main";
 import { MembershipFAQs } from "./membershipFAQs";
 import { NotFound } from "./notFound";
@@ -112,6 +116,10 @@ const User = () => (
       <MembershipFAQs path="/help" />
 
       <NotFound default={true} />
+    </Router>
+    <Router>
+      <SuppressConsentBanner path="/payment/*" />
+      <ConsentsBanner default={true} />
     </Router>
   </Main>
 );


### PR DESCRIPTION
## Added the standard Guardian consent banner
![image](https://user-images.githubusercontent.com/19289579/59421971-799f4480-8dc7-11e9-8a2a-4734feaf57fa.png)


- Displays only if **`GU_TK`** cookie is NOT present
- The `I'm OK with that` button writes the cookie on the parent domain, i.e. not `manage` sub-domain
- Fairly similar to https://github.com/guardian/support-frontend/pull/1677
- Uses another top-level `<Router>` instance in `user.tsx` to cleanly prevent the banner on the payment flow.

_Also required additions to `<Button>` component (to display the ✔️) plus some tweaks/corrections to the shared colour palette (although this file should be refactored in a future PR to exactly match https://design.theguardian.com/#colour-palette)._