### PR TITLE
holiday stops : self-serve : estimated credits

### DIFF
--- a/app/client/components/holiday/holidayConfirmed.tsx
+++ b/app/client/components/holiday/holidayConfirmed.tsx
@@ -1,4 +1,8 @@
 import React from "react";
+import {
+  hasProduct,
+  MembersDataApiResponseContext
+} from "../../../shared/productResponse";
 import { LinkButton } from "../buttons";
 import { GenericErrorScreen } from "../genericErrorScreen";
 import {
@@ -22,39 +26,53 @@ export const HolidayConfirmed = (props: RouteableStepProps) => (
   <HolidayStopsResponseContext.Consumer>
     {holidayStopsResponse =>
       isHolidayStopsResponse(holidayStopsResponse) ? (
-        <HolidayDateChooserStateContext.Consumer>
-          {dateChooserState =>
-            isSharedHolidayDateChooserState(dateChooserState) ? (
-              <WizardStep routeableStepProps={props} hideBackButton>
-                <div>
-                  <h1>Your schedule has been set</h1>
-                  <p>{creditExplainerSentence}</p>
-                  <SummaryTable data={dateChooserState} />
-                  <div css={{ ...buttonBarCss, justifyContent: "flex-end" }}>
-                    <div css={{ marginBottom: "10px" }}>
-                      <LinkButton
-                        to={"/suspend/" + props.productType.urlPart + "/create"}
-                        onClick={holidayStopsResponse.reload}
-                        text="Schedule another suspension"
-                        right
+        <MembersDataApiResponseContext.Consumer>
+          {productDetail => (
+            <HolidayDateChooserStateContext.Consumer>
+              {dateChooserState =>
+                isSharedHolidayDateChooserState(dateChooserState) &&
+                hasProduct(productDetail) ? (
+                  <WizardStep routeableStepProps={props} hideBackButton>
+                    <div>
+                      <h1>Your schedule has been set</h1>
+                      <p>{creditExplainerSentence}</p>
+                      <SummaryTable
+                        data={dateChooserState}
+                        subscription={productDetail.subscription}
                       />
+                      <div
+                        css={{ ...buttonBarCss, justifyContent: "flex-end" }}
+                      >
+                        <div css={{ marginBottom: "10px" }}>
+                          <LinkButton
+                            to={
+                              "/suspend/" +
+                              props.productType.urlPart +
+                              "/create"
+                            }
+                            onClick={holidayStopsResponse.reload}
+                            text="Schedule another suspension"
+                            right
+                          />
+                        </div>
+                        <div css={{ marginBottom: "10px", marginLeft: "20px" }}>
+                          <LinkButton
+                            to={"/" + props.productType.urlPart}
+                            text="Manage your subscriptions"
+                            primary
+                            right
+                          />
+                        </div>
+                      </div>
                     </div>
-                    <div css={{ marginBottom: "10px", marginLeft: "20px" }}>
-                      <LinkButton
-                        to={"/" + props.productType.urlPart}
-                        text="Manage your subscriptions"
-                        primary
-                        right
-                      />
-                    </div>
-                  </div>
-                </div>
-              </WizardStep>
-            ) : (
-              visuallyNavigateToParent(props)
-            )
-          }
-        </HolidayDateChooserStateContext.Consumer>
+                  </WizardStep>
+                ) : (
+                  visuallyNavigateToParent(props)
+                )
+              }
+            </HolidayDateChooserStateContext.Consumer>
+          )}
+        </MembersDataApiResponseContext.Consumer>
       ) : (
         <GenericErrorScreen loggingMessage="No holiday stop response" />
       )

--- a/app/client/components/holiday/holidayDateChooser.tsx
+++ b/app/client/components/holiday/holidayDateChooser.tsx
@@ -7,7 +7,6 @@ import React from "react";
 import { OnSelectCallbackParam } from "react-daterange-picker";
 import {
   hasProduct,
-  MDA_TEST_USER_HEADER,
   MembersDataApiResponseContext
 } from "../../../shared/productResponse";
 import palette from "../../colours";
@@ -27,14 +26,14 @@ import {
 } from "./holidayQuestionsModal";
 import {
   calculateIssuesImpactedPerYear,
-  DATE_INPUT_FORMAT,
+  convertRawPotentialHolidayStopDetail,
+  createPotentialHolidayStopsFetcher,
+  HolidayStopDetail,
   HolidayStopsResponseContext,
   isHolidayStopsResponse,
   IssuesImpactedPerYear,
   momentiseDateStr,
-  momentiseRawHolidayStopDetail,
-  PotentialHolidayStopsResponse,
-  RawHolidayStopDetail
+  PotentialHolidayStopsResponse
 } from "./holidayStopApi";
 
 export const cancelLinkCss = {
@@ -85,28 +84,26 @@ const anniversaryDateToElement = (renewalDateMoment: Moment) => (
   </>
 );
 
-export const HolidayDateChooserStateContext: React.Context<
-  HolidayDateChooserState | {}
-> = React.createContext({});
-
-export function isSharedHolidayDateChooserState(
-  state: any
-): state is SharedHolidayDateChooserState {
-  return (
-    !!state && state.selectedRange && state.issuesImpactedPerYearBySelection
-  );
-}
-
 interface HolidayDateChooserState {
   selectedRange?: DateRange;
-  totalIssueCountImpactedBySelection?: number;
+  publicationsImpacted?: HolidayStopDetail[];
   issuesImpactedPerYearBySelection?: IssuesImpactedPerYear | null;
   validationErrorMessage: React.ReactNode | null;
 }
 
 export interface SharedHolidayDateChooserState {
   selectedRange: DateRange;
-  issuesImpactedPerYearBySelection: IssuesImpactedPerYear;
+  publicationsImpacted: HolidayStopDetail[];
+}
+
+export const HolidayDateChooserStateContext: React.Context<
+  SharedHolidayDateChooserState | {}
+> = React.createContext({});
+
+export function isSharedHolidayDateChooserState(
+  state: any
+): state is SharedHolidayDateChooserState {
+  return !!state && state.selectedRange && state.publicationsImpacted;
 }
 
 export class HolidayDateChooser extends React.Component<
@@ -277,18 +274,14 @@ export class HolidayDateChooser extends React.Component<
         validationErrorMessage: null
       },
       () =>
-        fetch(
-          `/api/holidays/${
-            this.props.productType.urlPart
-          }/${subscriptionName}/potential?startDate=${start.format(
-            DATE_INPUT_FORMAT
-          )}&endDate=${end.format(DATE_INPUT_FORMAT)}`,
-          {
-            headers: {
-              [MDA_TEST_USER_HEADER]: `${isTestUser}`
-            }
-          }
-        )
+        createPotentialHolidayStopsFetcher(
+          false,
+          this.props.productType.urlPart,
+          subscriptionName,
+          start,
+          end,
+          isTestUser
+        )()
           .then(response => {
             const locationHeader = response.headers.get("Location");
             if (
@@ -303,38 +296,38 @@ export class HolidayDateChooser extends React.Component<
             }
             return Promise.reject(`${response.status} from holiday-stop-api`);
           })
-          .then(
-            ({
-              potentials
-            }: PotentialHolidayStopsResponse<RawHolidayStopDetail>) => {
-              const issuesImpactedPerYearBySelection = calculateIssuesImpactedPerYear(
-                potentials.map(momentiseRawHolidayStopDetail),
-                renewalDateMoment
-              );
+          .then(({ potentials }: PotentialHolidayStopsResponse) => {
+            const publicationsImpacted = potentials.map(
+              convertRawPotentialHolidayStopDetail
+            );
 
-              const issuesRemainingThisYear =
-                annualIssueLimit -
-                combinedIssuesImpactedPerYear.issueThisYear.length;
+            const issuesImpactedPerYearBySelection = calculateIssuesImpactedPerYear(
+              publicationsImpacted,
+              renewalDateMoment
+            );
 
-              const issuesRemainingNextYear =
-                annualIssueLimit -
-                combinedIssuesImpactedPerYear.issueNextYear.length;
+            const issuesRemainingThisYear =
+              annualIssueLimit -
+              combinedIssuesImpactedPerYear.issueThisYear.length;
 
-              const validationErrorMessage: React.ReactNode = this.validateIssuesSelected(
-                renewalDateMoment,
-                annualIssueLimit,
-                issuesImpactedPerYearBySelection.issueThisYear.length,
-                issuesRemainingThisYear,
-                issuesImpactedPerYearBySelection.issueNextYear.length,
-                issuesRemainingNextYear
-              );
-              this.setState({
-                totalIssueCountImpactedBySelection: potentials.length,
-                issuesImpactedPerYearBySelection,
-                validationErrorMessage
-              });
-            }
-          )
+            const issuesRemainingNextYear =
+              annualIssueLimit -
+              combinedIssuesImpactedPerYear.issueNextYear.length;
+
+            const validationErrorMessage: React.ReactNode = this.validateIssuesSelected(
+              renewalDateMoment,
+              annualIssueLimit,
+              issuesImpactedPerYearBySelection.issueThisYear.length,
+              issuesRemainingThisYear,
+              issuesImpactedPerYearBySelection.issueNextYear.length,
+              issuesRemainingNextYear
+            );
+            this.setState({
+              publicationsImpacted,
+              issuesImpactedPerYearBySelection,
+              validationErrorMessage
+            });
+          })
           .catch(error => {
             this.setState({
               validationErrorMessage:
@@ -438,7 +431,7 @@ export class HolidayDateChooser extends React.Component<
           >
             Suspending{" "}
             {displayNumberOfIssuesAsText(
-              this.state.totalIssueCountImpactedBySelection || 0
+              (this.state.publicationsImpacted || []).length
             )}
           </div>
           <div

--- a/app/client/components/holiday/holidayDateChooser.tsx
+++ b/app/client/components/holiday/holidayDateChooser.tsx
@@ -28,12 +28,13 @@ import {
 import {
   calculateIssuesImpactedPerYear,
   DATE_INPUT_FORMAT,
-  HolidayStopDetail,
   HolidayStopsResponseContext,
   isHolidayStopsResponse,
   IssuesImpactedPerYear,
   momentiseDateStr,
-  PotentialHolidayStopsResponse
+  momentiseRawHolidayStopDetail,
+  PotentialHolidayStopsResponse,
+  RawHolidayStopDetail
 } from "./holidayStopApi";
 
 export const cancelLinkCss = {
@@ -130,7 +131,7 @@ export class HolidayDateChooser extends React.Component<
 
                 const combinedIssuesImpactedPerYear = calculateIssuesImpactedPerYear(
                   holidayStopsResponse.existing.flatMap(
-                    existing => existing.publicationDatesToBeStopped
+                    existing => existing.publicationsImpacted
                   ),
                   renewalDateMoment
                 );
@@ -305,28 +306,26 @@ export class HolidayDateChooser extends React.Component<
           .then(
             ({
               potentials
-            }: PotentialHolidayStopsResponse<HolidayStopDetail>) => {
+            }: PotentialHolidayStopsResponse<RawHolidayStopDetail>) => {
               const issuesImpactedPerYearBySelection = calculateIssuesImpactedPerYear(
-                potentials.map(({ publicationDate }) =>
-                  momentiseDateStr(publicationDate)
-                ),
+                potentials.map(momentiseRawHolidayStopDetail),
                 renewalDateMoment
               );
 
               const issuesRemainingThisYear =
                 annualIssueLimit -
-                combinedIssuesImpactedPerYear.issueDatesThisYear.length;
+                combinedIssuesImpactedPerYear.issueThisYear.length;
 
               const issuesRemainingNextYear =
                 annualIssueLimit -
-                combinedIssuesImpactedPerYear.issueDatesNextYear.length;
+                combinedIssuesImpactedPerYear.issueNextYear.length;
 
               const validationErrorMessage: React.ReactNode = this.validateIssuesSelected(
                 renewalDateMoment,
                 annualIssueLimit,
-                issuesImpactedPerYearBySelection.issueDatesThisYear.length,
+                issuesImpactedPerYearBySelection.issueThisYear.length,
                 issuesRemainingThisYear,
-                issuesImpactedPerYearBySelection.issueDatesNextYear.length,
+                issuesImpactedPerYearBySelection.issueNextYear.length,
                 issuesRemainingNextYear
               );
               this.setState({
@@ -398,16 +397,16 @@ export class HolidayDateChooser extends React.Component<
   ) => {
     const issuesRemainingThisYear =
       annualIssueLimit -
-      combinedIssuesImpactedPerYear.issueDatesThisYear.length -
+      combinedIssuesImpactedPerYear.issueThisYear.length -
       (this.state.issuesImpactedPerYearBySelection
-        ? this.state.issuesImpactedPerYearBySelection.issueDatesThisYear.length
+        ? this.state.issuesImpactedPerYearBySelection.issueThisYear.length
         : 0);
 
     const issuesRemainingNextYear =
       annualIssueLimit -
-      combinedIssuesImpactedPerYear.issueDatesNextYear.length -
+      combinedIssuesImpactedPerYear.issueNextYear.length -
       (this.state.issuesImpactedPerYearBySelection
-        ? this.state.issuesImpactedPerYearBySelection.issueDatesNextYear.length
+        ? this.state.issuesImpactedPerYearBySelection.issueNextYear.length
         : 0);
 
     if (this.state.validationErrorMessage) {
@@ -457,8 +456,8 @@ export class HolidayDateChooser extends React.Component<
             {displayNumberOfIssuesAsText(issuesRemainingThisYear)} available to
             suspend before {anniversaryDateToElement(renewalDateMoment)}
             {this.state.issuesImpactedPerYearBySelection &&
-              this.state.issuesImpactedPerYearBySelection.issueDatesNextYear
-                .length > 0 && (
+              this.state.issuesImpactedPerYearBySelection.issueNextYear.length >
+                0 && (
                 <>
                   {" "}
                   and {displayNumberOfIssuesAsText(

--- a/app/client/components/holiday/holidayDateChooser.tsx
+++ b/app/client/components/holiday/holidayDateChooser.tsx
@@ -308,18 +308,18 @@ export class HolidayDateChooser extends React.Component<
 
             const issuesRemainingThisYear =
               annualIssueLimit -
-              combinedIssuesImpactedPerYear.issueThisYear.length;
+              combinedIssuesImpactedPerYear.issuesThisYear.length;
 
             const issuesRemainingNextYear =
               annualIssueLimit -
-              combinedIssuesImpactedPerYear.issueNextYear.length;
+              combinedIssuesImpactedPerYear.issuesNextYear.length;
 
             const validationErrorMessage: React.ReactNode = this.validateIssuesSelected(
               renewalDateMoment,
               annualIssueLimit,
-              issuesImpactedPerYearBySelection.issueThisYear.length,
+              issuesImpactedPerYearBySelection.issuesThisYear.length,
               issuesRemainingThisYear,
-              issuesImpactedPerYearBySelection.issueNextYear.length,
+              issuesImpactedPerYearBySelection.issuesNextYear.length,
               issuesRemainingNextYear
             );
             this.setState({
@@ -390,16 +390,16 @@ export class HolidayDateChooser extends React.Component<
   ) => {
     const issuesRemainingThisYear =
       annualIssueLimit -
-      combinedIssuesImpactedPerYear.issueThisYear.length -
+      combinedIssuesImpactedPerYear.issuesThisYear.length -
       (this.state.issuesImpactedPerYearBySelection
-        ? this.state.issuesImpactedPerYearBySelection.issueThisYear.length
+        ? this.state.issuesImpactedPerYearBySelection.issuesThisYear.length
         : 0);
 
     const issuesRemainingNextYear =
       annualIssueLimit -
-      combinedIssuesImpactedPerYear.issueNextYear.length -
+      combinedIssuesImpactedPerYear.issuesNextYear.length -
       (this.state.issuesImpactedPerYearBySelection
-        ? this.state.issuesImpactedPerYearBySelection.issueNextYear.length
+        ? this.state.issuesImpactedPerYearBySelection.issuesNextYear.length
         : 0);
 
     if (this.state.validationErrorMessage) {
@@ -449,8 +449,8 @@ export class HolidayDateChooser extends React.Component<
             {displayNumberOfIssuesAsText(issuesRemainingThisYear)} available to
             suspend before {anniversaryDateToElement(renewalDateMoment)}
             {this.state.issuesImpactedPerYearBySelection &&
-              this.state.issuesImpactedPerYearBySelection.issueNextYear.length >
-                0 && (
+              this.state.issuesImpactedPerYearBySelection.issuesNextYear
+                .length > 0 && (
                 <>
                   {" "}
                   and {displayNumberOfIssuesAsText(

--- a/app/client/components/holiday/holidayReview.tsx
+++ b/app/client/components/holiday/holidayReview.tsx
@@ -112,6 +112,7 @@ export class HolidayReview extends React.Component<
                         <SummaryTable
                           data={dateChooserState}
                           alternateSuspendedColumnHeading="To be suspended"
+                          subscription={productDetail.subscription}
                         />
                       </div>
                       {this.state.isCreating ? (

--- a/app/client/components/holiday/holidayReview.tsx
+++ b/app/client/components/holiday/holidayReview.tsx
@@ -4,7 +4,8 @@ import React from "react";
 import {
   hasProduct,
   MDA_TEST_USER_HEADER,
-  MembersDataApiResponseContext
+  MembersDataApiResponseContext,
+  ProductDetail
 } from "../../../shared/productResponse";
 import { ProductType } from "../../../shared/productTypes";
 import { maxWidth } from "../../styles/breakpoints";
@@ -20,18 +21,24 @@ import {
   buttonBarCss,
   cancelLinkCss,
   HolidayDateChooserStateContext,
-  isSharedHolidayDateChooserState
+  isSharedHolidayDateChooserState,
+  SharedHolidayDateChooserState
 } from "./holidayDateChooser";
 import {
   creditExplainerSentence,
   HolidayQuestionsModal
 } from "./holidayQuestionsModal";
 import {
+  convertRawPotentialHolidayStopDetail,
   CreateHolidayStopsAsyncLoader,
   CreateHolidayStopsResponse,
+  createPotentialHolidayStopsFetcher,
   DATE_INPUT_FORMAT,
   HolidayStopsResponseContext,
-  isHolidayStopsResponse
+  isHolidayStopsResponse,
+  PotentialHolidayStopsAsyncLoader,
+  PotentialHolidayStopsResponse,
+  ReloadableGetHolidayStopsResponse
 } from "./holidayStopApi";
 import { SummaryTable } from "./summaryTable";
 
@@ -93,95 +100,23 @@ export class HolidayReview extends React.Component<
               <HolidayDateChooserStateContext.Consumer>
                 {dateChooserState =>
                   isSharedHolidayDateChooserState(dateChooserState) &&
-                  hasProduct(productDetail) &&
-                  this.props.navigate ? (
-                    <WizardStep routeableStepProps={this.props} hideBackButton>
-                      <div>
-                        <h1>Review details before confirming</h1>
-                        <p>
-                          Check the details carefully and amend them if
-                          necessary. {creditExplainerSentence}
-                        </p>
-                        <HolidayQuestionsModal
-                          annualIssueLimit={
-                            holidayStopsResponse.productSpecifics
-                              .annualIssueLimit
-                          }
-                        />
-                        <div css={{ height: "25px" }} />
-                        <SummaryTable
-                          data={dateChooserState}
-                          alternateSuspendedColumnHeading="To be suspended"
-                          subscription={productDetail.subscription}
-                        />
-                      </div>
-                      {this.state.isCreating ? (
-                        <div css={{ marginTop: "40px", textAlign: "right" }}>
-                          <CreateHolidayStopsAsyncLoader
-                            fetch={getPerformCreation(
-                              dateChooserState.selectedRange,
-                              productDetail.subscription.subscriptionId,
-                              productDetail.isTestUser,
-                              this.props.productType
-                            )}
-                            render={getRenderCreationSuccess(
-                              this.props.navigate
-                            )}
-                            errorRender={renderCreationError}
-                            loadingMessage="Creating your suspension"
-                            spinnerScale={0.7}
-                            inline
-                          />
-                        </div>
-                      ) : (
-                        <div
-                          css={{
-                            ...buttonBarCss,
-                            justifyContent: "space-between",
-                            marginTop: "20px",
-                            [maxWidth.mobileMedium]: {
-                              flexDirection: "column",
-                              marginTop: 0
-                            }
-                          }}
-                        >
-                          <div
-                            css={{
-                              marginTop: "20px",
-                              alignSelf: "flex-start"
-                            }}
-                          >
-                            <Button
-                              text="Amend"
-                              onClick={() =>
-                                (this.props.navigate || navigate)("..")
-                              }
-                              left
-                              hollow
-                            />
-                          </div>
-                          <div
-                            css={{
-                              ...buttonBarCss,
-                              marginTop: "20px",
-                              alignSelf: "flex-end"
-                            }}
-                          >
-                            <Link css={cancelLinkCss} to="../.." replace={true}>
-                              Cancel
-                            </Link>
-                            <Button
-                              text="Confirm"
-                              onClick={() =>
-                                this.setState({ isCreating: true })
-                              }
-                              right
-                              primary
-                            />
-                          </div>
-                        </div>
+                  hasProduct(productDetail) ? (
+                    <PotentialHolidayStopsAsyncLoader
+                      fetch={createPotentialHolidayStopsFetcher(
+                        true,
+                        this.props.productType.urlPart,
+                        productDetail.subscription.subscriptionId,
+                        dateChooserState.selectedRange.start,
+                        dateChooserState.selectedRange.end,
+                        productDetail.isTestUser
                       )}
-                    </WizardStep>
+                      render={this.buildActualRenderer(
+                        holidayStopsResponse,
+                        productDetail,
+                        dateChooserState
+                      )}
+                      loadingMessage="Calculating expected credit..."
+                    />
                   ) : (
                     visuallyNavigateToParent(this.props)
                   )
@@ -195,4 +130,108 @@ export class HolidayReview extends React.Component<
       }
     </HolidayStopsResponseContext.Consumer>
   );
+
+  private buildActualRenderer = (
+    holidayStopsResponse: ReloadableGetHolidayStopsResponse,
+    productDetail: ProductDetail,
+    dateChooserState: SharedHolidayDateChooserState
+  ) => (
+    potentialHolidayStopsResponseWithCredits: PotentialHolidayStopsResponse
+  ) => {
+    const dateChooserStateWithCredits: SharedHolidayDateChooserState = {
+      ...dateChooserState,
+      publicationsImpacted: potentialHolidayStopsResponseWithCredits.potentials.map(
+        convertRawPotentialHolidayStopDetail
+      )
+    };
+
+    return this.props.navigate ? (
+      <HolidayDateChooserStateContext.Provider
+        value={dateChooserStateWithCredits}
+      >
+        <WizardStep routeableStepProps={this.props} hideBackButton>
+          <div>
+            <h1>Review details before confirming</h1>
+            <p>
+              Check the details carefully and amend them if necessary.{" "}
+              {creditExplainerSentence}
+            </p>
+            <HolidayQuestionsModal
+              annualIssueLimit={
+                holidayStopsResponse.productSpecifics.annualIssueLimit
+              }
+            />
+            <div css={{ height: "25px" }} />
+            <SummaryTable
+              data={dateChooserStateWithCredits}
+              alternateSuspendedColumnHeading="To be suspended"
+              subscription={productDetail.subscription}
+            />
+          </div>
+          {this.state.isCreating ? (
+            <div css={{ marginTop: "40px", textAlign: "right" }}>
+              <CreateHolidayStopsAsyncLoader
+                fetch={getPerformCreation(
+                  dateChooserState.selectedRange,
+                  productDetail.subscription.subscriptionId,
+                  productDetail.isTestUser,
+                  this.props.productType
+                )}
+                render={getRenderCreationSuccess(this.props.navigate)}
+                errorRender={renderCreationError}
+                loadingMessage="Creating your suspension..."
+                spinnerScale={0.7}
+                inline
+              />
+            </div>
+          ) : (
+            <div
+              css={{
+                ...buttonBarCss,
+                justifyContent: "space-between",
+                marginTop: "20px",
+                [maxWidth.mobileMedium]: {
+                  flexDirection: "column",
+                  marginTop: 0
+                }
+              }}
+            >
+              <div
+                css={{
+                  marginTop: "20px",
+                  alignSelf: "flex-start"
+                }}
+              >
+                <Button
+                  text="Amend"
+                  onClick={() => (this.props.navigate || navigate)("..")}
+                  left
+                  hollow
+                />
+              </div>
+              <div
+                css={{
+                  ...buttonBarCss,
+                  marginTop: "20px",
+                  alignSelf: "flex-end"
+                }}
+              >
+                <Link css={cancelLinkCss} to="../.." replace={true}>
+                  Cancel
+                </Link>
+                <Button
+                  text="Confirm"
+                  onClick={() => this.setState({ isCreating: true })}
+                  right
+                  primary
+                />
+              </div>
+            </div>
+          )}
+        </WizardStep>
+      </HolidayDateChooserStateContext.Provider>
+    ) : (
+      visuallyNavigateToParent(this.props)
+    );
+  };
 }

--- a/app/client/components/holiday/holidayStopApi.ts
+++ b/app/client/components/holiday/holidayStopApi.ts
@@ -164,8 +164,8 @@ export const embellishExistingHolidayStops = async (response: Response) => {
 };
 
 export interface IssuesImpactedPerYear {
-  issueThisYear: HolidayStopDetail[];
-  issueNextYear: HolidayStopDetail[];
+  issuesThisYear: HolidayStopDetail[];
+  issuesNextYear: HolidayStopDetail[];
 }
 
 export const calculateIssuesImpactedPerYear = (
@@ -173,14 +173,14 @@ export const calculateIssuesImpactedPerYear = (
   nextYearStartDate: Moment
 ) => {
   return {
-    issueThisYear: publicationsImpacted.filter(
+    issuesThisYear: publicationsImpacted.filter(
       issue =>
         issue.publicationDate.isBefore(nextYearStartDate) &&
         issue.publicationDate.isSameOrAfter(
           nextYearStartDate.clone().subtract(1, "year")
         )
     ),
-    issueNextYear: publicationsImpacted.filter(
+    issuesNextYear: publicationsImpacted.filter(
       issue =>
         issue.publicationDate.isSameOrAfter(nextYearStartDate) &&
         issue.publicationDate.isBefore(nextYearStartDate.clone().add(1, "year"))

--- a/app/client/components/holiday/holidaysOverview.tsx
+++ b/app/client/components/holiday/holidaysOverview.tsx
@@ -71,7 +71,7 @@ const renderHolidayStopsOverview = (
 
   const combinedIssuesImpactedPerYear = calculateIssuesImpactedPerYear(
     holidayStopsResponse.existing.flatMap(
-      existing => existing.publicationDatesToBeStopped
+      existing => existing.publicationsImpacted
     ),
     renewalDateMoment
   );
@@ -133,24 +133,21 @@ const renderHolidayStopsOverview = (
                       <div>
                         You have suspended{" "}
                         <strong>
-                          {
-                            combinedIssuesImpactedPerYear.issueDatesThisYear
-                              .length
-                          }/{
+                          {combinedIssuesImpactedPerYear.issueThisYear.length}/{
                             holidayStopsResponse.productSpecifics
                               .annualIssueLimit
                           }
                         </strong>{" "}
                         issues until{" "}
                         {renewalDateMoment.format(friendlyLongDateFormat)}
-                        {combinedIssuesImpactedPerYear.issueDatesNextYear
-                          .length > 0 && (
+                        {combinedIssuesImpactedPerYear.issueNextYear.length >
+                          0 && (
                           <span>
                             {" "}
                             and{" "}
                             <strong>
                               {
-                                combinedIssuesImpactedPerYear.issueDatesNextYear
+                                combinedIssuesImpactedPerYear.issueNextYear
                                   .length
                               }/{
                                 holidayStopsResponse.productSpecifics
@@ -197,7 +194,10 @@ const renderHolidayStopsOverview = (
               heading="Details"
               content={
                 holidayStopsResponse.existing.length > 0 ? (
-                  <SummaryTable data={holidayStopsResponse.existing} />
+                  <SummaryTable
+                    data={holidayStopsResponse.existing}
+                    subscription={productDetail.subscription}
+                  />
                 ) : (
                   "You currently don't have any scheduled suspensions."
                 )

--- a/app/client/components/holiday/holidaysOverview.tsx
+++ b/app/client/components/holiday/holidaysOverview.tsx
@@ -134,21 +134,21 @@ const renderHolidayStopsOverview = (
                       <div>
                         You have suspended{" "}
                         <strong>
-                          {combinedIssuesImpactedPerYear.issueThisYear.length}/{
+                          {combinedIssuesImpactedPerYear.issuesThisYear.length}/{
                             holidayStopsResponse.productSpecifics
                               .annualIssueLimit
                           }
                         </strong>{" "}
                         issues until{" "}
                         {renewalDateMoment.format(friendlyLongDateFormat)}
-                        {combinedIssuesImpactedPerYear.issueNextYear.length >
+                        {combinedIssuesImpactedPerYear.issuesNextYear.length >
                           0 && (
                           <span>
                             {" "}
                             and{" "}
                             <strong>
                               {
-                                combinedIssuesImpactedPerYear.issueNextYear
+                                combinedIssuesImpactedPerYear.issuesNextYear
                                   .length
                               }/{
                                 holidayStopsResponse.productSpecifics

--- a/app/client/components/holiday/holidaysOverview.tsx
+++ b/app/client/components/holiday/holidaysOverview.tsx
@@ -1,9 +1,11 @@
 import { navigate } from "@reach/router";
 import React from "react";
 import {
+  MDA_TEST_USER_HEADER,
   MembersDataApiResponseContext,
   ProductDetail
 } from "../../../shared/productResponse";
+import { ProductUrlPart } from "../../../shared/productTypes";
 import { maxWidth, minWidth } from "../../styles/breakpoints";
 import { sans } from "../../styles/fonts";
 import { ReFetch } from "../asyncLoader";
@@ -23,7 +25,6 @@ import {
 } from "./holidayQuestionsModal";
 import {
   calculateIssuesImpactedPerYear,
-  createGetHolidayStopsFetcher,
   embellishExistingHolidayStops,
   GetHolidayStopsAsyncLoader,
   GetHolidayStopsResponse,
@@ -237,6 +238,17 @@ const renderHolidayStopsOverview = (
   );
 };
 
+const createGetHolidayStopsFetcher = (
+  productUrlPart: ProductUrlPart,
+  subscriptionName: string,
+  isTestUser: boolean
+) => () =>
+  fetch(`/api/holidays/${productUrlPart}/${subscriptionName}`, {
+    headers: {
+      [MDA_TEST_USER_HEADER]: `${isTestUser}`
+    }
+  });
+
 export const HolidaysOverview = (props: RouteableStepProps) => (
   <FlowStartMultipleProductDetailHandler
     {...props}
@@ -262,7 +274,7 @@ export const HolidaysOverview = (props: RouteableStepProps) => (
                 productDetail,
                 routeableStepProps
               )}
-              loadingMessage="Loading existing suspensions"
+              loadingMessage="Loading existing suspensions..."
               readerOnOK={embellishExistingHolidayStops}
             />
           ) : (

--- a/app/client/components/holiday/summaryTable.tsx
+++ b/app/client/components/holiday/summaryTable.tsx
@@ -1,7 +1,11 @@
 import { BorderCollapseProperty, TextAlignProperty } from "csstype";
-import { Moment } from "moment";
 import { DateRange } from "moment-range";
 import React from "react";
+import {
+  getMainPlan,
+  isPaidSubscriptionPlan,
+  Subscription
+} from "../../../shared/productResponse";
 import palette from "../../colours";
 import { maxWidth, minWidth } from "../../styles/breakpoints";
 import { sans } from "../../styles/fonts";
@@ -9,7 +13,7 @@ import {
   isSharedHolidayDateChooserState,
   SharedHolidayDateChooserState
 } from "./holidayDateChooser";
-import { HolidayStopRequest } from "./holidayStopApi";
+import { HolidayStopDetail, HolidayStopRequest } from "./holidayStopApi";
 
 const cellCss = {
   padding: "8px 16px 8px 16px",
@@ -18,6 +22,7 @@ const cellCss = {
 
 export interface SummaryTableProps {
   data: HolidayStopRequest[] | SharedHolidayDateChooserState;
+  subscription: Subscription;
   alternateSuspendedColumnHeading?: string;
 }
 
@@ -35,9 +40,21 @@ const formatDateRangeAsFriendly = (range: DateRange) =>
 
 interface SummaryTableRowProps {
   dateRange: DateRange;
-  publicationDatesToBeStopped: Moment[];
+  publicationsImpacted: HolidayStopDetail[];
+  currency?: string;
   asTD?: true;
 }
+
+const formattedCreditIfAvailable = (
+  detail: HolidayStopDetail,
+  currency?: string
+) => {
+  const rawAmount = detail.actualPrice || detail.estimatedPrice;
+  const amountTwoDecimalPlaces = rawAmount ? rawAmount.toFixed(2) : undefined;
+  return currency && rawAmount
+    ? ` (${currency}${amountTwoDecimalPlaces})`
+    : undefined;
+};
 
 const SummaryTableRow = (props: SummaryTableRowProps) => {
   const dateRangeStr = formatDateRangeAsFriendly(props.dateRange);
@@ -45,14 +62,18 @@ const SummaryTableRow = (props: SummaryTableRowProps) => {
   const detailPart = (
     <>
       <strong>
-        {props.publicationDatesToBeStopped.length} issue{props
-          .publicationDatesToBeStopped.length !== 1
+        {props.publicationsImpacted.length} issue{props.publicationsImpacted
+          .length !== 1
           ? "s"
           : ""}
       </strong>
-      {props.publicationDatesToBeStopped.map((date, index) => (
+      {props.publicationsImpacted.map((detail, index) => (
         <div key={index}>
-          - {date.format(friendlyDateFormatPrefix + friendlyDateFormatSuffix)}
+          -{" "}
+          {detail.publicationDate.format(
+            friendlyDateFormatPrefix + friendlyDateFormatSuffix
+          )}
+          {formattedCreditIfAvailable(detail, props.currency)}
         </div>
       ))}
     </>
@@ -86,13 +107,18 @@ export const SummaryTable = (props: SummaryTableProps) => {
     ? [
         {
           dateRange: props.data.selectedRange,
-          publicationDatesToBeStopped: [
-            ...props.data.issuesImpactedPerYearBySelection.issueDatesThisYear,
-            ...props.data.issuesImpactedPerYearBySelection.issueDatesNextYear
+          publicationsImpacted: [
+            ...props.data.issuesImpactedPerYearBySelection.issueThisYear,
+            ...props.data.issuesImpactedPerYearBySelection.issueNextYear
           ]
         }
       ]
     : props.data;
+
+  const mainPlan = getMainPlan(props.subscription);
+  const currency = isPaidSubscriptionPlan(mainPlan)
+    ? mainPlan.currency
+    : undefined;
 
   return (
     <div
@@ -127,7 +153,12 @@ export const SummaryTable = (props: SummaryTableProps) => {
             <th>{props.alternateSuspendedColumnHeading || "Suspended"}</th>
           </tr>
           {holidayStopRequestsList.map((holidayStopRequest, index) => (
-            <SummaryTableRow asTD key={index} {...holidayStopRequest} />
+            <SummaryTableRow
+              asTD
+              key={index}
+              currency={currency}
+              {...holidayStopRequest}
+            />
           ))}
         </tbody>
       </table>
@@ -139,7 +170,11 @@ export const SummaryTable = (props: SummaryTableProps) => {
         }}
       >
         {holidayStopRequestsList.map((holidayStopRequest, index) => (
-          <SummaryTableRow key={index} {...holidayStopRequest} />
+          <SummaryTableRow
+            key={index}
+            currency={currency}
+            {...holidayStopRequest}
+          />
         ))}
       </div>
     </div>

--- a/app/client/components/holiday/summaryTable.tsx
+++ b/app/client/components/holiday/summaryTable.tsx
@@ -107,10 +107,7 @@ export const SummaryTable = (props: SummaryTableProps) => {
     ? [
         {
           dateRange: props.data.selectedRange,
-          publicationsImpacted: [
-            ...props.data.issuesImpactedPerYearBySelection.issueThisYear,
-            ...props.data.issuesImpactedPerYearBySelection.issueNextYear
-          ]
+          publicationsImpacted: props.data.publicationsImpacted
         }
       ]
     : props.data;


### PR DESCRIPTION
Had to move a fair bit of code around and instead of passing around arrays of `string`/`Moment`, pass around objects which contain `publicationDate` and optionally `estimatedCredit`. 

Also involved creating `PotentialHolidayStopsAsyncLoader` for the Review Screen now that it needs to call `/potential` endpoint passing `&estimateCredit=true`. The results of which are displayed on both the Review Screen AND make their way to the Confirmed Screen, by overriding the `SharedHolidayDateChooserState` object by inserting a new `<HolidayDateChooserStateContext.Provider>` in the DOM with the `publicationDate` swapped out for the ones including the estimated credit (from the the /potential endpoint).

### Overview Screen
Now displays estimated (or indeed actual) credit on the overview screen (from what's stored in Salesforce), and gracefully doesn't show if not available (for whatever reason, either historically wasn't calculated or Zuora couldn't be contacted at the time the record was created).
![image](https://user-images.githubusercontent.com/19289579/65133697-f7906e80-d9fa-11e9-8ae8-22acab7eb4af.png)

### Review Screen
![image](https://user-images.githubusercontent.com/19289579/65133583-c2841c00-d9fa-11e9-8f76-718ba5f8ecd4.png)

### Confirmed Screen
![image](https://user-images.githubusercontent.com/19289579/65133601-cdd74780-d9fa-11e9-94bb-fba9ebd8787f.png)
