### PR TITLE
FIX undefined window.Stripe for certain reloads of page 1 of payment update flow

### DIFF
--- a/app/server/html.ts
+++ b/app/server/html.ts
@@ -32,7 +32,6 @@ const html: (
       <title>${title}</title>
       ${insertGlobals(globals)}
       <link rel="shortcut icon" type="image/png" href="https://assets.guim.co.uk/images/favicons/46bd2faa1ab438684a6d4528a655a8bd/32x32.ico" />
-      <script src="https://js.stripe.com/v3/" async></script>
     </head>
     <body style="margin:0">
         ${


### PR DESCRIPTION
If the user had navigated from one of the product pages into the respective payment update flow (i.e. it was instantly passing the productDetail via the browser history state rather than loading again from members-data-api) then if the user reloaded that page it wouldn't have loaded Stripe.js in time and would throw a `window.Stripe is not a function` error.

Fairly rare in production but happened occasionally...
![image](https://user-images.githubusercontent.com/19289579/62965003-07190800-bdfc-11e9-8182-fa29cb1b7ccc.png)

**Now**, it no longer loads the Stripe.js as `async` in the main html template, and instead only loads it dynamically when the card input form is added (which reduces unnecessary downloads for many user journeys 🎉), **the card input form now shows as loading until it has both loaded and initialised Stripe.**
 
_NOTE: this was extracted from https://github.com/guardian/manage-frontend/pull/241 in order to release it quicker._