### PR TITLE
Ensure displayName also set when username updated

### DIFF
--- a/app/client/components/identity/idapi/user.ts
+++ b/app/client/components/identity/idapi/user.ts
@@ -9,7 +9,7 @@ import {
 
 type UserPublicFields = Partial<
   Pick<User, "aboutMe" | "interests" | "location" | "username">
->;
+> & { displayName?: string };
 
 type UserPrivateFields = Partial<
   Pick<
@@ -80,7 +80,10 @@ const toUserApiRequest = (user: Partial<User>): UserAPIRequest => {
       aboutMe: user.aboutMe,
       interests: user.interests,
       location: user.location,
-      username: user.username
+      username: user.username,
+      // Currently displayname and username must be set to the same value, but this is not enforced on IDAPI
+      // and clients are expected to implement this logic for the time being.
+      displayName: user.username
     },
     privateFields: {
       title: user.title,
@@ -141,15 +144,12 @@ const getFieldNameFromContext = (context: string): string => {
 };
 
 const toUserError = (response: UserAPIErrorResponse): UserError => {
-  const error = response.errors.reduce(
-    (a, e) => {
-      return {
-        ...a,
-        [getFieldNameFromContext(e.context)]: e.description
-      };
-    },
-    {} as UserError["error"]
-  );
+  const error = response.errors.reduce((a, e) => {
+    return {
+      ...a,
+      [getFieldNameFromContext(e.context)]: e.description
+    };
+  }, {} as UserError["error"]);
   return {
     type: ErrorTypes.VALIDATION,
     error


### PR DESCRIPTION
## Description
Temporarily fixes an issue where displayName and username (two concepts that should be invisible to manage-frontend) are not set to the same value, causing many major problems with displaying usernames in discussion and modtools. This should be reverted once necessary changes are made to IDAPI that eradicate displayName.