### PR TITLE
de-parallelise the 'pre-commit' hook

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -24,7 +24,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn fix && GIT_DIR=../.git && (yarn type-check & yarn lint & yarn bundle-check-client-if-changed)"
+      "pre-commit": "yarn fix && GIT_DIR=../.git && yarn type-check && yarn lint && yarn bundle-check-client-if-changed"
     }
   },
   "cloudformation": "../cfn.yaml",


### PR DESCRIPTION
The 'parallelisation' attempted in https://github.com/guardian/manage-frontend/blame/b5675a3c/app/package.json#L27 was in-fact forking/backgrounding the `type-check' and 'lint' steps, allowing the pre-commit hook to pass even if there were problems - not ideal.

To achieve actual  'parallelisation' would require something like https://stackoverflow.com/questions/356100/how-to-wait-in-bash-for-several-subprocesses-to-finish-and-return-exit-code-0