### PR TITLE
increase canary percentage of GW Holiday Stops CTA (from subscriptions tab) to 50% 

### DIFF
--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -393,16 +393,34 @@ const getProductDetailRenderer = (
               ))}
             {shouldHaveHolidayStopsFlow(productType) &&
               window &&
-              (`${window.guardian.identityDetails.userId}`.endsWith(
-                "2" /* approx 10% rollout */
+              (["0", "2", "4", "6", "8"].includes(
+                `${window.guardian.identityDetails.userId}`.charAt(
+                  `${window.guardian.identityDetails.userId}`.length - 1
+                )
               ) ||
                 parse(window.location.href, true).query.showHolidayStops ===
                   "true") && (
-                <LinkButton
-                  text="Manage your suspensions"
-                  to={"/suspend/" + productType.urlPart}
-                  state={productDetail}
-                  right
+                <ProductDetailRow
+                  label="Holiday stop"
+                  data={
+                    <div>
+                      <div
+                        css={{
+                          display: "inline-block",
+                          margin: "10px",
+                          marginLeft: 0
+                        }}
+                      >
+                        Going on holiday?
+                      </div>
+                      <LinkButton
+                        text="Manage your suspensions"
+                        to={"/suspend/" + productType.urlPart}
+                        state={productDetail}
+                        right
+                      />
+                    </div>
+                  }
                 />
               )}
           </PageContainer>


### PR DESCRIPTION
With the existing 10% and minimal CTA we were simply not seeing enough traffic to evaluate the Holiday Stops Flow feature. This PR **ups that to 50%** (based on `identity ID` ending with a `0`,`2`,`4`,`6` OR `8`).

Also includes slightly more inviting copy (which mentions 'Holiday stop' explicitly)...

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/19289579/64712513-45651e00-d4b3-11e9-9531-ee5f685e556b.png) | ![image](https://user-images.githubusercontent.com/19289579/64713052-26b35700-d4b4-11e9-9efd-81553ec6e06a.png) |
