### PR TITLE
remove canary percentage logic for GW Holiday Stops CTA (i.e. release 💯%)

### DIFF
--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -4,7 +4,6 @@ import { startCase } from "lodash";
 import { toWords } from "number-to-words";
 import Raven from "raven-js";
 import React from "react";
-import parse from "url-parse";
 import {
   alertTextWithoutCTA,
   annotateMdaResponseWithTestUserFromHeaders,
@@ -391,38 +390,30 @@ const getProductDetailRenderer = (
                   />
                 </a>
               ))}
-            {shouldHaveHolidayStopsFlow(productType) &&
-              window &&
-              (["0", "2", "4", "6", "8"].includes(
-                `${window.guardian.identityDetails.userId}`.charAt(
-                  `${window.guardian.identityDetails.userId}`.length - 1
-                )
-              ) ||
-                parse(window.location.href, true).query.showHolidayStops ===
-                  "true") && (
-                <ProductDetailRow
-                  label="Holiday stop"
-                  data={
-                    <div>
-                      <div
-                        css={{
-                          display: "inline-block",
-                          margin: "10px",
-                          marginLeft: 0
-                        }}
-                      >
-                        Going on holiday?
-                      </div>
-                      <LinkButton
-                        text="Manage your suspensions"
-                        to={"/suspend/" + productType.urlPart}
-                        state={productDetail}
-                        right
-                      />
+            {shouldHaveHolidayStopsFlow(productType) && (
+              <ProductDetailRow
+                label="Holiday stop"
+                data={
+                  <div>
+                    <div
+                      css={{
+                        display: "inline-block",
+                        margin: "10px",
+                        marginLeft: 0
+                      }}
+                    >
+                      Going on holiday?
                     </div>
-                  }
-                />
-              )}
+                    <LinkButton
+                      text="Manage your suspensions"
+                      to={"/suspend/" + productType.urlPart}
+                      state={productDetail}
+                      right
+                    />
+                  </div>
+                }
+              />
+            )}
           </PageContainer>
         </>
       )}


### PR DESCRIPTION
Follows on from

- 10% canary release - https://github.com/guardian/manage-frontend/pull/266
- 50% canary release - https://github.com/guardian/manage-frontend/pull/270

This PR removes all that canary percentage logic and also the URL parameter since there's no point in that now.