### PR TITLE
Added no-empty-interface tslint rule

### DIFF
--- a/app/tslint.json
+++ b/app/tslint.json
@@ -10,6 +10,7 @@
   "rules": {
     "object-literal-sort-keys": false, // we use emotion css objects for styles alphabetising the rules will make them harder to reason about
     "interface-name": false,
+    "no-empty-interface": true,
     // Recommended built-in rules
     "no-var-keyword": true,
     "no-parameter-reassignment": true,


### PR DESCRIPTION
Added the `no-empty-interface` tslint rule that prevents using a type/interface that's hasn't been declared. Before it would silently assume type `any`. Now it'll throw an error instead.