### PR TITLE
polyfill Number.isInteger (which is used in 'react-daterange-picker') for IE11 & Mobile Safari 8

### DIFF
--- a/app/client/components/hackedDateRangePicker.tsx
+++ b/app/client/components/hackedDateRangePicker.tsx
@@ -13,6 +13,9 @@ import { Button } from "./buttons";
 
 const gridBorderCssValue = `1px solid ${palette.neutral["5"]} !important;`;
 
+// this forces Babel to polyfill Number.isInteger (which is used in onefinestay/react-daterange-picker")
+Number.isInteger(1);
+
 const iconDayPseudoAfterCss = (dayOfWeek: number) => `
 .DateRangePicker__Week .DateRangePicker__Date:nth-of-type(${dayOfWeek})::after {
   content: "";


### PR DESCRIPTION
As per Sentry `/create` is breaking on IE and Mobile Safari...

![image](https://user-images.githubusercontent.com/19289579/68782689-b2bb3980-0631-11ea-92a9-f53825f06612.png)
_17 instances of this_

... 🙈