### PR TITLE
Fix minor bug causing APIFetch's last resort error decode to fail

### DIFF
--- a/app/client/components/identity/idapi/fetch.ts
+++ b/app/client/components/identity/idapi/fetch.ts
@@ -2,10 +2,12 @@ import { IdentityLocations } from "../IdentityLocations";
 
 const handleResponseFailure = async (response: Response) => {
   let err;
+  // json() and text() can only be used once on a response, so a copy is needed
+  const responseCopy = response.clone();
   try {
     err = await response.json();
   } catch (e) {
-    err = await response.text();
+    err = await responseCopy.text();
   }
   throw new Error(`Response error: ${err}`);
 };

--- a/app/client/components/identity/idapi/fetch.ts
+++ b/app/client/components/identity/idapi/fetch.ts
@@ -1,14 +1,7 @@
 import { IdentityLocations } from "../IdentityLocations";
 
 const handleResponseFailure = async (response: Response) => {
-  let err;
-  // json() and text() can only be used once on a response, so a copy is needed
-  const responseCopy = response.clone();
-  try {
-    err = await response.json();
-  } catch (e) {
-    err = await responseCopy.text();
-  }
+  const err = await response.text();
   throw new Error(`Response error: ${err}`);
 };
 


### PR DESCRIPTION
## Description
As a last resort, APIFetch will attempt to decode a response as text if the previous attempt at decoding it as JSON fails. However the fetch response object may only call a decode function once, so a clone is needed.