### PR TITLE
[RB] - make header title clickable

### DIFF
--- a/app/client/__tests__/__snapshots__/main.tsx.snap
+++ b/app/client/__tests__/__snapshots__/main.tsx.snap
@@ -67,14 +67,29 @@ exports[`Main renders something 1`] = `
               "msGridColumnSpan": "8",
               "msGridRow": "1",
             },
-            "color": "white",
+            "color": "#FFFFFF",
             "display": "none",
             "fontSize": "1.75rem",
             "fontWeight": "bold",
           }
         }
       >
-        My account
+        <a
+          aria-current="page"
+          css={
+            Object {
+              ":visited": Object {
+                "color": "inherit",
+              },
+              "color": "#FFFFFF",
+              "textDecoration": "none",
+            }
+          }
+          href="/"
+          onClick={[Function]}
+        >
+          My account
+        </a>
       </h1>
       <nav
         css={

--- a/app/client/components/header.tsx
+++ b/app/client/components/header.tsx
@@ -1,4 +1,5 @@
 import { breakpoints, palette } from "@guardian/src-foundations";
+import { Link } from "@reach/router";
 import React from "react";
 import { minWidth } from "../styles/breakpoints";
 import { gridBase, gridItemPlacement } from "../styles/grid";
@@ -32,7 +33,7 @@ const Header = () => (
         css={{
           fontSize: "1.75rem",
           fontWeight: "bold",
-          color: "white",
+          color: palette.neutral["100"],
           display: "none",
           [minWidth.desktop]: {
             display: "block",
@@ -40,7 +41,16 @@ const Header = () => (
           }
         }}
       >
-        My account
+        <Link
+          to={"/"}
+          css={{
+            textDecoration: "none",
+            color: palette.neutral["100"],
+            ":visited": { color: "inherit" }
+          }}
+        >
+          My account
+        </Link>
       </h1>
       <UserNav />
       <GridRoundel


### PR DESCRIPTION
On desktop, now the 'My account' dropdown has fewer options, being able to click the big 'My account' heading allows the user to exit the flow.