### PR TITLE
Send message from CMP UI to notify parent consent has been saved

### DIFF
--- a/app/client/components/consent/PrivacySettings.tsx
+++ b/app/client/components/consent/PrivacySettings.tsx
@@ -14,6 +14,7 @@ const CONSENT_SCREEN = 0;
 const CONSENT_LANGUAGE = "en";
 const CMP_READY_MSG = "readyCmp";
 const CMP_CLOSE_MSG = "closeCmp";
+const CMP_SAVED_MSG = "savedCmp";
 
 const iabVendorListURL =
   "https://assets.guim.co.uk/data/vendor/4f4a6324c7fe376c17ceb2288a84a076/cmp_vendorlist.json";
@@ -486,6 +487,9 @@ export class PrivacySettings extends Component<{}, State> {
     consentData.setVendorsAllowed(allowedVendors);
 
     writeIabCookie(consentData.getConsentString());
+
+    // Notify parent that consent has been saved
+    window.parent.postMessage(CMP_SAVED_MSG, "*");
 
     return true;
   }

--- a/app/server/consent/html.ts
+++ b/app/server/consent/html.ts
@@ -82,8 +82,6 @@ const html: (
                 e.data.fonts.forEach(useFont);
               }
             });
-
-            document.body.appendChild(iframe);
           };
 
           document.addEventListener('DOMContentLoaded', loadFonts);


### PR DESCRIPTION
This PR introduces a new post message emitted from the CMP UI to notify it's `window.parent` consent has been saved. The module [lib/cmp.js](https://github.com/guardian/frontend/blob/master/static/src/javascripts/lib/cmp.js) that currently lives in frontend will listen for this message and upon receiving it will execute any callbacks that have been scheduled to execute when consent changes.

The corresponding PR that handles these events is here: https://github.com/guardian/frontend/pull/21766