### PR TITLE
correct limited release of delivery problem reporting 

### DIFF
--- a/app/client/__tests__/components/delivery/records/deliveryRecords/step1.tsx
+++ b/app/client/__tests__/components/delivery/records/deliveryRecords/step1.tsx
@@ -169,7 +169,11 @@ describe("DeliveryRecords", () => {
       });
     });
     // tslint:disable-next-line: no-object-mutation
-    global.window.identityDetails = { userId: "15849095" };
+    global.window.guardian = {
+      domain: "test",
+      dsn: null,
+      identityDetails: { userId: "15849095" }
+    };
   });
 
   it("renders without crashing", async done => {

--- a/app/client/components/cancel/stages/executeCancellation.tsx
+++ b/app/client/components/cancel/stages/executeCancellation.tsx
@@ -73,7 +73,7 @@ const getCaseUpdatingCancellationSummary = (
   caseId: string,
   productType: ProductTypeWithCancellationFlow
 ) => (productDetails: ProductDetail[]) => {
-  const productDetail = productDetails[0];
+  const productDetail = productDetails[0] || { subscription: {} };
   return (
     <CaseUpdateAsyncLoader
       fetch={getCaseUpdateWithCancelOutcomeFunc(

--- a/app/client/components/delivery/records/deliveryRecords.tsx
+++ b/app/client/components/delivery/records/deliveryRecords.tsx
@@ -266,7 +266,7 @@ export const DeliveryRecordsFC = (props: DeliveryRecordsFCProps) => {
           </div>
           {props.data.results.find(record => !record.problemCaseId) &&
             window &&
-            window.identityDetails?.userId === "15849095" && (
+            window.guardian.identityDetails.userId === "15849095" && (
               <>
                 <h2
                   css={css`

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -436,7 +436,8 @@ const getProductDetailRenderer = (
                 data={
                   <LinkButton
                     text={
-                      window && window.identityDetails?.userId === "15849095"
+                      window &&
+                      window.guardian.identityDetails.userId === "15849095"
                         ? "Report problem"
                         : "View delivery history"
                     }

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -61,6 +61,17 @@ export const wrappingContainerCSS = css({
   }
 });
 
+const giftFlag = (
+  <i
+    css={css`
+      line-height: 100%;
+      margin-left: ${space[3]}px;
+    `}
+  >
+    <GiftIcon alignArrowToThisSide={"right"} />
+  </i>
+);
+
 const ProductDetailRow = (props: ProductRowProps) => {
   const alignAtTopObj = props.alignItemsAtTop
     ? { alignItems: "flex-start" }
@@ -258,16 +269,7 @@ const getProductDetailRenderer = (
                 <h2>
                   {productType.alternateTierValue || productDetail.tier}
                   {mainPlan.name && <i>&nbsp;({mainPlan.name})</i>}
-                  {isGift(subscription) && (
-                    <i
-                      css={css`
-                        line-height: 100%;
-                        margin-left: ${space[3]}px;
-                      `}
-                    >
-                      <GiftIcon alignArrowToThisSide={"right"} />
-                    </i>
-                  )}
+                  {isGift(subscription) && giftFlag}
                 </h2>
               )}
             </PageContainer>
@@ -347,7 +349,7 @@ const getProductDetailRenderer = (
                         productType.alternateTierValue || productDetail.tier
                       )}
                       {mainPlan.name && <i>&nbsp;({mainPlan.name})</i>}
-                      {isGift(subscription) && " [GIFT]"}
+                      {isGift(subscription) && giftFlag}
                     </>
                   }
                 />


### PR DESCRIPTION
In https://github.com/guardian/manage-frontend/pull/366, there was a little oversight in the logic to release delivery problem reporting to me only, this PR fixes that.

PLUS

- a little tweak to use the new gift flag/badge more widely
- fix to the modified cancellation stuff to ensure it still works for 'effective immediately' cancellations (e.g. contributions)