### PR TITLE
canary launch GW holiday stops to  approx. 10% of users (based on their identity ID)

### DIFF
--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -391,10 +391,11 @@ const getProductDetailRenderer = (
                   />
                 </a>
               ))}
-            {shouldHaveHolidayStopsFlow(
-              productType
-            ) /* `${window.guardian.identityDetails.userId}`.endsWith("2") || /* approx 10% rollout TODO uncomment to launch the canary release*/ &&
-              (window &&
+            {shouldHaveHolidayStopsFlow(productType) &&
+              window &&
+              (`${window.guardian.identityDetails.userId}`.endsWith(
+                "2" /* approx 10% rollout */
+              ) ||
                 parse(window.location.href, true).query.showHolidayStops ===
                   "true") && (
                 <LinkButton


### PR DESCRIPTION
This PR displays the entry button into the holiday stops flow for Guardian Weekly, on the subscriptions tab, for approx 10% of users 🚀.

This approx 10% is determined by the users identity ID, specifically if their identity ID ends in `2`. Using this approach for canary release is to ensure that the same customers who initially see this functionality always have access to it, including across devices - which isn't guaranteed when using other approaches.

#### Related PRs
Main PR - https://github.com/guardian/manage-frontend/pull/227
Responsiveness PR - https://github.com/guardian/manage-frontend/pull/267