### PR TITLE
FIX missing space in call centre numbers

### DIFF
--- a/app/client/components/callCenterEmailAndNumbers.tsx
+++ b/app/client/components/callCenterEmailAndNumbers.tsx
@@ -143,7 +143,13 @@ export const CallCentreEmailAndNumbers = (props: CallCentreNumbersProps) => {
                 ${innerSectionPCss}
               `}
             >
-              <span>+44 (0) 330 333 6790</span>
+              <span
+                css={css`
+                  ${innerSectionBlockSpanCss}
+                `}
+              >
+                +44 (0) 330 333 6790
+              </span>
               8am - 8pm on weekdays, 8am - 6pm at weekends (GMP/BST)
             </p>
           </div>


### PR DESCRIPTION
### Before
![image](https://user-images.githubusercontent.com/19289579/74439500-3fa9a500-4e64-11ea-85d2-2c0891faaf06.png)

### After
![image](https://user-images.githubusercontent.com/19289579/74441991-a0d37780-4e68-11ea-94cd-e8ad44059a5f.png)

Rather than just adding a space, I decided to make the number bold, like the email above and the numbers for AUS & USA.