### PR TITLE
remove delivery address for gift subscriptions

### DIFF
--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -229,14 +229,6 @@ const getProductDetailRenderer = (
     productType.alternateManagementCtaLabel &&
     productType.alternateManagementCtaLabel(productDetail);
   const mainPlan = getMainPlan(productDetail.subscription);
-  // tslint:disable-next-line: no-console
-  console.log(
-    `JSON.stringify(productDetail, null, " ") = ${JSON.stringify(
-      productDetail,
-      null,
-      " "
-    )}`
-  );
   return (
     <div
       key={productDetail.subscription.subscriptionId}

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -413,7 +413,8 @@ const getProductDetailRenderer = (
                   }
                 />
               )}
-            {productType.showDeliveryAddress?.(productDetail) &&
+            {productType.showDeliveryAddress &&
+              productType.showDeliveryAddress(productDetail) &&
               productDetail.subscription.deliveryAddress && (
                 <ProductDetailRow
                   label="Delivery address"

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -229,6 +229,14 @@ const getProductDetailRenderer = (
     productType.alternateManagementCtaLabel &&
     productType.alternateManagementCtaLabel(productDetail);
   const mainPlan = getMainPlan(productDetail.subscription);
+  // tslint:disable-next-line: no-console
+  console.log(
+    `JSON.stringify(productDetail, null, " ") = ${JSON.stringify(
+      productDetail,
+      null,
+      " "
+    )}`
+  );
   return (
     <div
       key={productDetail.subscription.subscriptionId}
@@ -405,7 +413,7 @@ const getProductDetailRenderer = (
                   }
                 />
               )}
-            {productType.showDeliveryAddress &&
+            {productType.showDeliveryAddress?.(productDetail) &&
               productDetail.subscription.deliveryAddress && (
                 <ProductDetailRow
                   label="Delivery address"

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -117,7 +117,7 @@ export interface Subscription {
   currentPlans: SubscriptionPlan[];
   futurePlans: SubscriptionPlan[];
   trialLength: number;
-  readerType?: ReaderType;
+  readerType: ReaderType;
   deliveryAddress?: DeliveryAddress;
   contactId?: string;
   // THIS IS NOT PART OF THE members-data-api RESPONSE (it's injected server-side - see server/routes/api.ts)

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -97,6 +97,8 @@ export interface DeliveryAddress {
   country: string;
 }
 
+export type ReaderType = "Gift" | "Direct" | "Agent" | "Complementary";
+
 export interface Subscription {
   subscriptionId: string;
   start?: string;
@@ -115,6 +117,7 @@ export interface Subscription {
   currentPlans: SubscriptionPlan[];
   futurePlans: SubscriptionPlan[];
   trialLength: number;
+  readerType?: ReaderType;
   deliveryAddress?: DeliveryAddress;
   contactId?: string;
   // THIS IS NOT PART OF THE members-data-api RESPONSE (it's injected server-side - see server/routes/api.ts)

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -109,7 +109,7 @@ export interface ProductType {
   mapGroupedToSpecific?: (productDetail: ProductDetail) => ProductType;
   updateAmountMdaEndpoint?: string;
   holidayStops?: HolidayStopFlowProperties;
-  showDeliveryAddress?: true;
+  showDeliveryAddress?: (productDetail: ProductDetail) => boolean;
   fulfilmentDateCalculator?: {
     productFilenamePart: string;
     explicitSingleDayOfWeek?: string;
@@ -208,6 +208,9 @@ const getNoProductInTabCopy = (links: NavItem[]) => {
     </>
   );
 };
+
+const showDeliveryAddressAS = (productDetail: ProductDetail) =>
+  productDetail.subscription.readerType !== "Gift";
 
 export type ProductTypeKeys =
   | "membership"
@@ -330,7 +333,7 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
     urlPart: "paper",
     getOphanProductType: () => "PRINT_SUBSCRIPTION",
     includeGuardianInTitles: true,
-    showDeliveryAddress: true,
+    showDeliveryAddress: showDeliveryAddressAS,
     productPage: "subscriptions"
   },
   homedelivery: {
@@ -341,7 +344,7 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
     includeGuardianInTitles: true,
     alternateManagementUrl: domainSpecificSubsManageURL,
     alternateManagementCtaLabel: () => "manage your holiday stops", // TODO this can be removed once HD holiday stops are supported by the new approach (like GW & Voucher)
-    showDeliveryAddress: true,
+    showDeliveryAddress: showDeliveryAddressAS,
     productPage: "subscriptions",
     fulfilmentDateCalculator: {
       productFilenamePart: "Newspaper - Home Delivery"
@@ -366,7 +369,7 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
           "We monitor voucher usage and reserve the right to cancel credits where vouchers have been used during the suspension period."
       }
     },
-    showDeliveryAddress: true,
+    showDeliveryAddress: showDeliveryAddressAS,
     productPage: "subscriptions"
   },
   guardianweekly: {
@@ -383,7 +386,7 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
     holidayStops: {
       issueKeyword: "issue"
     },
-    showDeliveryAddress: true,
+    showDeliveryAddress: showDeliveryAddressAS,
     productPage: "subscriptions",
     fulfilmentDateCalculator: {
       productFilenamePart: "Guardian Weekly",

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -209,7 +209,7 @@ const getNoProductInTabCopy = (links: NavItem[]) => {
   );
 };
 
-const showDeliveryAddressAS = (productDetail: ProductDetail) =>
+const showDeliveryAddressCheck = (productDetail: ProductDetail) =>
   productDetail.subscription.readerType !== "Gift";
 
 export type ProductTypeKeys =
@@ -333,7 +333,7 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
     urlPart: "paper",
     getOphanProductType: () => "PRINT_SUBSCRIPTION",
     includeGuardianInTitles: true,
-    showDeliveryAddress: showDeliveryAddressAS,
+    showDeliveryAddress: showDeliveryAddressCheck,
     productPage: "subscriptions"
   },
   homedelivery: {
@@ -344,7 +344,7 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
     includeGuardianInTitles: true,
     alternateManagementUrl: domainSpecificSubsManageURL,
     alternateManagementCtaLabel: () => "manage your holiday stops", // TODO this can be removed once HD holiday stops are supported by the new approach (like GW & Voucher)
-    showDeliveryAddress: showDeliveryAddressAS,
+    showDeliveryAddress: showDeliveryAddressCheck,
     productPage: "subscriptions",
     fulfilmentDateCalculator: {
       productFilenamePart: "Newspaper - Home Delivery"
@@ -369,7 +369,7 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
           "We monitor voucher usage and reserve the right to cancel credits where vouchers have been used during the suspension period."
       }
     },
-    showDeliveryAddress: showDeliveryAddressAS,
+    showDeliveryAddress: showDeliveryAddressCheck,
     productPage: "subscriptions"
   },
   guardianweekly: {
@@ -386,7 +386,7 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
     holidayStops: {
       issueKeyword: "issue"
     },
-    showDeliveryAddress: showDeliveryAddressAS,
+    showDeliveryAddress: showDeliveryAddressCheck,
     productPage: "subscriptions",
     fulfilmentDateCalculator: {
       productFilenamePart: "Guardian Weekly",


### PR DESCRIPTION
Currently if you have a subscription that is a gift the delivery address displayed is that of the gift-er not the gift-ee, which is not so helpful.

Until the API is ready to pass through the gift-ee's address and also update that address, hide the display of the delivery address and the edit address button for gift subscriptions.

[trello ticket](https://trello.com/c/4oQHqLEM/774-remove-delivery-address-display-and-update-for-subscriptions-that-are-gifts)

![deliveryAddressGifts](https://user-images.githubusercontent.com/2510683/71267224-fd6f5600-2341-11ea-96c6-f3cf3ee55d6f.png)
