### PR TITLE
CMP UI - New CMP UI A/B test without cancel button

### DIFF
--- a/app/client/components/consent/App.tsx
+++ b/app/client/components/consent/App.tsx
@@ -5,16 +5,18 @@ import React from "react";
 import resetCSS from /* preval */ "../../styles/reset-css";
 import { ConsentManagementPortal } from "./ConsentMangementPortal";
 
-export const App = () => (
-  <>
-    <Global styles={css(`${resetCSS}`)} />
-    <Global
-      styles={css(`
-      body {
-        overflow-x: hidden;
-        background-color: ${palette.brand.main};
-      }`)}
-    />
-    <ConsentManagementPortal />
-  </>
-);
+export const App = (props: { abTestVariant: string }) => {
+  return (
+    <>
+      <Global styles={css(`${resetCSS}`)} />
+      <Global
+        styles={css(`
+        body {
+          overflow-x: hidden;
+          background-color: ${palette.brand.main};
+        }`)}
+      />
+      <ConsentManagementPortal abTestVariant={props.abTestVariant} />
+    </>
+  );
+};

--- a/app/client/components/consent/ConsentMangementPortal.tsx
+++ b/app/client/components/consent/ConsentMangementPortal.tsx
@@ -58,13 +58,17 @@ const scrollableStyles = (scrollbarWidth: number) => css`
   margin-right: ${-scrollbarWidth}px;
 `;
 
+interface Props {
+  abTestVariant: string;
+}
+
 interface State {
   headerWidth: number;
   scrollbarWidth: number;
 }
 
-export class ConsentManagementPortal extends Component<{}, State> {
-  constructor(props: {}) {
+export class ConsentManagementPortal extends Component<Props, State> {
+  constructor(props: Props) {
     super(props);
 
     this.state = {
@@ -105,6 +109,7 @@ export class ConsentManagementPortal extends Component<{}, State> {
                 }
               );
             }}
+            abTestVariant={this.props.abTestVariant}
           />
         </div>
       </>

--- a/app/client/components/consent/PrivacySettings.tsx
+++ b/app/client/components/consent/PrivacySettings.tsx
@@ -266,6 +266,7 @@ interface State {
 }
 
 interface Props {
+  abTestVariant: string;
   hideScrollBar: () => void;
 }
 
@@ -660,7 +661,8 @@ export class PrivacySettings extends Component<Props, State> {
     const msgData: CmpMsgData = {
       allowedPurposes,
       allowedVendors,
-      iabVendorList: this.rawVendorList
+      iabVendorList: this.rawVendorList,
+      abTestVariant: this.props.abTestVariant
     };
 
     // Notify parent that consent has been saved

--- a/app/client/components/consent/PrivacySettings.tsx
+++ b/app/client/components/consent/PrivacySettings.tsx
@@ -324,6 +324,8 @@ export class PrivacySettings extends Component<Props, State> {
     const firstIabPurposeList = iabPurposesList.slice(0, 3);
     const secondIabPurposeList = iabPurposesList.slice(3);
     const { iabNullResponses } = this.state;
+    const { abTestVariant } = this.props;
+    const showCancel = abTestVariant !== "CmpUiNonDismissable-variant";
 
     return (
       <div id={CONTAINER_ID} css={containerStyles}>
@@ -428,18 +430,20 @@ export class PrivacySettings extends Component<Props, State> {
                         privacy policy
                       </a>.
                     </p>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        close();
-                      }}
-                      css={css`
-                        ${buttonStyles};
-                        ${blueButtonStyles};
-                      `}
-                    >
-                      Cancel
-                    </button>
+                    {showCancel && (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          close();
+                        }}
+                        css={css`
+                          ${buttonStyles};
+                          ${blueButtonStyles};
+                        `}
+                      >
+                        Cancel
+                      </button>
+                    )}
                     <button
                       type="button"
                       onClick={() => {

--- a/app/client/consent.tsx
+++ b/app/client/consent.tsx
@@ -16,7 +16,10 @@ if (typeof window !== "undefined" && window.guardian && window.guardian.dsn) {
 const onPolyfilled = (): void => {
   const element = document.getElementById("app");
 
-  ReactDOM.hydrate(<App />, element);
+  ReactDOM.hydrate(
+    <App abTestVariant={window.guardian.abTestVariant || ""} />,
+    element
+  );
 };
 
 const run = (): void => {
@@ -34,10 +37,13 @@ const run = (): void => {
   }
 };
 
-if (document.readyState !== 'loading') {
+if (document.readyState !== "loading") {
   run();
 } else {
-  document.addEventListener('DOMContentLoaded', (): void => {
-    run();
-  });
+  document.addEventListener(
+    "DOMContentLoaded",
+    (): void => {
+      run();
+    }
+  );
 }

--- a/app/package.json
+++ b/app/package.json
@@ -123,7 +123,7 @@
   "dependencies": {
     "@emotion/core": "^10.0.14",
     "@emotion/styled": "^10.0.14",
-    "@guardian/consent-management-platform": "1.0.2",
+    "@guardian/consent-management-platform": "1.1.0-beta-5",
     "@guardian/src-foundations": "^0.2.0",
     "@reach/router": "^1.2.1",
     "aws-sdk": "^2.383.0",

--- a/app/package.json
+++ b/app/package.json
@@ -123,7 +123,7 @@
   "dependencies": {
     "@emotion/core": "^10.0.14",
     "@emotion/styled": "^10.0.14",
-    "@guardian/consent-management-platform": "1.1.0-beta-5",
+    "@guardian/consent-management-platform": "1.1.0-beta.5",
     "@guardian/src-foundations": "^0.2.0",
     "@reach/router": "^1.2.1",
     "aws-sdk": "^2.383.0",

--- a/app/package.json
+++ b/app/package.json
@@ -123,7 +123,7 @@
   "dependencies": {
     "@emotion/core": "^10.0.14",
     "@emotion/styled": "^10.0.14",
-    "@guardian/consent-management-platform": "1.1.0-beta.5",
+    "@guardian/consent-management-platform": "1.1.0",
     "@guardian/src-foundations": "^0.2.0",
     "@reach/router": "^1.2.1",
     "aws-sdk": "^2.383.0",

--- a/app/server/routes/consent.ts
+++ b/app/server/routes/consent.ts
@@ -1,4 +1,4 @@
-import { Response, Router } from "express";
+import { Request, Response, Router } from "express";
 import { renderToString } from "react-dom/server";
 import { App } from "../../client/components/consent/App";
 import { conf, Environments } from "../config";
@@ -16,18 +16,20 @@ if (conf.ENVIRONMENT === Environments.PRODUCTION && !conf.CLIENT_DSN) {
 
 const router = Router();
 
-router.get("/", (_, res: Response) => {
+router.use("/", (req: Request, res: Response) => {
   try {
+    const { abTestVariant = "" } = req.query;
     const polyfillIO =
       "https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry&flags=gated&callback=guardianPolyfilled&unknown=polyfill";
     const consentJS = "/static/consent.js";
     const scripts = [polyfillIO, consentJS];
-    const body = renderToString(App());
+    const body = renderToString(App({ abTestVariant }));
     const title = "Consent Management Platform | The Guardian";
     const globals = {
       domain: conf.DOMAIN,
       dsn: clientDSN,
-      polyfilled: false
+      polyfilled: false,
+      abTestVariant
     };
 
     const resp = html({

--- a/app/shared/globals.ts
+++ b/app/shared/globals.ts
@@ -17,6 +17,7 @@ export interface Globals extends CommonGlobals {
   };
   abTest?: AbTest;
   identityDetails: IdentityDetails;
+  abTestVariant?: string;
 }
 
 declare global {

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -886,10 +886,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.3.tgz#dfa0c92efe44a1d1a7974fb49ffeb40ef2da5a27"
   integrity sha512-zVgvPwGK7c1aVdUVc9Qv7SqepOGRDrqCw7KZPSZziWGxSlbII3gmvGLPzLX4d0n0BMbamBacUrN22zOMyFFEkQ==
 
-"@guardian/consent-management-platform@1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-1.0.2.tgz#f757c92a268a1c5ed198f3bb053d272d35d92e8f"
-  integrity sha512-YM75Fgf0T55lyIFraYWTMgO8xonDyf2X5wVF+/I5zdO5YD8KgQxiUK1C7oBMMLd+ez62T/6W/9xfRemWS7Tfig==
+"@guardian/consent-management-platform@1.1.0-beta-5":
+  version "1.1.0-beta-5"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-1.1.0-beta-5.tgz#04e3e2dc143a58da20a42c89f859f8093880b39a"
+  integrity sha512-irY5/KCq9x4HIPCuJOVYU1DgOsJjigjxzVul0TvBZQqCn/RlA22eM4gIosrRBAUFZUyInOBqee9m1c+L3I6BZQ==
   dependencies:
     consent-string "^1.5.1"
     js-cookie "^2.2.1"

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -886,10 +886,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.3.tgz#dfa0c92efe44a1d1a7974fb49ffeb40ef2da5a27"
   integrity sha512-zVgvPwGK7c1aVdUVc9Qv7SqepOGRDrqCw7KZPSZziWGxSlbII3gmvGLPzLX4d0n0BMbamBacUrN22zOMyFFEkQ==
 
-"@guardian/consent-management-platform@1.1.0-beta-5":
-  version "1.1.0-beta-5"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-1.1.0-beta-5.tgz#04e3e2dc143a58da20a42c89f859f8093880b39a"
-  integrity sha512-irY5/KCq9x4HIPCuJOVYU1DgOsJjigjxzVul0TvBZQqCn/RlA22eM4gIosrRBAUFZUyInOBqee9m1c+L3I6BZQ==
+"@guardian/consent-management-platform@1.1.0-beta.5":
+  version "1.1.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-1.1.0-beta.5.tgz#9f1c3f8de7060fb6e1a846bc50e258abe325048a"
+  integrity sha512-8ahDEmmvepaWg5CGqY2cDfLnRlhJBPiNuiVOUJ9kK82PRDOc+dG0WpAjjPbq9SxApQNl3iOeO3XuWxAPLmzIQA==
   dependencies:
     consent-string "^1.5.1"
     js-cookie "^2.2.1"

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -886,10 +886,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.3.tgz#dfa0c92efe44a1d1a7974fb49ffeb40ef2da5a27"
   integrity sha512-zVgvPwGK7c1aVdUVc9Qv7SqepOGRDrqCw7KZPSZziWGxSlbII3gmvGLPzLX4d0n0BMbamBacUrN22zOMyFFEkQ==
 
-"@guardian/consent-management-platform@1.1.0-beta.5":
-  version "1.1.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-1.1.0-beta.5.tgz#9f1c3f8de7060fb6e1a846bc50e258abe325048a"
-  integrity sha512-8ahDEmmvepaWg5CGqY2cDfLnRlhJBPiNuiVOUJ9kK82PRDOc+dG0WpAjjPbq9SxApQNl3iOeO3XuWxAPLmzIQA==
+"@guardian/consent-management-platform@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-1.1.0.tgz#ca93b41c9649f3f90c8075fa1b64065406ea682c"
+  integrity sha512-+C1IzMb+PDCatnmA9B2oNx4KVbaQw/U0fwpIAUC7l/ebDhU2a6b94ha4xTu+iE2gAt/heOMKLs+o3avCNdSGqA==
   dependencies:
     consent-string "^1.5.1"
     js-cookie "^2.2.1"


### PR DESCRIPTION
We need to be able to A/B test the new CMP UI. Whilst we continue to use the `iframe` we propose that we use the A/B test framework on frontend and notify the CMP UI of the variant the user is in via a query string parameter:`?abTestVariant=CmpUiNonDismissable-variant`.

The value of `abTestVariant` is in the format _TestId_-_VariantId_, we're padding a single string around as this string is eventually sent in the data we post to the consent logs which expects a single string in this format as appose to an Object such as `{ testId: "CmpUiNonDismissable", variantId: "variant" }`

We notify the `<App>` component of the variant by passing it down as a prop `abTestVariant` when we initialise it.If this is `abTestVariant` query string parameter isn't we set the default value of the `abTestVariant` to an empty string.

Using this setup we can now support the new CMP UI A/B test that tests the UI without a cancel button.

The supporting PR on `frontend` that passes the query string parameter is here: https://github.com/guardian/frontend/pull/21993