### PR TITLE
replace hardcoded "issue" with the dynamic product-specific 'issueKeyword'

### DIFF
--- a/app/client/components/holiday/holidayConfirmed.tsx
+++ b/app/client/components/holiday/holidayConfirmed.tsx
@@ -42,6 +42,9 @@ export const HolidayConfirmed = (props: HolidayStopsRouteableStepProps) => (
                       <SummaryTable
                         data={dateChooserState}
                         subscription={productDetail.subscription}
+                        issueKeyword={
+                          props.productType.holidayStops.issueKeyword
+                        }
                       />
                       <div
                         css={{ ...buttonBarCss, justifyContent: "flex-end" }}

--- a/app/client/components/holiday/holidayReview.tsx
+++ b/app/client/components/holiday/holidayReview.tsx
@@ -168,6 +168,7 @@ export class HolidayReview extends React.Component<
               data={dateChooserStateWithCredits}
               alternateSuspendedColumnHeading="To be suspended"
               subscription={productDetail.subscription}
+              issueKeyword={this.props.productType.holidayStops.issueKeyword}
             />
             {this.props.productType.holidayStops
               .explicitConfirmationRequired && (

--- a/app/client/components/holiday/holidayStopApi.ts
+++ b/app/client/components/holiday/holidayStopApi.ts
@@ -39,9 +39,12 @@ export interface PotentialHolidayStopsResponse {
   potentials: RawPotentialHolidayStopDetail[];
 }
 
-export interface HolidayStopRequest {
+export interface MinimalHolidayStopRequest {
   publicationsImpacted: HolidayStopDetail[];
   dateRange: DateRange;
+}
+
+export interface HolidayStopRequest extends MinimalHolidayStopRequest {
   id: string;
   subscriptionName: string;
 }

--- a/app/client/components/holiday/holidaysOverview.tsx
+++ b/app/client/components/holiday/holidaysOverview.tsx
@@ -215,6 +215,7 @@ const renderHolidayStopsOverview = (
                   <SummaryTable
                     data={holidayStopsResponse.existing}
                     subscription={productDetail.subscription}
+                    issueKeyword={props.productType.holidayStops.issueKeyword}
                   />
                 ) : (
                   "You currently don't have any scheduled suspensions."

--- a/app/client/components/holiday/summaryTable.tsx
+++ b/app/client/components/holiday/summaryTable.tsx
@@ -13,7 +13,11 @@ import {
   isSharedHolidayDateChooserState,
   SharedHolidayDateChooserState
 } from "./holidayDateChooser";
-import { HolidayStopDetail, HolidayStopRequest } from "./holidayStopApi";
+import {
+  HolidayStopDetail,
+  HolidayStopRequest,
+  MinimalHolidayStopRequest
+} from "./holidayStopApi";
 
 const cellCss = {
   padding: "8px 16px 8px 16px",
@@ -23,6 +27,7 @@ const cellCss = {
 export interface SummaryTableProps {
   data: HolidayStopRequest[] | SharedHolidayDateChooserState;
   subscription: Subscription;
+  issueKeyword: string;
   alternateSuspendedColumnHeading?: string;
 }
 
@@ -38,9 +43,8 @@ const formatDateRangeAsFriendly = (range: DateRange) =>
   " - " +
   range.end.format(friendlyDateFormatPrefix + friendlyDateFormatSuffix);
 
-interface SummaryTableRowProps {
-  dateRange: DateRange;
-  publicationsImpacted: HolidayStopDetail[];
+interface SummaryTableRowProps extends MinimalHolidayStopRequest {
+  issueKeyword: string;
   currency?: string;
   asTD?: true;
 }
@@ -62,10 +66,8 @@ const SummaryTableRow = (props: SummaryTableRowProps) => {
   const detailPart = (
     <>
       <strong>
-        {props.publicationsImpacted.length} issue{props.publicationsImpacted
-          .length !== 1
-          ? "s"
-          : ""}
+        {props.publicationsImpacted.length} {props.issueKeyword}
+        {props.publicationsImpacted.length !== 1 ? "s" : ""}
       </strong>
       {props.publicationsImpacted.map((detail, index) => (
         <div key={index}>
@@ -101,7 +103,7 @@ const SummaryTableRow = (props: SummaryTableRowProps) => {
 };
 
 export const SummaryTable = (props: SummaryTableProps) => {
-  const holidayStopRequestsList: SummaryTableRowProps[] = isSharedHolidayDateChooserState(
+  const holidayStopRequestsList: MinimalHolidayStopRequest[] = isSharedHolidayDateChooserState(
     props.data
   )
     ? [
@@ -152,6 +154,7 @@ export const SummaryTable = (props: SummaryTableProps) => {
           {holidayStopRequestsList.map((holidayStopRequest, index) => (
             <SummaryTableRow
               asTD
+              issueKeyword={props.issueKeyword}
               key={index}
               currency={currency}
               {...holidayStopRequest}
@@ -169,6 +172,7 @@ export const SummaryTable = (props: SummaryTableProps) => {
         {holidayStopRequestsList.map((holidayStopRequest, index) => (
           <SummaryTableRow
             key={index}
+            issueKeyword={props.issueKeyword}
             currency={currency}
             {...holidayStopRequest}
           />


### PR DESCRIPTION
replaced one remaining instance of hardcoded "issue" with the dynamic product-specific `issueKeyword` (which was missed in the main voucher holiday stops PR)