### PR TITLE
release home delivery problem reporting

### DIFF
--- a/app/client/components/delivery/address/deliveryAddressForm.tsx
+++ b/app/client/components/delivery/address/deliveryAddressForm.tsx
@@ -491,13 +491,10 @@ const Form = (props: FormProps) => {
           label={"Country"}
           options={COUNTRIES}
           width={30}
-          additionalcss={css`
+          additionalCSS={css`
             margin-top: 14px;
           `}
           value={props.country}
-          optional={props.subscriptionsNames.includes(
-            ProductTypes.voucher.friendlyName
-          )}
           changeSetState={props.setCountry}
           inErrorState={
             props.formStatus === formStates.VALIDATION_ERROR &&

--- a/app/client/components/delivery/address/formValidation.tsx
+++ b/app/client/components/delivery/address/formValidation.tsx
@@ -48,14 +48,14 @@ export const isFormValid = (
         : "Please enter a postcode"
   };
 
-  const userHasVoucerSubscription = subscriptionsNames.includes(
+  const userHasVoucherSubscription = subscriptionsNames.includes(
     ProductTypes.voucher.friendlyName
   );
 
   const country = {
-    isValid: userHasVoucerSubscription ? formData.country === "GB" : true,
+    isValid: userHasVoucherSubscription ? formData.country === "GB" : true,
     message:
-      userHasVoucerSubscription && formData.country.length > 0
+      userHasVoucherSubscription && formData.country.length > 0
         ? `Voucher subscriptions must be delivered in the UK. Please contact us to discuss further: ${ukPhoneNumberWithoutPrefix}`
         : "Please select a country"
   };

--- a/app/client/components/delivery/address/select.tsx
+++ b/app/client/components/delivery/address/select.tsx
@@ -17,8 +17,7 @@ interface SelectProps {
   options: SelectOption[];
   width: number;
   value: string;
-  optional?: boolean;
-  additionalcss?: SerializedStyles;
+  additionalCSS?: SerializedStyles;
   changeSetState?: setStateFunc;
   inErrorState?: boolean;
   errorMessage?: string;
@@ -29,23 +28,11 @@ export const Select = (props: SelectProps) => (
     css={css`
       display: block;
       color: ${palette.neutral["7"]};
-      ${textSans.medium()} ${props.additionalcss};
+      ${textSans.medium()} ${props.additionalCSS};
       font-weight: bold;
     `}
   >
     {props.label}
-    {props.optional && (
-      <span
-        css={css`
-          font-style: italic;
-          font-weight: normal;
-          color: ${palette.neutral["46"]};
-        `}
-      >
-        {" "}
-        optional
-      </span>
-    )}
     {props.inErrorState && (
       <span
         css={css`

--- a/app/client/components/delivery/records/deliveryRecordCard.tsx
+++ b/app/client/components/delivery/records/deliveryRecordCard.tsx
@@ -236,7 +236,7 @@ export const DeliveryRecordCard = (props: DeliveryRecordCardProps) => {
             >
               {`${props.recordCurrency}${Math.abs(
                 props.deliveryRecord.credit.amount
-              )} `}
+              ).toFixed(2)} `}
               {props.deliveryRecord.credit.invoiceDate && (
                 <p
                   css={css`

--- a/app/client/components/delivery/records/deliveryRecords.tsx
+++ b/app/client/components/delivery/records/deliveryRecords.tsx
@@ -292,102 +292,98 @@ export const DeliveryRecordsFC = (props: DeliveryRecordsFCProps) => {
               isGift={isGift(props.productDetail.subscription)}
             />
           </div>
-          {productType.delivery.records.canReportProblem &&
-            props.data.results.find(record => !record.problemCaseId) && (
-              <>
-                <h2
+          {props.data.results.find(record => !record.problemCaseId) && (
+            <>
+              <h2
+                css={css`
+                  border-top: 1px solid ${palette.neutral["86"]};
+                  ${headline.small()};
+                  font-weight: bold;
+                  ${maxWidth.tablet} {
+                    font-size: 1.25rem;
+                    line-height: 1.6;
+                  }
+                `}
+              >
+                Report delivery problems
+              </h2>
+              <div
+                css={css`
+                  margin-bottom: ${pageStatus !== PageStatus.REPORT_ISSUE_STEP_2
+                    ? space[12]
+                    : space[5]}px;
+                  ${textSans.medium()};
+                `}
+              >
+                <p
                   css={css`
-                    border-top: 1px solid ${palette.neutral["86"]};
-                    ${headline.small()};
-                    font-weight: bold;
-                    ${maxWidth.tablet} {
-                      font-size: 1.25rem;
-                      line-height: 1.6;
-                    }
-                  `}
-                >
-                  Report delivery problems
-                </h2>
-                <div
-                  css={css`
-                    margin-bottom: ${pageStatus !==
-                    PageStatus.REPORT_ISSUE_STEP_2
-                      ? space[12]
-                      : space[5]}px;
                     ${textSans.medium()};
                   `}
                 >
-                  <p
+                  Have you been experiencing problems with your delivery? Report
+                  it and we will take care of it for you. Depending on the type
+                  of problem, you will be credited or contacted by our customer
+                  service team.
+                </p>
+                <p
+                  css={css`
+                    ${textSans.medium()};
+                  `}
+                >
+                  Is your problem urgent?{" "}
+                  <span
                     css={css`
-                      ${textSans.medium()};
+                      cursor: pointer;
+                      color: ${palette.brand[500]};
+                      text-decoration: underline;
                     `}
+                    onClick={() =>
+                      setTopCallCentreNumbersVisibility(
+                        !showTopCallCentreNumbers
+                      )
+                    }
                   >
-                    Have you been experiencing problems with your delivery?
-                    Report it and we will take care of it for you. Depending on
-                    the type of problem, you will be credited or contacted by
-                    our customer service team.
-                  </p>
-                  <p
-                    css={css`
-                      ${textSans.medium()};
-                    `}
+                    Contact us
+                  </span>
+                  .
+                </p>
+                {showTopCallCentreNumbers && <CallCentreEmailAndNumbers />}
+                {pageStatus === PageStatus.READ_ONLY && (
+                  <Button
+                    onClick={() => {
+                      trackEvent({
+                        eventCategory: "delivery-problem",
+                        eventAction: "report_delivery_problem_button_click",
+                        product: {
+                          productType,
+                          productDetail: props.productDetail
+                        },
+                        eventLabel: productType.urlPart
+                      });
+                      setSelectedProblemRecords([]);
+                      setPageStatus(PageStatus.REPORT_ISSUE_STEP_1);
+                    }}
                   >
-                    Is your problem urgent?{" "}
-                    <span
-                      css={css`
-                        cursor: pointer;
-                        color: ${palette.brand[500]};
-                        text-decoration: underline;
-                      `}
-                      onClick={() =>
-                        setTopCallCentreNumbersVisibility(
-                          !showTopCallCentreNumbers
-                        )
-                      }
-                    >
-                      Contact us
-                    </span>
-                    .
-                  </p>
-                  {showTopCallCentreNumbers && <CallCentreEmailAndNumbers />}
-                  {pageStatus === PageStatus.READ_ONLY && (
-                    <Button
-                      onClick={() => {
-                        trackEvent({
-                          eventCategory: "delivery-problem",
-                          eventAction: "report_delivery_problem_button_click",
-                          product: {
-                            productType,
-                            productDetail: props.productDetail
-                          },
-                          eventLabel: productType.urlPart
-                        });
-                        setSelectedProblemRecords([]);
-                        setPageStatus(PageStatus.REPORT_ISSUE_STEP_1);
-                      }}
-                    >
-                      Report a problem
-                    </Button>
-                  )}
-                  {(pageStatus === PageStatus.REPORT_ISSUE_STEP_1 ||
-                    pageStatus === PageStatus.REPORT_ISSUE_STEP_2) && (
-                    <DeliveryRecordProblemForm
-                      showNextStepButton={
-                        pageStatus !== PageStatus.REPORT_ISSUE_STEP_2
-                      }
-                      onResetDeliveryRecordsPage={resetDeliveryRecordsPage}
-                      onFormSubmit={step1FormSubmitListener}
-                      inValidationState={step1formValidationState}
-                      updateValidationStatusCallback={step1FormUpdateCallback}
-                      updateRadioSelectionCallback={
-                        step1FormRadioOptionCallback
-                      }
-                      problemTypes={problemTypes}
-                    />
-                  )}
-                </div>
-              </>
-            )}
+                    Report a problem
+                  </Button>
+                )}
+                {(pageStatus === PageStatus.REPORT_ISSUE_STEP_1 ||
+                  pageStatus === PageStatus.REPORT_ISSUE_STEP_2) && (
+                  <DeliveryRecordProblemForm
+                    showNextStepButton={
+                      pageStatus !== PageStatus.REPORT_ISSUE_STEP_2
+                    }
+                    onResetDeliveryRecordsPage={resetDeliveryRecordsPage}
+                    onFormSubmit={step1FormSubmitListener}
+                    inValidationState={step1formValidationState}
+                    updateValidationStatusCallback={step1FormUpdateCallback}
+                    updateRadioSelectionCallback={step1FormRadioOptionCallback}
+                    problemTypes={problemTypes}
+                  />
+                )}
+              </div>
+            </>
+          )}
           <h2
             css={css`
               border-top: 1px solid ${palette.neutral["86"]};

--- a/app/client/components/delivery/records/deliveryRecords.tsx
+++ b/app/client/components/delivery/records/deliveryRecords.tsx
@@ -248,7 +248,7 @@ export const DeliveryRecordsFC = (props: DeliveryRecordsFCProps) => {
           productType.shortFriendlyName || productType.friendlyName
         ),
         apiProductName:
-          productType.fulfilmentDateCalculator?.productFilenamePart,
+          productType.delivery.records.productNameForProblemReport,
         problemType: deliveryProblem,
         affectedRecords: props.data.results.filter(record =>
           selectedProblemRecords.includes(record.id)

--- a/app/client/components/delivery/records/deliveryRecordsAddress.tsx
+++ b/app/client/components/delivery/records/deliveryRecordsAddress.tsx
@@ -66,7 +66,7 @@ export const RecordAddress = (props: DeliveryAddress) => {
             margin-bottom: ${showAddress ? -1 : 2}px;
             border-top: 1px solid ${palette.brand.bright};
             border-right: 1px solid ${palette.brand.bright};
-            rotate: ${showAddress ? -45 : 135}deg;
+            transform: rotate(${showAddress ? -45 : 135}deg);
           `}
         />
       </span>

--- a/app/client/components/delivery/records/deliveryRecordsApi.ts
+++ b/app/client/components/delivery/records/deliveryRecordsApi.ts
@@ -16,10 +16,10 @@ export interface DeliveryProblemMap {
 
 export interface ContactPhoneNumbers {
   id: string;
-  Phone?: string;
-  HomePhone?: string;
-  MobilePhone?: string;
-  OtherPhone?: string;
+  Phone?: string | null;
+  HomePhone?: string | null;
+  MobilePhone?: string | null;
+  OtherPhone?: string | null;
 }
 
 export type ContactPhoneNumbersType =

--- a/app/client/components/delivery/records/deliveryRecordsProblemConfirmation.tsx
+++ b/app/client/components/delivery/records/deliveryRecordsProblemConfirmation.tsx
@@ -150,7 +150,7 @@ const DeliveryRecordsProblemConfirmationFC = (
           </i>
           {deliveryProblemCredit?.showCredit
             ? "Thank you for reporting your delivery problem. We will credit you for the affected issues and apologise for any inconvenience caused. We monitor these reports closely and use them to improve our service."
-            : "Your case is high priority. Our customer service team will try their best to contact you within 48 hours to resolve the issue."}
+            : "Your case is high priority. Our customer service team will try their best to contact you as soon as possible to resolve the issue."}
         </span>
         <section
           css={css`

--- a/app/client/components/delivery/records/deliveryRecordsProblemConfirmation.tsx
+++ b/app/client/components/delivery/records/deliveryRecordsProblemConfirmation.tsx
@@ -16,7 +16,6 @@ import { maxWidth, minWidth } from "../../../styles/breakpoints";
 import { LinkButton } from "../../buttons";
 import { navLinks } from "../../nav";
 import { PageHeaderContainer, PageNavAndContentContainer } from "../../page";
-import { ErrorIcon } from "../../svgs/errorIcon";
 import { InfoIconDark } from "../../svgs/infoIconDark";
 import {
   RouteableStepProps,
@@ -82,8 +81,8 @@ const DeliveryRecordsProblemConfirmationFC = (
     ? props.data.deliveryProblemMap[problemCaseId]?.ref
     : "-";
 
-  const dtCss: string = `
-    font-weight: bold; 
+  const dtCss = css`
+    font-weight: bold;
     display: inline-block;
     vertical-align: top;
     min-width: 12ch;
@@ -91,7 +90,7 @@ const DeliveryRecordsProblemConfirmationFC = (
       min-width: 16ch;
     }
   `;
-  const ddCss: string = `
+  const ddCss = css`
     margin: 0;
     display: inline-block;
     vertical-align: top;
@@ -179,245 +178,62 @@ const DeliveryRecordsProblemConfirmationFC = (
               ${textSans.medium()};
               display: flex;
               flex-wrap: wrap;
+              flex-direction: column;
               justify-content: space-between;
               ${minWidth.tablet} {
+                flex-direction: initial;
                 padding: 0 ${space[5]}px;
+              }
+              div {
+                margin-top: 16px;
+                ${minWidth.tablet} {
+                  min-width: 50%;
+                }
               }
             `}
           >
-            <div
-              css={css`
-                ${minWidth.tablet} {
-                  min-width: 50%;
-                }
-              `}
-            >
-              <dt
-                css={css`
-                  ${dtCss}
-                `}
-              >
-                Reference:
-              </dt>
-              <dd
-                css={css`
-                  ${ddCss}
-                  ${minWidth.tablet} {
-                    min-width: 12ch;
-                  }
-                `}
-              >
-                {problemReferenceId}
-              </dd>
+            <div>
+              <dt css={dtCss}>Reference:</dt>
+              <dd css={ddCss}>{problemReferenceId}</dd>
             </div>
-            <div
-              css={css`
-                flex-grow: 1;
-                margin-top: 16px;
-                ${minWidth.tablet} {
-                  margin-top: 0;
-                }
-              `}
-            >
-              <dt
-                css={css`
-                  ${dtCss}
-                `}
-              >
-                Status:
-              </dt>
-              <dd
-                css={css`
-                  ${ddCss}
-                `}
-              >
-                <span
-                  css={css`
-                    display: block;
-                    font-weight: bold;
-                    padding-left: 30px;
-                    position: relative;
-                  `}
-                >
-                  <i
-                    css={css`
-                      position: absolute;
-                      top: 0;
-                      left: 0;
-                    `}
-                  >
-                    <ErrorIcon fill={palette.brandYellow[300]} />
-                  </i>
-                  Reported
-                </span>
-              </dd>
+            <div>
+              <dt css={dtCss}>Date reported:</dt>
+              <dd css={ddCss}>{moment().format("D MMM YYYY")}</dd>
             </div>
-            <div
-              css={css`
-                flex-basis: 100%;
-                height: 0;
-                ${minWidth.tablet} {
-                  margin-top: ${space[5]}px;
-                }
-              `}
-            />
-            <div
-              css={css`
-                margin-top: 16px;
-                ${minWidth.tablet} {
-                  margin-top: 0;
-                  min-width: 50%;
-                }
-              `}
-            >
-              <dt
-                css={css`
-                  ${dtCss}
-                `}
-              >
-                Date reported:
-              </dt>
-              <dd
-                css={css`
-                  ${ddCss}
-                  ${minWidth.tablet} {
-                    min-width: 12ch;
-                  }
-                `}
-              >
-                {moment().format("D MMM YYYY")}
-              </dd>
+            <div>
+              <dt css={dtCss}>Subscription ID:</dt>
+              <dd css={ddCss}>{props.subscriptionId}</dd>
             </div>
-            <div
-              css={css`
-                flex-grow: 1;
-                margin-top: 16px;
-                ${minWidth.tablet} {
-                  margin-top: 0;
-                }
-              `}
-            >
-              <dt
-                css={css`
-                  ${dtCss}
-                `}
-              >
-                Subscription ID:
-              </dt>
-              <dd
-                css={css`
-                  ${ddCss}
-                `}
-              >
-                {props.subscriptionId}
-              </dd>
-            </div>
-            <div
-              css={css`
-                flex-basis: 100%;
-                height: 0;
-                ${minWidth.tablet} {
-                  margin-top: ${space[5]}px;
-                }
-              `}
-            />
-            <div
-              css={css`
-                margin-top: 16px;
-                ${minWidth.tablet} {
-                  margin-top: 0;
-                  min-width: 50%;
-                }
-              `}
-            >
-              <dt
-                css={css`
-                  ${dtCss}
-                `}
-              >
-                Product:
-              </dt>
-              <dd
-                css={css`
-                  ${ddCss}
-                  ${minWidth.tablet} {
-                    min-width: 12ch;
-                  }
-                `}
-              >
+            <div>
+              <dt css={dtCss}>Product:</dt>
+              <dd css={ddCss}>
                 {props.routeableStepProps.productType.shortFriendlyName}
               </dd>
             </div>
-            <div
-              css={css`
-                flex-grow: 1;
-                margin-top: 16px;
-                ${minWidth.tablet} {
-                  margin-top: 0;
-                }
-              `}
-            >
-              <dt
-                css={css`
-                  ${dtCss}
-                `}
-              >
-                Contact number:
-              </dt>
-              <dd
-                css={css`
-                  ${ddCss}
-                `}
-              >
-                {"-" ||
-                  Object.entries(props.data.contactPhoneNumbers)
-                    .filter(
-                      phoneNumber =>
-                        phoneNumber[0].toLowerCase() !== "id" && phoneNumber[1]
-                    )
-                    .map((phoneNumber, index) => (
-                      <span
-                        key={`phoneNo-${index}`}
-                        css={css`
-                          display: block;
-                          margin-bottom: ${space[3]};
-                        `}
-                      >
-                        {phoneNumber[1]}
-                      </span>
-                    ))}
+            <div>
+              <dt css={dtCss}>Contact number:</dt>
+              <dd css={ddCss}>
+                {Object.entries(props.data.contactPhoneNumbers)
+                  .filter(
+                    ([phoneType, phoneNumber]) =>
+                      phoneType.toLowerCase() !== "id" && phoneNumber
+                  )
+                  .map(([_, phoneNumber], index) => (
+                    <span
+                      key={`phoneNo-${index}`}
+                      css={css`
+                        display: block;
+                        margin-bottom: ${space[3]};
+                      `}
+                    >
+                      {phoneNumber}
+                    </span>
+                  )) || "-"}
               </dd>
             </div>
-            <div
-              css={css`
-                flex-basis: 100%;
-                height: 0;
-                ${minWidth.tablet} {
-                  margin-top: ${space[5]}px;
-                }
-              `}
-            />
-            <div
-              css={css`
-                flex-grow: 1;
-                margin-top: 16px;
-                ${minWidth.tablet} {
-                  margin-top: 0;
-                }
-              `}
-            >
-              <dt
-                css={css`
-                  ${dtCss}
-                `}
-              >
-                Selected Issue(s):
-              </dt>
-              <dd
-                css={css`
-                  ${ddCss}
-                `}
-              >
+            <div>
+              <dt css={dtCss}>Selected Issue(s):</dt>
+              <dd css={ddCss}>
                 {deliveryIssuePostPayload?.deliveryRecords?.length}
               </dd>
             </div>

--- a/app/client/components/delivery/records/deliveryRecordsProblemReview.tsx
+++ b/app/client/components/delivery/records/deliveryRecordsProblemReview.tsx
@@ -231,8 +231,10 @@ const DeliveryRecordsProblemReviewFC = (
                     ${textSans.medium()};
                     display: flex;
                     flex-wrap: wrap;
+                    flex-direction: column;
                     justify-content: space-between;
                     ${minWidth.tablet} {
+                      flex-direction: initial;
                       padding: 0 ${space[5]}px;
                     }
                   `}

--- a/app/client/components/delivery/records/deliveryRecordsProblemReview.tsx
+++ b/app/client/components/delivery/records/deliveryRecordsProblemReview.tsx
@@ -495,7 +495,7 @@ const DeliveryRecordsProblemReviewFC = (
                     </i>
                     Once you submit your report, your case will be marked as
                     high priority. Our customer service team will try their best
-                    to contact you within 48 hours to resolve the issue.
+                    to contact you as soon as possible to resolve the issue.
                   </span>
                   {newPhoneNumbers && (
                     <UserPhoneNumber

--- a/app/client/components/delivery/records/deliveryRecordsProblemReview.tsx
+++ b/app/client/components/delivery/records/deliveryRecordsProblemReview.tsx
@@ -55,17 +55,11 @@ export const DeliveryRecordsProblemReview = (
   const renderReviewDetails = (
     potentialHolidayStopsResponseWithCredits: PotentialHolidayStopsResponse
   ) => {
-    const totalCreditAmount = potentialHolidayStopsResponseWithCredits
-      .potentials.length
-      ? Math.abs(
-          potentialHolidayStopsResponseWithCredits.potentials
-            .flatMap<number>(x => [x.credit as number])
-            .reduce(
-              (accumulator, currentValue) =>
-                accumulator + Math.abs(currentValue)
-            )
-        )
-      : 0;
+    const totalCreditAmount: number =
+      potentialHolidayStopsResponseWithCredits.potentials.length &&
+      potentialHolidayStopsResponseWithCredits.potentials
+        .flatMap(x => [Math.abs(x.credit || 0)])
+        .reduce((accumulator, currentValue) => accumulator + currentValue);
 
     return (
       <DeliveryRecordsProblemReviewFC

--- a/app/client/components/delivery/records/deliveryRecordsProblemReview.tsx
+++ b/app/client/components/delivery/records/deliveryRecordsProblemReview.tsx
@@ -74,7 +74,9 @@ export const DeliveryRecordsProblemReview = (
         creditDate={
           potentialHolidayStopsResponseWithCredits.nextInvoiceDateAfterToday
         }
-        holidayStopRecords={potentialHolidayStopsResponseWithCredits.potentials}
+        relatedPublications={
+          potentialHolidayStopsResponseWithCredits.potentials
+        }
         totalCreditAmount={totalCreditAmount}
       />
     );
@@ -111,7 +113,7 @@ interface DeliveryRecordsProblemReviewFCProps
   showCredit?: true;
   creditDate?: string;
   totalCreditAmount?: number;
-  holidayStopRecords?: RawPotentialHolidayStopDetail[];
+  relatedPublications?: RawPotentialHolidayStopDetail[];
 }
 
 const DeliveryRecordsProblemReviewFC = (
@@ -148,15 +150,17 @@ const DeliveryRecordsProblemReviewFC = (
         problemType: deliveryProblemContext?.problemType?.category,
         repeatDeliveryProblem: deliveryProblemContext?.repeatDeliveryProblem,
         deliveryRecords:
-          props.showCredit && props.holidayStopRecords
+          props.showCredit && props.relatedPublications
             ? deliveryProblemContext?.affectedRecords.map(record => {
-                const matchingHolidayStop = props.holidayStopRecords?.find(
+                const matchingPublication = props.relatedPublications?.find(
                   x => x.publicationDate === record.deliveryDate
                 );
                 return {
                   id: record.id,
-                  creditAmount: matchingHolidayStop?.credit,
-                  invoiceDate: props.creditDate
+                  creditAmount: matchingPublication?.credit,
+                  invoiceDate: matchingPublication
+                    ? props.creditDate
+                    : undefined
                 };
               })
             : deliveryProblemContext?.affectedRecords.map(record => {

--- a/app/client/components/delivery/records/deliveryRecordsProblemReview.tsx
+++ b/app/client/components/delivery/records/deliveryRecordsProblemReview.tsx
@@ -120,7 +120,7 @@ const DeliveryRecordsProblemReviewFC = (
   props: DeliveryRecordsProblemReviewFCProps
 ) => {
   const deliveryProblemContext = useContext(DeliveryRecordsProblemContext);
-  const [phoneNumbers, setPhoneNumbers] = useState<
+  const [newPhoneNumbers, setPhoneNumbers] = useState<
     ContactPhoneNumbers | undefined
   >(deliveryProblemContext?.contactPhoneNumbers);
   const [showCallCenterNumbers, setShowCallCenterNumbers] = useState<boolean>(
@@ -166,11 +166,11 @@ const DeliveryRecordsProblemReviewFC = (
             : deliveryProblemContext?.affectedRecords.map(record => {
                 return { id: record.id };
               }),
-        ...((phoneNumbers?.Phone ||
-          phoneNumbers?.HomePhone ||
-          phoneNumbers?.MobilePhone ||
-          phoneNumbers?.OtherPhone) && {
-          newContactPhoneNumbers: phoneNumbers
+        ...((newPhoneNumbers?.Phone ||
+          newPhoneNumbers?.HomePhone ||
+          newPhoneNumbers?.MobilePhone ||
+          newPhoneNumbers?.OtherPhone) && {
+          newContactPhoneNumbers: newPhoneNumbers
         })
       }}
     >
@@ -503,11 +503,13 @@ const DeliveryRecordsProblemReviewFC = (
                     high priority. Our customer service team will try their best
                     to contact you within 48 hours to resolve the issue.
                   </span>
-                  {phoneNumbers && (
+                  {newPhoneNumbers && (
                     <UserPhoneNumber
-                      existingPhoneNumbers={phoneNumbers}
-                      callback={(newNumber: ContactPhoneNumbers) => {
-                        setPhoneNumbers(newNumber);
+                      existingPhoneNumbers={
+                        deliveryProblemContext?.contactPhoneNumbers
+                      }
+                      callback={(newNumbers: ContactPhoneNumbers) => {
+                        setPhoneNumbers(newNumbers);
                       }}
                     />
                   )}

--- a/app/client/components/delivery/records/productDetailsTable.tsx
+++ b/app/client/components/delivery/records/productDetailsTable.tsx
@@ -22,6 +22,7 @@ export const ProductDetailsTable = (props: ProductDetailsTableProps) => {
     }
     & div {
       display: inline-block;
+      width: 100%;
       ${minWidth.tablet} {
         width: 50%;
       }

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -435,11 +435,7 @@ const getProductDetailRenderer = (
                 label="Delivery history"
                 data={
                   <LinkButton
-                    text={
-                      productType.delivery.records.canReportProblem
-                        ? "Report problem"
-                        : "View delivery history"
-                    }
+                    text="Report problem"
                     to={`/delivery/${productType.urlPart}/records`}
                     state={productDetail}
                     right

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -112,7 +112,6 @@ export const commonDeliveryProblemTypes: DeliveryProblemType[] = [
 
 interface DeliveryRecordsProperties {
   showDeliveryInstructions?: true;
-  canReportProblem: boolean;
   numberOfProblemRecordsToShow: number;
   contactUserOnExistingProblemReport: boolean;
   availableProblemTypes: DeliveryProblemType[];
@@ -403,7 +402,6 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
       showAddress: showDeliveryAddressCheck,
       records: {
         showDeliveryInstructions: true,
-        canReportProblem: false,
         numberOfProblemRecordsToShow: 14,
         contactUserOnExistingProblemReport: true,
         availableProblemTypes: [
@@ -459,7 +457,6 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
     delivery: {
       showAddress: showDeliveryAddressCheck,
       records: {
-        canReportProblem: true,
         numberOfProblemRecordsToShow: 4,
         contactUserOnExistingProblemReport: false,
         availableProblemTypes: commonDeliveryProblemTypes

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -111,6 +111,7 @@ export const commonDeliveryProblemTypes: DeliveryProblemType[] = [
 ];
 
 interface DeliveryRecordsProperties {
+  productNameForProblemReport: string;
   showDeliveryInstructions?: true;
   numberOfProblemRecordsToShow: number;
   contactUserOnExistingProblemReport: boolean;
@@ -401,6 +402,7 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
     delivery: {
       showAddress: showDeliveryAddressCheck,
       records: {
+        productNameForProblemReport: "Home Delivery",
         showDeliveryInstructions: true,
         numberOfProblemRecordsToShow: 14,
         contactUserOnExistingProblemReport: true,
@@ -457,6 +459,7 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
     delivery: {
       showAddress: showDeliveryAddressCheck,
       records: {
+        productNameForProblemReport: "Guardian Weekly",
         numberOfProblemRecordsToShow: 4,
         contactUserOnExistingProblemReport: false,
         availableProblemTypes: commonDeliveryProblemTypes


### PR DESCRIPTION
- Removed the notion of `canReportProblem` since we now want problem reporting enabled for all products which have delivery records configured (Home Delivery and Guardian Weekly).
- Also removed the usage of `fulfilmentDateCalculator` config in the delivery problem reporting logic, for better separation of concerns (replaced it with the same product name strings repeated in the section of `productTypes.tsx` dedicated to delivery records).

#### PLUS
- Fixed a little display bug on the 'Show more' button on the delivery addresses
- Fixed little layout bug in the detail tables between mobile and tablet breakpoints, throughout the delivery problem flow (now just always stacks vertically below tablet).
- Fixed the phone number updater
- Fixed the total credit amount calculation (which means some will have appeared as if they're escalated when they're not 😞 and some will have displayed an incorrect total )
- Fixed bug with number of issues displayed for when reporting a problem
- Fixed incorrect `optional` label on Country in delivery address update flow
- Fixed excluding of digipack from affected subscriptions list in delivery address update flow
- Fixed data table layout on confirmation page and removed redundant top-level status
---

Follows...
- https://github.com/guardian/support-service-lambdas/pull/605
- https://github.com/guardian/salesforce/pull/184 