### PR TITLE
removed redundant `estimateCredit` query param on 'holiday-stop-api' call to 'potential' endpoint

### DIFF
--- a/app/client/components/holiday/holidayDateChooser.tsx
+++ b/app/client/components/holiday/holidayDateChooser.tsx
@@ -376,7 +376,6 @@ export class HolidayDateChooser extends React.Component<
       },
       () =>
         getPotentialHolidayStopsFetcher(
-          false,
           subscriptionName,
           start,
           end,

--- a/app/client/components/holiday/holidayReview.tsx
+++ b/app/client/components/holiday/holidayReview.tsx
@@ -114,7 +114,6 @@ export class HolidayReview extends React.Component<
                   isProduct(productDetail) ? (
                     <PotentialHolidayStopsAsyncLoader
                       fetch={getPotentialHolidayStopsFetcher(
-                        true,
                         productDetail.subscription.subscriptionId,
                         dateChooserState.selectedRange.start,
                         dateChooserState.selectedRange.end,

--- a/app/client/components/holiday/holidayStopApi.ts
+++ b/app/client/components/holiday/holidayStopApi.ts
@@ -102,7 +102,6 @@ export class PotentialHolidayStopsAsyncLoader extends AsyncLoader<
 > {}
 
 export const getPotentialHolidayStopsFetcher = (
-  shouldEstimateCredit: boolean,
   subscriptionName: string,
   startDate: Moment,
   endDate: Moment,
@@ -111,9 +110,7 @@ export const getPotentialHolidayStopsFetcher = (
   fetch(
     `/api/holidays/${subscriptionName}/potential?startDate=${startDate.format(
       DATE_INPUT_FORMAT
-    )}&endDate=${endDate.format(DATE_INPUT_FORMAT)}${
-      shouldEstimateCredit ? "&estimateCredit=true" : ""
-    }`,
+    )}&endDate=${endDate.format(DATE_INPUT_FORMAT)}`,
     {
       headers: {
         [MDA_TEST_USER_HEADER]: `${isTestUser}`


### PR DESCRIPTION
since it is redundant following https://github.com/guardian/support-service-lambdas/pull/561