### PR TITLE
eliminated reliance on GU_SIGNIN_EMAIL cookie 

### DIFF
--- a/app/client/components/payment/update/updatePaymentFlow.tsx
+++ b/app/client/components/payment/update/updatePaymentFlow.tsx
@@ -1,5 +1,4 @@
 import { NavigateFn } from "@reach/router";
-import { get as getCookie } from "es-cookie";
 import Raven from "raven-js";
 import React from "react";
 import {
@@ -134,10 +133,6 @@ interface PaymentUpdaterStepState {
   newPaymentMethodDetail?: NewPaymentMethodDetail;
 }
 
-const getSignInEmailFromCookie = () => {
-  return getCookie("GU_SIGNIN_EMAIL"); // TODO eliminate this because it can be incorrect in the case of 'social' accounts
-};
-
 class PaymentUpdaterStep extends React.Component<
   PaymentUpdaterStepProps,
   PaymentUpdaterStepState
@@ -223,7 +218,7 @@ class PaymentUpdaterStep extends React.Component<
           <CardInputForm
             stripeApiKey={subscription.stripePublicKeyForCardAddition}
             newPaymentMethodDetailUpdater={this.newPaymentMethodDetailUpdater}
-            userEmail={getSignInEmailFromCookie()}
+            userEmail={window.guardian.identityDetails.email}
           />
         ) : (
           <GenericErrorScreen loggingMessage="No Stripe key provided to enable adding a payment method" />
@@ -234,7 +229,9 @@ class PaymentUpdaterStep extends React.Component<
           <CardInputForm
             stripeApiKey={subscription.card.stripePublicKeyForUpdate}
             newPaymentMethodDetailUpdater={this.newPaymentMethodDetailUpdater}
-            userEmail={subscription.card.email || getSignInEmailFromCookie()}
+            userEmail={
+              subscription.card.email || window.guardian.identityDetails.email
+            }
           />
         ) : (
           <GenericErrorScreen loggingMessage="No existing card information to update from" />

--- a/app/package.json
+++ b/app/package.json
@@ -122,7 +122,6 @@
     "base-64": "^0.1.0",
     "browserslist-useragent": "^3.0.0",
     "color": "^3.0.0",
-    "es-cookie": "^1.2.0",
     "express": "^4.16.3",
     "helmet": "^3.12.1",
     "lodash.startcase": "^4.4.0",

--- a/app/server/routes/frontend.ts
+++ b/app/server/routes/frontend.ts
@@ -3,7 +3,6 @@ import { Request, Response, Router } from "express";
 import Raven from "raven";
 import { renderToString } from "react-dom/server";
 import { ServerUser } from "../../client/components/user";
-import { Globals } from "../../shared/globals";
 import { conf, Environments } from "../config";
 import html from "../html";
 import { log } from "../log";
@@ -18,12 +17,6 @@ const clientDSN =
 if (conf.ENVIRONMENT === Environments.PRODUCTION && !conf.CLIENT_DSN) {
   log.error("NO SENTRY IN CLIENT PROD!");
 }
-
-const globals: Globals = {
-  domain: conf.DOMAIN,
-  dsn: clientDSN,
-  supportedBrowser: true
-};
 
 router.use(withIdentity(), (req: Request, res: Response) => {
   /**
@@ -56,7 +49,12 @@ router.use(withIdentity(), (req: Request, res: Response) => {
       body,
       title,
       src,
-      globals
+      globals: {
+        domain: conf.DOMAIN,
+        dsn: clientDSN,
+        supportedBrowser: true,
+        identityDetails: res.locals.identity
+      }
     })
   );
 });

--- a/app/shared/globals.ts
+++ b/app/shared/globals.ts
@@ -14,6 +14,7 @@ export interface Globals {
   abTest?: AbTest;
   polyfilled?: boolean;
   onPolyfilled?: () => void;
+  identityDetails: IdentityDetails;
 }
 
 declare global {

--- a/app/types/express-with-identity.d.ts
+++ b/app/types/express-with-identity.d.ts
@@ -1,5 +1,6 @@
 interface IdentityDetails {
   userId?: string;
+  email?: string;
   displayName?: string;
 }
 

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -3784,11 +3784,6 @@ es-abstract@^1.5.1:
     is-regex "^1.0.4"
     object-keys "^1.0.12"
 
-es-cookie@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/es-cookie/-/es-cookie-1.2.0.tgz#1f942d37f67ebc27739aa3f35cf9432cf2ee3ae9"
-  integrity sha512-Rq23x7fV2NRhDbYHA+ebMUHJGyrHWtLd+xFoQ+Tq5kpsAv6FmqpC/SFdDpFJWiwNW7XUhG3GDxVKymDz7KxSRQ==
-
 es-to-primitive@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377"


### PR DESCRIPTION
(as this being deprecated/decommed and was a nasty long-standing TODO) 

instead using the `email` provided by the IDAPI `/redirect` endpoint response (`email` field added in https://github.com/guardian/identity/pull/1579)