### PR TITLE
CMP UI - scroll enhancement

### DIFF
--- a/app/client/components/consent/ConsentMangementPortal.tsx
+++ b/app/client/components/consent/ConsentMangementPortal.tsx
@@ -1,23 +1,92 @@
 import { css } from "@emotion/core";
+import { palette, space } from "@guardian/src-foundations";
 import React, { Component } from "react";
+import { minWidth } from "../../styles/breakpoints";
+import { TheGuardianLogo } from "../svgs/theGuardianLogo";
 import { PrivacySettings } from "./PrivacySettings";
 
-const iosFixStyles = css`
+const HEADER_ID = "header";
+const SCROLLABLE_ID = "scrollable";
+
+const headerCSS = (headerWidth: number) => css`
+  background-color: ${palette.brand.main};
+  position: sticky;
+  top: 0;
+  z-index: 200;
+  width: 100%;
+  ${minWidth.mobileLandscape} {
+    width: ${headerWidth}px;
+  }
+`;
+
+const logoContainer = css`
+  padding: 6px ${space[2]}px 12px 0;
+  height: 100%;
+  width: 100%;
+  border-bottom: 1px solid ${palette.brand.pastel};
+  display: flex;
+  ::before {
+    content: "";
+    display: block;
+    flex: 1;
+    height: 100%;
+  }
+`;
+
+const logoStyles = css`
+  height: 55px;
+
+  ${minWidth.mobileLandscape} {
+    height: 90px;
+  }
+
+  path {
+    fill: ${palette.neutral[100]};
+  }
+`;
+
+/**
+ * Force the height of the scrollable to 100vh
+ * because it forces the parent iframe height on iOS
+ */
+const scrollableStyles = css`
   height: 1px;
   min-height: 100vh;
   overflow-y: scroll;
+  -webkit-overflow-scrolling: touch;
 `;
 
-export class ConsentManagementPortal extends Component<{}, {}> {
+interface State {
+  headerWidth: number;
+}
+
+export class ConsentManagementPortal extends Component<{}, State> {
   constructor(props: {}) {
     super(props);
+
+    this.state = {
+      headerWidth: 0
+    };
   }
 
   public render(): React.ReactNode {
     return (
-      <div css={iosFixStyles} id="scrollable">
-        <PrivacySettings />
-      </div>
+      <>
+        <div css={headerCSS(this.state.headerWidth)} id={HEADER_ID}>
+          <div css={logoContainer}>
+            <TheGuardianLogo css={logoStyles} />
+          </div>
+        </div>
+        <div css={scrollableStyles} id={SCROLLABLE_ID}>
+          <PrivacySettings
+            updateHeaderWidth={(headerWidth: number): void => {
+              this.setState({
+                headerWidth
+              });
+            }}
+          />
+        </div>
+      </>
     );
   }
 }

--- a/app/client/components/consent/ConsentMangementPortal.tsx
+++ b/app/client/components/consent/ConsentMangementPortal.tsx
@@ -10,7 +10,7 @@ const SCROLLABLE_ID = "scrollable";
 
 const headerCSS = (headerWidth: number) => css`
   background-color: ${palette.brand.main};
-  position: sticky;
+  position: fixed;
   top: 0;
   z-index: 200;
   width: 100%;

--- a/app/client/components/consent/PrivacySettings.tsx
+++ b/app/client/components/consent/PrivacySettings.tsx
@@ -43,7 +43,6 @@ const privacyPolicyURL = "https://www.theguardian.com/info/privacy";
 const cookiePolicyURL = "https://www.theguardian.com/info/cookies";
 const smallSpace = space[2]; // 12px
 const mediumSpace = smallSpace + smallSpace / 3; // 16px
-const headerBorderBottom = 1;
 
 const containerStyles = css`
   z-index: 0;
@@ -53,6 +52,10 @@ const containerStyles = css`
   ${minWidth.mobileLandscape} {
     width: 95%;
     max-width: 450px;
+  }
+  margin-top: 73px;
+  ${minWidth.mobileLandscape} {
+    margin-top: 108px;
   }
 `;
 
@@ -854,20 +857,25 @@ const scrollToPurposes = (): void => {
   const scrollableElem: HTMLElement | null = document.getElementById(
     SCROLLABLE_ID
   );
+  const containerElem: HTMLElement | null = document.getElementById(
+    CONTAINER_ID
+  );
 
-  if (!purposeElem || !scrollableElem) {
+  if (!purposeElem || !scrollableElem || !containerElem) {
     return;
   }
 
   const purposeElemOffsetTop = purposeElem.offsetTop;
   const scrollableElemOffsetTop = scrollableElem.offsetTop;
+  const containerElemOffsetTop = containerElem.offsetTop;
+
   // scrollTop can return subpixel on hidpi resolutions so round up to integer
   const initDistanceScrolled = Math.ceil(scrollableElem.scrollTop);
   const scrollLength =
     purposeElemOffsetTop -
     scrollableElemOffsetTop -
-    initDistanceScrolled +
-    headerBorderBottom;
+    containerElemOffsetTop -
+    initDistanceScrolled;
 
   const duration: number = 750;
   const startTime: number =


### PR DESCRIPTION
On iOS the height of the iframe that contains the CMP UI always grows to match the content of the CMP UI, this is a problem as it breaks the positioning of all sticky elements  (eg. the buttons which we want to be visible on the initial impression are no longer visible).

To overcome this we introduce a containing `div` in the CMP UI that wraps all the content, we refer to this as the "scrollable". The scrollable has a height set to `100vh`, which tricks iOS into keeping the iframe that contains the CMP UI to be 100% viewport height too. 

We've then had to add the CSS rule `overflow-y: scroll;` to the scrollable so users can scroll this area. This works on mobile, but you don't get any smooth "momentum scrolling". In order to achieve this momentum scrolling this PR adds the CSS rule `-webkit-overflow-scrolling: touch;`.

After adding `-webkit-overflow-scrolling: touch;` to the scrollable I found the "header" would bounce on scrolling as the header was a child of the scrollable. To fix the bounce I've moved the header out of the scrollable container.

I then found the header width didn't match the scrollable width, even though they both had `width: 95%` CSS rule - the reason for this is the scrollable width was actually 95% of the width - the scrollbar. Therefore I've had to introduce logic which resizes the header to match the scrollable's width.

