### PR TITLE
Adds a referer to IDAPI requests 

### DIFF
--- a/app/server/routes/idapi.ts
+++ b/app/server/routes/idapi.ts
@@ -82,7 +82,7 @@ const getOptions = (
     "X-GU-ID-Client-Access-Token": `Bearer ${config.accessToken}`,
     ...securityCookieToHeader(cookies),
     "Content-Type": "application/json",
-    Referer: "manage-frontend"
+    "Referer": "manage-frontend"
   };
 
   const options = {

--- a/app/server/routes/idapi.ts
+++ b/app/server/routes/idapi.ts
@@ -81,7 +81,8 @@ const getOptions = (
   const headers = {
     "X-GU-ID-Client-Access-Token": `Bearer ${config.accessToken}`,
     ...securityCookieToHeader(cookies),
-    "Content-Type": "application/json"
+    "Content-Type": "application/json",
+    Referer: "manage-frontend"
   };
 
   const options = {


### PR DESCRIPTION
Adds a referer to IDAPI requests coming from manage-frontend, to facilitate on going security audit of IDAPI. Can be reverted once complete. 