### PR TITLE
no cancellation cases are 'Open'ed when feedback is provided

### DIFF
--- a/app/client/components/cancel/stages/genericSaveAttempt.tsx
+++ b/app/client/components/cancel/stages/genericSaveAttempt.tsx
@@ -58,8 +58,7 @@ const getPatchUpdateCaseFunc = (
 ) => async () =>
   await getUpdateCasePromise(isTestUser, "_FEEDBACK", caseId, {
     Description: feedback,
-    Subject: "Online Cancellation Query",
-    Status: "Open"
+    Subject: "Online Cancellation Query"
   });
 
 const gaTrackFeedback = (actionString: string) =>


### PR DESCRIPTION
…due to Coronavirus volumes