### PR TITLE
Self-Serve Voucher holiday stops

### DIFF
--- a/app/client/components/datePicker.tsx
+++ b/app/client/components/datePicker.tsx
@@ -28,7 +28,7 @@ export interface LegendItemProps {
   extraCss?: string;
 }
 
-const legendItems: LegendItemProps[] = [
+const legendItems = (issueKeyword: string) => [
   {
     extraCss: `
   ::after {
@@ -42,7 +42,7 @@ const legendItems: LegendItemProps[] = [
     left: -14px;
   }
   `,
-    label: "Issue day"
+    label: `${issueKeyword} day`
   },
   stateDefinitions.existing
 ];
@@ -108,7 +108,8 @@ const LegendItem = (props: LegendItemProps) => (
 
 export interface DatePickerProps {
   firstAvailableDate: Moment;
-  issueDayOfWeek: number;
+  issueDaysOfWeek: number[];
+  issueKeyword: string;
   existingDates: DateRange[];
   selectedRange?: DateRange;
   selectionInfo?: React.ReactElement;
@@ -125,7 +126,7 @@ export const DatePicker = (props: DatePickerProps) => (
         marginBottom: "10px"
       }}
     >
-      {legendItems.map(itemProps => (
+      {legendItems(props.issueKeyword).map(itemProps => (
         <LegendItem key={itemProps.label} {...itemProps} />
       ))}
     </div>
@@ -157,7 +158,7 @@ export const DatePicker = (props: DatePickerProps) => (
             }))}
           defaultState="available"
           firstOfWeek={1}
-          dayOfWeekToIconify={props.issueDayOfWeek}
+          daysOfWeekToIconify={props.issueDaysOfWeek}
           dateToAsterisk={props.dateToAsterisk}
         />
       </div>

--- a/app/client/components/hackedDateRangePicker.tsx
+++ b/app/client/components/hackedDateRangePicker.tsx
@@ -13,8 +13,8 @@ import { Button } from "./buttons";
 
 const gridBorderCssValue = `1px solid ${palette.neutral["5"]} !important;`;
 
-const iconDayPseudoAfterCss = `
-::after {
+const iconDayPseudoAfterCss = (dayOfWeek: number) => `
+.DateRangePicker__Week .DateRangePicker__Date:nth-of-type(${dayOfWeek})::after {
   content: "";
   position: absolute;
   width: 14px;
@@ -128,7 +128,7 @@ class HackedDateRangePicker extends DateRangePicker {
 
 export interface WrappedDateRangePickerProps extends Props {
   dateToAsterisk?: Moment;
-  dayOfWeekToIconify: number;
+  daysOfWeekToIconify: number[];
 }
 
 export const WrappedDateRangePicker = (props: WrappedDateRangePickerProps) => (
@@ -208,9 +208,7 @@ export const WrappedDateRangePicker = (props: WrappedDateRangePickerProps) => (
         .DateRangePicker__Date.DateRangePicker__Date--weekend {
           background-color: transparent;
         }
-        .DateRangePicker__Week .DateRangePicker__Date:nth-of-type(${
-          props.dayOfWeekToIconify
-        })${iconDayPseudoAfterCss}
+        ${props.daysOfWeekToIconify.map(iconDayPseudoAfterCss).join("\n")}
         .DateRangePicker__MonthDates {
           border-collapse: collapse;
         }

--- a/app/client/components/holiday/holidayAnniversaryDateExplainerModal.tsx
+++ b/app/client/components/holiday/holidayAnniversaryDateExplainerModal.tsx
@@ -4,6 +4,7 @@ import { Modal } from "../modal";
 
 export interface HolidayAnniversaryDateExplainerModalProps {
   dateElement: JSX.Element;
+  issueKeyword: string;
 }
 
 export const HolidayAnniversaryDateExplainerModal = (
@@ -24,8 +25,8 @@ export const HolidayAnniversaryDateExplainerModal = (
     title="What is this date?"
   >
     <p>
-      {props.dateElement} is the anniversary of your subscription. The number of
-      issues you can suspend per year is reset on this date.
+      {props.dateElement} is the anniversary of your subscription. The number of{" "}
+      {props.issueKeyword}s you can suspend per year is reset on this date.
     </p>
   </Modal>
 );

--- a/app/client/components/holiday/holidayConfirmed.tsx
+++ b/app/client/components/holiday/holidayConfirmed.tsx
@@ -5,24 +5,21 @@ import {
 } from "../../../shared/productResponse";
 import { LinkButton } from "../buttons";
 import { GenericErrorScreen } from "../genericErrorScreen";
-import {
-  RouteableStepProps,
-  visuallyNavigateToParent,
-  WizardStep
-} from "../wizardRouterAdapter";
+import { visuallyNavigateToParent, WizardStep } from "../wizardRouterAdapter";
 import {
   buttonBarCss,
   HolidayDateChooserStateContext,
   isSharedHolidayDateChooserState
 } from "./holidayDateChooser";
 import { creditExplainerSentence } from "./holidayQuestionsModal";
+import { HolidayStopsRouteableStepProps } from "./holidaysOverview";
 import {
   HolidayStopsResponseContext,
   isHolidayStopsResponse
 } from "./holidayStopApi";
 import { SummaryTable } from "./summaryTable";
 
-export const HolidayConfirmed = (props: RouteableStepProps) => (
+export const HolidayConfirmed = (props: HolidayStopsRouteableStepProps) => (
   <HolidayStopsResponseContext.Consumer>
     {holidayStopsResponse =>
       isHolidayStopsResponse(holidayStopsResponse) ? (
@@ -35,7 +32,13 @@ export const HolidayConfirmed = (props: RouteableStepProps) => (
                   <WizardStep routeableStepProps={props} hideBackButton>
                     <div>
                       <h1>Your schedule has been set</h1>
-                      <p>{creditExplainerSentence}</p>
+                      <p>
+                        We will send an email to confirm the details.{" "}
+                        {creditExplainerSentence(
+                          props.productType.holidayStops.issueKeyword
+                        )}{" "}
+                        {props.productType.holidayStops.additionalHowAdvice}
+                      </p>
                       <SummaryTable
                         data={dateChooserState}
                         subscription={productDetail.subscription}

--- a/app/client/components/holiday/holidayDateChooser.tsx
+++ b/app/client/components/holiday/holidayDateChooser.tsx
@@ -1,5 +1,6 @@
 import { Link, navigate } from "@reach/router";
 import { FlexWrapProperty, FontWeightProperty } from "csstype";
+import { startCase } from "lodash";
 import { Moment } from "moment";
 import { DateRange } from "moment-range";
 import * as Raven from "raven-js";
@@ -200,9 +201,12 @@ export class HolidayDateChooser extends React.Component<
                           holidayStopsResponse.productSpecifics
                             .firstAvailableDate
                         }
-                        issueDayOfWeek={
-                          holidayStopsResponse.productSpecifics.issueDayOfWeek
+                        issueDaysOfWeek={
+                          holidayStopsResponse.productSpecifics.issueDaysOfWeek
                         }
+                        issueKeyword={startCase(
+                          this.props.productType.holidayStops.issueKeyword
+                        )}
                         existingDates={holidayStopsResponse.existing.map(
                           hsr => hsr.dateRange
                         )}

--- a/app/client/components/holiday/holidayQuestionsModal.tsx
+++ b/app/client/components/holiday/holidayQuestionsModal.tsx
@@ -1,14 +1,16 @@
 import React from "react";
+import { HolidayStopFlowProperties } from "../../../shared/productTypes";
 import { sans } from "../../styles/fonts";
 import { CallCentreNumbers } from "../callCentreNumbers";
 import { Modal } from "../modal";
 import { InfoIcon } from "../svgs/infoIcon";
 
-export const creditExplainerSentence =
-  "You will be credited for each suspended issue on the next bill after the issue date.";
+export const creditExplainerSentence = (issueKeyword: string) =>
+  `You will be credited for each suspended ${issueKeyword} on the next bill after the ${issueKeyword} date.`;
 
 export interface HolidayQuestionsModalProps {
   annualIssueLimit: number;
+  holidayStopFlowProperties: HolidayStopFlowProperties;
 }
 
 export const HolidayQuestionsModal = (props: HolidayQuestionsModalProps) => (
@@ -31,13 +33,25 @@ export const HolidayQuestionsModal = (props: HolidayQuestionsModalProps) => (
     <h3>Things to remember</h3>
     <ul>
       <li>
-        You can suspend up to {props.annualIssueLimit} issues in one year.
+        You can suspend up to {props.annualIssueLimit}{" "}
+        {props.holidayStopFlowProperties.issueKeyword}s in one year.
       </li>
       <li>
         A new suspension cannot begin from today as there is a notice period.
       </li>
-      <li>Notice period is for our printing and delivery schedule.</li>
-      <li>{creditExplainerSentence}</li>
+      {props.holidayStopFlowProperties.alternateNoticeString ? (
+        <li>
+          Please provide{" "}
+          <strong>
+            {props.holidayStopFlowProperties.alternateNoticeString}
+          </strong>.
+        </li>
+      ) : (
+        <li>Notice period is for our printing and delivery schedule.</li>
+      )}
+      <li>
+        {creditExplainerSentence(props.holidayStopFlowProperties.issueKeyword)}
+      </li>
     </ul>
     <h3>You will need to contact us by phone or email if you...</h3>
     <ul>
@@ -46,8 +60,8 @@ export const HolidayQuestionsModal = (props: HolidayQuestionsModalProps) => (
         the same country.
       </li>
       <li>
-        You want to suspend more than {props.annualIssueLimit} issues in one
-        year.
+        You want to suspend more than {props.annualIssueLimit}{" "}
+        {props.holidayStopFlowProperties.issueKeyword}s in one year.
       </li>
     </ul>
     <h3>How to contact us</h3>

--- a/app/client/components/holiday/holidayReview.tsx
+++ b/app/client/components/holiday/holidayReview.tsx
@@ -8,9 +8,13 @@ import {
   ProductDetail
 } from "../../../shared/productResponse";
 import { maxWidth } from "../../styles/breakpoints";
+import { sans } from "../../styles/fonts";
 import { Button } from "../buttons";
 import { CallCentreNumbers } from "../callCentreNumbers";
+import { Checkbox } from "../checkbox";
 import { GenericErrorScreen } from "../genericErrorScreen";
+import { Modal } from "../modal";
+import { InfoIcon } from "../svgs/infoIcon";
 import { visuallyNavigateToParent, WizardStep } from "../wizardRouterAdapter";
 import {
   buttonBarCss,
@@ -77,6 +81,7 @@ const renderCreationError = () => (
 );
 export interface HolidayReviewState {
   isCreating: boolean;
+  isCheckboxConfirmed: boolean;
 }
 
 export class HolidayReview extends React.Component<
@@ -84,7 +89,8 @@ export class HolidayReview extends React.Component<
   HolidayReviewState
 > {
   public state: HolidayReviewState = {
-    isCreating: false
+    isCreating: false,
+    isCheckboxConfirmed: false
   };
   public render = () => (
     <HolidayStopsResponseContext.Consumer>
@@ -163,6 +169,49 @@ export class HolidayReview extends React.Component<
               alternateSuspendedColumnHeading="To be suspended"
               subscription={productDetail.subscription}
             />
+            {this.props.productType.holidayStops
+              .explicitConfirmationRequired && (
+              <>
+                <div css={{ marginTop: "20px", marginBottom: "10px" }}>
+                  <Checkbox
+                    checked={this.state.isCheckboxConfirmed}
+                    onChange={newValue =>
+                      this.setState({ isCheckboxConfirmed: newValue })
+                    }
+                    label={
+                      this.props.productType.holidayStops
+                        .explicitConfirmationRequired.checkboxLabel
+                    }
+                  />
+                </div>
+                <Modal
+                  instigator={
+                    <a
+                      css={{
+                        fontFamily: sans,
+                        fontSize: "14px",
+                        cursor: "pointer",
+                        textDecoration: "underline",
+                        margin: "10px"
+                      }}
+                    >
+                      <InfoIcon />Tell me more
+                    </a>
+                  }
+                  title={
+                    this.props.productType.holidayStops
+                      .explicitConfirmationRequired.explainerModalTitle
+                  }
+                >
+                  <p>
+                    {
+                      this.props.productType.holidayStops
+                        .explicitConfirmationRequired.explainerModalBody
+                    }
+                  </p>
+                </Modal>
+              </>
+            )}
           </div>
           {this.state.isCreating ? (
             <div css={{ marginTop: "40px", textAlign: "right" }}>
@@ -216,6 +265,11 @@ export class HolidayReview extends React.Component<
                 </Link>
                 <Button
                   text="Confirm"
+                  disabled={
+                    !!this.props.productType.holidayStops
+                      .explicitConfirmationRequired &&
+                    !this.state.isCheckboxConfirmed
+                  }
                   onClick={() => this.setState({ isCreating: true })}
                   right
                   primary

--- a/app/client/components/holiday/holidayReview.tsx
+++ b/app/client/components/holiday/holidayReview.tsx
@@ -11,11 +11,7 @@ import { maxWidth } from "../../styles/breakpoints";
 import { Button } from "../buttons";
 import { CallCentreNumbers } from "../callCentreNumbers";
 import { GenericErrorScreen } from "../genericErrorScreen";
-import {
-  RouteableStepProps,
-  visuallyNavigateToParent,
-  WizardStep
-} from "../wizardRouterAdapter";
+import { visuallyNavigateToParent, WizardStep } from "../wizardRouterAdapter";
 import {
   buttonBarCss,
   cancelLinkCss,
@@ -27,6 +23,7 @@ import {
   creditExplainerSentence,
   HolidayQuestionsModal
 } from "./holidayQuestionsModal";
+import { HolidayStopsRouteableStepProps } from "./holidaysOverview";
 import {
   convertRawPotentialHolidayStopDetail,
   CreateHolidayStopsAsyncLoader,
@@ -83,7 +80,7 @@ export interface HolidayReviewState {
 }
 
 export class HolidayReview extends React.Component<
-  RouteableStepProps,
+  HolidayStopsRouteableStepProps,
   HolidayReviewState
 > {
   public state: HolidayReviewState = {
@@ -151,10 +148,14 @@ export class HolidayReview extends React.Component<
             <h1>Review details before confirming</h1>
             <p>
               Check the details carefully and amend them if necessary.{" "}
-              {creditExplainerSentence}
+              {creditExplainerSentence(
+                this.props.productType.holidayStops.issueKeyword
+              )}{" "}
+              {this.props.productType.holidayStops.additionalHowAdvice}
             </p>
             <HolidayQuestionsModal
               annualIssueLimit={holidayStopsResponse.annualIssueLimit}
+              holidayStopFlowProperties={this.props.productType.holidayStops}
             />
             <div css={{ height: "25px" }} />
             <SummaryTable

--- a/app/client/components/holiday/holidayStopApi.ts
+++ b/app/client/components/holiday/holidayStopApi.ts
@@ -49,7 +49,7 @@ export interface HolidayStopRequest {
 export interface GetHolidayStopsResponse {
   productSpecifics: {
     firstAvailableDate: Moment;
-    issueDayOfWeek: number;
+    issueDaysOfWeek: number[];
   };
   annualIssueLimit: number;
   existing: HolidayStopRequest[];
@@ -153,7 +153,7 @@ export const embellishExistingHolidayStops = async (response: Response) => {
       firstAvailableDate: moment.min(
         raw.issueSpecifics.map(_ => momentiseDateStr(_.firstAvailableDate))
       ),
-      issueDayOfWeek: raw.issueSpecifics.map(_ => _.issueDayOfWeek)[0] // TODO refactor to become issueDaysOfWeek in sep. PR
+      issueDaysOfWeek: raw.issueSpecifics.map(_ => _.issueDayOfWeek)
     },
     existing: raw.existing
       .map(embellishRawHolidayStop)

--- a/app/client/components/user.tsx
+++ b/app/client/components/user.tsx
@@ -7,6 +7,7 @@ import {
   ProductType,
   ProductTypes,
   ProductTypeWithCancellationFlow,
+  ProductTypeWithHolidayStopsFlow,
   ProductTypeWithProductPageProperties,
   shouldCreatePaymentUpdateFlow,
   shouldHaveHolidayStopsFlow
@@ -123,7 +124,7 @@ const User = () => (
 
       {Object.values(ProductTypes)
         .filter(shouldHaveHolidayStopsFlow)
-        .map((productType: ProductType) => (
+        .map((productType: ProductTypeWithHolidayStopsFlow) => (
           <HolidaysOverview
             key={productType.urlPart}
             path={"/suspend/" + productType.urlPart}

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -75,6 +75,12 @@ export interface ProductPageProperties {
   forceShowJoinDateOnly?: true;
 }
 
+export interface HolidayStopFlowProperties {
+  issueKeyword: string;
+  alternateNoticeString?: string;
+  additionalHowAdvice?: string;
+}
+
 export interface ProductType {
   friendlyName: ProductFriendlyName;
   allProductsProductTypeFilterString: AllProductsProductTypeFilterString;
@@ -95,7 +101,7 @@ export interface ProductType {
   showTrialRemainingIfApplicable?: true;
   mapGroupedToSpecific?: (productDetail: ProductDetail) => ProductType;
   updateAmountMdaEndpoint?: string;
-  shouldHaveHolidayStopsFlow?: true;
+  holidayStops?: HolidayStopFlowProperties;
 }
 
 export interface ProductTypeWithCancellationFlow extends ProductType {
@@ -131,8 +137,12 @@ export interface WithProductType<ProductTypeVariant extends ProductType> {
 export const shouldCreatePaymentUpdateFlow = (productType: ProductType) =>
   !productType.mapGroupedToSpecific;
 
-export const shouldHaveHolidayStopsFlow = (productType: ProductType) =>
-  productType.shouldHaveHolidayStopsFlow;
+export interface ProductTypeWithHolidayStopsFlow extends ProductType {
+  holidayStops: HolidayStopFlowProperties;
+}
+export const shouldHaveHolidayStopsFlow = (
+  productType: ProductType
+): productType is ProductTypeWithHolidayStopsFlow => !!productType.holidayStops;
 
 export const createProductDetailFetcher = (
   productType: ProductType,
@@ -285,6 +295,12 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
     urlPart: "voucher",
     getOphanProductType: () => "PRINT_SUBSCRIPTION",
     includeGuardianInTitles: true,
+    holidayStops: {
+      issueKeyword: "voucher",
+      alternateNoticeString: "one day's notice",
+      additionalHowAdvice:
+        "Please discard suspended vouchers before the voucher dates."
+    },
     productPage: "subscriptions"
   },
   guardianweekly: {
@@ -298,7 +314,9 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
       productDetail.subscription.autoRenew
         ? undefined
         : "renew your one-off Guardian Weekly subscription",
-    shouldHaveHolidayStopsFlow: true,
+    holidayStops: {
+      issueKeyword: "issue"
+    },
     productPage: "subscriptions"
   },
   digipack: {

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -304,7 +304,7 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
       issueKeyword: "voucher",
       alternateNoticeString: "one day's notice",
       additionalHowAdvice:
-        "Please discard suspended vouchers before the voucher dates.",
+        "Please discard suspended vouchers before the voucher dates. Please note that historical suspensions may not appear here.",
       explicitConfirmationRequired: {
         checkboxLabel: "I confirm that I will destroy suspended vouchers.",
         explainerModalTitle: "Destroying your vouchers",

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -79,6 +79,11 @@ export interface HolidayStopFlowProperties {
   issueKeyword: string;
   alternateNoticeString?: string;
   additionalHowAdvice?: string;
+  explicitConfirmationRequired?: {
+    checkboxLabel: string;
+    explainerModalTitle: string;
+    explainerModalBody: string;
+  };
 }
 
 export interface ProductType {
@@ -299,7 +304,13 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
       issueKeyword: "voucher",
       alternateNoticeString: "one day's notice",
       additionalHowAdvice:
-        "Please discard suspended vouchers before the voucher dates."
+        "Please discard suspended vouchers before the voucher dates.",
+      explicitConfirmationRequired: {
+        checkboxLabel: "I confirm that I will destroy suspended vouchers.",
+        explainerModalTitle: "Destroying your vouchers",
+        explainerModalBody:
+          "We monitor voucher usage and reserve the right to cancel credits where vouchers have been used during the suspension period."
+      }
     },
     productPage: "subscriptions"
   },


### PR DESCRIPTION
- Added configuration for voucher holiday stops flow and made all the steps use the product specific keywords and copy where they were hardcoded before.
- Made the date chooser support multiple 'Issue Day' indicators ('Voucher Day' in this scenario)
![image](https://user-images.githubusercontent.com/19289579/66935355-c1630080-f033-11e9-9a43-c74334a8aa38.png)
- Added a confirmation checkbox for this voucher flow only, where 'Confirm' is disabled until this is checked _(Guardian Weekly remains unaffected)_...
![image](https://user-images.githubusercontent.com/19289579/66935414-d6d82a80-f033-11e9-85ca-fbb02a57370d.png)
... with modal for more info ...
![image](https://user-images.githubusercontent.com/19289579/66935619-346c7700-f034-11e9-8c1a-8ca61a25fbc8.png)

<hr/>

_Using copy explained in https://docs.google.com/presentation/d/1d4wHdkZ-HFQY8rtoVjJD67dI3z0e4YVoDQq-Bt_DXZo with help text from https://docs.google.com/presentation/d/1c0hSAKxvELw_oX2w1Uu5r7H-f_tbhfLTfTwbG0hWLfQ_