### PR TITLE
add missing test user header on the DELETE holiday stops call

### DIFF
--- a/app/client/components/holiday/existingHolidayStopActions.tsx
+++ b/app/client/components/holiday/existingHolidayStopActions.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { friendlyLongDateFormat } from "../../../shared/dates";
+import { MDA_TEST_USER_HEADER } from "../../../shared/productResponse";
 import AsyncLoader, { ReFetch } from "../asyncLoader";
 import { Button, LinkButton } from "../buttons";
 import { HideFunction, Modal } from "../modal";
@@ -11,6 +12,7 @@ import { formatDateRangeAsFriendly } from "./summaryTable";
 
 export interface ExistingHolidayStopActionsProps
   extends MinimalHolidayStopRequest {
+  isTestUser: boolean;
   reloadParent?: ReFetch;
   setExistingHolidayStopToAmend?: (newValue: HolidayStopRequest | null) => void;
 }
@@ -139,6 +141,9 @@ export class ExistingHolidayStopActions extends React.Component<
 
   private withdrawHolidayStopFetch = () =>
     fetch(`/api/holidays/${this.props.subscriptionName}/${this.props.id}`, {
-      method: "DELETE"
+      method: "DELETE",
+      headers: {
+        [MDA_TEST_USER_HEADER]: `${this.props.isTestUser}`
+      }
     });
 }

--- a/app/client/components/holiday/holidayConfirmed.tsx
+++ b/app/client/components/holiday/holidayConfirmed.tsx
@@ -41,6 +41,7 @@ export const HolidayConfirmed = (props: HolidayStopsRouteableStepProps) => (
                       </p>
                       <SummaryTable
                         data={dateChooserState}
+                        isTestUser={productDetail.isTestUser}
                         subscription={productDetail.subscription}
                         issueKeyword={
                           props.productType.holidayStops.issueKeyword

--- a/app/client/components/holiday/holidayReview.tsx
+++ b/app/client/components/holiday/holidayReview.tsx
@@ -177,6 +177,7 @@ export class HolidayReview extends React.Component<
             <SummaryTable
               data={dateChooserStateWithCredits}
               alternateSuspendedColumnHeading="To be suspended"
+              isTestUser={productDetail.isTestUser}
               subscription={productDetail.subscription}
               issueKeyword={this.props.productType.holidayStops.issueKeyword}
             />

--- a/app/client/components/holiday/holidaysOverview.tsx
+++ b/app/client/components/holiday/holidaysOverview.tsx
@@ -266,6 +266,7 @@ const renderHolidayStopsOverview = (
                   {holidayStopsResponse.existing.length > 0 ? (
                     <SummaryTable
                       data={holidayStopsResponse.existing}
+                      isTestUser={productDetail.isTestUser}
                       subscription={productDetail.subscription}
                       issueKeyword={props.productType.holidayStops.issueKeyword}
                       reloadParent={reload}

--- a/app/client/components/holiday/summaryTable.tsx
+++ b/app/client/components/holiday/summaryTable.tsx
@@ -30,6 +30,7 @@ const cellCss = {
 
 export interface SummaryTableProps {
   data: HolidayStopRequest[] | SharedHolidayDateChooserState;
+  isTestUser: boolean;
   subscription: Subscription;
   issueKeyword: string;
   alternateSuspendedColumnHeading?: string;
@@ -51,6 +52,7 @@ export const formatDateRangeAsFriendly = (range: DateRange) =>
 
 interface SummaryTableRowProps extends MinimalHolidayStopRequest {
   issueKeyword: string;
+  isTestUser: boolean;
   isOperatingOnNewHolidayStop: boolean;
   reloadParent?: ReFetch;
   currency?: string;


### PR DESCRIPTION
The DELETE (a.k.a withdraw - see https://github.com/guardian/manage-frontend/pull/312) feature was not respecting 'test-users' and thus targeting the wrong instance `holiday-stop-api` when being used by a test-user.

This was because the test user header was missing from the request - this PR fixes that 🛠 