### PR TITLE
renaming and restructuring, in anticipation of consuming `fulfilment-date-calculator`

### DIFF
--- a/app/client/components/cancel/cancellationFlow.tsx
+++ b/app/client/components/cancel/cancellationFlow.tsx
@@ -1,7 +1,7 @@
 import { css } from "@emotion/core";
 import React from "react";
 import {
-  MembersDataApiResponseContext,
+  MembersDataApiItemContext,
   ProductDetail
 } from "../../../shared/productResponse";
 import {
@@ -108,7 +108,7 @@ const reasonsRenderer = (
     );
   }
   return (
-    <MembersDataApiResponseContext.Provider value={productDetail}>
+    <MembersDataApiItemContext.Provider value={productDetail}>
       <WizardStep routeableStepProps={routeableStepProps} hideBackButton>
         {
           routeableStepPropsWithCancellationFlow.productType.cancellation
@@ -123,7 +123,7 @@ const reasonsRenderer = (
           />
         </PageContainerSection>
       </WizardStep>
-    </MembersDataApiResponseContext.Provider>
+    </MembersDataApiItemContext.Provider>
   );
 };
 

--- a/app/client/components/cancel/caseCreationWrapper.tsx
+++ b/app/client/components/cancel/caseCreationWrapper.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { ProductDetail } from "../../../shared/productResponse";
-import { MembersDataApiResponse } from "../../../shared/productResponse";
+import { MembersDataApiItem } from "../../../shared/productResponse";
 import AsyncLoader from "../asyncLoader";
 import { CancellationCaseIdContext } from "./cancellationContexts";
 import { CancellationReasonContext } from "./cancellationContexts";
@@ -44,7 +44,7 @@ class CaseCreationAsyncLoader extends AsyncLoader<CaseCreationResponse> {}
 export interface CaseCreationWrapperProps {
   children: any;
   sfProduct: string;
-  membersDataApiResponse: MembersDataApiResponse;
+  membersDataApiItem: MembersDataApiItem;
 }
 
 export const CaseCreationWrapper = (props: CaseCreationWrapperProps) => (
@@ -54,7 +54,7 @@ export const CaseCreationWrapper = (props: CaseCreationWrapperProps) => (
         fetch={getCreateCaseFunc(
           reason,
           props.sfProduct,
-          props.membersDataApiResponse as ProductDetail
+          props.membersDataApiItem as ProductDetail
         )}
         render={renderWithCaseIdContextProvider(props.children)}
         errorRender={renderWithCaseIdContextProvider(props.children)}

--- a/app/client/components/cancel/stages/executeCancellation.tsx
+++ b/app/client/components/cancel/stages/executeCancellation.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import {
-  hasProduct,
-  MembersDataApiResponseContext,
+  isProduct,
+  MembersDataApiItemContext,
   Subscription,
   WithSubscription
 } from "../../../../shared/productResponse";
@@ -94,9 +94,9 @@ export const ExecuteCancellation = (
       {reason => (
         <CancellationCaseIdContext.Consumer>
           {caseId => (
-            <MembersDataApiResponseContext.Consumer>
+            <MembersDataApiItemContext.Consumer>
               {productDetail =>
-                hasProduct(productDetail) ? (
+                isProduct(productDetail) ? (
                   <PerformCancelAsyncLoader
                     fetch={getCancelFunc(
                       productDetail.subscription.subscriptionId,
@@ -116,7 +116,7 @@ export const ExecuteCancellation = (
                   <GenericErrorScreen loggingMessage="invalid product detail to cancel" />
                 )
               }
-            </MembersDataApiResponseContext.Consumer>
+            </MembersDataApiItemContext.Consumer>
           )}
         </CancellationCaseIdContext.Consumer>
       )}

--- a/app/client/components/cancel/stages/genericSaveAttempt.tsx
+++ b/app/client/components/cancel/stages/genericSaveAttempt.tsx
@@ -1,6 +1,6 @@
 import { navigate } from "@reach/router";
 import React, { ChangeEvent, ReactNode } from "react";
-import { MembersDataApiResponseContext } from "../../../../shared/productResponse";
+import { MembersDataApiItemContext } from "../../../../shared/productResponse";
 import {
   ProductTypeWithCancellationFlow,
   WithProductType
@@ -250,13 +250,13 @@ const ConfirmCancellationAndReturnRow = (
 );
 
 export const GenericSaveAttempt = (props: GenericSaveAttemptProps) => (
-  <MembersDataApiResponseContext.Consumer>
-    {membersDataApiResponse => (
+  <MembersDataApiItemContext.Consumer>
+    {membersDataApiItem => (
       <CancellationReasonContext.Provider
         value={props.path as CancellationReasonId}
       >
         <CaseCreationWrapper
-          membersDataApiResponse={membersDataApiResponse}
+          membersDataApiItem={membersDataApiItem}
           sfProduct={props.productType.cancellation.sfProduct}
         >
           <WizardStep routeableStepProps={props} hideBackButton>
@@ -308,5 +308,5 @@ export const GenericSaveAttempt = (props: GenericSaveAttemptProps) => (
         </CaseCreationWrapper>
       </CancellationReasonContext.Provider>
     )}
-  </MembersDataApiResponseContext.Consumer>
+  </MembersDataApiItemContext.Consumer>
 );

--- a/app/client/components/flowStartMultipleProductDetailHandler.tsx
+++ b/app/client/components/flowStartMultipleProductDetailHandler.tsx
@@ -3,13 +3,12 @@ import { toWords } from "number-to-words";
 import React from "react";
 import {
   alertTextWithoutCTA,
-  annotateMdaResponseWithTestUserFromHeaders,
   augmentInterval,
   formatDate,
   getMainPlan,
-  hasProduct,
   isPaidSubscriptionPlan,
-  MembersDataApiResponse,
+  isProduct,
+  MembersDataApiItem,
   MembersDatApiAsyncLoader,
   ProductDetail,
   sortByJoinDate,
@@ -79,11 +78,11 @@ const getProductDetailSelector = (
   props: FlowStartMultipleProductDetailHandlerProps,
   selectProductDetail: (productDetail: ProductDetail) => void,
   supportRefererSuffix: string
-) => (data: MembersDataApiResponse[]) => {
-  const sortedList = data.filter(hasProduct).sort(sortByJoinDate);
+) => (data: MembersDataApiItem[]) => {
+  const sortedList = data.filter(isProduct).sort(sortByJoinDate);
   if (sortedList.length > 0) {
     const first = sortedList[0];
-    if (sortedList.length === 1 && hasProduct(first)) {
+    if (sortedList.length === 1 && isProduct(first)) {
       return first.subscription.cancelledAt ? (
         <PageContainer>
           <h4>{props.cancelledExplainer}</h4>
@@ -240,7 +239,7 @@ export class FlowStartMultipleProductDetailHandler extends React.Component<
   public componentDidMount(): void {
     this.setState({
       selectedProductDetail:
-        this.props.location && hasProduct(this.props.location.state)
+        this.props.location && isProduct(this.props.location.state)
           ? this.props.location.state
           : null
     });
@@ -286,7 +285,6 @@ export class FlowStartMultipleProductDetailHandler extends React.Component<
               this.props.productType
             ) /*TODO reload on 'back' to page*/
           }
-          readerOnOK={annotateMdaResponseWithTestUserFromHeaders}
           render={this.preWiredProductDetailSelector}
           loadingMessage={
             this.props.loadingMessagePrefix +

--- a/app/client/components/holiday/holidayConfirmed.tsx
+++ b/app/client/components/holiday/holidayConfirmed.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import {
-  hasProduct,
-  MembersDataApiResponseContext
+  isProduct,
+  MembersDataApiItemContext
 } from "../../../shared/productResponse";
 import { LinkButton } from "../buttons";
 import { GenericErrorScreen } from "../genericErrorScreen";
@@ -23,12 +23,12 @@ export const HolidayConfirmed = (props: HolidayStopsRouteableStepProps) => (
   <HolidayStopsResponseContext.Consumer>
     {holidayStopsResponse =>
       isHolidayStopsResponse(holidayStopsResponse) ? (
-        <MembersDataApiResponseContext.Consumer>
+        <MembersDataApiItemContext.Consumer>
           {productDetail => (
             <HolidayDateChooserStateContext.Consumer>
               {dateChooserState =>
                 isSharedHolidayDateChooserState(dateChooserState) &&
-                hasProduct(productDetail) ? (
+                isProduct(productDetail) ? (
                   <WizardStep routeableStepProps={props} hideBackButton>
                     <div>
                       <h1>Your schedule has been set</h1>
@@ -78,7 +78,7 @@ export const HolidayConfirmed = (props: HolidayStopsRouteableStepProps) => (
               }
             </HolidayDateChooserStateContext.Consumer>
           )}
-        </MembersDataApiResponseContext.Consumer>
+        </MembersDataApiItemContext.Consumer>
       ) : (
         <GenericErrorScreen loggingMessage="No holiday stop response" />
       )

--- a/app/client/components/holiday/holidayDateChooser.tsx
+++ b/app/client/components/holiday/holidayDateChooser.tsx
@@ -7,8 +7,8 @@ import * as Raven from "raven-js";
 import React from "react";
 import { OnSelectCallbackParam } from "react-daterange-picker";
 import {
-  hasProduct,
-  MembersDataApiResponseContext
+  isProduct,
+  MembersDataApiItemContext
 } from "../../../shared/productResponse";
 import palette from "../../colours";
 import { maxWidth, minWidth, queries } from "../../styles/breakpoints";
@@ -166,9 +166,9 @@ export class HolidayDateChooser extends React.Component<
     <HolidayStopsResponseContext.Consumer>
       {holidayStopsResponse =>
         isHolidayStopsResponse(holidayStopsResponse) ? (
-          <MembersDataApiResponseContext.Consumer>
+          <MembersDataApiItemContext.Consumer>
             {productDetail => {
-              if (hasProduct(productDetail)) {
+              if (isProduct(productDetail)) {
                 const existingHolidayStopToAmendId =
                   holidayStopsResponse.existingHolidayStopToAmend &&
                   holidayStopsResponse.existingHolidayStopToAmend.id;
@@ -349,7 +349,7 @@ export class HolidayDateChooser extends React.Component<
                 );
               }
             }}
-          </MembersDataApiResponseContext.Consumer>
+          </MembersDataApiItemContext.Consumer>
         ) : (
           <GenericErrorScreen loggingMessage="No holiday stop response" />
         )

--- a/app/client/components/holiday/holidayReview.tsx
+++ b/app/client/components/holiday/holidayReview.tsx
@@ -2,9 +2,9 @@ import { Link, navigate, NavigateFn } from "@reach/router";
 import { DateRange } from "moment-range";
 import React from "react";
 import {
-  hasProduct,
+  isProduct,
   MDA_TEST_USER_HEADER,
-  MembersDataApiResponseContext,
+  MembersDataApiItemContext,
   ProductDetail
 } from "../../../shared/productResponse";
 import { maxWidth } from "../../styles/breakpoints";
@@ -106,12 +106,12 @@ export class HolidayReview extends React.Component<
     <HolidayStopsResponseContext.Consumer>
       {holidayStopsResponse =>
         isHolidayStopsResponse(holidayStopsResponse) ? (
-          <MembersDataApiResponseContext.Consumer>
+          <MembersDataApiItemContext.Consumer>
             {productDetail => (
               <HolidayDateChooserStateContext.Consumer>
                 {dateChooserState =>
                   isSharedHolidayDateChooserState(dateChooserState) &&
-                  hasProduct(productDetail) ? (
+                  isProduct(productDetail) ? (
                     <PotentialHolidayStopsAsyncLoader
                       fetch={getPotentialHolidayStopsFetcher(
                         true,
@@ -133,7 +133,7 @@ export class HolidayReview extends React.Component<
                 }
               </HolidayDateChooserStateContext.Consumer>
             )}
-          </MembersDataApiResponseContext.Consumer>
+          </MembersDataApiItemContext.Consumer>
         ) : (
           <GenericErrorScreen loggingMessage="No holiday stop response" />
         )

--- a/app/client/components/holiday/holidaysOverview.tsx
+++ b/app/client/components/holiday/holidaysOverview.tsx
@@ -4,7 +4,7 @@ import {
   getMainPlan,
   isPaidSubscriptionPlan,
   MDA_TEST_USER_HEADER,
-  MembersDataApiResponseContext,
+  MembersDataApiItemContext,
   ProductDetail
 } from "../../../shared/productResponse";
 import {
@@ -119,7 +119,7 @@ const renderHolidayStopsOverview = (
         existingHolidayStopToAmend: existingHolidayStopToAmend || undefined
       }}
     >
-      <MembersDataApiResponseContext.Provider value={productDetail}>
+      <MembersDataApiItemContext.Provider value={productDetail}>
         <WizardStep routeableStepProps={props} hideBackButton>
           <div>
             <h1>Suspend {props.productType.friendlyName}</h1>
@@ -292,7 +292,7 @@ const renderHolidayStopsOverview = (
             </div>
           </div>
         </WizardStep>
-      </MembersDataApiResponseContext.Provider>
+      </MembersDataApiItemContext.Provider>
     </HolidayStopsResponseContext.Provider>
   );
 };
@@ -336,7 +336,7 @@ export class HolidaysOverview extends React.Component<
         routeableStepProps: RouteableStepProps,
         productDetail: ProductDetail
       ) => (
-        <MembersDataApiResponseContext.Provider value={productDetail}>
+        <MembersDataApiItemContext.Provider value={productDetail}>
           <NavigateFnContext.Provider value={{ navigate: this.props.navigate }}>
             {" "}
             {productDetail.subscription.start ? (
@@ -358,7 +358,7 @@ export class HolidaysOverview extends React.Component<
               <GenericErrorScreen loggingMessage="Subscription had no start date" />
             )}
           </NavigateFnContext.Provider>
-        </MembersDataApiResponseContext.Provider>
+        </MembersDataApiItemContext.Provider>
       )}
     />
   );

--- a/app/client/components/payment/update/confirmPaymentUpdate.tsx
+++ b/app/client/components/payment/update/confirmPaymentUpdate.tsx
@@ -4,9 +4,9 @@ import {
   getScopeFromRequestPathOrEmptyString,
   X_GU_ID_FORWARDED_SCOPE
 } from "../../../../shared/identity";
-import { hasProduct } from "../../../../shared/productResponse";
+import { isProduct } from "../../../../shared/productResponse";
 import {
-  MembersDataApiResponseContext,
+  MembersDataApiItemContext,
   ProductDetail
 } from "../../../../shared/productResponse";
 import { trackEvent } from "../../analytics";
@@ -159,11 +159,11 @@ class ExecutePaymentUpdate extends React.Component<
 export const ConfirmPaymentUpdate = (props: RouteableStepProps) => (
   <NewPaymentMethodContext.Consumer>
     {newPaymentMethodDetail => (
-      <MembersDataApiResponseContext.Consumer>
+      <MembersDataApiItemContext.Consumer>
         {productDetail =>
           props.navigate &&
           isNewPaymentMethodDetail(newPaymentMethodDetail) &&
-          hasProduct(productDetail) ? (
+          isProduct(productDetail) ? (
             <WizardStep
               routeableStepProps={labelPaymentStepProps(props)}
               extraFooterComponents={
@@ -190,7 +190,7 @@ export const ConfirmPaymentUpdate = (props: RouteableStepProps) => (
             visuallyNavigateToParent(props)
           )
         }
-      </MembersDataApiResponseContext.Consumer>
+      </MembersDataApiItemContext.Consumer>
     )}
   </NewPaymentMethodContext.Consumer>
 );

--- a/app/client/components/payment/update/paymentUpdated.tsx
+++ b/app/client/components/payment/update/paymentUpdated.tsx
@@ -3,9 +3,9 @@ import {
   augmentInterval,
   formatDate,
   getMainPlan,
-  hasProduct,
   isPaidSubscriptionPlan,
-  MembersDataApiResponseContext,
+  isProduct,
+  MembersDataApiItemContext,
   ProductDetail,
   Subscription,
   WithSubscription
@@ -125,12 +125,12 @@ const WithSubscriptionRenderer = (
   );
 
 export const PaymentUpdated = (props: RouteableStepProps) => (
-  <MembersDataApiResponseContext.Consumer>
+  <MembersDataApiItemContext.Consumer>
     {previousProductDetail => (
       <NewPaymentMethodContext.Consumer>
         {newPaymentMethodDetail =>
           isNewPaymentMethodDetail(newPaymentMethodDetail) &&
-          hasProduct(previousProductDetail) ? (
+          isProduct(previousProductDetail) ? (
             <WizardStep
               routeableStepProps={labelPaymentStepProps(props)}
               extraFooterComponents={[
@@ -161,5 +161,5 @@ export const PaymentUpdated = (props: RouteableStepProps) => (
         }
       </NewPaymentMethodContext.Consumer>
     )}
-  </MembersDataApiResponseContext.Consumer>
+  </MembersDataApiItemContext.Consumer>
 );

--- a/app/client/components/payment/update/updatePaymentFlow.tsx
+++ b/app/client/components/payment/update/updatePaymentFlow.tsx
@@ -2,7 +2,7 @@ import { NavigateFn } from "@reach/router";
 import Raven from "raven-js";
 import React from "react";
 import {
-  MembersDataApiResponseContext,
+  MembersDataApiItemContext,
   ProductDetail,
   Subscription
 } from "../../../../shared/productResponse";
@@ -149,7 +149,7 @@ class PaymentUpdaterStep extends React.Component<
 
   public render(): React.ReactNode {
     return (
-      <MembersDataApiResponseContext.Provider value={this.props.productDetail}>
+      <MembersDataApiItemContext.Provider value={this.props.productDetail}>
         <NewPaymentMethodContext.Provider
           value={this.state.newPaymentMethodDetail || {}}
         >
@@ -204,7 +204,7 @@ class PaymentUpdaterStep extends React.Component<
             </WizardStep>
           </NavigateFnContext.Provider>
         </NewPaymentMethodContext.Provider>
-      </MembersDataApiResponseContext.Provider>
+      </MembersDataApiItemContext.Provider>
     );
   }
 

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -7,14 +7,13 @@ import Raven from "raven-js";
 import React from "react";
 import {
   alertTextWithoutCTA,
-  annotateMdaResponseWithTestUserFromHeaders,
   augmentInterval,
   formatDate,
   getFuturePlanIfVisible,
   getMainPlan,
-  hasProduct,
   isPaidSubscriptionPlan,
-  MembersDataApiResponse,
+  isProduct,
+  MembersDataApiItem,
   MembersDatApiAsyncLoader,
   ProductDetail,
   sortByJoinDate
@@ -428,8 +427,8 @@ const getProductDetailRenderer = (
 
 const getProductRenderer = (
   productType: ProductTypeWithProductPageProperties
-) => (apiResponse: MembersDataApiResponse[]) => {
-  const productDetailList = apiResponse.filter(hasProduct).sort(sortByJoinDate);
+) => (apiResponse: MembersDataApiItem[]) => {
+  const productDetailList = apiResponse.filter(isProduct).sort(sortByJoinDate);
   return (
     <>
       {productDetailList.length > 1 && (
@@ -477,7 +476,6 @@ export const ProductPage = (props: RouteableProductPropsWithProductPage) => (
       <MembersDatApiAsyncLoader
         fetch={createProductDetailFetcher(props.productType)}
         render={getProductRenderer(props.productType)}
-        readerOnOK={annotateMdaResponseWithTestUserFromHeaders}
         loadingMessage={`Loading your ${
           props.productType.friendlyName
         } details...`}

--- a/app/server/awsIntegration.ts
+++ b/app/server/awsIntegration.ts
@@ -25,12 +25,23 @@ export const handleAwsRelatedError = (message: string, detail?: any) => {
 
 export const s3ConfigPromise = <ConfigInterface>(
   configPathPart: string,
-  ...fields: string[]
+  ...fieldNamesToValidate: string[]
+) =>
+  s3FilePromise<ConfigInterface>(
+    "gu-reader-revenue-private",
+    `manage-frontend/${conf.STAGE}/${configPathPart}-${conf.STAGE}.json`,
+    ...fieldNamesToValidate
+  );
+
+export const s3FilePromise = <ConfigInterface>(
+  bucket: string,
+  fileKey: string,
+  ...fieldNamesToValidate: string[]
 ) =>
   (async () => {
     const configPath: GetObjectRequest = {
-      Bucket: "gu-reader-revenue-private",
-      Key: `manage-frontend/${conf.STAGE}/${configPathPart}-${conf.STAGE}.json`
+      Bucket: bucket,
+      Key: fileKey
     };
 
     const s3PromiseResult = await S3.getObject(configPath).promise();
@@ -38,24 +49,24 @@ export const s3ConfigPromise = <ConfigInterface>(
     if (s3PromiseResult.Body) {
       try {
         const parsed = JSON.parse(s3PromiseResult.Body.toString());
-        if (
-          fields.filter(field => parsed.hasOwnProperty(field)).length ===
-          fields.length
-        ) {
+        const missingProperties = fieldNamesToValidate.filter(
+          field => !parsed.hasOwnProperty(field)
+        );
+        if (missingProperties.length === 0) {
           return parsed as ConfigInterface;
         }
         handleAwsRelatedError(
-          `${configPathPart} config missing ${fields
-            .map(field => `'${field}'`)
-            .join(" and/or ")} properties`
+          `${fileKey} missing ${missingProperties.map(
+            field => `'${field}'`
+          )} properties in '${bucket}'`
         );
       } catch (err) {
-        handleAwsRelatedError(`could not parse ${configPathPart} config`, err);
+        handleAwsRelatedError(`could not parse ${fileKey} in '${bucket}'`, err);
       }
     }
 
     handleAwsRelatedError(
-      `error fetching ${configPathPart} config from S3`,
+      `S3 error fetching ${fileKey} in '${bucket}'`,
       s3PromiseResult
     );
   })();

--- a/app/server/middleware/apiMiddleware.ts
+++ b/app/server/middleware/apiMiddleware.ts
@@ -12,13 +12,13 @@ import {
 
 export type BodyHandler = (res: Response, body: string) => void;
 
-const straightThroughBodyHandler: BodyHandler = (res, jsonString) =>
-  res.send(jsonString);
+export const straightThroughBodyHandler: BodyHandler = (res, body) =>
+  res.send(body);
 
 export const proxyApiHandler = (
   basePath: string,
   ...headersToForward: string[]
-) => (bodyHandler: BodyHandler = straightThroughBodyHandler) => (
+) => (bodyHandler: BodyHandler) => (
   path: string,
   forwardQueryArgs?: boolean,
   ...pathParamNamesToReplace: string[]
@@ -69,14 +69,18 @@ export const proxyApiHandler = (
     })
     .then(body => bodyHandler(res, body))
     .catch(e => {
-      log.info(e);
+      log.error(e);
       res.status(500).send("Something broke!");
     });
 };
 
-export const sfCasesApiHandler = proxyApiHandler(conf.SF_CASES_URL)();
+export const sfCasesApiHandler = proxyApiHandler(conf.SF_CASES_URL)(
+  straightThroughBodyHandler
+);
 export const customMembersDataApiHandler = proxyApiHandler(
   "https://members-data-api." + conf.DOMAIN,
   MDA_TEST_USER_HEADER
 );
-export const membersDataApiHandler = customMembersDataApiHandler();
+export const membersDataApiHandler = customMembersDataApiHandler(
+  straightThroughBodyHandler
+);

--- a/app/server/middleware/apiMiddleware.ts
+++ b/app/server/middleware/apiMiddleware.ts
@@ -10,12 +10,15 @@ import {
   getCookiesOrEmptyString
 } from "./identityMiddleware";
 
-export type JsonHandler = (res: Response, jsonString: string) => void;
+export type BodyHandler = (res: Response, body: string) => void;
 
-export const apiHandler = (jsonHandler: JsonHandler) => (
+const straightThroughBodyHandler: BodyHandler = (res, jsonString) =>
+  res.send(jsonString);
+
+export const proxyApiHandler = (
   basePath: string,
   ...headersToForward: string[]
-) => (
+) => (bodyHandler: BodyHandler = straightThroughBodyHandler) => (
   path: string,
   forwardQueryArgs?: boolean,
   ...pathParamNamesToReplace: string[]
@@ -64,18 +67,16 @@ export const apiHandler = (jsonHandler: JsonHandler) => (
       }
       return intermediateResponse.text();
     })
-    .then(_ => jsonHandler(res, _))
+    .then(body => bodyHandler(res, body))
     .catch(e => {
       log.info(e);
       res.status(500).send("Something broke!");
     });
 };
 
-export const proxyApiHandler = apiHandler((res, jsonString) =>
-  res.send(jsonString)
-);
-export const sfCasesApiHandler = proxyApiHandler(conf.SF_CASES_URL);
-export const membersDataApiHandler = proxyApiHandler(
+export const sfCasesApiHandler = proxyApiHandler(conf.SF_CASES_URL)();
+export const customMembersDataApiHandler = proxyApiHandler(
   "https://members-data-api." + conf.DOMAIN,
   MDA_TEST_USER_HEADER
 );
+export const membersDataApiHandler = customMembersDataApiHandler();

--- a/app/server/routes/api.ts
+++ b/app/server/routes/api.ts
@@ -8,7 +8,8 @@ import {
   customMembersDataApiHandler,
   membersDataApiHandler,
   proxyApiHandler,
-  sfCasesApiHandler
+  sfCasesApiHandler,
+  straightThroughBodyHandler
 } from "../middleware/apiMiddleware";
 import { withIdentity } from "../middleware/identityMiddleware";
 import { stripeSetupIntentHandler } from "../stripeSetupIntentsHandler";
@@ -66,10 +67,9 @@ router.post(
 
 router.post(
   "/validate/payment/dd",
-  proxyApiHandler("https://payment." + conf.API_DOMAIN)()(
-    "direct-debit/check-account",
-    true
-  )
+  proxyApiHandler("https://payment." + conf.API_DOMAIN)(
+    straightThroughBodyHandler
+  )("direct-debit/check-account", true)
 );
 
 router.post("/case", sfCasesApiHandler("case"));

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -3,15 +3,15 @@ import React from "react";
 import AsyncLoader from "../client/components/asyncLoader";
 import { CardProps } from "../client/components/payment/cardDisplay";
 
-export type MembersDataApiResponse = ProductDetail | {};
+export type MembersDataApiItem = ProductDetail | {};
 
 export class MembersDatApiAsyncLoader extends AsyncLoader<
-  MembersDataApiResponse[]
+  MembersDataApiItem[]
 > {}
 
-export const MembersDataApiResponseContext: React.Context<
-  MembersDataApiResponse
-> = React.createContext({});
+export const MembersDataApiItemContext: React.Context<MembersDataApiItem> = React.createContext(
+  {}
+);
 
 export const formatDate = (shortForm: string) => {
   return new Date(shortForm).toLocaleDateString("en-GB", {
@@ -23,15 +23,6 @@ export const formatDate = (shortForm: string) => {
 
 export const MDA_TEST_USER_HEADER = "X-Gu-Membership-Test-User";
 
-export const annotateMdaResponseWithTestUserFromHeaders = async (
-  response: Response
-) =>
-  ((await response.json()) as MembersDataApiResponse[]).map(data =>
-    Object.assign({}, data, {
-      isTestUser: response.headers.get(MDA_TEST_USER_HEADER) === "true"
-    })
-  );
-
 export const alertTextWithoutCTA = (productDetail: ProductDetail) =>
   productDetail.alertText
     ? productDetail.alertText.replace(/Please check .*/g, "")
@@ -41,7 +32,7 @@ export const sortByJoinDate = (a: ProductDetail, b: ProductDetail) =>
   b.joinDate.localeCompare(a.joinDate);
 
 export interface ProductDetail extends WithSubscription {
-  isTestUser: boolean; // THIS IS NOT PART OF THE RESPONSE (but inferred from a header)
+  isTestUser: boolean; // THIS IS NOT PART OF THE members-data-api RESPONSE (but inferred from a header)
   isPaidTier: boolean;
   regNumber?: string;
   tier: string;
@@ -49,8 +40,8 @@ export interface ProductDetail extends WithSubscription {
   alertText?: string;
 }
 
-export function hasProduct(
-  data: MembersDataApiResponse | undefined
+export function isProduct(
+  data: MembersDataApiItem | undefined
 ): data is ProductDetail {
   return !!data && data.hasOwnProperty("tier");
 }


### PR DESCRIPTION
Shortly we will need to be augmenting the `members-data-api` response with `deliveryAddressChangeEffectiveDate` from `fulfilment-date-calculator`, so making some preparatory changes to keep that PR easier to digest.

#### Changes
- move `isTestUser` annotation of the `members-data-api` response to the server-side 
- various renaming and restructuring 