### PR TITLE
holiday-stops: use V2 /potential endpoint of holiday-stop-api

### DIFF
--- a/app/client/components/holiday/holidayDateChooser.tsx
+++ b/app/client/components/holiday/holidayDateChooser.tsx
@@ -474,7 +474,11 @@ export class HolidayDateChooser extends React.Component<
         </>
       );
     } else {
-      return <Spinner />;
+      return (
+        <div css={{ [maxWidth.phablet]: { width: "100%" } }}>
+          <Spinner />
+        </div>
+      );
     }
   };
 }

--- a/app/client/components/holiday/holidayDateChooser.tsx
+++ b/app/client/components/holiday/holidayDateChooser.tsx
@@ -129,9 +129,9 @@ export class HolidayDateChooser extends React.Component<
                 );
 
                 const combinedIssuesImpactedPerYear = calculateIssuesImpactedPerYear(
-                  holidayStopsResponse.existing
-                    .map(existing => existing.publicationDatesToBeStopped)
-                    .flat(),
+                  holidayStopsResponse.existing.flatMap(
+                    existing => existing.publicationDatesToBeStopped
+                  ),
                   renewalDateMoment
                 );
 

--- a/app/client/components/holiday/holidayStopApi.ts
+++ b/app/client/components/holiday/holidayStopApi.ts
@@ -20,6 +20,14 @@ export interface RawHolidayStopRequest {
   }>;
 }
 
+export interface HolidayStopDetail {
+  publicationDate: string;
+}
+
+export interface PotentialHolidayStopsResponse<T extends HolidayStopDetail> {
+  potentials: T[];
+}
+
 export interface HolidayStopRequest {
   publicationDatesToBeStopped: Moment[];
   dateRange: DateRange;

--- a/app/client/components/holiday/holidaysOverview.tsx
+++ b/app/client/components/holiday/holidaysOverview.tsx
@@ -70,9 +70,9 @@ const renderHolidayStopsOverview = (
   );
 
   const combinedIssuesImpactedPerYear = calculateIssuesImpactedPerYear(
-    holidayStopsResponse.existing
-      .map(existing => existing.publicationDatesToBeStopped)
-      .flat(),
+    holidayStopsResponse.existing.flatMap(
+      existing => existing.publicationDatesToBeStopped
+    ),
     renewalDateMoment
   );
 

--- a/app/server/holidayStopApiHandlers.ts
+++ b/app/server/holidayStopApiHandlers.ts
@@ -16,16 +16,17 @@ export const getHolidayStopApiHandler = (
         const hsrEnvConfig =
           testUserHeader === "true" ? hsrConfig.testMode : hsrConfig.normalMode;
         const isPotentialCall = req.params.sfId === "potential";
-        const maybeActualExistingSfId = !isPotentialCall
-          ? req.params.sfId
-          : undefined;
+        const basePathPart = isPotentialCall ? "potential" : "hsr";
+        const maybeActualExistingSfId = isPotentialCall
+          ? undefined
+          : req.params.sfId;
         fetch(
           url.format({
             protocol: "https",
             host: hsrEnvConfig.host,
             pathname:
               req.params && req.params.subscriptionName
-                ? `/${isPotentialCall ? "potential" : "hsr"}/${
+                ? `/${basePathPart}/${
                     req.params.subscriptionName
                   }/${maybeActualExistingSfId || ""}`
                 : "/hsr",

--- a/app/server/holidayStopApiHandlers.ts
+++ b/app/server/holidayStopApiHandlers.ts
@@ -15,19 +15,20 @@ export const getHolidayStopApiHandler = (
         const testUserHeader = req.header(MDA_TEST_USER_HEADER);
         const hsrEnvConfig =
           testUserHeader === "true" ? hsrConfig.testMode : hsrConfig.normalMode;
+        const isPotentialCall = req.params.sfId === "potential";
+        const maybeActualExistingSfId = !isPotentialCall
+          ? req.params.sfId
+          : undefined;
         fetch(
           url.format({
             protocol: "https",
             host: hsrEnvConfig.host,
             pathname:
-              (req.params && req.params.subscriptionName
-                ? req.params.subscriptionName === "potential"
-                  ? "/potential"
-                  : `/hsr/${req.params.subscriptionName}`
-                : "/hsr") +
-              (req.params && req.params.subscriptionName && req.params.sfId
-                ? `/${req.params.sfId}`
-                : ""),
+              req.params && req.params.subscriptionName
+                ? `/${isPotentialCall ? "potential" : "hsr"}/${
+                    req.params.subscriptionName
+                  }/${maybeActualExistingSfId || ""}`
+                : "/hsr",
             query: req.query
           }),
           {


### PR DESCRIPTION
Refactor to call V2 of the `/potential` endpoint of `holiday-stop-api` which now takes subscription name as a path parameter. This enables the transitionary code & naming in that lambda to be eliminated (see https://github.com/guardian/support-service-lambdas/pull/413).

PLUS couple of quick tweaks...

- replaced instances of `map()` followed by `flat()`, with `flatMap()` - for better browser compatibility
- minor UI tweak for /potential spinner on larger mobiles to prevent jank

### follow-up PR will actually display these estimated credits throughout the flow