### PR TITLE
fix regression in hiding delivery address for gifters

### DIFF
--- a/app/client/components/delivery/records/deliveryRecordsApi.ts
+++ b/app/client/components/delivery/records/deliveryRecordsApi.ts
@@ -4,12 +4,6 @@ import {
 } from "../../../../shared/productResponse";
 import AsyncLoader from "../../asyncLoader";
 
-export interface DeliveryDetails {
-  showAddress?: true;
-  showRecords?: true;
-  showDeliveryInstructions?: true;
-}
-
 interface DeliveryProblem {
   problemType: string;
 }

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -227,10 +227,11 @@ const getProductDetailRenderer = (
   const alternateManagementCtaLabel =
     productType.alternateManagementCtaLabel &&
     productType.alternateManagementCtaLabel(productDetail);
-  const mainPlan = getMainPlan(productDetail.subscription);
+  const subscription = productDetail.subscription;
+  const mainPlan = getMainPlan(subscription);
   return (
     <div
-      key={productDetail.subscription.subscriptionId}
+      key={subscription.subscriptionId}
       css={{
         borderTop:
           productDetailList.length > 1
@@ -239,8 +240,8 @@ const getProductDetailRenderer = (
         padding: "5px 0 20px"
       }}
     >
-      {productDetail.subscription.cancelledAt ? (
-        getCancellationSummary(productType)(productDetail.subscription)
+      {subscription.cancelledAt ? (
+        getCancellationSummary(productType)(subscription)
       ) : (
         <>
           {productDetailList.length > 1 && (
@@ -302,7 +303,7 @@ const getProductDetailRenderer = (
             {productPageProperties.showSubscriptionId && (
               <ProductDetailRow
                 label={"Subscription ID"}
-                data={productDetail.subscription.subscriptionId}
+                data={subscription.subscriptionId}
               />
             )}
             {productPageProperties.tierRowLabel &&
@@ -332,35 +333,31 @@ const getProductDetailRenderer = (
                       ) : (
                         productType.alternateTierValue || productDetail.tier
                       )}
-                      {getMainPlan(productDetail.subscription).name && (
-                        <i>
-                          &nbsp;({getMainPlan(productDetail.subscription).name})
-                        </i>
-                      )}
+                      {mainPlan.name && <i>&nbsp;({mainPlan.name})</i>}
                     </>
                   }
                 />
               )}
             {(productPageProperties.forceShowJoinDateOnly ||
-              !productDetail.subscription.start) && (
+              !subscription.start) && (
               <ProductDetailRow
                 label={"Join date"}
                 data={formatDate(productDetail.joinDate)}
               />
             )}
-            {productDetail.subscription.start &&
+            {subscription.start &&
               !productPageProperties.forceShowJoinDateOnly && (
                 <ProductDetailRow
                   label={"Start date"}
-                  data={formatDate(productDetail.subscription.start)}
+                  data={formatDate(subscription.start)}
                 />
               )}
             {productType.showTrialRemainingIfApplicable &&
-              productDetail.subscription.trialLength > 0 && (
+              subscription.trialLength > 0 && (
                 <ProductDetailRow
                   label={"Trial remaining"}
-                  data={`${productDetail.subscription.trialLength} day${
-                    productDetail.subscription.trialLength !== 1 ? "s" : ""
+                  data={`${subscription.trialLength} day${
+                    subscription.trialLength !== 1 ? "s" : ""
                   }`}
                 />
               )}
@@ -379,46 +376,44 @@ const getProductDetailRenderer = (
                   {"Cancel this " + productType.friendlyName}
                 </Link>
               )}
-            {shouldHaveHolidayStopsFlow(productType) &&
-              productDetail.subscription.autoRenew && (
-                <ProductDetailRow
-                  label="Holiday stop"
-                  data={
-                    <div>
-                      <div
-                        css={{
-                          display: "inline-block",
-                          margin: "10px",
-                          marginLeft: 0
-                        }}
-                      >
-                        Going on holiday?
-                      </div>
-                      <LinkButton
-                        text="Manage your suspensions"
-                        to={"/suspend/" + productType.urlPart}
-                        state={productDetail}
-                        right
-                      />
+            {shouldHaveHolidayStopsFlow(productType) && subscription.autoRenew && (
+              <ProductDetailRow
+                label="Holiday stop"
+                data={
+                  <div>
+                    <div
+                      css={{
+                        display: "inline-block",
+                        margin: "10px",
+                        marginLeft: 0
+                      }}
+                    >
+                      Going on holiday?
                     </div>
-                  }
-                />
-              )}
-            {productType.delivery?.showAddress &&
-              productDetail.subscription.deliveryAddress && (
-                <ProductDetailRow
-                  label="Delivery address"
-                  alignItemsAtTop
-                  data={
-                    <DeliveryAddressDisplay
-                      {...productDetail.subscription.deliveryAddress}
-                      withEditButton={true}
-                      allProductDetails={productDetailList}
-                      productUrlPart={productType.urlPart}
+                    <LinkButton
+                      text="Manage your suspensions"
+                      to={"/suspend/" + productType.urlPart}
+                      state={productDetail}
+                      right
                     />
-                  }
-                />
-              )}
+                  </div>
+                }
+              />
+            )}
+            {productType.delivery?.showAddress?.(subscription) && (
+              <ProductDetailRow
+                label="Delivery address"
+                alignItemsAtTop
+                data={
+                  <DeliveryAddressDisplay
+                    {...subscription.deliveryAddress}
+                    withEditButton={true}
+                    allProductDetails={productDetailList}
+                    productUrlPart={productType.urlPart}
+                  />
+                }
+              />
+            )}
             {productType.delivery?.showRecords && (
               <ProductDetailRow
                 label="Delivery history"

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -11,6 +11,7 @@ import {
   formatDate,
   getFuturePlanIfVisible,
   getMainPlan,
+  isGift,
   isPaidSubscriptionPlan,
   isProduct,
   MembersDataApiItem,
@@ -255,6 +256,7 @@ const getProductDetailRenderer = (
                 <h2>
                   {productType.alternateTierValue || productDetail.tier}
                   {mainPlan.name && <i>&nbsp;({mainPlan.name})</i>}
+                  {isGift(subscription) && " [GIFT]"}
                 </h2>
               )}
             </PageContainer>
@@ -334,6 +336,7 @@ const getProductDetailRenderer = (
                         productType.alternateTierValue || productDetail.tier
                       )}
                       {mainPlan.name && <i>&nbsp;({mainPlan.name})</i>}
+                      {isGift(subscription) && " [GIFT]"}
                     </>
                   }
                 />

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -127,6 +127,10 @@ export interface Subscription {
   deliveryAddressChangeEffectiveDate?: string;
 }
 
+export interface SubscriptionWithDeliveryAddress extends Subscription {
+  deliveryAddress: DeliveryAddress;
+}
+
 export interface WithSubscription {
   subscription: Subscription;
 }

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -135,6 +135,9 @@ export interface WithSubscription {
   subscription: Subscription;
 }
 
+export const isGift = (subscription: Subscription) =>
+  subscription.readerType === "Gift";
+
 export const getMainPlan: (subscription: Subscription) => SubscriptionPlan = (
   subscription: Subscription
 ) => {

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -16,6 +16,7 @@ import {
 import { OphanProduct } from "./ophanTypes";
 import {
   formatDate,
+  isGift,
   ProductDetail,
   Subscription,
   SubscriptionWithDeliveryAddress
@@ -228,7 +229,7 @@ const getNoProductInTabCopy = (links: NavItem[]) => {
 const showDeliveryAddressCheck = (
   subscription: Subscription
 ): subscription is SubscriptionWithDeliveryAddress =>
-  subscription.readerType !== "Gift" && !!subscription.deliveryAddress;
+  !isGift(subscription) && !!subscription.deliveryAddress;
 
 export type ProductTypeKeys =
   | "membership"

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -8,14 +8,18 @@ import { contributionsCancellationFlowStart } from "../client/components/cancel/
 import { contributionsCancellationReasons } from "../client/components/cancel/contributions/contributionsCancellationReasons";
 import { membershipCancellationFlowStart } from "../client/components/cancel/membership/membershipCancellationFlowStart";
 import { membershipCancellationReasons } from "../client/components/cancel/membership/membershipCancellationReasons";
-import { DeliveryDetails } from "../client/components/delivery/records/deliveryRecordsApi";
 import { NavItem, navLinks } from "../client/components/nav";
 import {
   getScopeFromRequestPathOrEmptyString,
   X_GU_ID_FORWARDED_SCOPE
 } from "./identity";
 import { OphanProduct } from "./ophanTypes";
-import { formatDate, ProductDetail, Subscription } from "./productResponse";
+import {
+  formatDate,
+  ProductDetail,
+  Subscription,
+  SubscriptionWithDeliveryAddress
+} from "./productResponse";
 
 export type ProductFriendlyName =
   | "membership"
@@ -89,6 +93,14 @@ export interface HolidayStopFlowProperties {
   };
 }
 
+export interface DeliveryProperties {
+  showAddress?: (
+    subscription: Subscription
+  ) => subscription is SubscriptionWithDeliveryAddress;
+  showRecords?: true;
+  showDeliveryInstructions?: true;
+}
+
 export interface ProductType {
   friendlyName: ProductFriendlyName;
   allProductsProductTypeFilterString: AllProductsProductTypeFilterString;
@@ -110,7 +122,7 @@ export interface ProductType {
   mapGroupedToSpecific?: (productDetail: ProductDetail) => ProductType;
   updateAmountMdaEndpoint?: string;
   holidayStops?: HolidayStopFlowProperties;
-  delivery?: DeliveryDetails;
+  delivery?: DeliveryProperties;
   fulfilmentDateCalculator?: {
     productFilenamePart: string;
     explicitSingleDayOfWeek?: string;
@@ -213,8 +225,10 @@ const getNoProductInTabCopy = (links: NavItem[]) => {
   );
 };
 
-const showDeliveryAddressCheck = (productDetail: ProductDetail) =>
-  productDetail.subscription.readerType !== "Gift";
+const showDeliveryAddressCheck = (
+  subscription: Subscription
+): subscription is SubscriptionWithDeliveryAddress =>
+  subscription.readerType !== "Gift" && !!subscription.deliveryAddress;
 
 export type ProductTypeKeys =
   | "membership"
@@ -338,7 +352,7 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
     getOphanProductType: () => "PRINT_SUBSCRIPTION",
     includeGuardianInTitles: true,
     delivery: {
-      showAddress: !!showDeliveryAddressCheck
+      showAddress: showDeliveryAddressCheck
     },
     productPage: "subscriptions"
   },
@@ -352,7 +366,7 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
       issueKeyword: "paper"
     },
     delivery: {
-      showAddress: !!showDeliveryAddressCheck,
+      showAddress: showDeliveryAddressCheck,
       showRecords: true,
       showDeliveryInstructions: true
     },
@@ -381,7 +395,7 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
       }
     },
     delivery: {
-      showAddress: !!showDeliveryAddressCheck
+      showAddress: showDeliveryAddressCheck
     },
     productPage: "subscriptions"
   },
@@ -400,7 +414,7 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
       issueKeyword: "issue"
     },
     delivery: {
-      showAddress: !!showDeliveryAddressCheck,
+      showAddress: showDeliveryAddressCheck,
       showRecords: true
     },
     productPage: "subscriptions",


### PR DESCRIPTION
It looks like https://github.com/guardian/manage-frontend/pull/353/files#diff-3804b2206d4f5da38c1348e201469148 introduced a pernicious little regression, where for gift subscriptions it started displaying the billing address of gifter under the heading of delivery address (and presented the `Edit address ->` CTA, but once in the flow it says `No addresses available for update` as expected).
This was caused by detecting the presence of the `showDeliveryAddressCheck` rather than executing it, nasty.

This PR fixes that, PLUS...
- few little refactors (like pulling out `subscription` on the `productDetail` into its own `const`, to avoid repetition of `productDetail.subscription`)
- displaying a really basic `[GIFT]` badge on gift subscriptions

### Before
![image](https://user-images.githubusercontent.com/19289579/74456644-0d597100-4e7f-11ea-9337-b24c921a2e33.png)

### After
![image](https://user-images.githubusercontent.com/19289579/74459382-1cdab900-4e83-11ea-84b2-8f911f93d5c5.png)