### PR TITLE
'digital pack' -> 'digital subscription'

### DIFF
--- a/app/server/routes/products.ts
+++ b/app/server/routes/products.ts
@@ -11,6 +11,22 @@ const routeProvider = (apiPathPrefix: string) => {
   const router = Router();
 
   Object.values(ProductTypes).forEach((productType: ProductType) => {
+    if (productType.legacyUrlPart) {
+      router.use(
+        `*/${productType.legacyUrlPart}*`,
+        (req: Request, res: Response) => {
+          res.redirect(
+            req.originalUrl.replace(
+              `/${productType.legacyUrlPart}`,
+              `/${productType.urlPart}`
+            )
+          );
+        }
+      );
+    }
+  });
+
+  Object.values(ProductTypes).forEach((productType: ProductType) => {
     router.use(
       "/banner/" + productType.urlPart,
       (req: Request, res: Response) => {

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -287,7 +287,8 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
     urlPart: "digitalpack",
     getOphanProductType: () => "DIGITAL_SUBSCRIPTION",
     showTrialRemainingIfApplicable: true,
-    productPage: "subscriptions"
+    productPage: "subscriptions",
+    alternateTierValue: "Digital Subscription"
   },
   contentSubscriptions: {
     friendlyName: "subscription",

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -26,7 +26,7 @@ export type ProductUrlPart =
   | "membership"
   | "contributions"
   | "paper"
-  | "digitalpack"
+  | "digital"
   | "guardianweekly"
   | "subscriptions";
 export type SfProduct = "Membership" | "Contribution";
@@ -74,6 +74,7 @@ export interface ProductType {
   friendlyName: ProductFriendlyName;
   allProductsProductTypeFilterString: AllProductsProductTypeFilterString;
   urlPart: ProductUrlPart;
+  legacyUrlPart?: string; // could easily adapt to be string[] if multiple were required in future
   getOphanProductType?: (
     productDetail: ProductDetail
   ) => OphanProduct | undefined;
@@ -284,7 +285,8 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
   digipack: {
     friendlyName: "digital subscription",
     allProductsProductTypeFilterString: "Digipack",
-    urlPart: "digitalpack",
+    urlPart: "digital",
+    legacyUrlPart: "digitalpack",
     getOphanProductType: () => "DIGITAL_SUBSCRIPTION",
     showTrialRemainingIfApplicable: true,
     productPage: "subscriptions",

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -19,7 +19,7 @@ export type ProductFriendlyName =
   | "membership"
   | "recurring contribution" // TODO use payment frequency instead of 'recurring' e.g. monthly annual etc
   | "newspaper subscription"
-  | "digital pack subscription"
+  | "digital subscription"
   | "Guardian Weekly subscription"
   | "subscription";
 export type ProductUrlPart =
@@ -282,7 +282,7 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
     productPage: "subscriptions"
   },
   digipack: {
-    friendlyName: "digital pack subscription",
+    friendlyName: "digital subscription",
     allProductsProductTypeFilterString: "Digipack",
     urlPart: "digitalpack",
     getOphanProductType: () => "DIGITAL_SUBSCRIPTION",


### PR DESCRIPTION
- Update the 'friendly name' for digipack in the `productTypes.tsx` to remove the 'pack' keyword, which is used in for example the heading of the payment flow SO now it looks like...
![image](https://user-images.githubusercontent.com/19289579/66419165-77f32f80-e9fb-11e9-9fd2-9d2253f17fd1.png)

- provide an alternate value for 'tier' on the digipack product to ensure we show 'Digital Subscription' (rather than 'Digital Pack', _which is provided by `members-data-api`_) SO now it looks like...
![image](https://user-images.githubusercontent.com/19289579/66421372-a541dc80-e9ff-11e9-8ba9-e46107231155.png)

- introduced 🆕 optional field `legacyUrlPart` on `ProductType` interface, and defined if for digipack as "digitalpack" and changed the `urlPart` to just "digital" 

- added blanket server-side redirect mechanism to replace the `legacyUrlPart` within any URL with the `urlPart`, _for example `/payment/digitalpack` ... redirects to ... `/payment/digital`_

#### Related PRs
https://github.com/guardian/members-data-api/pull/410