### PR TITLE
[RB] - dont show delivery instructions for Guardian weekly subscriptions

### DIFF
--- a/app/client/components/delivery/records/deliveryRecords.tsx
+++ b/app/client/components/delivery/records/deliveryRecords.tsx
@@ -39,6 +39,9 @@ const renderDeliveryRecords = (props: RouteableStepProps) => (
       <RecordsTable
         data={data.results}
         deliveryProblemMap={data.deliveryProblemMap}
+        showDeliveryInstructions={
+          props.productType.delivery?.showDeliveryInstructions
+        }
         resultsPerPage={7}
       />
     </PageNavAndContentContainer>

--- a/app/client/components/delivery/records/deliveryRecordsApi.ts
+++ b/app/client/components/delivery/records/deliveryRecordsApi.ts
@@ -7,6 +7,7 @@ import AsyncLoader from "../../asyncLoader";
 export interface DeliveryDetails {
   showAddress?: true;
   showRecords?: true;
+  showDeliveryInstructions?: true;
 }
 
 interface DeliveryProblem {

--- a/app/client/components/delivery/records/deliveryRecordsTable.tsx
+++ b/app/client/components/delivery/records/deliveryRecordsTable.tsx
@@ -178,6 +178,12 @@ export const RecordsTable = (props: RecordsTableProps) => {
                     data-title="Delivery postcode"
                     css={css`
                       order: 3;
+                      margin-bottom: ${props.showDeliveryInstructions
+                        ? "0"
+                        : space[5]}px;
+                      ${minWidth.tablet} {
+                        margin-bottom: 0;
+                      }
                     `}
                   >
                     {deliveryRecord.addressLine1 &&

--- a/app/client/components/delivery/records/deliveryRecordsTable.tsx
+++ b/app/client/components/delivery/records/deliveryRecordsTable.tsx
@@ -18,6 +18,7 @@ import { getRecordMessageString, RecordStatus } from "./deliveryRecordStatus";
 interface RecordsTableProps {
   data: DeliveryRecordsDetail[];
   deliveryProblemMap: DeliveryProblemMap;
+  showDeliveryInstructions?: true;
   resultsPerPage: number;
 }
 
@@ -117,7 +118,7 @@ export const RecordsTable = (props: RecordsTableProps) => {
             <th>Date</th>
             <th>Status</th>
             <th>Delivery postcode</th>
-            <th>Delivery instructions</th>
+            {props.showDeliveryInstructions && <th>Delivery instructions</th>}
           </tr>
         </thead>
         <tbody css={tbodyCSS}>
@@ -192,26 +193,28 @@ export const RecordsTable = (props: RecordsTableProps) => {
                       "-"
                     )}
                   </td>
-                  <td
-                    data-title-block="Delivery instructions"
-                    css={css`
-                      order: 4;
-                      margin-bottom: ${space[5]}px;
-                      ${minWidth.tablet} {
-                        max-width: 25ch;
-                        margin-bottom: 0;
-                      }
-                    `}
-                  >
-                    {deliveryRecord.deliveryInstruction &&
-                    !deliveryRecord.hasHolidayStop ? (
-                      <DeliveryRecordInstructions
-                        message={deliveryRecord.deliveryInstruction}
-                      />
-                    ) : (
-                      "-"
-                    )}
-                  </td>
+                  {props.showDeliveryInstructions && (
+                    <td
+                      data-title-block="Delivery instructions"
+                      css={css`
+                        order: 4;
+                        margin-bottom: ${space[5]}px;
+                        ${minWidth.tablet} {
+                          max-width: 25ch;
+                          margin-bottom: 0;
+                        }
+                      `}
+                    >
+                      {deliveryRecord.deliveryInstruction &&
+                      !deliveryRecord.hasHolidayStop ? (
+                        <DeliveryRecordInstructions
+                          message={deliveryRecord.deliveryInstruction}
+                        />
+                      ) : (
+                        "-"
+                      )}
+                    </td>
+                  )}
                 </tr>
                 {(deliveryRecord.isChangedAddress ||
                   deliveryRecord.problemCaseId ||

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -352,7 +352,8 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
     alternateManagementCtaLabel: () => "manage your holiday stops", // TODO this can be removed once HD holiday stops are supported by the new approach (like GW & Voucher)
     delivery: {
       showAddress: !!showDeliveryAddressCheck,
-      showRecords: true
+      showRecords: true,
+      showDeliveryInstructions: true
     },
     productPage: "subscriptions",
     fulfilmentDateCalculator: {


### PR DESCRIPTION
Guardian weekly subscriptions do not have delivery instructions associated with their delivery records.

Here is what it should look like (home delivery subscription for comparison):

#### Home delivery records:
![homeDelivery](https://user-images.githubusercontent.com/2510683/72628687-ba0b0600-3946-11ea-840d-efd43070b9a5.png)

#### Guardian weekly records:
![guardianWeekly](https://user-images.githubusercontent.com/2510683/72628720-d018c680-3946-11ea-849d-b76ff6bdfa20.png)
