### PR TITLE
Fix scrollToPurposes bugs

### DIFF
--- a/app/client/components/consent/PrivacySettings.tsx
+++ b/app/client/components/consent/PrivacySettings.tsx
@@ -787,15 +787,20 @@ const scrollToPurposes = (): void => {
   const purposeElemOffsetTop = purposeElem.offsetTop;
   const scrollableElemOffsetTop = scrollableElem.offsetTop;
   const containerElemOffsetTop = containerElem.offsetTop;
+  const initDistanceScrolled = scrollableElem.scrollTop;
   const scrollLength =
-    purposeElemOffsetTop + scrollableElemOffsetTop - containerElemOffsetTop;
+    purposeElemOffsetTop +
+    scrollableElemOffsetTop -
+    containerElemOffsetTop -
+    initDistanceScrolled;
   const duration: number = 750;
   const startTime: number =
     "now" in window.performance ? performance.now() : new Date().getTime();
 
-  console.log("*** purposeElemOffsetTop ***", purposeElemOffsetTop);
-  console.log("*** scrollableElemOffsetTop ***", scrollableElemOffsetTop);
-  console.log("*** containerElemOffsetTop ***", containerElemOffsetTop);
+  console.log("*** purposeElemOffsetTop", purposeElemOffsetTop);
+  console.log("*** scrollableElemOffsetTop", scrollableElemOffsetTop);
+  console.log("*** containerElemOffsetTop", containerElemOffsetTop);
+  console.log("*** scrollLength", scrollLength);
 
   const scroll = (): void => {
     const now: number =
@@ -806,15 +811,26 @@ const scrollToPurposes = (): void => {
         ? 4 * time * time * time
         : (time - 1) * (2 * time - 2) * (2 * time - 2) + 1; // easeInOutCubic
 
+    const newScrollTop =
+      Math.ceil(
+        easing * (scrollLength - scrollableElemOffsetTop) +
+          scrollableElemOffsetTop
+      ) + initDistanceScrolled;
+
     // tslint:disable-next-line: no-object-mutation
-    scrollableElem.scrollTop = Math.ceil(
-      easing * (scrollLength - scrollableElemOffsetTop) +
-        scrollableElemOffsetTop
+    scrollableElem.scrollTop = newScrollTop;
+
+    console.log("***");
+    console.log("newScrollTop --->", newScrollTop);
+    console.log(
+      "actual scrollableElem.scrollTop --->",
+      scrollableElem.scrollTop
     );
 
-    console.log("*** scroll ***", scrollableElem.scrollTop, scrollLength);
-
-    if (scrollableElem.scrollTop === scrollLength) {
+    if (
+      scrollableElem.scrollTop === scrollLength + initDistanceScrolled ||
+      newScrollTop !== scrollableElem.scrollTop
+    ) {
       return;
     }
 

--- a/app/client/components/consent/PrivacySettings.tsx
+++ b/app/client/components/consent/PrivacySettings.tsx
@@ -822,14 +822,15 @@ const scrollToPurposes = (): void => {
 
     console.log("***");
     console.log("newScrollTop --->", newScrollTop);
-    console.log(
-      "actual scrollableElem.scrollTop --->",
-      Math.ceil(scrollableElem.scrollTop)
-    );
+
+    // scrollTop can return subpixel on hidpi resolutions so round up to integer
+    const intScrollTop = Math.ceil(scrollableElem.scrollTop);
+
+    console.log("intScrollTop --->", intScrollTop);
 
     if (
-      scrollableElem.scrollTop === scrollLength + initDistanceScrolled ||
-      newScrollTop - scrollableElem.scrollTop > 1
+      intScrollTop === scrollLength + initDistanceScrolled ||
+      newScrollTop !== intScrollTop
     ) {
       return;
     }

--- a/app/client/components/consent/PrivacySettings.tsx
+++ b/app/client/components/consent/PrivacySettings.tsx
@@ -768,6 +768,8 @@ const close = () => {
 };
 
 const scrollToPurposes = (): void => {
+  console.log("*** scrollToPurposes ***");
+
   const purposeElem: HTMLElement | null = document.getElementById(PURPOSES_ID);
   const scrollableElem: HTMLElement | null = document.getElementById(
     SCROLLABLE_ID
@@ -789,7 +791,13 @@ const scrollToPurposes = (): void => {
   const startTime: number =
     "now" in window.performance ? performance.now() : new Date().getTime();
 
+  console.log("*** purposeElemOffsetTop ***", purposeElemOffsetTop);
+  console.log("*** scrollableElemOffsetTop ***", scrollableElemOffsetTop);
+  console.log("*** containerElemOffsetTop ***", containerElemOffsetTop);
+
   const scroll = (): void => {
+    console.log("*** scroll ***");
+
     const now: number =
       "now" in window.performance ? performance.now() : new Date().getTime();
     const time: number = Math.min(1, (now - startTime) / duration);

--- a/app/client/components/consent/PrivacySettings.tsx
+++ b/app/client/components/consent/PrivacySettings.tsx
@@ -798,8 +798,6 @@ const scrollToPurposes = (): void => {
   console.log("*** containerElemOffsetTop ***", containerElemOffsetTop);
 
   const scroll = (): void => {
-    console.log("*** scroll ***");
-
     const now: number =
       "now" in window.performance ? performance.now() : new Date().getTime();
     const time: number = Math.min(1, (now - startTime) / duration);
@@ -813,6 +811,8 @@ const scrollToPurposes = (): void => {
       easing * (scrollLength - scrollableElemOffsetTop) +
         scrollableElemOffsetTop
     );
+
+    console.log("*** scroll ***", scrollableElem.scrollTop, scrollLength);
 
     if (scrollableElem.scrollTop === scrollLength) {
       return;

--- a/app/client/components/consent/PrivacySettings.tsx
+++ b/app/client/components/consent/PrivacySettings.tsx
@@ -1,3 +1,5 @@
+// tslint:disable: no-console
+
 import { css } from "@emotion/core";
 import { cmpConfig, cmpCookie } from "@guardian/consent-management-platform";
 import {

--- a/app/client/components/consent/PrivacySettings.tsx
+++ b/app/client/components/consent/PrivacySettings.tsx
@@ -787,7 +787,8 @@ const scrollToPurposes = (): void => {
   const purposeElemOffsetTop = purposeElem.offsetTop;
   const scrollableElemOffsetTop = scrollableElem.offsetTop;
   const containerElemOffsetTop = containerElem.offsetTop;
-  const initDistanceScrolled = scrollableElem.scrollTop;
+  // scrollTop can return subpixel on hidpi resolutions so round up to integer
+  const initDistanceScrolled = Math.ceil(scrollableElem.scrollTop);
   const scrollLength =
     purposeElemOffsetTop +
     scrollableElemOffsetTop -

--- a/app/client/components/consent/PrivacySettings.tsx
+++ b/app/client/components/consent/PrivacySettings.tsx
@@ -1,5 +1,3 @@
-// tslint:disable: no-console
-
 import { css } from "@emotion/core";
 import { cmpConfig, cmpCookie } from "@guardian/consent-management-platform";
 import {
@@ -770,8 +768,6 @@ const close = () => {
 };
 
 const scrollToPurposes = (): void => {
-  console.log("*** scrollToPurposes ***");
-
   const purposeElem: HTMLElement | null = document.getElementById(PURPOSES_ID);
   const scrollableElem: HTMLElement | null = document.getElementById(
     SCROLLABLE_ID
@@ -798,11 +794,6 @@ const scrollToPurposes = (): void => {
   const startTime: number =
     "now" in window.performance ? performance.now() : new Date().getTime();
 
-  console.log("*** purposeElemOffsetTop", purposeElemOffsetTop);
-  console.log("*** scrollableElemOffsetTop", scrollableElemOffsetTop);
-  console.log("*** containerElemOffsetTop", containerElemOffsetTop);
-  console.log("*** scrollLength", scrollLength);
-
   const scroll = (): void => {
     const now: number =
       "now" in window.performance ? performance.now() : new Date().getTime();
@@ -821,13 +812,8 @@ const scrollToPurposes = (): void => {
     // tslint:disable-next-line: no-object-mutation
     scrollableElem.scrollTop = newScrollTop;
 
-    console.log("***");
-    console.log("newScrollTop --->", newScrollTop);
-
     // scrollTop can return subpixel on hidpi resolutions so round up to integer
     const intScrollTop = Math.ceil(scrollableElem.scrollTop);
-
-    console.log("intScrollTop --->", intScrollTop);
 
     if (
       intScrollTop === scrollLength + initDistanceScrolled ||

--- a/app/client/components/consent/PrivacySettings.tsx
+++ b/app/client/components/consent/PrivacySettings.tsx
@@ -824,12 +824,12 @@ const scrollToPurposes = (): void => {
     console.log("newScrollTop --->", newScrollTop);
     console.log(
       "actual scrollableElem.scrollTop --->",
-      scrollableElem.scrollTop
+      Math.ceil(scrollableElem.scrollTop)
     );
 
     if (
       scrollableElem.scrollTop === scrollLength + initDistanceScrolled ||
-      newScrollTop !== scrollableElem.scrollTop
+      newScrollTop - scrollableElem.scrollTop > 1
     ) {
       return;
     }

--- a/app/server/server.ts
+++ b/app/server/server.ts
@@ -60,7 +60,6 @@ server.use(
       "Content-Security-Policy",
       `frame-ancestors ${frameAncestors}`
     );
-    res.removeHeader("X-Frame-Options");
     next();
   },
   routes.consent


### PR DESCRIPTION
The `scrollToPurposes` function was buggy on mobile devices, to fix this we've refactored the function so we check whether the scrollable container has scrolled the maximum it can, and if so we kill the `requsetAnimationFrame` cycle.