### PR TITLE
hide holiday stops row on product page for non-auto renewing subs

### DIFF
--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -390,30 +390,31 @@ const getProductDetailRenderer = (
                   />
                 </a>
               ))}
-            {shouldHaveHolidayStopsFlow(productType) && (
-              <ProductDetailRow
-                label="Holiday stop"
-                data={
-                  <div>
-                    <div
-                      css={{
-                        display: "inline-block",
-                        margin: "10px",
-                        marginLeft: 0
-                      }}
-                    >
-                      Going on holiday?
+            {shouldHaveHolidayStopsFlow(productType) &&
+              productDetail.subscription.autoRenew && (
+                <ProductDetailRow
+                  label="Holiday stop"
+                  data={
+                    <div>
+                      <div
+                        css={{
+                          display: "inline-block",
+                          margin: "10px",
+                          marginLeft: 0
+                        }}
+                      >
+                        Going on holiday?
+                      </div>
+                      <LinkButton
+                        text="Manage your suspensions"
+                        to={"/suspend/" + productType.urlPart}
+                        state={productDetail}
+                        right
+                      />
                     </div>
-                    <LinkButton
-                      text="Manage your suspensions"
-                      to={"/suspend/" + productType.urlPart}
-                      state={productDetail}
-                      right
-                    />
-                  </div>
-                }
-              />
-            )}
+                  }
+                />
+              )}
           </PageContainer>
         </>
       )}


### PR DESCRIPTION
Follows on from https://github.com/guardian/manage-frontend/pull/319 - this hides holiday stops row on product page for to avoid disappointment when they then find out holiday stops are not supported for non-auto renewing subs.