### PR TITLE
FIX redundant call to members-data-api from the 'flow start component'

### DIFF
--- a/app/client/components/flowStartMultipleProductDetailHandler.tsx
+++ b/app/client/components/flowStartMultipleProductDetailHandler.tsx
@@ -192,16 +192,14 @@ export interface FlowStartMultipleProductDetailHandlerProps
 }
 
 export interface FlowStartMultipleProductDetailHandlerState {
-  selectedProductDetail?: any;
+  selectedProductDetail?: ProductDetail | null;
 }
 
 export class FlowStartMultipleProductDetailHandler extends React.Component<
   FlowStartMultipleProductDetailHandlerProps,
   FlowStartMultipleProductDetailHandlerState
 > {
-  public state: FlowStartMultipleProductDetailHandlerState = {
-    selectedProductDetail: undefined
-  };
+  public state: FlowStartMultipleProductDetailHandlerState = {};
 
   private readonly preWiredProductDetailSelector = getProductDetailSelector(
     this.props,
@@ -212,11 +210,12 @@ export class FlowStartMultipleProductDetailHandler extends React.Component<
 
   // client side render only
   public componentDidMount(): void {
-    if (this.props.location && this.props.location.state) {
-      this.setState({
-        selectedProductDetail: this.props.location.state
-      });
-    }
+    this.setState({
+      selectedProductDetail:
+        this.props.location && hasProduct(this.props.location.state)
+          ? this.props.location.state
+          : null
+    });
   }
 
   public render(): React.ReactNode {
@@ -229,27 +228,34 @@ export class FlowStartMultipleProductDetailHandler extends React.Component<
             {this.props.productType.friendlyName}
           </h1>
         </PageContainer>
-
-        {hasProduct(this.state.selectedProductDetail) ? (
-          this.preWiredProductDetailSelector([this.state.selectedProductDetail])
-        ) : (
-          <MembersDatApiAsyncLoader
-            fetch={
-              createProductDetailFetcher(
-                this.props.productType
-              ) /*TODO reload on 'back' to page*/
-            }
-            readerOnOK={annotateMdaResponseWithTestUserFromHeaders}
-            render={this.preWiredProductDetailSelector}
-            loadingMessage={
-              this.props.loadingMessagePrefix +
-              " " +
-              this.props.productType.friendlyName +
-              "..."
-            }
-          />
-        )}
+        {this.renderInner()}
       </div>
     );
   }
+
+  private renderInner = () => {
+    if (this.state.selectedProductDetail) {
+      return this.preWiredProductDetailSelector([
+        this.state.selectedProductDetail
+      ]);
+    } else if (this.state.selectedProductDetail === null) {
+      return (
+        <MembersDatApiAsyncLoader
+          fetch={
+            createProductDetailFetcher(
+              this.props.productType
+            ) /*TODO reload on 'back' to page*/
+          }
+          readerOnOK={annotateMdaResponseWithTestUserFromHeaders}
+          render={this.preWiredProductDetailSelector}
+          loadingMessage={
+            this.props.loadingMessagePrefix +
+            " " +
+            this.props.productType.friendlyName +
+            "..."
+          }
+        />
+      );
+    }
+  };
 }


### PR DESCRIPTION
The `FlowStartMultipleProductDetailHandler` component wraps all multi-step flows (e.g. payment update flow, cancellation flow, holiday-stops flow), it's purpose is to handle scenarios where people have multiple subscriptions of the same type of product and present them with a flow-specific way of selecting the right subscription. If a user navigates from one of the product pages then we already use the [browser history state](https://developer.mozilla.org/en-US/docs/Web/API/History/state) to avoid the user waiting to load the same data again from `members-data-api` however if the user comes to a flow directly (say from a payment failure email) and they have multiple subscriptions of the same type of product then they see the options.

When working on https://github.com/guardian/manage-frontend/pull/241, I noticed an unnecessary call to members-data-api, which then resulted in a `no-op` when it attempted to call `setState()` on the `MembersDatApiAsyncLoader` component that had only been on the screen momentarily (because it had been server-side rendered).

Essentially a race condition where the `componentDidMount()` of the `MembersDatApiAsyncLoader` would fire before the `componentDidMount()` of `FlowStartMultipleProductDetailHandler`. The issues arise to do with server-side rendering, as `componentDidMount()` is only fired on the client-side (i.e. where we have the browser history state)
Now we make use of `null` for `selectedProductDetail` to denote that there definitely isn't any browser history state and render the `MembersDatApiAsyncLoader` which in turn will actually call `members-data-api`. In the server-side render `selectedProductDetail` will be undefined and so won't render anything in the new approach.