### PR TITLE
[RB] - hide the gift subscription from the list of subscriptions that…

### DIFF
--- a/app/client/components/delivery/address/deliveryAddressForm.tsx
+++ b/app/client/components/delivery/address/deliveryAddressForm.tsx
@@ -90,7 +90,9 @@ const renderDeliveryAddressForm = (routeableStepProps: RouteableStepProps) => (
 ) => (
   <FormContainer
     contactIdToArrayOfProductDetail={getValidDeliveryAddressChangeEffectiveDates(
-      allProductDetail.filter(isProduct)
+      allProductDetail
+        .filter(isProduct)
+        .filter(product => product.subscription.readerType !== "Gift")
     )}
     routeableStepProps={routeableStepProps}
   />


### PR DESCRIPTION
The list of affected subscriptions re a delivery address update should not include gift subscriptions.

Here are the before an afters:

|  ...before | ...after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/2510683/71276328-94d9a680-234c-11ea-8113-716a60c27987.png) | ![image](https://user-images.githubusercontent.com/2510683/71276466-9efba500-234c-11ea-9b40-305066b55e1e.png) |
