### PR TITLE
Fix Invariant Violation error

### DIFF
--- a/app/client/consent.tsx
+++ b/app/client/consent.tsx
@@ -34,4 +34,10 @@ const run = (): void => {
   }
 };
 
-run();
+if (document.readyState !== 'loading') {
+  run();
+} else {
+  document.addEventListener('DOMContentLoaded', function () {
+    run();
+  });
+}

--- a/app/client/consent.tsx
+++ b/app/client/consent.tsx
@@ -37,7 +37,7 @@ const run = (): void => {
 if (document.readyState !== 'loading') {
   run();
 } else {
-  document.addEventListener('DOMContentLoaded', function () {
+  document.addEventListener('DOMContentLoaded', (): void => {
     run();
   });
 }


### PR DESCRIPTION
Sentry has been reporting Invariant Violation errors ("Target container is not a DOM element") which we believe are being caused by calling `document.getElementById("app")` inside `run()` before the body is parsed.

Despite not being able to recreate the issue locally we believe this change will fix it.

Tested locally and on CODE to make sure there are no adverse effects.