### PR TITLE
hide "Next payment date" and 'next payment' rows for one-off subs

### DIFF
--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -167,40 +167,42 @@ const getPaymentPart = (
     return (
       <>
         {productDetail.subscription.nextPaymentDate &&
+          productDetail.subscription.autoRenew &&
           !productDetail.alertText && (
             <ProductDetailRow
               label={"Next payment date"}
               data={formatDate(productDetail.subscription.nextPaymentDate)}
             />
           )}
-        {}
-        <ProductDetailRow
-          label={`Next ${mainPlanInterval} payment`}
-          data={
-            <>
-              <UpdatableAmount
-                mainPlan={mainPlan}
-                nextPaymentPrice={productDetail.subscription.nextPaymentPrice}
-                subscriptionId={productDetail.subscription.subscriptionId}
-                productType={productType}
-              />
-              {futurePlan &&
-                futurePlan.amount !== mainPlan.amount && (
-                  <div css={{ fontStyle: "italic" }}>
-                    {futurePlan.currency}{" "}
-                    {(futurePlan.amount / 100.0).toFixed(2)}{" "}
-                    {futurePlan.currencyISO}{" "}
-                    {futurePlan.interval !== mainPlan.interval && (
-                      <strong>
-                        {augmentInterval(futurePlan.interval) + " "}
-                      </strong>
-                    )}
-                    starting {formatDate(futurePlan.start)}
-                  </div>
-                )}
-            </>
-          }
-        />
+        {productDetail.subscription.autoRenew && (
+          <ProductDetailRow
+            label={`Next ${mainPlanInterval} payment`}
+            data={
+              <>
+                <UpdatableAmount
+                  mainPlan={mainPlan}
+                  nextPaymentPrice={productDetail.subscription.nextPaymentPrice}
+                  subscriptionId={productDetail.subscription.subscriptionId}
+                  productType={productType}
+                />
+                {futurePlan &&
+                  futurePlan.amount !== mainPlan.amount && (
+                    <div css={{ fontStyle: "italic" }}>
+                      {futurePlan.currency}{" "}
+                      {(futurePlan.amount / 100.0).toFixed(2)}{" "}
+                      {futurePlan.currencyISO}{" "}
+                      {futurePlan.interval !== mainPlan.interval && (
+                        <strong>
+                          {augmentInterval(futurePlan.interval) + " "}
+                        </strong>
+                      )}
+                      starting {formatDate(futurePlan.start)}
+                    </div>
+                  )}
+              </>
+            }
+          />
+        )}
         {getPaymentMethodRow(productDetail, "/payment/" + productType.urlPart)}
       </>
     );


### PR DESCRIPTION
Given we're now selling new types of one-off gift subs (see https://github.com/guardian/support-frontend/pull/2188) we need to hide the following nastiness...
![image](https://user-images.githubusercontent.com/19289579/69444863-243d6b00-0d49-11ea-8e8d-7a0098506e43.png)
...the red rows do not make sense for these new one-offs.