### PR TITLE
allow frame ancestors from localhost and thegulocal when CODE

### DIFF
--- a/app/server/server.ts
+++ b/app/server/server.ts
@@ -45,13 +45,20 @@ server.use("/profile/", routes.profile);
 server.use("/api/", routes.api);
 server.use(routes.productsProvider("/api/"));
 
+const isCode = conf.DOMAIN === "code.dev-theguardian.com";
+const frameAncestors = isCode
+  ? `https://*.${
+      conf.DOMAIN
+    } http://localhost:9000 http://localhost:3000 http://*.thegulocal.com`
+  : `https://*.${conf.DOMAIN}`;
+
 server.use(
   "/consent/",
   (req, res, next) => {
     // This route can be loaded in an iframe from the domains listed below only
     res.setHeader(
       "Content-Security-Policy",
-      `frame-ancestors https://*.${conf.DOMAIN}`
+      `frame-ancestors ${frameAncestors}`
     );
     next();
   },


### PR DESCRIPTION
This PR updates the `content-security-policy` for the `/consent` route to allow it to be iframed in from sites running on `localhost` and `thegulocal` when `manage-fromtend` is running on `CODE`.

We're doing this so developers running `frontend` locally don't have to have `manage-frontend` running locally to see a CMP UI.