### PR TITLE
Fix missing consents bug on Email and Marketing tab

### DIFF
--- a/app/client/components/identity/idapi/user.ts
+++ b/app/client/components/identity/idapi/user.ts
@@ -16,15 +16,23 @@ interface UserAPIResponse {
   };
 }
 
+const getConsentedTo = (response: UserAPIResponse) => {
+  if ("consents" in response.user) {
+    return response.user.consents
+      .filter((consent: any) => consent.consented)
+      .map((consent: any) => consent.id);
+  } else {
+    return [];
+  }
+};
+
 export const read = async (): Promise<User> => {
   const url = "/user/me";
   const response: UserAPIResponse = await identityFetch(
     url,
     APIUseCredentials({})
   );
-  const consents = response.user.consents
-    .filter((consent: any) => consent.consented)
-    .map((consent: any) => consent.id);
+  const consents = getConsentedTo(response);
   return {
     email: response.user.primaryEmailAddress,
     consents,


### PR DESCRIPTION
## Description
It is possible for a user to have no consent information, we suspect these are users using a legacy setup. IDAPI will return no consent information. The moment they submit a consent option, their consent information will be created for them and they will be able to carry on as usual. 