### PR TITLE
better message(s) when users go direct to a flow on a cancelled sub

### DIFF
--- a/app/client/components/cancel/cancellationFlow.tsx
+++ b/app/client/components/cancel/cancellationFlow.tsx
@@ -140,6 +140,9 @@ export const CancellationFlow = (
     headingPrefix="Cancel"
     supportRefererSuffix="cancellation_flow"
     loadingMessagePrefix="Checking the status of your"
+    cancelledExplainer={`This ${
+      props.productType.friendlyName
+    } is already cancelled.`}
     singleProductDetailRenderer={reasonsRenderer(props)}
   />
 );

--- a/app/client/components/cancel/cancellationFlow.tsx
+++ b/app/client/components/cancel/cancellationFlow.tsx
@@ -142,7 +142,9 @@ export const CancellationFlow = (
     loadingMessagePrefix="Checking the status of your"
     cancelledExplainer={`This ${
       props.productType.friendlyName
-    } is already cancelled.`}
+    } has been cancelled. Please contact us if you would like to re-start this ${
+      props.productType.friendlyName
+    }, make any amendments or need further help.`}
     singleProductDetailRenderer={reasonsRenderer(props)}
   />
 );

--- a/app/client/components/flowStartMultipleProductDetailHandler.tsx
+++ b/app/client/components/flowStartMultipleProductDetailHandler.tsx
@@ -86,7 +86,7 @@ const getProductDetailSelector = (
       return first.subscription.cancelledAt ? (
         <PageContainer>
           <h4>{props.cancelledExplainer}</h4>
-          <CallCentreNumbers prefixText="To contact us" />
+          <CallCentreNumbers />
           <div css={{ marginTop: "30px" }}>
             <ReturnToYourProductButton productType={props.productType} />
           </div>

--- a/app/client/components/holiday/holidaysOverview.tsx
+++ b/app/client/components/holiday/holidaysOverview.tsx
@@ -328,9 +328,10 @@ export class HolidaysOverview extends React.Component<
       loadingMessagePrefix="Retrieving details of your"
       cancelledExplainer={`This ${
         this.props.productType.friendlyName
-      } is cancelled, so unfortunately you can no longer create holiday 
-      suspensions for this subscription. Any existing holiday suspensions should 
-      have been dealt with at the point of cancellation with customer services.`}
+      } has been cancelled. Any scheduled holiday suspensions have been removed. 
+      Please contact us if you would like to re-start this ${
+        this.props.productType.friendlyName
+      }, make any amendments or need further help.`}
       singleProductDetailRenderer={(
         routeableStepProps: RouteableStepProps,
         productDetail: ProductDetail

--- a/app/client/components/holiday/holidaysOverview.tsx
+++ b/app/client/components/holiday/holidaysOverview.tsx
@@ -326,6 +326,11 @@ export class HolidaysOverview extends React.Component<
       hideHeading
       supportRefererSuffix="holiday_stop_flow"
       loadingMessagePrefix="Retrieving details of your"
+      cancelledExplainer={`This ${
+        this.props.productType.friendlyName
+      } is cancelled, so unfortunately you can no longer create holiday 
+      suspensions for this subscription. Any existing holiday suspensions should 
+      have been dealt with at the point of cancellation with customer services.`}
       singleProductDetailRenderer={(
         routeableStepProps: RouteableStepProps,
         productDetail: ProductDetail

--- a/app/client/components/payment/update/updatePaymentFlow.tsx
+++ b/app/client/components/payment/update/updatePaymentFlow.tsx
@@ -281,6 +281,9 @@ export const PaymentUpdateFlow = (props: RouteableStepProps) => (
     headingPrefix="Update payment for"
     supportRefererSuffix="payment_flow"
     loadingMessagePrefix="Retrieving current payment details for your"
+    cancelledExplainer={`This ${
+      props.productType.friendlyName
+    } is cancelled, so unfortunately you cannot update the payment details.`}
     singleProductDetailRenderer={(
       routeableStepProps: RouteableStepProps,
       productDetail: ProductDetail

--- a/app/client/components/payment/update/updatePaymentFlow.tsx
+++ b/app/client/components/payment/update/updatePaymentFlow.tsx
@@ -283,7 +283,9 @@ export const PaymentUpdateFlow = (props: RouteableStepProps) => (
     loadingMessagePrefix="Retrieving current payment details for your"
     cancelledExplainer={`This ${
       props.productType.friendlyName
-    } is cancelled, so unfortunately you cannot update the payment details.`}
+    } has been cancelled. Please contact us if you would like to re-start this ${
+      props.productType.friendlyName
+    }, make any amendments or need further help.`}
     singleProductDetailRenderer={(
       routeableStepProps: RouteableStepProps,
       productDetail: ProductDetail


### PR DESCRIPTION
If customers have multiple subscriptions of a given type (e.g. `guardianweekly`) and they enter any of the flows directly (for example enter the holiday stops flow direct from an email or FAQ page) then they're presented with a list of subs of that type so they can select the one they want to proceed with. _Note that if they come from the product tab (e.g. subscriptions) then it uses the 'browser history state' to denote the desired one to proceed with._

**Previously, 'cancelled' subs would be filtered out of this list**, likewise if the customer had just one subscription of that type which was cancelled and entered the flow directly they would just see the generic `NoProduct` page (which states for example `You do not currently have a newspaper voucher subscription.`) which is kind of misleading.

So now 'cancelled' subs are no longer filtered out of this list, and instead marked with a little `CANCELLED` badge...
![image](https://user-images.githubusercontent.com/19289579/69145718-2fcd2f80-0ac6-11ea-9703-760eb7d82572.png)

If the user proceeds with a cancelled sub (or if they only have one of that type and so don't go via the list) they see the following message...

#### Holiday Stops Flow _(GW & Voucher only currently)_
![image](https://user-images.githubusercontent.com/19289579/69154400-dc63dd00-0ad7-11ea-881d-a6ea5f6ab099.png)

#### Payment Update Flow
![image](https://user-images.githubusercontent.com/19289579/69154445-f1d90700-0ad7-11ea-8b98-28cac2dca34d.png)

#### Cancellation Flow _(Membership & Contributions only currently)_
![image](https://user-images.githubusercontent.com/19289579/69154489-01585000-0ad8-11ea-9fea-202c53fb7641.png)

