### PR TITLE
remove "browserslist-useragent" since we're not really making proper use of it

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -121,7 +121,6 @@
     "@reach/router": "^1.2.1",
     "aws-sdk": "^2.383.0",
     "base-64": "^0.1.0",
-    "browserslist-useragent": "^3.0.0",
     "color": "^3.0.0",
     "express": "^4.16.3",
     "helmet": "^3.12.1",

--- a/app/server/html.ts
+++ b/app/server/html.ts
@@ -34,11 +34,6 @@ const html: (
       <link rel="shortcut icon" type="image/png" href="https://assets.guim.co.uk/images/favicons/46bd2faa1ab438684a6d4528a655a8bd/32x32.ico" />
     </head>
     <body style="margin:0">
-        ${
-          globals.supportedBrowser
-            ? ""
-            : '<p style="text-align: center; margin: 0; padding: 10px; background-color: #005689; color: #fff">manage.theguardian.com is not optimised for your current browser, for more information, see <a href="https://www.theguardian.com/help/recommended-browsers" style="color: #FFF; text-decoration: underline">our list of recommended browsers</a></p>'
-        }
       <div id="app">${body}</div>
       </body>
       <script>

--- a/app/server/routes/frontend.ts
+++ b/app/server/routes/frontend.ts
@@ -1,6 +1,4 @@
-import { matchesUA } from "browserslist-useragent";
 import { Request, Response, Router } from "express";
-import Raven from "raven";
 import { renderToString } from "react-dom/server";
 import { ServerUser } from "../../client/components/user";
 import { conf, Environments } from "../config";
@@ -26,23 +24,6 @@ router.use(withIdentity(), (req: Request, res: Response) => {
   const body = renderToString(ServerUser(req.url));
   const title = "My Account | The Guardian";
   const src = "/static/user.js";
-  const supportedBrowser = matchesUA(req.headers["user-agent"], {
-    env:
-      conf.ENVIRONMENT === Environments.PRODUCTION
-        ? "production"
-        : "development",
-    allowHigherVersions: true
-  });
-
-  // Object.assign(globals, { supportedBrowser });
-
-  if (!supportedBrowser) {
-    log.warn(`Unsupported Browser. UA: ${req.headers["user-agent"]}`);
-
-    Raven.captureMessage("Unsupported Browser", {
-      extra: { "User-Agent": req.headers["user-agent"] }
-    });
-  }
 
   res.send(
     html({
@@ -52,7 +33,6 @@ router.use(withIdentity(), (req: Request, res: Response) => {
       globals: {
         domain: conf.DOMAIN,
         dsn: clientDSN,
-        supportedBrowser: true,
         identityDetails: res.locals.identity
       }
     })

--- a/app/shared/globals.ts
+++ b/app/shared/globals.ts
@@ -3,7 +3,6 @@ import { AbTest, OphanComponentEvent } from "./ophanTypes";
 export interface Globals {
   domain: string;
   dsn: string | null;
-  supportedBrowser: boolean;
   spaTransition?: true;
   INTCMP?: string;
   ophan?: {

--- a/app/types/browserslist-useragent.d.ts
+++ b/app/types/browserslist-useragent.d.ts
@@ -1,1 +1,0 @@
-declare module "browserslist-useragent";

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2617,24 +2617,6 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
-browserslist-useragent@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/browserslist-useragent/-/browserslist-useragent-3.0.0.tgz#700d21aea15cf4b3de9322f6981c9a8a19400ee8"
-  integrity sha512-WtTf+Mk4cmQB7Wwnq6P0R5IjY5Y+fjHvEeNpbxCtD0Lgfe5NEojLL63c1PgW6BIFZbmncpNNoOsSlhYS0SxSTw==
-  dependencies:
-    browserslist "^4.3.6"
-    semver "^5.6.0"
-    useragent "^2.3.0"
-
-browserslist@^4.3.6:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.6.2.tgz#574c665950915c2ac73a4594b8537a9eba26203f"
-  integrity sha512-2neU/V0giQy9h3XMPwLhEY3+Ao0uHSwHvU8Q1Ea6AgLVL1sXbX3dzPrJ8NWe5Hi4PoTkCYXOtVR9rfRLI0J/8Q==
-  dependencies:
-    caniuse-lite "^1.0.30000974"
-    electron-to-chromium "^1.3.150"
-    node-releases "^1.1.23"
-
 browserslist@^4.5.2, browserslist@^4.5.4:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.5.4.tgz#166c4ecef3b51737a42436ea8002aeea466ea2c7"
@@ -2799,11 +2781,6 @@ caniuse-lite@^1.0.30000955:
   version "1.0.30000960"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000960.tgz#ec48297037e5607f582f246ae7b12bee66a78999"
   integrity sha512-7nK5qs17icQaX6V3/RYrJkOsZyRNnroA4+ZwxaKJzIKy+crIy0Mz5CBlLySd2SNV+4nbUZeqeNfiaEieUBu3aA==
-
-caniuse-lite@^1.0.30000974:
-  version "1.0.30000974"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000974.tgz#b7afe14ee004e97ce6dc73e3f878290a12928ad8"
-  integrity sha512-xc3rkNS/Zc3CmpMKuczWEdY2sZgx09BkAxfvkxlAEBTqcMHeL8QnPqhKse+5sRTi3nrw2pJwToD2WvKn1Uhvww==
 
 capture-exit@^1.2.0:
   version "1.2.0"
@@ -3767,11 +3744,6 @@ electron-to-chromium@^1.3.122:
   version "1.3.124"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.124.tgz#861fc0148748a11b3e5ccebdf8b795ff513fa11f"
   integrity sha512-glecGr/kFdfeXUHOHAWvGcXrxNU+1wSO/t5B23tT1dtlvYB26GY8aHzZSWD7HqhqC800Lr+w/hQul6C5AF542w==
-
-electron-to-chromium@^1.3.150:
-  version "1.3.155"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.155.tgz#ebf0cc8eeaffd6151d1efad60fd9e021fb45fd3a"
-  integrity sha512-/ci/XgZG8jkLYOgOe3mpJY1onxPPTDY17y7scldhnSjjZqV6VvREG/LvwhRuV7BJbnENFfuDWZkSqlTh4x9ZjQ==
 
 elliptic@^6.0.0:
   version "6.4.1"
@@ -6395,7 +6367,7 @@ lowercase-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
   integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
 
-lru-cache@4.1.x, lru-cache@^4.0.0, lru-cache@^4.0.1, lru-cache@^4.1.1, lru-cache@^4.1.2:
+lru-cache@^4.0.0, lru-cache@^4.0.1, lru-cache@^4.1.1, lru-cache@^4.1.2:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
   integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
@@ -6953,13 +6925,6 @@ node-releases@^1.1.13:
   version "1.1.14"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.14.tgz#f1f41c83cac82caebd6739e6313d56b3b09c9189"
   integrity sha512-d58EpVZRhQE60kWiWUaaPlK9dyC4zg3ZoMcHcky2d4hDksyQj0rUozwInOl0C66mBsqo01Tuns8AvxnL5S7PKg==
-  dependencies:
-    semver "^5.3.0"
-
-node-releases@^1.1.23:
-  version "1.1.23"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.23.tgz#de7409f72de044a2fa59c097f436ba89c39997f0"
-  integrity sha512-uq1iL79YjfYC0WXoHbC/z28q/9pOl8kSHaXdWmAAc8No+bDwqkZbzIJz55g/MUsPgSGm9LZ7QSUbzTcH5tz47w==
   dependencies:
     semver "^5.3.0"
 
@@ -9434,7 +9399,7 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
-tmp@0.0.33, tmp@0.0.x, tmp@^0.0.33:
+tmp@0.0.33, tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
   integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
@@ -9847,14 +9812,6 @@ user-home@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"
   integrity sha1-K1viOjK2Onyd640PKNSFcko98ZA=
-
-useragent@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/useragent/-/useragent-2.3.0.tgz#217f943ad540cb2128658ab23fc960f6a88c9972"
-  integrity sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==
-  dependencies:
-    lru-cache "4.1.x"
-    tmp "0.0.x"
 
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
A **long time back** we added `browserslist-useragent` dependency in-order to be able to interpret our '[browserlist](https://browserl.ist/)' config (in the `package.json` and used by 'babel') and use it at runtime (server-side) to compare against the `User-Agent`, so we could present an 'unsupported browser' banner accordingly - see - see https://github.com/guardian/manage-frontend/pull/101.

Shortly after we observed some mistaken displays of this banner on browsers which were actually supported, so we added some logging (https://github.com/guardian/manage-frontend/pull/102) but ultimately disabled the banner by forcing the `supportedBrowser` boolean to true (https://github.com/guardian/manage-frontend/pull/104) leaving the logging in place to see if we could figure out a pattern to the mistakes... **this was almost a year ago**.

**I don't anticipate being able to diagnose the problems with the `matchesUA` function any time soon and since `browserslist-useragent` and the underlying transitive dependency `useragent` has a Snyk vulnerability it makes sense to remove this stuff for the foreseeable.** _Not to mention it spamming the logs and Sentry._