### PR TITLE
[RB] - replaced alternating grey backgrounds on product pages with divider lines

### DIFF
--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -225,16 +225,12 @@ const getProductDetailRenderer = (
   const alternateManagementCtaLabel =
     productType.alternateManagementCtaLabel &&
     productType.alternateManagementCtaLabel(productDetail);
-  const shouldShowShadedBackground =
-    productDetailListLength > 1 && (listIndex + 1) % 2 !== 0;
   const mainPlan = getMainPlan(productDetail.subscription);
   return (
     <div
       key={productDetail.subscription.subscriptionId}
       css={{
-        background: shouldShowShadedBackground
-          ? palette.neutral["97"]
-          : undefined,
+        borderTop: `1px solid ${palette.neutral["86"]}`,
         padding: "5px 0 20px"
       }}
     >


### PR DESCRIPTION
Alternating backgrounds used to stretch to 100% width which is now doesn't look great within the new grid placement...
![image](https://user-images.githubusercontent.com/19289579/69659921-24a27280-1077-11ea-995b-10c475490aae.png)


Added separating lines instead...

![image](https://user-images.githubusercontent.com/2510683/69660158-9a0e4300-1077-11ea-8251-5da2b13893b5.png)