### PR TITLE
improve manage-frontend 5XX alarm (backend + ELB)

### DIFF
--- a/app/server/routes/api.ts
+++ b/app/server/routes/api.ts
@@ -1,4 +1,4 @@
-import { Router } from "express";
+import { Router, Response } from "express";
 import Raven from "raven";
 import {
   isProduct,
@@ -23,6 +23,10 @@ const router = Router();
 router.use(withIdentity(401));
 
 router.get("/me", membersDataApiHandler("user-attributes/me"));
+
+router.get("/test-5xx", (_, res: Response) => {
+  res.status(500).send({ status: 500, message: "Internal service error" });
+});
 
 router.get(
   "/existing-payment-options",

--- a/app/server/routes/api.ts
+++ b/app/server/routes/api.ts
@@ -1,4 +1,4 @@
-import { Response, Router } from "express";
+import { Router } from "express";
 import Raven from "raven";
 import {
   isProduct,
@@ -23,10 +23,6 @@ const router = Router();
 router.use(withIdentity(401));
 
 router.get("/me", membersDataApiHandler("user-attributes/me"));
-
-router.get("/test-5xx", (_, res: Response) => {
-  res.status(500).send({ status: 500, message: "Internal service error" });
-});
 
 router.get(
   "/existing-payment-options",

--- a/app/server/routes/api.ts
+++ b/app/server/routes/api.ts
@@ -1,4 +1,4 @@
-import { Router, Response } from "express";
+import { Response, Router } from "express";
 import Raven from "raven";
 import {
   isProduct,

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -307,49 +307,49 @@ Resources:
       - TargetGroup
       - ElasticLoadBalancer
 
-    High5XXRateAlarm:
-      Type: AWS::CloudWatch::Alarm
-      Condition: CreateProdResources
-      Properties:
-        AlarmActions:
-          - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
-        AlarmName: !Sub High 5XX rate for manage-frontend in ${Stage}
-        ComparisonOperator: GreaterThanOrEqualToThreshold
-        Threshold: 3
-        EvaluationPeriods: 2
-        TreatMissingData: notBreaching
-        Metrics:
-          - Id: total5xx
-            Expression: backend5XX + elb5XX
-            Label: "Count of Backend AND ELB 5XX"
-          - Id: backend5XX
-            MetricStat:
-              Metric:
-                Namespace: AWS/ApplicationELB
-                MetricName: HTTPCode_Backend_5XX
-                Dimensions:
-                  - Name: LoadBalancerName
-                    Value: !GetAtt ElasticLoadBalancer.LoadBalancerFullName
-                  - Name: TargetGroup
-                    Value: !GetAtt TargetGroup.TargetGroupFullName
-              Period: 60
-              Stat: Sum
-              Unit: Count
-            ReturnData: false
-          - Id: elb5XX
-            MetricStat:
-              Metric:
-                Namespace: AWS/ApplicationELB
-                MetricName: HTTPCode_ELB_5XX
-                Dimensions:
-                  - Name: LoadBalancerName
-                    Value: !GetAtt ElasticLoadBalancer.LoadBalancerFullName
-                  - Name: TargetGroup
-                    Value: !GetAtt TargetGroup.TargetGroupFullName
-              Period: 60 
-              Stat: Sum
-              Unit: Count
-            ReturnData: false
-      DependsOn:
-        - TargetGroup
-        - ElasticLoadBalancer
+  High5XXRateAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: CreateProdResources
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
+      AlarmName: !Sub High 5XX rate for manage-frontend in ${Stage}
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Threshold: 3
+      EvaluationPeriods: 2
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: total5xx
+          Expression: backend5XX + elb5XX
+          Label: "Count of Backend AND ELB 5XX"
+        - Id: backend5XX
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApplicationELB
+              MetricName: HTTPCode_Backend_5XX
+              Dimensions:
+                - Name: LoadBalancerName
+                  Value: !GetAtt ElasticLoadBalancer.LoadBalancerFullName
+                - Name: TargetGroup
+                  Value: !GetAtt TargetGroup.TargetGroupFullName
+            Period: 60
+            Stat: Sum
+            Unit: Count
+          ReturnData: false
+        - Id: elb5XX
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApplicationELB
+              MetricName: HTTPCode_ELB_5XX
+              Dimensions:
+                - Name: LoadBalancerName
+                  Value: !GetAtt ElasticLoadBalancer.LoadBalancerFullName
+                - Name: TargetGroup
+                  Value: !GetAtt TargetGroup.TargetGroupFullName
+            Period: 60 
+            Stat: Sum
+            Unit: Count
+          ReturnData: false
+    DependsOn:
+      - TargetGroup
+      - ElasticLoadBalancer

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -312,7 +312,7 @@ Resources:
     Condition: CreateProdResources
     Properties:
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev-mk-test
       AlarmName: !Sub High 5XX rate for manage-frontend in ${Stage}
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Threshold: 3

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -340,12 +340,10 @@ Resources:
           MetricStat:
             Metric:
               Namespace: AWS/ApplicationELB
-              MetricName: HTTPCode_ELB_5XX
+              MetricName: HTTPCode_ELB_5XX_Count
               Dimensions:
                 - Name: LoadBalancer
                   Value: !GetAtt ElasticLoadBalancer.LoadBalancerFullName
-                - Name: TargetGroup
-                  Value: !GetAtt TargetGroup.TargetGroupFullName
             Period: 60
             Stat: Sum
             Unit: Count

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -309,7 +309,7 @@ Resources:
 
   High5XXRateAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: CreateProdResources
+    # Condition: CreateProdResources
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev-mk-test
@@ -346,7 +346,7 @@ Resources:
                   Value: !GetAtt ElasticLoadBalancer.LoadBalancerFullName
                 - Name: TargetGroup
                   Value: !GetAtt TargetGroup.TargetGroupFullName
-            Period: 60 
+            Period: 60
             Stat: Sum
             Unit: Count
           ReturnData: false

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -309,10 +309,10 @@ Resources:
 
   High5XXRateAlarm:
     Type: AWS::CloudWatch::Alarm
-    # Condition: CreateProdResources
+    Condition: CreateProdResources
     Properties:
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev-mk-test
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
       AlarmName: !Sub High 5XX rate for manage-frontend in ${Stage}
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Threshold: 3

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -307,26 +307,49 @@ Resources:
       - TargetGroup
       - ElasticLoadBalancer
 
-  High5XXRateAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Condition: CreateProdResources
-    Properties:
-      AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
-      AlarmName: !Sub High 5XX rate for manage-frontend in ${Stage}
-      MetricName: HTTPCode_Target_5XX_Count
-      Namespace: AWS/ApplicationELB
-      Dimensions:
-        - Name: LoadBalancer
-          Value: !GetAtt ElasticLoadBalancer.LoadBalancerFullName
-        - Name: TargetGroup
-          Value: !GetAtt TargetGroup.TargetGroupFullName
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      Threshold: 3
-      Period: 60
-      EvaluationPeriods: 2
-      Statistic: Sum
-      TreatMissingData: notBreaching
-    DependsOn:
-      - TargetGroup
-      - ElasticLoadBalancer
+    High5XXRateAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Condition: CreateProdResources
+      Properties:
+        AlarmActions:
+          - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
+        AlarmName: !Sub High 5XX rate for manage-frontend in ${Stage}
+        ComparisonOperator: GreaterThanOrEqualToThreshold
+        Threshold: 3
+        EvaluationPeriods: 2
+        TreatMissingData: notBreaching
+        Metrics:
+          - Id: total5xx
+            Expression: backend5XX + elb5XX
+            Label: "Count of Backend AND ELB 5XX"
+          - Id: backend5XX
+            MetricStat:
+              Metric:
+                Namespace: AWS/ApplicationELB
+                MetricName: HTTPCode_Backend_5XX
+                Dimensions:
+                  - Name: LoadBalancerName
+                    Value: !GetAtt ElasticLoadBalancer.LoadBalancerFullName
+                  - Name: TargetGroup
+                    Value: !GetAtt TargetGroup.TargetGroupFullName
+              Period: 60
+              Stat: Sum
+              Unit: Count
+            ReturnData: false
+          - Id: elb5XX
+            MetricStat:
+              Metric:
+                Namespace: AWS/ApplicationELB
+                MetricName: HTTPCode_ELB_5XX
+                Dimensions:
+                  - Name: LoadBalancerName
+                    Value: !GetAtt ElasticLoadBalancer.LoadBalancerFullName
+                  - Name: TargetGroup
+                    Value: !GetAtt TargetGroup.TargetGroupFullName
+              Period: 60 
+              Stat: Sum
+              Unit: Count
+            ReturnData: false
+      DependsOn:
+        - TargetGroup
+        - ElasticLoadBalancer

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -326,9 +326,9 @@ Resources:
           MetricStat:
             Metric:
               Namespace: AWS/ApplicationELB
-              MetricName: HTTPCode_Backend_5XX
+              MetricName: HTTPCode_Target_5XX_Count
               Dimensions:
-                - Name: LoadBalancerName
+                - Name: LoadBalancer
                   Value: !GetAtt ElasticLoadBalancer.LoadBalancerFullName
                 - Name: TargetGroup
                   Value: !GetAtt TargetGroup.TargetGroupFullName
@@ -342,7 +342,7 @@ Resources:
               Namespace: AWS/ApplicationELB
               MetricName: HTTPCode_ELB_5XX
               Dimensions:
-                - Name: LoadBalancerName
+                - Name: LoadBalancer
                   Value: !GetAtt ElasticLoadBalancer.LoadBalancerFullName
                 - Name: TargetGroup
                   Value: !GetAtt TargetGroup.TargetGroupFullName

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -39,6 +39,12 @@ Conditions:
   CreateProdResources: !Equals [!Ref "Stage", "PROD"]
   CreateCodeResources: !Equals [!Ref "Stage", "CODE"]
 Mappings:
+  Constants:
+    Alarm:
+      Process: Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit
+      Urgent: URGENT 9-5 -
+    MetricFilters:
+      MetricNamespace: manage-frontend
   StageVariables:
     CODE:
       MaxInstances: 2
@@ -313,7 +319,16 @@ Resources:
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
-      AlarmName: !Sub High 5XX rate for manage-frontend in ${Stage}
+      AlarmName: !Join
+        - " "
+        - - !FindInMap [Constants, Alarm, Urgent]
+          - !Ref "Stage"
+          - !FindInMap [Constants, MetricFilters, MetricNamespace]
+          - "High 5XX rate"
+      AlarmDescription: !Join
+        - " "
+        - - Impact - we're serving errors to too many people
+          - !FindInMap [Constants, Alarm, Process]
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Threshold: 3
       EvaluationPeriods: 2


### PR DESCRIPTION
## Overview
improve manage-frontend 5XX alarm (backend + ELB)

- trigger alarm on any 500 happening on the application server
- trigger alarm on any 500 happening on the LoadBalancer

## Tests
- [x] CODE

tested for both situation for
- failing app server
- ELB giving 503 when number of EC2 instances was 0
 
## Background
- https://trello.com/c/tvxGB2UF/937-task-improve-manage-frontend-5xx-alarm-backend-elb
- Following the precedent set here https://github.com/guardian/members-data-api/pull/425