### PR TITLE
refactor to use cleaned/simplified version of 'holiday-stops-api'

### DIFF
--- a/app/client/components/holiday/holidayDateChooser.tsx
+++ b/app/client/components/holiday/holidayDateChooser.tsx
@@ -168,8 +168,7 @@ export class HolidayDateChooser extends React.Component<
                         >
                           <HolidayQuestionsModal
                             annualIssueLimit={
-                              holidayStopsResponse.productSpecifics
-                                .annualIssueLimit
+                              holidayStopsResponse.annualIssueLimit
                             }
                           />
                         </div>
@@ -190,14 +189,13 @@ export class HolidayDateChooser extends React.Component<
                         selectionInfo={this.getSelectionInfoElement(
                           renewalDateMoment,
                           combinedIssuesImpactedPerYear,
-                          holidayStopsResponse.productSpecifics.annualIssueLimit
+                          holidayStopsResponse.annualIssueLimit
                         )}
                         onSelect={this.onSelect(
                           renewalDateMoment,
                           productDetail.subscription.subscriptionId,
                           combinedIssuesImpactedPerYear,
-                          holidayStopsResponse.productSpecifics
-                            .annualIssueLimit,
+                          holidayStopsResponse.annualIssueLimit,
                           productDetail.isTestUser
                         )}
                         dateToAsterisk={renewalDateMoment}
@@ -219,8 +217,7 @@ export class HolidayDateChooser extends React.Component<
                         >
                           <HolidayQuestionsModal
                             annualIssueLimit={
-                              holidayStopsResponse.productSpecifics
-                                .annualIssueLimit
+                              holidayStopsResponse.annualIssueLimit
                             }
                           />
                         </div>
@@ -276,7 +273,6 @@ export class HolidayDateChooser extends React.Component<
       () =>
         createPotentialHolidayStopsFetcher(
           false,
-          this.props.productType.urlPart,
           subscriptionName,
           start,
           end,

--- a/app/client/components/holiday/holidayReview.tsx
+++ b/app/client/components/holiday/holidayReview.tsx
@@ -7,7 +7,6 @@ import {
   MembersDataApiResponseContext,
   ProductDetail
 } from "../../../shared/productResponse";
-import { ProductType } from "../../../shared/productTypes";
 import { maxWidth } from "../../styles/breakpoints";
 import { Button } from "../buttons";
 import { CallCentreNumbers } from "../callCentreNumbers";
@@ -45,10 +44,9 @@ import { SummaryTable } from "./summaryTable";
 const getPerformCreation = (
   selectedRange: DateRange,
   subscriptionName: string,
-  isTestUser: boolean,
-  productType: ProductType
+  isTestUser: boolean
 ) => () =>
-  fetch(`/api/holidays/${productType.urlPart}`, {
+  fetch(`/api/holidays`, {
     credentials: "include",
     method: "POST",
     mode: "same-origin",
@@ -104,7 +102,6 @@ export class HolidayReview extends React.Component<
                     <PotentialHolidayStopsAsyncLoader
                       fetch={createPotentialHolidayStopsFetcher(
                         true,
-                        this.props.productType.urlPart,
                         productDetail.subscription.subscriptionId,
                         dateChooserState.selectedRange.start,
                         dateChooserState.selectedRange.end,
@@ -157,9 +154,7 @@ export class HolidayReview extends React.Component<
               {creditExplainerSentence}
             </p>
             <HolidayQuestionsModal
-              annualIssueLimit={
-                holidayStopsResponse.productSpecifics.annualIssueLimit
-              }
+              annualIssueLimit={holidayStopsResponse.annualIssueLimit}
             />
             <div css={{ height: "25px" }} />
             <SummaryTable
@@ -174,8 +169,7 @@ export class HolidayReview extends React.Component<
                 fetch={getPerformCreation(
                   dateChooserState.selectedRange,
                   productDetail.subscription.subscriptionId,
-                  productDetail.isTestUser,
-                  this.props.productType
+                  productDetail.isTestUser
                 )}
                 render={getRenderCreationSuccess(this.props.navigate)}
                 errorRender={renderCreationError}

--- a/app/client/components/holiday/holidaysOverview.tsx
+++ b/app/client/components/holiday/holidaysOverview.tsx
@@ -5,7 +5,6 @@ import {
   MembersDataApiResponseContext,
   ProductDetail
 } from "../../../shared/productResponse";
-import { ProductUrlPart } from "../../../shared/productTypes";
 import { maxWidth, minWidth } from "../../styles/breakpoints";
 import { sans } from "../../styles/fonts";
 import { ReFetch } from "../asyncLoader";
@@ -92,8 +91,7 @@ const renderHolidayStopsOverview = (
                   <div>
                     You can suspend up to{" "}
                     <strong>
-                      {holidayStopsResponse.productSpecifics.annualIssueLimit}{" "}
-                      issues
+                      {holidayStopsResponse.annualIssueLimit} issues
                     </strong>{" "}
                     per year of your subscription. <br />
                   </div>
@@ -118,9 +116,7 @@ const renderHolidayStopsOverview = (
                     </div>
                   </div>
                   <HolidayQuestionsModal
-                    annualIssueLimit={
-                      holidayStopsResponse.productSpecifics.annualIssueLimit
-                    }
+                    annualIssueLimit={holidayStopsResponse.annualIssueLimit}
                   />
                 </>
               }
@@ -135,8 +131,7 @@ const renderHolidayStopsOverview = (
                         You have suspended{" "}
                         <strong>
                           {combinedIssuesImpactedPerYear.issuesThisYear.length}/{
-                            holidayStopsResponse.productSpecifics
-                              .annualIssueLimit
+                            holidayStopsResponse.annualIssueLimit
                           }
                         </strong>{" "}
                         issues until{" "}
@@ -150,10 +145,7 @@ const renderHolidayStopsOverview = (
                               {
                                 combinedIssuesImpactedPerYear.issuesNextYear
                                   .length
-                              }/{
-                                holidayStopsResponse.productSpecifics
-                                  .annualIssueLimit
-                              }
+                              }/{holidayStopsResponse.annualIssueLimit}
                             </strong>{" "}
                             issues the following year
                           </span>
@@ -163,9 +155,7 @@ const renderHolidayStopsOverview = (
                   ) : (
                     <div>
                       You have{" "}
-                      <strong>
-                        {holidayStopsResponse.productSpecifics.annualIssueLimit}
-                      </strong>{" "}
+                      <strong>{holidayStopsResponse.annualIssueLimit}</strong>{" "}
                       issues available to suspend until{" "}
                       {renewalDateMoment.format(friendlyLongDateFormat)}.
                     </div>
@@ -239,11 +229,10 @@ const renderHolidayStopsOverview = (
 };
 
 const createGetHolidayStopsFetcher = (
-  productUrlPart: ProductUrlPart,
   subscriptionName: string,
   isTestUser: boolean
 ) => () =>
-  fetch(`/api/holidays/${productUrlPart}/${subscriptionName}`, {
+  fetch(`/api/holidays/${subscriptionName}`, {
     headers: {
       [MDA_TEST_USER_HEADER]: `${isTestUser}`
     }
@@ -266,7 +255,6 @@ export const HolidaysOverview = (props: RouteableStepProps) => (
           {productDetail.subscription.start ? (
             <GetHolidayStopsAsyncLoader
               fetch={createGetHolidayStopsFetcher(
-                routeableStepProps.productType.urlPart,
                 productDetail.subscription.subscriptionId,
                 productDetail.isTestUser
               )}

--- a/app/package.json
+++ b/app/package.json
@@ -24,7 +24,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn fix && GIT_DIR=../.git && yarn type-check && yarn bundle-check-client-if-changed"
+      "pre-commit": "yarn fix && GIT_DIR=../.git && (yarn type-check & yarn lint & yarn bundle-check-client-if-changed)"
     }
   },
   "cloudformation": "../cfn.yaml",

--- a/app/server/holidayStopApiHandlers.ts
+++ b/app/server/holidayStopApiHandlers.ts
@@ -2,13 +2,13 @@ import express from "express";
 import fetch from "node-fetch";
 import url from "url";
 import { MDA_TEST_USER_HEADER } from "../shared/productResponse";
-import { HolidayStopsApiProductNamePrefix } from "../shared/productTypes";
 import { holidayStopApiConfigPromise } from "./holidayStopApiConfig";
 import { log } from "./log";
 
-export const getHolidayStopApiHandler = (
-  holidayStopsApiProductNamePrefix?: HolidayStopsApiProductNamePrefix
-) => (req: express.Request, res: express.Response) =>
+export const holidayStopApiHandler = (
+  req: express.Request,
+  res: express.Response
+) =>
   holidayStopApiConfigPromise
     .then(hsrConfig => {
       if (hsrConfig && res.locals.identity && res.locals.identity.userId) {
@@ -36,10 +36,7 @@ export const getHolidayStopApiHandler = (
             method: req.method,
             headers: {
               "x-api-key": hsrEnvConfig.apiKey,
-              "x-identity-id": res.locals.identity.userId,
-              ...(holidayStopsApiProductNamePrefix
-                ? { "x-product-name-prefix": holidayStopsApiProductNamePrefix }
-                : {})
+              "x-identity-id": res.locals.identity.userId
             },
             body: req.method !== "GET" ? req.body : undefined
           }

--- a/app/server/routes/products.ts
+++ b/app/server/routes/products.ts
@@ -4,7 +4,7 @@ import {
   ProductType,
   ProductTypes
 } from "../../shared/productTypes";
-import { getHolidayStopApiHandler } from "../holidayStopApiHandlers";
+import { holidayStopApiHandler } from "../holidayStopApiHandlers";
 import { membersDataApiHandler } from "../middleware/apiMiddleware";
 
 const routeProvider = (apiPathPrefix: string) => {
@@ -53,17 +53,13 @@ const routeProvider = (apiPathPrefix: string) => {
         res.redirect("/" + productType.productPage);
       });
     }
-    if (productType.holidayStopsApiProductNamePrefix) {
-      router.use(
-        `${apiPathPrefix}holidays/${
-          productType.urlPart
-        }/:subscriptionName?/:sfId?`,
-        getHolidayStopApiHandler(productType.holidayStopsApiProductNamePrefix)
-      );
-    }
   });
 
-  router.get(`${apiPathPrefix}holidays/`, getHolidayStopApiHandler());
+  router.use(
+    `${apiPathPrefix}holidays/:subscriptionName?/:sfId?`,
+    holidayStopApiHandler
+  );
+
   return router;
 };
 

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -44,7 +44,6 @@ export type AllProductsProductTypeFilterString =
   | "Membership"
   | "Digipack"
   | "ContentSubscription";
-export type HolidayStopsApiProductNamePrefix = "Guardian Weekly";
 
 export interface CancellationFlowProperties {
   reasons: CancellationReason[];
@@ -96,7 +95,7 @@ export interface ProductType {
   showTrialRemainingIfApplicable?: true;
   mapGroupedToSpecific?: (productDetail: ProductDetail) => ProductType;
   updateAmountMdaEndpoint?: string;
-  holidayStopsApiProductNamePrefix?: HolidayStopsApiProductNamePrefix;
+  shouldHaveHolidayStopsFlow?: true;
 }
 
 export interface ProductTypeWithCancellationFlow extends ProductType {
@@ -133,7 +132,7 @@ export const shouldCreatePaymentUpdateFlow = (productType: ProductType) =>
   !productType.mapGroupedToSpecific;
 
 export const shouldHaveHolidayStopsFlow = (productType: ProductType) =>
-  !!productType.holidayStopsApiProductNamePrefix;
+  productType.shouldHaveHolidayStopsFlow;
 
 export const createProductDetailFetcher = (
   productType: ProductType,
@@ -299,7 +298,7 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
       productDetail.subscription.autoRenew
         ? undefined
         : "renew your one-off Guardian Weekly subscription",
-    holidayStopsApiProductNamePrefix: "Guardian Weekly",
+    shouldHaveHolidayStopsFlow: true,
     productPage: "subscriptions"
   },
   digipack: {


### PR DESCRIPTION
Following https://github.com/guardian/support-service-lambdas/pull/456, the `holiday-stop-api` uses the subscription name that was already part of all of the URLs to determine the product variant, rather than relying on headers or query params.

**This PR simplifies the calling logic and reads the new response structures.**