### PR TITLE
Remove X-Frame-Options from /consent route

### DIFF
--- a/app/server/server.ts
+++ b/app/server/server.ts
@@ -62,7 +62,7 @@ server.use(
     );
     res.setHeader(
       "X-Frame-Options",
-      `allow from https://code.dev-theguardian.com/`
+      `allow-from https://code.dev-theguardian.com/`
     );
     next();
   },

--- a/app/server/server.ts
+++ b/app/server/server.ts
@@ -60,10 +60,7 @@ server.use(
       "Content-Security-Policy",
       `frame-ancestors ${frameAncestors}`
     );
-    res.setHeader(
-      "X-Frame-Options",
-      `allow-from https://code.dev-theguardian.com/`
-    );
+    res.removeHeader("X-Frame-Options");
     next();
   },
   routes.consent

--- a/app/server/server.ts
+++ b/app/server/server.ts
@@ -60,6 +60,7 @@ server.use(
       "Content-Security-Policy",
       `frame-ancestors ${frameAncestors}`
     );
+    res.setHeader("X-Frame-Options", `allow from ${frameAncestors}`);
     next();
   },
   routes.consent

--- a/app/server/server.ts
+++ b/app/server/server.ts
@@ -60,7 +60,10 @@ server.use(
       "Content-Security-Policy",
       `frame-ancestors ${frameAncestors}`
     );
-    res.setHeader("X-Frame-Options", `allow from ${frameAncestors}`);
+    res.setHeader(
+      "X-Frame-Options",
+      `allow from https://code.dev-theguardian.com/`
+    );
     next();
   },
   routes.consent


### PR DESCRIPTION
The PR https://github.com/guardian/manage-frontend/pull/254 updated the `/consent` route to allow it to be iframed in from Guardian domains. This has been working when we've been testing on our desktop browsers/operating systems, however when cross browser testing using Safari on iOS we found the `X-Frame-Options` header that's added by the express security middleware `helmetjs` was preventing the `/consent` route from loading in an iframe.  The error we'd see in the console was: `Refused to display 'https://manage.theguardian.com/consent' in a frame because it set 'X-Frame-Options' to 'SAMEORIGIN'.`

This PR updates the `/consent` route only so the `X-Frame-Options` header is not included. This  was the best course of action we could take as you can't allow `X-Frame-Options` to take multiple domains or wild cards in the uri.