### PR TITLE
'amend' holiday stop feature

### DIFF
--- a/app/client/components/dateInput.tsx
+++ b/app/client/components/dateInput.tsx
@@ -34,6 +34,7 @@ export interface DateInputProps {
   selectedDate?: Moment;
   defaultDate: Moment;
   labelText: string;
+  disabled?: boolean;
   // onChange: (newValue: DateInputState) => void; // TODO: UNCOMMENT WHEN INPUT ACTIVATED
 }
 
@@ -91,6 +92,7 @@ export class DateInput extends React.Component<DateInputProps, DateInputState> {
           margin: 0
         }}
         aria-describedby="validation-message"
+        disabled={this.props.disabled}
       >
         <input
           css={dayMonthCss}

--- a/app/client/components/hackedDateRangePicker.tsx
+++ b/app/client/components/hackedDateRangePicker.tsx
@@ -1,6 +1,7 @@
 import rawDateRangePickerCSS from "!!raw-loader!react-daterange-picker/dist/css/react-calendar.css";
 import { css, Global } from "@emotion/core";
 import { Moment } from "moment";
+import { DateRange } from "moment-range";
 import React from "react";
 import DateRangePicker, {
   PaginationArrowProps,
@@ -100,6 +101,22 @@ class HackedDateRangePicker extends DateRangePicker {
       // @ts-ignore
       super.isStartOrEndVisible = () => true;
     }
+
+    const lockedStartDate = (this.props as WrappedDateRangePickerProps)
+      .maybeLockedStartDate;
+    if (lockedStartDate) {
+      // overriding https://github.com/onefinestay/react-daterange-picker/blob/c73c9/src/DateRangePicker.jsx#L269-L288
+      // @ts-ignore
+      super.onSelectDate = (endDate: Moment) => {
+        // @ts-ignore
+        if (!this.isDateDisabled(endDate) && this.isDateSelectable(endDate)) {
+          // @ts-ignore
+          this.highlightRange(new DateRange(lockedStartDate, endDate));
+          // @ts-ignore
+          this.completeRangeSelection();
+        }
+      };
+    }
   }
 
   public componentDidMount(): void {
@@ -132,6 +149,7 @@ class HackedDateRangePicker extends DateRangePicker {
 export interface WrappedDateRangePickerProps extends Props {
   dateToAsterisk?: Moment;
   daysOfWeekToIconify: number[];
+  maybeLockedStartDate: Moment | null;
 }
 
 export const WrappedDateRangePicker = (props: WrappedDateRangePickerProps) => (

--- a/app/client/components/hackedDateRangePicker.tsx
+++ b/app/client/components/hackedDateRangePicker.tsx
@@ -98,15 +98,17 @@ class HackedDateRangePicker extends DateRangePicker {
     super(props);
     if (this.props.numberOfCalendars && this.props.numberOfCalendars > 12) {
       // this prevents jumping to the selection when in 'infinite mode' (i.e. loads of vertically stacked cals)
-      // @ts-ignore
+      // @ts-ignore - required because this function is internal and typescript doesn't know about it
       super.isStartOrEndVisible = () => true;
     }
 
+    // this casting is required because this class extends 'DateRangePicker' from a library so the 'props' type is fixed
+    // however, the 'maybeLockedStartDate' prop IS being passed in, so with a cast we can retrieve it without compilation error
     const lockedStartDate = (this.props as WrappedDateRangePickerProps)
       .maybeLockedStartDate;
     if (lockedStartDate) {
       // overriding https://github.com/onefinestay/react-daterange-picker/blob/c73c9/src/DateRangePicker.jsx#L269-L288
-      // @ts-ignore
+      // @ts-ignore - required because these functions are internal and typescript doesn't know about them
       super.onSelectDate = (endDate: Moment) => {
         // @ts-ignore
         if (!this.isDateDisabled(endDate) && this.isDateSelectable(endDate)) {

--- a/app/client/components/holiday/existingHolidayStopActions.tsx
+++ b/app/client/components/holiday/existingHolidayStopActions.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import AsyncLoader, { ReFetch } from "../asyncLoader";
-import { Button } from "../buttons";
+import { Button, LinkButton } from "../buttons";
 import { HideFunction, Modal } from "../modal";
 import {
   friendlyLongDateFormat,
+  HolidayStopRequest,
   MinimalHolidayStopRequest
 } from "./holidayStopApi";
 import { formatDateRangeAsFriendly } from "./summaryTable";
@@ -11,6 +12,7 @@ import { formatDateRangeAsFriendly } from "./summaryTable";
 export interface ExistingHolidayStopActionsProps
   extends MinimalHolidayStopRequest {
   reloadParent?: ReFetch;
+  setExistingHolidayStopToAmend?: (newValue: HolidayStopRequest | null) => void;
 }
 
 export interface ExistingHolidayStopActionsState {
@@ -43,8 +45,20 @@ export class ExistingHolidayStopActions extends React.Component<
     if (
       this.props.reloadParent &&
       this.props.mutabilityFlags &&
-      this.props.mutabilityFlags.isFullyMutable
+      (this.props.mutabilityFlags.isFullyMutable ||
+        this.props.mutabilityFlags.isEndDateEditable)
     ) {
+      const shouldShowAmendButton = this.props.mutabilityFlags
+        .isEndDateEditable;
+      const shouldShowDeleteButton = this.props.mutabilityFlags.isFullyMutable;
+
+      const shouldBeOnlyAmendEndDate =
+        this.props.mutabilityFlags.isEndDateEditable &&
+        !this.props.mutabilityFlags.isFullyMutable;
+
+      const setExistingHolidayStopToAmend = this.props
+        .setExistingHolidayStopToAmend;
+
       const reloadParent: ReFetch = this.props.reloadParent;
 
       const yesButton = (hideFunction: HideFunction) => (
@@ -89,15 +103,34 @@ export class ExistingHolidayStopActions extends React.Component<
           )}
         />
       ) : (
-        <Modal
-          title="Are you sure?"
-          alternateOkText="No"
-          additionalButton={yesButton}
-          instigator={<Button text="Delete" />}
-        >
-          Are you sure you want to delete your{" "}
-          <strong>{friendlyDateRange}</strong> suspension?
-        </Modal>
+        <>
+          {shouldShowAmendButton &&
+            setExistingHolidayStopToAmend && (
+              <div
+                css={{ display: "inline-block", margin: "10px", marginLeft: 0 }}
+              >
+                <LinkButton
+                  text={`Amend${shouldBeOnlyAmendEndDate ? " end date" : ""}`}
+                  to="amend"
+                  onClick={() =>
+                    setExistingHolidayStopToAmend(this
+                      .props as HolidayStopRequest)
+                  }
+                />
+              </div>
+            )}
+          {shouldShowDeleteButton && (
+            <Modal
+              title="Are you sure?"
+              alternateOkText="No"
+              additionalButton={yesButton}
+              instigator={<Button text="Delete" hollow />}
+            >
+              Are you sure you want to delete your{" "}
+              <strong>{friendlyDateRange}</strong> suspension?
+            </Modal>
+          )}
+        </>
       );
     }
 

--- a/app/client/components/holiday/holidayStopApi.ts
+++ b/app/client/components/holiday/holidayStopApi.ts
@@ -78,6 +78,7 @@ export interface GetHolidayStopsResponse {
 export interface ReloadableGetHolidayStopsResponse
   extends GetHolidayStopsResponse {
   reload: ReFetch;
+  existingHolidayStopToAmend?: HolidayStopRequest;
 }
 
 interface RawGetHolidayStopsResponse {
@@ -106,7 +107,7 @@ export class PotentialHolidayStopsAsyncLoader extends AsyncLoader<
   PotentialHolidayStopsResponse
 > {}
 
-export const createPotentialHolidayStopsFetcher = (
+export const getPotentialHolidayStopsFetcher = (
   shouldEstimateCredit: boolean,
   subscriptionName: string,
   start: Moment,
@@ -126,13 +127,13 @@ export const createPotentialHolidayStopsFetcher = (
     }
   );
 
-export interface CreateHolidayStopsResponse {
+export interface CreateOrAmendHolidayStopsResponse {
   success: string;
 }
 
 // tslint:disable-next-line:max-classes-per-file
-export class CreateHolidayStopsAsyncLoader extends AsyncLoader<
-  CreateHolidayStopsResponse
+export class CreateOrAmendHolidayStopsAsyncLoader extends AsyncLoader<
+  CreateOrAmendHolidayStopsResponse
 > {}
 
 export const HolidayStopsResponseContext: React.Context<

--- a/app/client/components/holiday/summaryTable.tsx
+++ b/app/client/components/holiday/summaryTable.tsx
@@ -34,6 +34,7 @@ export interface SummaryTableProps {
   issueKeyword: string;
   alternateSuspendedColumnHeading?: string;
   reloadParent?: ReFetch;
+  setExistingHolidayStopToAmend?: (newValue: HolidayStopRequest | null) => void;
 }
 
 const friendlyDateFormatPrefix = "D\xa0MMMM"; // non-breaking space
@@ -191,7 +192,7 @@ export const SummaryTable = (props: SummaryTableProps) => {
             {isOperatingOnNewHolidayStop ? (
               <th>Expected Credits</th>
             ) : (
-              <th>Actions</th>
+              <th css={{ minWidth: "205px" }}>Actions</th>
             )}
           </tr>
           {holidayStopRequestsList.map((holidayStopRequest, index) => (

--- a/app/client/components/user.tsx
+++ b/app/client/components/user.tsx
@@ -149,6 +149,24 @@ const User = () => (
                 />
               </HolidayReview>
             </HolidayDateChooser>
+            <HolidayDateChooser
+              path="amend"
+              productType={productType}
+              currentStep={1}
+              requiresExistingHolidayStopToAmendInContext
+            >
+              <HolidayReview
+                path="review"
+                productType={productType}
+                currentStep={2}
+              >
+                <HolidayConfirmed
+                  path="confirmed"
+                  productType={productType}
+                  currentStep={3}
+                />
+              </HolidayReview>
+            </HolidayDateChooser>
           </HolidaysOverview>
         ))}
 


### PR DESCRIPTION
This PR follows on from https://github.com/guardian/manage-frontend/pull/312 but adds the ability to **amend** existing holiday stop requests.

This makes further use of the `mutabilityFlags` from `holiday-stop-api` (introduced in https://github.com/guardian/support-service-lambdas/pull/463) to determine whether to show an **`Amend`** button or an **`Amend end date`** button or indeed no amend related button (for when it's too late to change the holiday stop request in any way).

![image](https://user-images.githubusercontent.com/19289579/68031154-f8334a80-fcb2-11e9-8780-08d33d46ab5d.png)


## `Amend` button & flow
This displays if `mutabilityFlags.isFullyMutable` is `true`.

If the user clicks it, this sets a new optional property (`existingHolidayStopToAmend`) of the `ReloadableGetHolidayStopsResponse` which is available to all the steps of the flow via the existing `HolidayStopsResponseContext` with the full detail of that holiday stop (i.e. a `HolidayStopRequest` which has importantly the `dateRange` and the `mutabilityFlags`).

They then see the familiar date chooser but with the following differences...
- the url is `/amend` rather than `/create`
- extra legend item
![image](https://user-images.githubusercontent.com/19289579/68032817-5a417f00-fcb6-11e9-9a00-86caeac9343e.png)
- starts off with original dates selected and validation message
![image](https://user-images.githubusercontent.com/19289579/68032903-7fce8880-fcb6-11e9-9f7a-227e46176cc4.png)
- the original dates of the one being amended coloured differently and **selectable** (unlike the teal for other existing stops)
![image](https://user-images.githubusercontent.com/19289579/68032975-b3111780-fcb6-11e9-9c3a-b64378b7b8e7.png)

Once they hit **`Review details`** button then they're presented with the same UI for reviewing and seeing estimated credits etc. From here when they click **`Confirm`** it makes a `PATCH` call to the new amend endpoint (see https://github.com/guardian/support-service-lambdas/pull/467) instead of the `POST` to the create endpoint (although still sending the same payload). The spinner phrasing is different accordingly...
![image](https://user-images.githubusercontent.com/19289579/68033898-92e25800-fcb8-11e9-9671-ab9cb3810ef3.png)
 
## `Amend end date` button & flow 

This displays if `mutabilityFlags.isFullyMutable` is `false` BUT `mutabilityFlags.isEndDateEditable` is `true`.

This flow is very similar to the full amend like above, but only the end date is moveable (i.e. when user clicks on a date it changes only the end date of the range) - this required overriding one of the private methods 🙈.
![image](https://user-images.githubusercontent.com/19289579/68043390-1312b880-fccd-11e9-8052-4c066c4ecc66.png)
NOTE the disabled start date box and wordier initial validation message.