### PR TITLE
Fix visual regression on userflows (layouts that don't yet use grid)

### DIFF
--- a/app/client/components/flowStartMultipleProductDetailHandler.tsx
+++ b/app/client/components/flowStartMultipleProductDetailHandler.tsx
@@ -247,16 +247,20 @@ export class FlowStartMultipleProductDetailHandler extends React.Component<
 
   public render(): React.ReactNode {
     return (
-      <PageContainer withMaxWidth>
+      <div>
         {!this.props.hideHeading && (
-          <h1 css={{ fontSize: "24px" }}>
-            {this.props.headingPrefix + " your "}
-            {this.props.productType.includeGuardianInTitles ? "Guardian " : ""}
-            {this.props.productType.friendlyName}
-          </h1>
+          <PageContainer>
+            <h1 css={{ fontSize: "24px" }}>
+              {this.props.headingPrefix + " your "}
+              {this.props.productType.includeGuardianInTitles
+                ? "Guardian "
+                : ""}
+              {this.props.productType.friendlyName}
+            </h1>
+          </PageContainer>
         )}
         {this.renderInner()}
-      </PageContainer>
+      </div>
     );
   }
 

--- a/app/client/components/flowStartMultipleProductDetailHandler.tsx
+++ b/app/client/components/flowStartMultipleProductDetailHandler.tsx
@@ -247,20 +247,16 @@ export class FlowStartMultipleProductDetailHandler extends React.Component<
 
   public render(): React.ReactNode {
     return (
-      <div>
+      <PageContainer withMaxWidth>
         {!this.props.hideHeading && (
-          <PageContainer>
-            <h1 css={{ fontSize: "24px" }}>
-              {this.props.headingPrefix + " your "}
-              {this.props.productType.includeGuardianInTitles
-                ? "Guardian "
-                : ""}
-              {this.props.productType.friendlyName}
-            </h1>
-          </PageContainer>
+          <h1 css={{ fontSize: "24px" }}>
+            {this.props.headingPrefix + " your "}
+            {this.props.productType.includeGuardianInTitles ? "Guardian " : ""}
+            {this.props.productType.friendlyName}
+          </h1>
         )}
         {this.renderInner()}
-      </div>
+      </PageContainer>
     );
   }
 

--- a/app/client/components/nav.tsx
+++ b/app/client/components/nav.tsx
@@ -129,7 +129,7 @@ if (typeof window !== "undefined" && window.guardian) {
 }
 
 export interface NavProps {
-  selectedNavItem: NavItem;
+  selectedNavItem?: NavItem;
 }
 
 export const Nav = (props: NavProps) => (

--- a/app/client/components/page.tsx
+++ b/app/client/components/page.tsx
@@ -75,13 +75,12 @@ export const PageNavAndContentContainer: React.SFC<
 export interface PageContainerProps {
   noVerticalMargin?: true;
   children: React.ReactNode;
-  withMaxWidth?: true;
 }
 export const PageContainer = (props: PageContainerProps) => (
   <div
     css={{
       margin: `${props.noVerticalMargin ? "0" : "1.8125rem"} auto 0`,
-      maxWidth: props.withMaxWidth ? "980px" : undefined
+      maxWidth: "980px"
     }}
   >
     {props.children}

--- a/app/client/components/page.tsx
+++ b/app/client/components/page.tsx
@@ -8,6 +8,7 @@ import { Nav, NavProps } from "./nav";
 
 export interface PageNavAndContentContainerProps extends NavProps {
   children: React.ReactNode;
+  withoutNav?: true;
 }
 
 export const PageNavAndContentContainer: React.SFC<
@@ -29,38 +30,40 @@ export const PageNavAndContentContainer: React.SFC<
       }
     }}
   >
-    <nav
-      css={{
-        marginTop: `calc(-1 * (${space[5]}px + ${space[9]}px))`,
-        display: "none",
+    {!props.withoutNav && (
+      <nav
+        css={{
+          marginTop: `calc(-1 * (${space[5]}px + ${space[9]}px))`,
+          display: "none",
 
-        [minWidth.desktop]: {
-          ...gridItemPlacement(1, 4),
-          display: "block",
-          paddingRight: "1.25rem"
-        },
+          [minWidth.desktop]: {
+            ...gridItemPlacement(1, 4),
+            display: "block",
+            paddingRight: "1.25rem"
+          },
 
-        [minWidth.wide]: {
-          paddingRight: "0"
-        }
-      }}
-    >
-      <Nav {...props} />
-    </nav>
+          [minWidth.wide]: {
+            paddingRight: "0"
+          }
+        }}
+      >
+        <Nav {...props} />
+      </nav>
+    )}
     <section
       css={{
         ...gridItemPlacement(1, 4),
 
         [minWidth.tablet]: {
-          ...gridItemPlacement(1, 11)
+          ...gridItemPlacement(1, 12)
         },
 
         [minWidth.desktop]: {
-          ...gridItemPlacement(5, 7)
+          ...gridItemPlacement(5, 8)
         },
 
         [minWidth.wide]: {
-          ...gridItemPlacement(6, 9)
+          ...gridItemPlacement(6, 10)
         }
       }}
     >
@@ -69,17 +72,19 @@ export const PageNavAndContentContainer: React.SFC<
   </div>
 );
 
-// Standard width, centered container
-export const PageContainer: React.SFC<{ noVerticalMargin?: true }> = ({
-  children,
-  noVerticalMargin
-}) => (
+export interface PageContainerProps {
+  noVerticalMargin?: true;
+  children: React.ReactNode;
+  withMaxWidth?: true;
+}
+export const PageContainer = (props: PageContainerProps) => (
   <div
     css={{
-      margin: (noVerticalMargin ? "0" : "1.8125rem") + " auto 0"
+      margin: `${props.noVerticalMargin ? "0" : "1.8125rem"} auto 0`,
+      maxWidth: props.withMaxWidth ? "980px" : undefined
     }}
   >
-    {children}
+    {props.children}
   </div>
 );
 


### PR DESCRIPTION
`maxWidth` was removed from the `PageContainer` component in https://github.com/guardian/manage-frontend/pull/324... which made the flows (e.g. payment, holiday stops, cancellation) go full width ... so added `maxWidth` back in.

`PageContainer` will be phased out in future once the flows use the grid and final design.s