### PR TITLE
Update contact centre opening times for USA & Canada

### DIFF
--- a/app/client/components/callCentreNumbers.tsx
+++ b/app/client/components/callCentreNumbers.tsx
@@ -45,7 +45,7 @@ export const CallCentreNumbers = (props: CallCentreNumbersProps) => (
         <div>
           <b>+1 917-900-4663</b> (outside USA)
         </div>
-        <div>9:15am - 6pm Monday - Friday (EST)</div>
+        <div>9am - 5pm on weekdays (EST/EDT)</div>
       </div>
     </Accordion>
   </div>


### PR DESCRIPTION
PR to update the opening times of the contact centre in the USA & Canada as it is now open from 9 to 5 rather than 9:15 to 6pm

A similar PR is there to update the old subscribe.../manage (https://github.com/guardian/subscriptions-frontend/pull/1284)

![image](https://user-images.githubusercontent.com/5294853/68199076-3bdccb80-ffb5-11e9-92c3-195e9af0cc31.png)
