### PR TITLE
CMP UI - IE fix

### DIFF
--- a/app/server/consent/html.ts
+++ b/app/server/consent/html.ts
@@ -36,7 +36,9 @@ const html: (
         }
         (function() {
             var firstScript = document.scripts[0];
-            [${scripts.map(script => JSON.stringify(script))}].forEach(url => {
+            [${scripts.map(script =>
+              JSON.stringify(script)
+            )}].forEach(function(url) {
                 if ('async' in firstScript) {
                     // modern browsers
                     var script = document.createElement('script');


### PR DESCRIPTION
An arrow function exists in the the `<head>` of the CMP UI, as expected this causes errors on older browsers that don't support this JS feature, replacing with a standard function fixes this.