### PR TITLE
Enable raven/sentry on the CMP UI

### DIFF
--- a/app/client/consent.tsx
+++ b/app/client/consent.tsx
@@ -1,6 +1,17 @@
+import Raven from "raven-js";
 import React from "react";
 import ReactDOM from "react-dom";
 import { App } from "../client/components/consent/App";
+
+declare var WEBPACK_BUILD: string;
+
+if (typeof window !== "undefined" && window.guardian && window.guardian.dsn) {
+  Raven.config(window.guardian.dsn, {
+    release: WEBPACK_BUILD || "local",
+    environment: window.guardian.domain,
+    tags: { feature: "CMP" }
+  }).install();
+}
 
 const onPolyfilled = (): void => {
   const element = document.getElementById("app");

--- a/app/server/consent/html.ts
+++ b/app/server/consent/html.ts
@@ -1,11 +1,20 @@
+import { CommonGlobals } from "../../shared/globals";
+
+const insertGlobals = (globals: CommonGlobals) => {
+  return `<script>
+  window.guardian = ${JSON.stringify(globals)}
+  </script>`;
+};
+
 const fontLoaderClassName = "gu-font-loader-iframe";
 const html: (
   _: {
     readonly body: string;
     readonly title: string;
     readonly scripts: string[];
+    readonly globals: CommonGlobals;
   }
-) => string = ({ body, title, scripts }) => `
+) => string = ({ body, title, scripts, globals }) => `
   <!DOCTYPE html>
   <html>
     <head>
@@ -16,14 +25,9 @@ const html: (
         .map(url => `<link rel="preload" href="${url}" as="script">`)
         .join("\n")}
       <link rel="shortcut icon" type="image/png" href="https://assets.guim.co.uk/images/favicons/46bd2faa1ab438684a6d4528a655a8bd/32x32.ico" />
+      ${insertGlobals(globals)}
       <script>
-        // we use the window.guardian.polyfilled to identify whether polyfill.io has run
-        window.guardian = {
-          polyfilled: false
-        };
-        // this is a global that's called at the bottom of the pf.io response,
-        // once the polyfills have run. This may be useful for debugging.
-        // mainly to support browsers that don't support async=false or defer
+        // we use the window.guardian.polyfilled to identify whether polyfill.io has run.
         function guardianPolyfilled() {
             try {
                 window.guardian.polyfilled = true;

--- a/app/server/routes/consent.ts
+++ b/app/server/routes/consent.ts
@@ -1,7 +1,18 @@
 import { Response, Router } from "express";
 import { renderToString } from "react-dom/server";
 import { App } from "../../client/components/consent/App";
+import { conf, Environments } from "../config";
 import html from "../consent/html";
+import { log } from "../log";
+
+const clientDSN =
+  conf.ENVIRONMENT === Environments.PRODUCTION && conf.CLIENT_DSN
+    ? conf.CLIENT_DSN
+    : null;
+
+if (conf.ENVIRONMENT === Environments.PRODUCTION && !conf.CLIENT_DSN) {
+  log.error("NO SENTRY IN CLIENT PROD!");
+}
 
 const router = Router();
 
@@ -13,11 +24,17 @@ router.get("/", (_, res: Response) => {
     const scripts = [polyfillIO, consentJS];
     const body = renderToString(App());
     const title = "Consent Management Platform | The Guardian";
+    const globals = {
+      domain: conf.DOMAIN,
+      dsn: clientDSN,
+      polyfilled: false
+    };
 
     const resp = html({
       body,
       title,
-      scripts
+      scripts,
+      globals
     });
 
     res.status(200).send(resp);

--- a/app/shared/globals.ts
+++ b/app/shared/globals.ts
@@ -1,8 +1,13 @@
 import { AbTest, OphanComponentEvent } from "./ophanTypes";
 
-export interface Globals {
+export interface CommonGlobals {
   domain: string;
   dsn: string | null;
+  polyfilled?: boolean;
+  onPolyfilled?: () => void;
+}
+
+export interface Globals extends CommonGlobals {
   spaTransition?: true;
   INTCMP?: string;
   ophan?: {
@@ -11,8 +16,6 @@ export interface Globals {
     sendInitialEvent: (url?: string, referer?: string) => void;
   };
   abTest?: AbTest;
-  polyfilled?: boolean;
-  onPolyfilled?: () => void;
   identityDetails: IdentityDetails;
 }
 


### PR DESCRIPTION
This PR enables raven/sentry error capturing on the CMP UI. The implementation is largely based upon the technique used elsewhere in `manage-frontend`.