### PR TITLE
Display holiday credit invoice dates

### DIFF
--- a/app/client/components/holiday/collatedCredits.tsx
+++ b/app/client/components/holiday/collatedCredits.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { friendlyLongDateFormat, HolidayStopDetail } from "./holidayStopApi";
+
+interface CollatedCreditByInvoiceDate {
+  [invoiceDateString: string]: number;
+}
+
+const collateCreditsByInvoiceDate = (
+  publicationsImpacted: HolidayStopDetail[]
+) =>
+  publicationsImpacted.reduce(
+    (accumulator, currentValue) => {
+      const credit = currentValue.actualPrice || currentValue.estimatedPrice;
+      if (currentValue.invoiceDate && credit) {
+        const invoiceDateAsString = currentValue.invoiceDate.format(
+          friendlyLongDateFormat
+        );
+        return {
+          ...accumulator,
+          [invoiceDateAsString]:
+            credit + (accumulator[invoiceDateAsString] || 0)
+        };
+      }
+      return {}; // if we don't have credits and dates for every entry we shouldn't show anything
+    },
+    {} as CollatedCreditByInvoiceDate
+  );
+
+export interface CollatedCreditsProps {
+  publicationsImpacted: HolidayStopDetail[];
+  currency?: string;
+  withBullet?: true;
+}
+
+export const CollatedCredits = (props: CollatedCreditsProps) => {
+  const collatedCreditsByInvoiceDate = collateCreditsByInvoiceDate(
+    props.publicationsImpacted
+  );
+
+  const invoiceDateStrings = Object.keys(collatedCreditsByInvoiceDate);
+
+  return (
+    <div>
+      {invoiceDateStrings.length === 0 && "Unavailable at this time."}
+      {invoiceDateStrings.map((invoiceDateString, index) => (
+        <div key={`cc-${index}`}>
+          {props.withBullet && "- "}
+          <strong>
+            {props.currency}
+            {Math.abs(collatedCreditsByInvoiceDate[invoiceDateString]).toFixed(
+              2
+            )}
+          </strong>{" "}
+          off your {invoiceDateString} payment
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/app/client/components/holiday/collatedCredits.tsx
+++ b/app/client/components/holiday/collatedCredits.tsx
@@ -5,26 +5,22 @@ interface CollatedCreditByInvoiceDate {
   [invoiceDateString: string]: number;
 }
 
-const collateCreditsByInvoiceDate = (
-  publicationsImpacted: HolidayStopDetail[]
-) =>
-  publicationsImpacted.reduce(
-    (accumulator, currentValue) => {
-      const credit = currentValue.actualPrice || currentValue.estimatedPrice;
-      if (currentValue.invoiceDate && credit) {
-        const invoiceDateAsString = currentValue.invoiceDate.format(
-          friendlyLongDateFormat
-        );
-        return {
-          ...accumulator,
-          [invoiceDateAsString]:
-            credit + (accumulator[invoiceDateAsString] || 0)
-        };
-      }
-      return {}; // if we don't have credits and dates for every entry we shouldn't show anything
-    },
-    {} as CollatedCreditByInvoiceDate
-  );
+const reduceCreditCallback = (
+  accumulator: CollatedCreditByInvoiceDate | null,
+  currentValue: HolidayStopDetail
+) => {
+  const credit = currentValue.actualPrice || currentValue.estimatedPrice;
+  if (accumulator && currentValue.invoiceDate && credit) {
+    const invoiceDateAsString = currentValue.invoiceDate.format(
+      friendlyLongDateFormat
+    );
+    return {
+      ...accumulator,
+      [invoiceDateAsString]: credit + (accumulator[invoiceDateAsString] || 0)
+    };
+  }
+  return null; // if we don't have credits and dates for EVERY entry we shouldn't show anything
+};
 
 export interface CollatedCreditsProps {
   publicationsImpacted: HolidayStopDetail[];
@@ -33,27 +29,29 @@ export interface CollatedCreditsProps {
 }
 
 export const CollatedCredits = (props: CollatedCreditsProps) => {
-  const collatedCreditsByInvoiceDate = collateCreditsByInvoiceDate(
-    props.publicationsImpacted
+  const collatedCreditsByInvoiceDate: CollatedCreditByInvoiceDate | null = props.publicationsImpacted.reduce(
+    reduceCreditCallback,
+    {} as CollatedCreditByInvoiceDate
   );
-
-  const invoiceDateStrings = Object.keys(collatedCreditsByInvoiceDate);
 
   return (
     <div>
-      {invoiceDateStrings.length === 0 && "Unavailable at this time."}
-      {invoiceDateStrings.map((invoiceDateString, index) => (
-        <div key={`cc-${index}`}>
-          {props.withBullet && "- "}
-          <strong>
-            {props.currency}
-            {Math.abs(collatedCreditsByInvoiceDate[invoiceDateString]).toFixed(
-              2
-            )}
-          </strong>{" "}
-          off your {invoiceDateString} payment
-        </div>
-      ))}
+      {collatedCreditsByInvoiceDate
+        ? Object.keys(collatedCreditsByInvoiceDate).map(
+            (invoiceDateString, index) => (
+              <div key={`cc-${index}`}>
+                {props.withBullet && "- "}
+                <strong>
+                  {props.currency}
+                  {Math.abs(
+                    collatedCreditsByInvoiceDate[invoiceDateString]
+                  ).toFixed(2)}
+                </strong>{" "}
+                off your {invoiceDateString} payment
+              </div>
+            )
+          )
+        : "Unavailable at this time."}
     </div>
   );
 };

--- a/app/client/components/holiday/holidayStopApi.ts
+++ b/app/client/components/holiday/holidayStopApi.ts
@@ -16,10 +16,12 @@ export interface CommonCreditProperties {
 
 export interface RawHolidayStopDetail extends CommonCreditProperties {
   publicationDate: string;
+  invoiceDate?: string;
 }
 
 export interface HolidayStopDetail extends CommonCreditProperties {
   publicationDate: Moment;
+  invoiceDate?: Moment;
 }
 
 export interface RawHolidayStopRequest {
@@ -33,6 +35,7 @@ export interface RawHolidayStopRequest {
 export interface RawPotentialHolidayStopDetail {
   publicationDate: string;
   credit?: number;
+  invoiceDate?: string;
 }
 
 export interface PotentialHolidayStopsResponse {
@@ -76,6 +79,7 @@ export const convertRawPotentialHolidayStopDetail = (
   raw: RawPotentialHolidayStopDetail
 ) => ({
   estimatedPrice: raw.credit,
+  invoiceDate: raw.invoiceDate ? momentiseDateStr(raw.invoiceDate) : undefined,
   publicationDate: momentiseDateStr(raw.publicationDate)
 });
 
@@ -141,7 +145,10 @@ const embellishRawHolidayStop = (
     publicationsImpacted: rawHolidayStopRequest.publicationsImpacted.map(
       raw => ({
         ...raw,
-        publicationDate: momentiseDateStr(raw.publicationDate)
+        publicationDate: momentiseDateStr(raw.publicationDate),
+        invoiceDate: raw.invoiceDate
+          ? momentiseDateStr(raw.invoiceDate)
+          : undefined
       })
     )
   } as HolidayStopRequest);

--- a/app/client/components/holiday/holidayStopApi.ts
+++ b/app/client/components/holiday/holidayStopApi.ts
@@ -6,6 +6,8 @@ import AsyncLoader, { ReFetch } from "../asyncLoader";
 
 export const DATE_INPUT_FORMAT = "YYYY-MM-DD";
 
+export const friendlyLongDateFormat = "D MMMM YYYY";
+
 export const momentiseDateStr = (dateStr: string) =>
   moment(dateStr, DATE_INPUT_FORMAT);
 

--- a/app/client/components/holiday/holidaysOverview.tsx
+++ b/app/client/components/holiday/holidaysOverview.tsx
@@ -1,6 +1,8 @@
 import { navigate } from "@reach/router";
 import React from "react";
 import {
+  getMainPlan,
+  isPaidSubscriptionPlan,
   MDA_TEST_USER_HEADER,
   MembersDataApiResponseContext,
   ProductDetail
@@ -22,6 +24,7 @@ import {
   RouteableStepProps,
   WizardStep
 } from "../wizardRouterAdapter";
+import { CollatedCredits } from "./collatedCredits";
 import {
   creditExplainerSentence,
   HolidayQuestionsModal
@@ -29,6 +32,7 @@ import {
 import {
   calculateIssuesImpactedPerYear,
   embellishExistingHolidayStops,
+  friendlyLongDateFormat,
   GetHolidayStopsAsyncLoader,
   GetHolidayStopsResponse,
   HolidayStopsResponseContext,
@@ -53,7 +57,7 @@ const OverviewRow = (props: OverviewRowProps) => (
       marginBottom: "20px"
     }}
   >
-    <div css={{ flex: "1 1 150px" }}>
+    <div css={{ flex: "1 1 180px" }}>
       <h3 css={{ marginTop: "0", paddingTop: "0" }}>{props.heading}</h3>
     </div>
     <div
@@ -65,8 +69,6 @@ const OverviewRow = (props: OverviewRowProps) => (
     </div>
   </div>
 );
-
-const friendlyLongDateFormat = "D MMMM YYYY";
 
 const renderHolidayStopsOverview = (
   productDetail: ProductDetail,
@@ -82,6 +84,11 @@ const renderHolidayStopsOverview = (
     ),
     renewalDateMoment
   );
+
+  const mainPlan = getMainPlan(productDetail.subscription);
+  const currency = isPaidSubscriptionPlan(mainPlan)
+    ? mainPlan.currency
+    : undefined;
 
   return (
     <HolidayStopsResponseContext.Provider
@@ -202,6 +209,16 @@ const renderHolidayStopsOverview = (
                 </div>
               </>
             </OverviewRow>
+            {holidayStopsResponse.existing.length > 0 && (
+              <OverviewRow heading="Expected Credits">
+                <CollatedCredits
+                  publicationsImpacted={holidayStopsResponse.existing.flatMap(
+                    _ => _.publicationsImpacted
+                  )}
+                  currency={currency}
+                />
+              </OverviewRow>
+            )}
             <OverviewRow heading="Details">
               {holidayStopsResponse.existing.length > 0 ? (
                 <SummaryTable

--- a/app/client/components/holiday/summaryTable.tsx
+++ b/app/client/components/holiday/summaryTable.tsx
@@ -10,6 +10,7 @@ import palette from "../../colours";
 import { ExpanderButton } from "../../expanderButton";
 import { maxWidth, minWidth } from "../../styles/breakpoints";
 import { sans } from "../../styles/fonts";
+import { CollatedCredits } from "./collatedCredits";
 import {
   isSharedHolidayDateChooserState,
   SharedHolidayDateChooserState
@@ -46,6 +47,7 @@ const formatDateRangeAsFriendly = (range: DateRange) =>
 
 interface SummaryTableRowProps extends MinimalHolidayStopRequest {
   issueKeyword: string;
+  shouldShowExpectedCredit: boolean;
   currency?: string;
   asTD?: true;
 }
@@ -89,6 +91,11 @@ const SummaryTableRow = (props: SummaryTableRowProps) => {
     <tr>
       <td>{dateRangeStr}</td>
       <td>{detailPart}</td>
+      {props.shouldShowExpectedCredit && (
+        <td>
+          <CollatedCredits {...props} />
+        </td>
+      )}
     </tr>
   ) : (
     <div css={{ marginBottom: "20px" }}>
@@ -102,6 +109,12 @@ const SummaryTableRow = (props: SummaryTableRowProps) => {
         {dateRangeStr}
       </div>
       <div css={cellCss}>{detailPart}</div>
+      {props.shouldShowExpectedCredit && (
+        <div css={{ ...cellCss, borderTop: 0 }}>
+          <strong>Expected Credits</strong>
+          <CollatedCredits {...props} withBullet />
+        </div>
+      )}
     </div>
   );
 };
@@ -122,6 +135,8 @@ export const SummaryTable = (props: SummaryTableProps) => {
   const currency = isPaidSubscriptionPlan(mainPlan)
     ? mainPlan.currency
     : undefined;
+
+  const shouldShowExpectedCredit = isSharedHolidayDateChooserState(props.data);
 
   return (
     <div
@@ -156,10 +171,12 @@ export const SummaryTable = (props: SummaryTableProps) => {
             <th css={{ minWidth: "250px" }}>
               {props.alternateSuspendedColumnHeading || "Suspended"}
             </th>
+            {shouldShowExpectedCredit && <th>Expected Credits</th>}
           </tr>
           {holidayStopRequestsList.map((holidayStopRequest, index) => (
             <SummaryTableRow
               asTD
+              shouldShowExpectedCredit={shouldShowExpectedCredit}
               issueKeyword={props.issueKeyword}
               key={index}
               currency={currency}
@@ -178,6 +195,7 @@ export const SummaryTable = (props: SummaryTableProps) => {
         {holidayStopRequestsList.map((holidayStopRequest, index) => (
           <SummaryTableRow
             key={index}
+            shouldShowExpectedCredit={shouldShowExpectedCredit}
             issueKeyword={props.issueKeyword}
             currency={currency}
             {...holidayStopRequest}


### PR DESCRIPTION
#### PRE-REQUISITE PRs

- ✅ https://github.com/guardian/support-service-lambdas/pull/461
- ✅ https://github.com/guardian/manage-frontend/pull/308
- ✅ https://github.com/guardian/manage-frontend/pull/307
- ✅ https://github.com/guardian/support-service-lambdas/pull/462
- ✅ https://github.com/guardian/manage-frontend/pull/310

## Changes

- Introduced new `CollatedCredits` component, which aggregates credits by 'invoice date'.
- `CollatedCredits` is used on the overview screen (aggregating across ALL existing holiday stops) and in the SummaryTable (on Review and Confirmed screens only) to show the collated credits for just the new holiday stop request. 
- IMPORTANT: Invoice date and credit amount (estimated or actual) MUST be present on all the publications - otherwise it will display _"Unavailable at this time."_

### Overview Screen
![image](https://user-images.githubusercontent.com/19289579/67276742-3a8fa700-f4bd-11e9-9269-9455a775f93c.png)

### Review Screen
![image](https://user-images.githubusercontent.com/19289579/67276830-61e67400-f4bd-11e9-9fc4-656bc7c6e0f2.png)

### Confirmed Screen
![image](https://user-images.githubusercontent.com/19289579/67276861-70cd2680-f4bd-11e9-93b2-db8eeaacd2b9.png)

### Invoice Date or Credit Amount MISSING on some publications 
![image](https://user-images.githubusercontent.com/19289579/67276939-9c501100-f4bd-11e9-8bcd-9e0c0d80c21c.png)
_There is some work underway to fix the scenario in which these are not available, once this is resolved we'll do a backfill - after which customers should never see this message._