### PR TITLE
[delivery-address-flow] add timestamp to the address change information

### DIFF
--- a/app/client/components/delivery/address/deliveryAddressForm.tsx
+++ b/app/client/components/delivery/address/deliveryAddressForm.tsx
@@ -24,6 +24,7 @@ import { textSans } from "@guardian/src-foundations/typography";
 // @ts-ignore
 import { SvgArrowRightStraight } from "@guardian/src-svgs";
 import { Link } from "@reach/router";
+import moment from "moment";
 import { momentiseDateStr } from "../../../../shared/dates";
 import { CallCentreNumbers } from "../../callCentreNumbers";
 import { navLinks } from "../../nav";
@@ -287,9 +288,13 @@ const FormContainer = (props: FormContainerProps) => {
                   fetch={updateAddressFetcher(
                     {
                       ...evolvingAddressObject,
-                      addressChangeInformation: addressChangeInformation.join(
-                        "\n"
-                      )
+                      addressChangeInformation: [
+                        ...addressChangeInformation,
+                        "",
+                        `(as displayed on confirmation page at ${moment().format(
+                          "H:mm:ss zz [on] Do MMMM YYYY"
+                        )})`
+                      ].join("\n")
                     },
                     Object.keys(props.contactIdToArrayOfProductDetail)[0]
                   )}


### PR DESCRIPTION
…which makes its way into `Address_Change_Information_Last_Quoted__c` (see https://github.com/guardian/manage-frontend/pull/365).

![image](https://user-images.githubusercontent.com/19289579/77431749-0ce4bc00-6dd5-11ea-8982-f9a847590969.png)

This is to help keep the email confirmation as simple as possible, because the `AfterInsert` Salesforce trigger on `Contact` need only check if `Address_Change_Information_Last_Quoted__c` has changed. However without the addition of this timestamp, then a user could update their address multiple times in the same day and only receive email confirmation for the first change, or we'd need more complexity on the Salesforce side.