### PR TITLE
Fix huge consent button on IE11

### DIFF
--- a/app/client/components/buttons.tsx
+++ b/app/client/components/buttons.tsx
@@ -156,7 +156,7 @@ export const ArrowIcon = () => (
 export const TickIcon = () => (
   <svg
     viewBox="0 0 10.79 8.608"
-    css={{ height: "auto", width: "21px", marginRight: "10px" }}
+    css={{ height: "16px", width: "21px", marginRight: "10px" }}
   >
     <path d="M2.99 6.58L10.24 0l.55.53-7.8 8.08h-.26L0 4.79l.55-.55 2.44 2.33z" />
   </svg>


### PR DESCRIPTION
# Fix huge consent button on IE11

## Description.
On IE 11 the accept cookies button is unusually large:  
  
![Screen Shot 2019-06-26 at 10 34 36](https://user-images.githubusercontent.com/3016741/60170504-72812900-9800-11e9-9c94-be51c794aa78.png)

By setting the height to a fixed value it prevents the bug:

![Screen Shot 2019-06-26 at 10 43 27](https://user-images.githubusercontent.com/3016741/60170563-95134200-9800-11e9-9aa3-9a0c4d9c0117.png)

## Changes
* Give tick svg a fixed height in `leftTick` `Button` variant.