### PR TITLE
FIX delivery records for 'test-user'

### DIFF
--- a/app/client/components/delivery/records/deliveryRecords.tsx
+++ b/app/client/components/delivery/records/deliveryRecords.tsx
@@ -650,7 +650,8 @@ export const DeliveryRecords = (props: DeliveryRecordsRouteableStepProps) => {
         <DeliveryRecordsApiAsyncLoader
           render={renderDeliveryRecords(props, productDetail)}
           fetch={createDeliveryRecordsFetcher(
-            productDetail.subscription.subscriptionId
+            productDetail.subscription.subscriptionId,
+            productDetail.isTestUser
           )}
           loadingMessage={"Loading delivery history..."}
         />

--- a/app/client/components/delivery/records/deliveryRecordsApi.ts
+++ b/app/client/components/delivery/records/deliveryRecordsApi.ts
@@ -1,5 +1,6 @@
 import {
   DeliveryRecordApiItem,
+  MDA_TEST_USER_HEADER,
   Subscription
 } from "../../../../shared/productResponse";
 import AsyncLoader from "../../asyncLoader";
@@ -78,11 +79,19 @@ export class DeliveryRecordsApiAsyncLoader extends AsyncLoader<
   DeliveryRecordsResponse
 > {}
 
-export const createDeliveryRecordsFetcher = (subscriptionId: string) => () =>
-  fetch(`/api/delivery-records/${subscriptionId}`);
+export const createDeliveryRecordsFetcher = (
+  subscriptionId: string,
+  isTestUser: boolean
+) => () =>
+  fetch(`/api/delivery-records/${subscriptionId}`, {
+    headers: {
+      [MDA_TEST_USER_HEADER]: `${isTestUser}`
+    }
+  });
 
 export const createDeliveryRecordsProblemPost = (
   subscriptionId: string,
+  isTestUser: boolean,
   payload: DeliveryRecordsPostPayload
 ) => () =>
   fetch(`/api/delivery-records/${subscriptionId}`, {
@@ -90,6 +99,7 @@ export const createDeliveryRecordsProblemPost = (
     method: "POST",
     body: JSON.stringify(payload),
     headers: {
-      "Content-Type": "application/json"
+      "Content-Type": "application/json",
+      [MDA_TEST_USER_HEADER]: `${isTestUser}`
     }
   });

--- a/app/client/components/delivery/records/deliveryRecordsProblemConfirmation.tsx
+++ b/app/client/components/delivery/records/deliveryRecordsProblemConfirmation.tsx
@@ -577,6 +577,7 @@ export const DeliveryRecordsProblemConfirmation = (
       )}
       fetch={createDeliveryRecordsProblemPost(
         deliveryRecordsProblemContext.subscription.subscriptionId,
+        deliveryRecordsProblemContext.isTestUser,
         deliveryIssuePostPayload
       )}
       loadingMessage={"Reporting problem..."}


### PR DESCRIPTION
`test-user`s were not being respected for the `delivery-records-api` calls from manage.

This is because the server-side portion of manage requires the `X-Gu-Membership-Test-User` request header to be present so it knows what instance of the lambda to call. The client was not sending this... now it is 😸 

In an ideal world, `test-user`s would be a first-class concept in identity and would come back from calls to IDAPI (rather than separately implemented in loads of RR stacks)... I'll try and push for this with identity.