### PR TITLE
'deliveryAddressChangeEffectiveDate' now available on 'members-data-api' mma response

### DIFF
--- a/app/server/fulfilmentDateCalculatorReader.ts
+++ b/app/server/fulfilmentDateCalculatorReader.ts
@@ -1,7 +1,9 @@
+import Raven from "raven-js";
 import { ProductDetail } from "../shared/productResponse";
 import { ProductTypes } from "../shared/productTypes";
 import { s3FilePromise } from "./awsIntegration";
 import { conf } from "./config";
+import { log } from "./log";
 
 interface RawFulfilmentDateCalculatorDates {
   today: string;
@@ -44,7 +46,9 @@ export const augmentProductDetailWithDeliveryAddressChangeEffectiveDateForToday 
     maybeFulfilmentDateCalculatorProductFilenamePart &&
     !maybeDeliveryAddressChangeEffectiveDate
   ) {
-    // TODO add warning if product type should have that value but its not there
+    const errorMessage = `Expected 'deliveryAddressChangeEffectiveDate' to be available for ${maybeProductType}, but wasn't.`;
+    log.error(errorMessage);
+    Raven.captureMessage(errorMessage);
   }
   return maybeDeliveryAddressChangeEffectiveDate
     ? {

--- a/app/server/fulfilmentDateCalculatorReader.ts
+++ b/app/server/fulfilmentDateCalculatorReader.ts
@@ -1,0 +1,58 @@
+import { ProductDetail } from "../shared/productResponse";
+import { ProductTypes } from "../shared/productTypes";
+import { s3FilePromise } from "./awsIntegration";
+import { conf } from "./config";
+
+interface RawFulfilmentDateCalculatorDates {
+  today: string;
+  acquisitionsStartDate: string;
+  deliveryAddressChangeEffectiveDate: string;
+  holidayStopFirstAvailableDate: string;
+  finalFulfilmentFileGenerationDate: string;
+  nextAffectablePublicationDateOnFrontCover: string;
+}
+
+const getFulfilmentRelatedDatesPromise = (filenameProductPart: string) =>
+  s3FilePromise<RawFulfilmentDateCalculatorDates>(
+    `fulfilment-date-calculator-${conf.STAGE.toLowerCase()}`,
+    `${filenameProductPart}/${new Date()
+      .toISOString()
+      .substr(0, 10)}_${filenameProductPart}.json`,
+    "deliveryAddressChangeEffectiveDate"
+  );
+
+const getDeliveryAddressChangeEffectiveDateForToday = async (
+  filenameProductPart: string
+) =>
+  (await getFulfilmentRelatedDatesPromise(filenameProductPart))
+    ?.deliveryAddressChangeEffectiveDate;
+
+export const augmentProductDetailWithDeliveryAddressChangeEffectiveDateForToday = async (
+  productDetail: ProductDetail
+) => {
+  const maybeProductType = ProductTypes.contentSubscriptions.mapGroupedToSpecific?.(
+    productDetail
+  );
+  const maybeFulfilmentDateCalculatorProductFilenamePart =
+    maybeProductType?.fulfilmentDateCalculatorProductFilenamePart;
+  const maybeDeliveryAddressChangeEffectiveDate =
+    maybeFulfilmentDateCalculatorProductFilenamePart &&
+    (await getDeliveryAddressChangeEffectiveDateForToday(
+      maybeFulfilmentDateCalculatorProductFilenamePart
+    ));
+  if (
+    maybeFulfilmentDateCalculatorProductFilenamePart &&
+    !maybeDeliveryAddressChangeEffectiveDate
+  ) {
+    // TODO add warning if product type should have that value but its not there
+  }
+  return maybeDeliveryAddressChangeEffectiveDate
+    ? {
+        ...productDetail,
+        subscription: {
+          ...productDetail.subscription,
+          deliveryAddressChangeEffectiveDate: maybeDeliveryAddressChangeEffectiveDate
+        }
+      }
+    : productDetail;
+};

--- a/app/server/fulfilmentDateCalculatorReader.ts
+++ b/app/server/fulfilmentDateCalculatorReader.ts
@@ -36,9 +36,8 @@ const getDeliveryAddressChangeEffectiveDateForToday = async (
         new Date(earliestAcc) > new Date(deliveryAddressChangeEffectiveDateStr)
       ) {
         return deliveryAddressChangeEffectiveDateStr || "";
-      } else {
-        return earliestAcc;
       }
+      return earliestAcc;
     }, "")
   );
 };

--- a/app/server/fulfilmentDateCalculatorReader.ts
+++ b/app/server/fulfilmentDateCalculatorReader.ts
@@ -1,33 +1,47 @@
 import Raven from "raven-js";
-import { ProductDetail } from "../shared/productResponse";
+import { getMainPlan, ProductDetail } from "../shared/productResponse";
 import { ProductTypes } from "../shared/productTypes";
 import { s3FilePromise } from "./awsIntegration";
 import { conf } from "./config";
 import { log } from "./log";
 
 interface RawFulfilmentDateCalculatorDates {
-  today: string;
-  acquisitionsStartDate: string;
-  deliveryAddressChangeEffectiveDate: string;
-  holidayStopFirstAvailableDate: string;
-  finalFulfilmentFileGenerationDate: string;
-  nextAffectablePublicationDateOnFrontCover: string;
+  [dayOfWeek: string]: {
+    deliveryAddressChangeEffectiveDate?: string;
+    // there are a number of other fields, but we don't need them
+  };
 }
 
-const getFulfilmentRelatedDatesPromise = (filenameProductPart: string) =>
-  s3FilePromise<RawFulfilmentDateCalculatorDates>(
+const getDeliveryAddressChangeEffectiveDateForToday = async (
+  filenameProductPart: string,
+  daysOfWeek: string[]
+) => {
+  const datesByDayOfWeek = await s3FilePromise<
+    RawFulfilmentDateCalculatorDates
+  >(
     `fulfilment-date-calculator-${conf.STAGE.toLowerCase()}`,
     `${filenameProductPart}/${new Date()
       .toISOString()
       .substr(0, 10)}_${filenameProductPart}.json`,
-    "deliveryAddressChangeEffectiveDate"
+    ...daysOfWeek
   );
-
-const getDeliveryAddressChangeEffectiveDateForToday = async (
-  filenameProductPart: string
-) =>
-  (await getFulfilmentRelatedDatesPromise(filenameProductPart))
-    ?.deliveryAddressChangeEffectiveDate;
+  return (
+    datesByDayOfWeek &&
+    daysOfWeek.reduce((earliestAcc, dayOfWeek) => {
+      const deliveryAddressChangeEffectiveDateStr =
+        datesByDayOfWeek[dayOfWeek].deliveryAddressChangeEffectiveDate;
+      if (
+        !earliestAcc ||
+        !deliveryAddressChangeEffectiveDateStr ||
+        new Date(earliestAcc) > new Date(deliveryAddressChangeEffectiveDateStr)
+      ) {
+        return deliveryAddressChangeEffectiveDateStr || "";
+      } else {
+        return earliestAcc;
+      }
+    }, "")
+  );
+};
 
 export const augmentProductDetailWithDeliveryAddressChangeEffectiveDateForToday = async (
   productDetail: ProductDetail
@@ -36,17 +50,24 @@ export const augmentProductDetailWithDeliveryAddressChangeEffectiveDateForToday 
     productDetail
   );
   const maybeFulfilmentDateCalculatorProductFilenamePart =
-    maybeProductType?.fulfilmentDateCalculatorProductFilenamePart;
+    maybeProductType?.fulfilmentDateCalculator?.productFilenamePart;
+  const maybeExplicitSingleDayOfWeek =
+    maybeProductType?.fulfilmentDateCalculator?.explicitSingleDayOfWeek;
+  const maybeDaysOfWeek = maybeExplicitSingleDayOfWeek
+    ? [maybeExplicitSingleDayOfWeek]
+    : getMainPlan(productDetail.subscription).daysOfWeek;
   const maybeDeliveryAddressChangeEffectiveDate =
     maybeFulfilmentDateCalculatorProductFilenamePart &&
+    maybeDaysOfWeek &&
     (await getDeliveryAddressChangeEffectiveDateForToday(
-      maybeFulfilmentDateCalculatorProductFilenamePart
+      maybeFulfilmentDateCalculatorProductFilenamePart,
+      maybeDaysOfWeek
     ));
   if (
     maybeFulfilmentDateCalculatorProductFilenamePart &&
-    !maybeDeliveryAddressChangeEffectiveDate
+    !(maybeDeliveryAddressChangeEffectiveDate && maybeDaysOfWeek)
   ) {
-    const errorMessage = `Expected 'deliveryAddressChangeEffectiveDate' to be available for ${maybeProductType}, but wasn't.`;
+    const errorMessage = `Expected 'deliveryAddressChangeEffectiveDate' to be available for ${maybeProductType?.friendlyName}, but wasn't.`;
     log.error(errorMessage);
     Raven.captureMessage(errorMessage);
   }

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -61,6 +61,7 @@ export interface SubscriptionPlan {
   name: string | null;
   start?: string;
   shouldBeVisible: boolean;
+  daysOfWeek?: string[];
 }
 
 export interface CurrencyAndIntervalDetail {

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -105,6 +105,8 @@ export interface Subscription {
   currentPlans: SubscriptionPlan[];
   futurePlans: SubscriptionPlan[];
   trialLength: number;
+  // THIS IS NOT PART OF THE members-data-api RESPONSE (it's injected server-side - see server/routes/api.ts)
+  deliveryAddressChangeEffectiveDate?: string;
 }
 
 export interface WithSubscription {

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -109,7 +109,10 @@ export interface ProductType {
   mapGroupedToSpecific?: (productDetail: ProductDetail) => ProductType;
   updateAmountMdaEndpoint?: string;
   holidayStops?: HolidayStopFlowProperties;
-  fulfilmentDateCalculatorProductFilenamePart?: string;
+  fulfilmentDateCalculator?: {
+    productFilenamePart: string;
+    explicitSingleDayOfWeek?: string;
+  };
 }
 
 export interface ProductTypeWithCancellationFlow extends ProductType {
@@ -324,7 +327,10 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
     includeGuardianInTitles: true,
     alternateManagementUrl: domainSpecificSubsManageURL,
     alternateManagementCtaLabel: () => "manage your holiday stops", // TODO this can be removed once HD holiday stops are supported by the new approach (like GW & Voucher)
-    productPage: "subscriptions"
+    productPage: "subscriptions",
+    fulfilmentDateCalculator: {
+      productFilenamePart: "Newspaper - Home Delivery"
+    }
   },
   voucher: {
     friendlyName: "newspaper voucher subscription",
@@ -362,7 +368,10 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
       issueKeyword: "issue"
     },
     productPage: "subscriptions",
-    fulfilmentDateCalculatorProductFilenamePart: "WEEKLY"
+    fulfilmentDateCalculator: {
+      productFilenamePart: "Guardian Weekly",
+      explicitSingleDayOfWeek: "Friday"
+    }
   },
   digipack: {
     friendlyName: "digital subscription",

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -109,6 +109,7 @@ export interface ProductType {
   mapGroupedToSpecific?: (productDetail: ProductDetail) => ProductType;
   updateAmountMdaEndpoint?: string;
   holidayStops?: HolidayStopFlowProperties;
+  fulfilmentDateCalculatorProductFilenamePart?: string;
 }
 
 export interface ProductTypeWithCancellationFlow extends ProductType {
@@ -360,7 +361,8 @@ export const ProductTypes: { [productKey: string]: ProductType } = {
     holidayStops: {
       issueKeyword: "issue"
     },
-    productPage: "subscriptions"
+    productPage: "subscriptions",
+    fulfilmentDateCalculatorProductFilenamePart: "WEEKLY"
   },
   digipack: {
     friendlyName: "digital subscription",

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -161,9 +161,15 @@ Resources:
         - PolicyName: ReadPrivateCredentials
           PolicyDocument:
             Statement:
-            - Effect: Allow
-              Action: s3:GetObject
-              Resource: !Sub arn:aws:s3:::gu-reader-revenue-private/manage-frontend/${Stage}/*
+              - Effect: Allow
+                Action: s3:GetObject
+                Resource: !Sub arn:aws:s3:::gu-reader-revenue-private/manage-frontend/${Stage}/*
+        - PolicyName: ReadFulfilmentDateCalculatorOutput
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action: s3:GetObject
+                Resource: !Sub arn:aws:s3:::fulfilment-date-calculator-*
 
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile


### PR DESCRIPTION
_Preparatory refactor PR : https://github.com/guardian/manage-frontend/pull/337
Also relies on https://github.com/guardian/members-data-api/pull/418_

When proxying the `mma` endpoint of `members-data-api` before sending on the response to the client, in addition to adding the `isTestUser` (see https://github.com/guardian/manage-frontend/pull/337) on **each** item (i.e. each subscription) in the array it now adds a `deliveryAddressChangeEffectiveDate` on each response **IF**...

1. ... the `ProductType` inferred from the item/subscription has a `fulfilmentDateCalculatorProductFilenamePart` defined

2. AND there is a file **for today** in the `fulfilment-date-calculator-STAGE` S3 bucket **for that product**
_(it logs and fires a Sentry error if there isn't such a file but one is expected because of condition 1. above.)_
