### PR TITLE
Activate Profile Tab Migration Test

### DIFF
--- a/app/client/__tests__/__snapshots__/main.tsx.snap
+++ b/app/client/__tests__/__snapshots__/main.tsx.snap
@@ -96,7 +96,7 @@ exports[`Main renders something 1`] = `
                   "styles": "padding:7px 20px 15px 30px;text-decoration:none;color:currentColor;white-space:nowrap;position:relative;margin-top:-1px;display:flex;align-items:center;:hover, :focus{background-color:#ececec;text-decoration:none;}:focus{outline:0;}",
                 }
               }
-              href="https://profile.thegulocal.com/public/edit"
+              href="/public-settings"
             >
               <span>
                 Public profile

--- a/app/client/components/nav.tsx
+++ b/app/client/components/nav.tsx
@@ -82,7 +82,8 @@ export interface NavLinks {
 export const navLinks: NavLinks = {
   publicProfile: {
     title: "Public profile",
-    link: "/public/edit"
+    link: "/public-settings",
+    local: true
   },
   accountDetails: {
     title: "Account details",

--- a/app/client/components/userNav.tsx
+++ b/app/client/components/userNav.tsx
@@ -133,7 +133,7 @@ export class UserNav extends React.Component {
     },
     {
       title: "Public profile",
-      link: `${profileHostName}/public/edit`
+      link: `/public-settings`
     },
     {
       title: "Account details",


### PR DESCRIPTION
## Description
Partially release #239 to audience. Users will only be able to access the new tab via indirect navigation, i.e. navigating to another manage.guardian tab and then navigating to the public profile tab

## Depends on
* #239 