### PR TITLE
CMP UI - hide scroll bar

### DIFF
--- a/app/client/components/consent/App.tsx
+++ b/app/client/components/consent/App.tsx
@@ -11,6 +11,7 @@ export const App = () => (
     <Global
       styles={css(`
       body {
+        overflow-x: hidden;
         background-color: ${palette.brand.main};
       }`)}
     />

--- a/app/client/components/consent/ConsentMangementPortal.tsx
+++ b/app/client/components/consent/ConsentMangementPortal.tsx
@@ -87,7 +87,6 @@ export class ConsentManagementPortal extends Component<{}, State> {
         >
           <PrivacySettings
             hideScrollBar={(): void => {
-              // if (document) {
               const scrollableElem = document.getElementById(SCROLLABLE_ID);
 
               if (!scrollableElem) {
@@ -105,7 +104,6 @@ export class ConsentManagementPortal extends Component<{}, State> {
                   this.updateHeaderWidth();
                 }
               );
-              // }
             }}
           />
         </div>
@@ -114,7 +112,6 @@ export class ConsentManagementPortal extends Component<{}, State> {
   }
 
   private updateHeaderWidth(): void {
-    // if (document) {
     const containerElem = document.getElementById(CONTAINER_ID);
 
     if (!containerElem) {
@@ -126,6 +123,5 @@ export class ConsentManagementPortal extends Component<{}, State> {
     this.setState({
       headerWidth
     });
-    // }
   }
 }

--- a/app/client/components/consent/ConsentMangementPortal.tsx
+++ b/app/client/components/consent/ConsentMangementPortal.tsx
@@ -7,6 +7,7 @@ import { PrivacySettings } from "./PrivacySettings";
 
 const HEADER_ID = "header";
 const SCROLLABLE_ID = "scrollable";
+const CONTAINER_ID = "container";
 
 const headerCSS = (headerWidth: number) => css`
   background-color: ${palette.brand.main};
@@ -49,15 +50,17 @@ const logoStyles = css`
  * Force the height of the scrollable to 100vh
  * because it forces the parent iframe height on iOS
  */
-const scrollableStyles = css`
+const scrollableStyles = (scrollbarWidth: number) => css`
   height: 1px;
   min-height: 100vh;
   overflow-y: scroll;
   -webkit-overflow-scrolling: touch;
+  margin-right: ${-scrollbarWidth}px;
 `;
 
 interface State {
   headerWidth: number;
+  scrollbarWidth: number;
 }
 
 export class ConsentManagementPortal extends Component<{}, State> {
@@ -65,7 +68,8 @@ export class ConsentManagementPortal extends Component<{}, State> {
     super(props);
 
     this.state = {
-      headerWidth: 0
+      headerWidth: 0,
+      scrollbarWidth: 0
     };
   }
 
@@ -77,16 +81,51 @@ export class ConsentManagementPortal extends Component<{}, State> {
             <TheGuardianLogo css={logoStyles} />
           </div>
         </div>
-        <div css={scrollableStyles} id={SCROLLABLE_ID}>
+        <div
+          css={scrollableStyles(this.state.scrollbarWidth)}
+          id={SCROLLABLE_ID}
+        >
           <PrivacySettings
-            updateHeaderWidth={(headerWidth: number): void => {
-              this.setState({
-                headerWidth
-              });
+            hideScrollBar={(): void => {
+              // if (document) {
+              const scrollableElem = document.getElementById(SCROLLABLE_ID);
+
+              if (!scrollableElem) {
+                return;
+              }
+
+              const scrollbarWidth =
+                scrollableElem.offsetWidth - scrollableElem.clientWidth;
+
+              this.setState(
+                {
+                  scrollbarWidth
+                },
+                () => {
+                  this.updateHeaderWidth();
+                }
+              );
+              // }
             }}
           />
         </div>
       </>
     );
+  }
+
+  private updateHeaderWidth(): void {
+    // if (document) {
+    const containerElem = document.getElementById(CONTAINER_ID);
+
+    if (!containerElem) {
+      return;
+    }
+
+    const headerWidth = containerElem.offsetWidth;
+
+    this.setState({
+      headerWidth
+    });
+    // }
   }
 }

--- a/app/client/components/consent/PrivacySettings.tsx
+++ b/app/client/components/consent/PrivacySettings.tsx
@@ -266,7 +266,7 @@ interface State {
 }
 
 interface Props {
-  updateHeaderWidth: (headerWidth: number) => void;
+  hideScrollBar: () => void;
 }
 
 export class PrivacySettings extends Component<Props, State> {
@@ -281,14 +281,6 @@ export class PrivacySettings extends Component<Props, State> {
   }
 
   public componentDidMount(): void {
-    // Update header width to account for scrollbar on container
-    this.updateHeaderWidth();
-
-    window.addEventListener("resize", () => {
-      // Update header width to on resize
-      this.updateHeaderWidth();
-    });
-
     fetch(cmpConfig.IAB_VENDOR_LIST_URL)
       .then(response => {
         if (response.ok) {
@@ -307,6 +299,14 @@ export class PrivacySettings extends Component<Props, State> {
         );
       })
       .then(() => {
+        // Update header width to account for scrollbar on container
+        this.hideScrollBar();
+
+        window.addEventListener("resize", () => {
+          // Update header width to on resize
+          this.hideScrollBar();
+        });
+
         window.parent.postMessage({ msgType: cmpConfig.CMP_READY_MSG }, "*");
       })
       .catch(error => {
@@ -703,13 +703,14 @@ export class PrivacySettings extends Component<Props, State> {
     }));
   }
 
-  private updateHeaderWidth(): void {
-    const containerElem = document.getElementById(CONTAINER_ID);
+  private hideScrollBar(): void {
+    this.props.hideScrollBar();
+    // const containerElem = document.getElementById(CONTAINER_ID);
 
-    if (containerElem) {
-      const containerWidth = containerElem.offsetWidth;
-      this.props.updateHeaderWidth(containerWidth);
-    }
+    // if (containerElem) {
+    //   const containerWidth = containerElem.offsetWidth;
+    //   this.props.updateHeaderWidth(containerWidth);
+    // }
   }
 }
 const parseGuPurposeList = (

--- a/app/client/components/consent/PrivacySettings.tsx
+++ b/app/client/components/consent/PrivacySettings.tsx
@@ -299,12 +299,14 @@ export class PrivacySettings extends Component<Props, State> {
         );
       })
       .then(() => {
+        const { hideScrollBar } = this.props;
+
         // hide scrollbar and update header width
-        this.hideScrollBar();
+        hideScrollBar();
 
         window.addEventListener("resize", () => {
           // hide scrollbar and update header width
-          this.hideScrollBar();
+          hideScrollBar();
         });
 
         window.parent.postMessage({ msgType: cmpConfig.CMP_READY_MSG }, "*");
@@ -701,16 +703,6 @@ export class PrivacySettings extends Component<Props, State> {
           )
         : []
     }));
-  }
-
-  private hideScrollBar(): void {
-    this.props.hideScrollBar();
-    // const containerElem = document.getElementById(CONTAINER_ID);
-
-    // if (containerElem) {
-    //   const containerWidth = containerElem.offsetWidth;
-    //   this.props.updateHeaderWidth(containerWidth);
-    // }
   }
 }
 const parseGuPurposeList = (

--- a/app/client/components/consent/PrivacySettings.tsx
+++ b/app/client/components/consent/PrivacySettings.tsx
@@ -299,11 +299,11 @@ export class PrivacySettings extends Component<Props, State> {
         );
       })
       .then(() => {
-        // Update header width to account for scrollbar on container
+        // hide scrollbar and update header width
         this.hideScrollBar();
 
         window.addEventListener("resize", () => {
-          // Update header width to on resize
+          // hide scrollbar and update header width
           this.hideScrollBar();
         });
 


### PR DESCRIPTION
Because we load the CMP UI within an iframe from the righthand side of theguardian.com you get 2 scrollbars positioned side by side, one for the iframe scrollable area and one for the parent site. To overcome this we can position the content of the iframe to take into account the scrollbar and hide it. We do this with JavaScript by calculating the `scrollbarWidth`.