### PR TITLE
Fix: Prevent unnecessary Avatar 404 logging

### DIFF
--- a/app/client/components/identity/PublicProfile/AvatarSection.tsx
+++ b/app/client/components/identity/PublicProfile/AvatarSection.tsx
@@ -33,7 +33,14 @@ const imgCss: CSSObject = {
   width: "60px"
 };
 
+const isEmptyAvatarError = (e: any): boolean => {
+  return e.type && e.type === ErrorTypes.NOT_FOUND;
+};
+
 const errorHandler = (e: any) => {
+  if (isEmptyAvatarError(e)) {
+    return;
+  }
   Raven.captureException(e);
   trackEvent({
     eventCategory: "publicProfileError",

--- a/app/client/components/identity/models.ts
+++ b/app/client/components/identity/models.ts
@@ -11,6 +11,7 @@ export enum Theme {
 
 export enum ErrorTypes {
   GENERAL = "GENERAL",
+  NOT_FOUND = "NOT_FOUND",
   VALIDATION = "VALIDATION"
 }
 


### PR DESCRIPTION
# [Stop Profile tab logging avatar 404s](https://trello.com/c/RnbM4YvX/1615-stop-profile-tab-logging-avatar-404s).

## Description
The Avatar api returns a 404 error when a user has not set an Avatar. This legitimate response should not be logged to Sentry. This Fix makes the Avatar form error handler ignore this type of error when dispatching to Sentry.

## Changes
* Add a `NOT_FOUND` error type.
* IDAPI `avatar` adapter will now return the `NOT_FOUND` error type specifically on Avatar not found responses.
* `PublicProfile/AvatarSection` will not log `NOT_FOUND` errors returned during an Avatar api transaction.