### PR TITLE
Fix UI glitches for Safari on iOS 6

### DIFF
--- a/app/client/components/consent/OnOffRadio.tsx
+++ b/app/client/components/consent/OnOffRadio.tsx
@@ -12,6 +12,7 @@ import React, { Component } from "react";
 let idCounter: number = 0;
 
 const radioContainerStyles = css`
+  flex-shrink: 0;
   cursor: default;
   display: flex;
   justify-content: flex-start;

--- a/app/client/components/consent/PrivacySettings.tsx
+++ b/app/client/components/consent/PrivacySettings.tsx
@@ -130,7 +130,7 @@ const buttonStyles = css`
   position: relative;
   text-decoration: none;
   font-size: 16px;
-  line-height: 22px;
+  line-height: 40px;
   font-family: "Guardian Text Sans Web", Helvetica Neue, Helvetica, Arial,
     Lucida Grande, sans-serif;
   font-weight: 700;
@@ -391,7 +391,7 @@ export class PrivacySettings extends Component<Props, State> {
                     ${yellowButtonStyles};
                   `}
                 >
-                  <span>Enable all and close</span>
+                  Enable all and close
                   <ArrowIcon />
                 </button>
               </div>


### PR DESCRIPTION
This PR fixes 2 bugs that were showing up in Safari on iOS:
- Buttons with SVGs as children would render below their expected position. (how: Increased the `line-height` on buttons to make sure they stay in the same position)
- Radio buttons get squashed to the side (how: added `flex-shrink: 0` on the container around the radio buttons) 

Before:
![Screenshot 2019-10-25 at 12 05 05](https://user-images.githubusercontent.com/48949546/67566447-b852ed00-f71f-11e9-8ab1-eae71035857a.png)

After:
![Screenshot 2019-10-25 at 12 04 44](https://user-images.githubusercontent.com/48949546/67566454-bbe67400-f71f-11e9-86b2-f7519ee3ac4f.png)
