### PR TITLE
hide 'delivery redirection' bullet point in help modal on voucher flow

### DIFF
--- a/app/client/components/holiday/holidayQuestionsModal.tsx
+++ b/app/client/components/holiday/holidayQuestionsModal.tsx
@@ -55,10 +55,12 @@ export const HolidayQuestionsModal = (props: HolidayQuestionsModalProps) => (
     </ul>
     <h3>You will need to contact us by phone or email if you...</h3>
     <ul>
-      <li>
-        You want to have your delivery redirected to a temporary address within
-        the same country.
-      </li>
+      {!props.holidayStopFlowProperties.hideDeliveryRedirectionHelpBullet && (
+        <li>
+          You want to have your delivery redirected to a temporary address
+          within the same country.
+        </li>
+      )}
       <li>
         You want to suspend more than {props.annualIssueLimit}{" "}
         {props.holidayStopFlowProperties.issueKeyword}s in one year.

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -79,6 +79,7 @@ export interface HolidayStopFlowProperties {
   issueKeyword: string;
   alternateNoticeString?: string;
   additionalHowAdvice?: string;
+  hideDeliveryRedirectionHelpBullet?: true;
   explicitConfirmationRequired?: {
     checkboxLabel: string;
     explainerModalTitle: string;
@@ -305,6 +306,7 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
       alternateNoticeString: "one day's notice",
       additionalHowAdvice:
         "Please discard suspended vouchers before the voucher dates. Please note that historical suspensions may not appear here.",
+      hideDeliveryRedirectionHelpBullet: true,
       explicitConfirmationRequired: {
         checkboxLabel: "I confirm that I will destroy suspended vouchers.",
         explainerModalTitle: "Destroying your vouchers",


### PR DESCRIPTION
This PR hides the selected text below for the voucher holiday stop flow...
![image](https://user-images.githubusercontent.com/19289579/67111429-ca3b0a00-f1cc-11e9-892d-5ae28ba1b63e.png)
