### PR TITLE
Digipack cancellation flow

### DIFF
--- a/app/client/components/callCentreNumbers.tsx
+++ b/app/client/components/callCentreNumbers.tsx
@@ -1,59 +1,26 @@
-import { css } from "@emotion/core";
 import React from "react";
-import { Accordion } from "./accordion";
+import palette from "../colours";
 
-const contactUsStyles = {
-  margin: "0 0 10px",
-  paddingRight: "5px"
-};
-
-const callCenterStyles = css({
-  marginBottom: "10px",
-  display: "flex",
-  flexWrap: "wrap",
-  textAlign: "left",
-  fontWeight: "normal"
-});
-
-const ukPhoneCommonPart = "330 333 6790";
-export const ukPhoneNumber = `+44 (0) ${ukPhoneCommonPart}`;
-export const ukPhoneNumberWithoutPrefix = `0${ukPhoneCommonPart}`;
-
-export const ukOpeningTimes =
-  "8am - 8pm on weekdays, 8am-6pm at weekends (GMT/BST)";
+export const ukPhoneNumberWithoutPrefix = "0330 333 6790";
 
 export interface CallCentreNumbersProps {
   prefixText?: string;
 }
 
+// TODO after Coronavirus, migrate uses of this to the newer callCenterEmailAndNumbers.tsx
 export const CallCentreNumbers = (props: CallCentreNumbersProps) => (
-  <div css={callCenterStyles}>
-    {props.prefixText && <p css={contactUsStyles}>{props.prefixText}</p>}
-    <Accordion>
-      <div title="United Kingdom, Europe and rest of world">
-        <div>
-          <b>{ukPhoneNumber}</b>
-        </div>
-        <div>{ukOpeningTimes}</div>
-      </div>
-      <div title="Australia, New Zealand, and Asia Pacific">
-        <div>
-          <b>1800 773 766</b> (within Australia)
-        </div>
-        <div>
-          <b>+61 2​ 8​076 8599</b> (outside Australia)
-        </div>
-        <div>9am - 5pm Monday - Friday (AEDT)</div>
-      </div>
-      <div title="Canada and USA">
-        <div>
-          <b>1-844-632-2010</b> (toll free USA)
-        </div>
-        <div>
-          <b>+1 917-900-4663</b> (outside USA)
-        </div>
-        <div>9am - 5pm on weekdays (EST/EDT)</div>
-      </div>
-    </Accordion>
+  <div>
+    {props.prefixText || "To contact us"}&nbsp;directly, please email&nbsp;
+    <a
+      css={{
+        textDecoration: "underline",
+        color: palette.blue.dark,
+        ":visited": { color: palette.blue.dark }
+      }}
+      href="mailto:customer.help@theguardian.com"
+    >
+      customer.help@theguardian.com
+    </a>
+    .
   </div>
 );

--- a/app/client/components/cancel/cancellationConstants.ts
+++ b/app/client/components/cancel/cancellationConstants.ts
@@ -1,5 +1,5 @@
 export const standardSaveBody =
   "It would be really helpful for us to understand a bit more about your reason for cancelling.";
 
-export const standardFeedbackIntro =
+export const standardAlternateFeedbackIntro =
   "Please submit your comments in the box below. Thank you.";

--- a/app/client/components/cancel/cancellationConstants.ts
+++ b/app/client/components/cancel/cancellationConstants.ts
@@ -1,0 +1,5 @@
+export const standardSaveBody =
+  "It would be really helpful for us to understand a bit more about your reason for cancelling.";
+
+export const standardFeedbackIntro =
+  "Please submit your comments in the box below. Thank you.";

--- a/app/client/components/cancel/cancellationReason.ts
+++ b/app/client/components/cancel/cancellationReason.ts
@@ -1,7 +1,7 @@
 export interface CancellationReason {
   reasonId: CancellationReasonId;
   linkLabel: string;
-  saveTitle: string;
+  saveTitle?: string;
   saveBody: string | JSX.Element;
   experimentSaveBody?: JSX.Element;
   experimentTriggerFlag?: string;
@@ -14,6 +14,9 @@ export interface CancellationReason {
 }
 
 export type CancellationReasonId =
+  | "mma_time"
+  | "mma_better_offer"
+  | "mma_issue"
   | "mma_financial_circumstances"
   | "mma_payment_issue"
   | "mma_article"

--- a/app/client/components/cancel/caseCreationWrapper.tsx
+++ b/app/client/components/cancel/caseCreationWrapper.tsx
@@ -14,7 +14,7 @@ export interface CaseCreationResponse {
 
 const getCreateCaseFunc = (
   reason: OptionalCancellationReasonId,
-  sfProduct: string,
+  sfCaseProduct: string,
   productDetail: ProductDetail
 ) => async () =>
   await fetch("/api/case", {
@@ -23,7 +23,7 @@ const getCreateCaseFunc = (
     mode: "same-origin",
     body: JSON.stringify({
       reason,
-      product: sfProduct,
+      product: sfCaseProduct,
       subscriptionName: productDetail.subscription.subscriptionId,
       gaData: "" + JSON.stringify(window.gaData)
     }),
@@ -48,7 +48,7 @@ class CaseCreationAsyncLoader extends AsyncLoader<CaseCreationResponse> {}
 
 export interface CaseCreationWrapperProps {
   children: any;
-  sfProduct: string;
+  sfCaseProduct: string;
   productDetail: ProductDetail;
 }
 
@@ -56,7 +56,11 @@ export const CaseCreationWrapper = (props: CaseCreationWrapperProps) => (
   <CancellationReasonContext.Consumer>
     {reason => (
       <CaseCreationAsyncLoader
-        fetch={getCreateCaseFunc(reason, props.sfProduct, props.productDetail)}
+        fetch={getCreateCaseFunc(
+          reason,
+          props.sfCaseProduct,
+          props.productDetail
+        )}
         render={renderWithCaseIdContextProvider(props.children)}
         errorRender={renderWithCaseIdContextProvider(props.children)}
         loadingMessage="Capturing your cancellation reason..."

--- a/app/client/components/cancel/contributions/contributionsCancellationFlowStart.tsx
+++ b/app/client/components/cancel/contributions/contributionsCancellationFlowStart.tsx
@@ -11,12 +11,10 @@ export const contributionsCancellationFlowStart = (
       Your support means The Guardian can remain editorially independent, free
       from the influence of billionaire owners and politicians. This enables us
       to give a voice to the voiceless, challenge the powerful and hold them to
-      account. And our readers’ support helps us to keep our journalism free of
-      a paywall, so it’s open and accessible to all.
+      account. Our readers’ support helps us to keep our journalism free of a
+      paywall, so it’s open and accessible to all.
     </p>
 
-    <p>
-      Please could you take take a moment to tell us why you want to cancel?
-    </p>
+    <p>Please could you take a moment to tell us why you want to cancel?</p>
   </PageContainerSection>
 );

--- a/app/client/components/cancel/contributions/contributionsCancellationReasons.tsx
+++ b/app/client/components/cancel/contributions/contributionsCancellationReasons.tsx
@@ -2,7 +2,7 @@ import { Link } from "@reach/router";
 import React from "react";
 import palette from "../../../colours";
 import {
-  standardFeedbackIntro,
+  standardAlternateFeedbackIntro,
   standardSaveBody
 } from "../cancellationConstants";
 import { CancellationReason } from "../cancellationReason";
@@ -13,21 +13,21 @@ export const contributionsCancellationReasons: CancellationReason[] = [
     linkLabel: "As a result of a specific article I read",
     saveTitle: "As a result of a specific article you read",
     saveBody: standardSaveBody,
-    alternateFeedbackIntro: standardFeedbackIntro
+    alternateFeedbackIntro: standardAlternateFeedbackIntro
   },
   {
     reasonId: "mma_editorial",
     linkLabel: "I disagree with some editorial decisions",
     saveTitle: "You disagree with some of The Guardian’s editorial decisions",
     saveBody: standardSaveBody,
-    alternateFeedbackIntro: standardFeedbackIntro
+    alternateFeedbackIntro: standardAlternateFeedbackIntro
   },
   {
     reasonId: "mma_values",
     linkLabel: "I don’t feel that The Guardian values my support",
     saveTitle: "You don’t feel that The Guardian values your support",
     saveBody: standardSaveBody,
-    alternateFeedbackIntro: standardFeedbackIntro
+    alternateFeedbackIntro: standardAlternateFeedbackIntro
   },
   {
     reasonId: "mma_support_another_way",
@@ -35,7 +35,7 @@ export const contributionsCancellationReasons: CancellationReason[] = [
     saveTitle:
       "You support The Guardian in another way, e.g. with a subscription",
     saveBody: standardSaveBody,
-    alternateFeedbackIntro: standardFeedbackIntro
+    alternateFeedbackIntro: standardAlternateFeedbackIntro
   },
   {
     reasonId: "mma_financial_circumstances",
@@ -65,7 +65,7 @@ export const contributionsCancellationReasons: CancellationReason[] = [
     linkLabel: "I wasn’t getting value for money",
     saveTitle: "You don’t feel your contribution offers you adequate value",
     saveBody: standardSaveBody,
-    alternateFeedbackIntro: standardFeedbackIntro
+    alternateFeedbackIntro: standardAlternateFeedbackIntro
   },
   {
     reasonId: "mma_payment_issue",
@@ -90,7 +90,7 @@ export const contributionsCancellationReasons: CancellationReason[] = [
         <p>{standardSaveBody}</p>
       </>
     ),
-    alternateFeedbackIntro: standardFeedbackIntro
+    alternateFeedbackIntro: standardAlternateFeedbackIntro
   },
   {
     reasonId: "mma_direct_debit",
@@ -113,7 +113,7 @@ export const contributionsCancellationReasons: CancellationReason[] = [
         <p>{standardSaveBody}</p>
       </>
     ),
-    alternateFeedbackIntro: standardFeedbackIntro
+    alternateFeedbackIntro: standardAlternateFeedbackIntro
   },
   {
     reasonId: "mma_wants_annual_contribution",
@@ -128,7 +128,7 @@ export const contributionsCancellationReasons: CancellationReason[] = [
         <p>{standardSaveBody}</p>
       </>
     ),
-    alternateFeedbackIntro: standardFeedbackIntro
+    alternateFeedbackIntro: standardAlternateFeedbackIntro
   },
   {
     reasonId: "mma_wants_monthly_contribution",
@@ -143,7 +143,7 @@ export const contributionsCancellationReasons: CancellationReason[] = [
         <p>{standardSaveBody}</p>
       </>
     ),
-    alternateFeedbackIntro: standardFeedbackIntro
+    alternateFeedbackIntro: standardAlternateFeedbackIntro
   },
   {
     reasonId: "mma_health",
@@ -159,6 +159,6 @@ export const contributionsCancellationReasons: CancellationReason[] = [
     linkLabel: "None of the above",
     saveTitle: "",
     saveBody: standardSaveBody,
-    alternateFeedbackIntro: standardFeedbackIntro
+    alternateFeedbackIntro: standardAlternateFeedbackIntro
   }
 ];

--- a/app/client/components/cancel/digipack/digipackCancellationFlowStart.tsx
+++ b/app/client/components/cancel/digipack/digipackCancellationFlowStart.tsx
@@ -11,12 +11,10 @@ export const digipackCancellationFlowStart = (
       Your support means The Guardian can remain editorially independent, free
       from the influence of billionaire owners and politicians. This enables us
       to give a voice to the voiceless, challenge the powerful and hold them to
-      account. And our readers’ support helps us to keep our journalism free of
-      a paywall, so it’s open and accessible to all.
+      account. Our readers’ support helps us to keep our journalism free of a
+      paywall, so it’s open and accessible to all.
     </p>
 
-    <p>
-      Please could you take take a moment to tell us why you want to cancel?
-    </p>
+    <p>Please could you take a moment to tell us why you want to cancel?</p>
   </PageContainerSection>
 );

--- a/app/client/components/cancel/digipack/digipackCancellationFlowStart.tsx
+++ b/app/client/components/cancel/digipack/digipackCancellationFlowStart.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { PageContainerSection } from "../../page";
+
+export const digipackCancellationFlowStart = (
+  <PageContainerSection>
+    <h3>
+      We’re sorry to hear you’re thinking of cancelling your digital
+      subscription.
+    </h3>
+    <p>
+      Your support means The Guardian can remain editorially independent, free
+      from the influence of billionaire owners and politicians. This enables us
+      to give a voice to the voiceless, challenge the powerful and hold them to
+      account. And our readers’ support helps us to keep our journalism free of
+      a paywall, so it’s open and accessible to all.
+    </p>
+
+    <p>
+      Please could you take take a moment to tell us why you want to cancel?
+    </p>
+  </PageContainerSection>
+);

--- a/app/client/components/cancel/digipack/digipackCancellationReasons.tsx
+++ b/app/client/components/cancel/digipack/digipackCancellationReasons.tsx
@@ -1,164 +1,132 @@
-import { Link } from "@reach/router";
 import React from "react";
 import palette from "../../../colours";
-import {
-  standardFeedbackIntro,
-  standardSaveBody
-} from "../cancellationConstants";
+import { standardAlternateFeedbackIntro } from "../cancellationConstants";
 import { CancellationReason } from "../cancellationReason";
+
+const inOrderToImproveSubs =
+  "In order to improve our subscription and supporter model, we’d love to know more about why you are thinking of cancelling.";
 
 export const digipackCancellationReasons: CancellationReason[] = [
   {
-    reasonId: "mma_article",
-    linkLabel: "As a result of a specific article I read",
-    saveTitle: "As a result of a specific article you read",
-    saveBody: standardSaveBody,
-    alternateFeedbackIntro: standardFeedbackIntro
-  },
-  {
     reasonId: "mma_editorial",
-    linkLabel: "I disagree with some editorial decisions",
-    saveTitle: "You disagree with some of The Guardian’s editorial decisions",
-    saveBody: standardSaveBody,
-    alternateFeedbackIntro: standardFeedbackIntro
-  },
-  {
-    reasonId: "mma_values",
-    linkLabel: "I don’t feel that The Guardian values my support",
-    saveTitle: "You don’t feel that The Guardian values your support",
-    saveBody: standardSaveBody,
-    alternateFeedbackIntro: standardFeedbackIntro
-  },
-  {
-    reasonId: "mma_support_another_way",
-    linkLabel: "I support in another way, e.g. with a subscription",
-    saveTitle:
-      "You support The Guardian in another way, e.g. with a subscription",
-    saveBody: standardSaveBody,
-    alternateFeedbackIntro: standardFeedbackIntro
+    linkLabel: "I am unhappy with Guardian journalism",
+    saveBody:
+      "In order to improve our journalism, we’d love to know more about why you are thinking of cancelling.",
+    alternateFeedbackIntro: standardAlternateFeedbackIntro
   },
   {
     reasonId: "mma_financial_circumstances",
-    linkLabel: "I can no longer afford it",
-    saveTitle: "You can no longer afford your current contribution",
+    linkLabel: "A change in my financial circumstances",
     saveBody: (
       <>
-        We understand that financial circumstances change, and your current
-        contribution might not suit you right now. To change your contribution
-        amount yourself, please go to{" "}
-        <Link
+        We understand that financial circumstances can change from time to time.
+        <br />
+        Making a smaller contribution to the Guardian can be an inexpensive way
+        of keeping journalism open for everyone to read and enjoy. Once you’ve
+        completed your cancellation below, we hope you’ll consider a small
+        one&nbsp;off or recurring contribution in the future.
+      </>
+    ),
+    skipFeedback: true
+  },
+  {
+    reasonId: "mma_support_another_way",
+    linkLabel:
+      "I am going to support The Guardian in another way, eg. by subscribing",
+    saveBody: (
+      <>
+        Thank you for your ongoing support.
+        <br />
+        <br />
+        Once you’ve completed your cancellation below, you can set up a new
+        product via our online checkouts.
+      </>
+    ),
+    skipFeedback: true
+  },
+  {
+    reasonId: "mma_health",
+    linkLabel: "Ill-health",
+    saveBody: (
+      <>
+        Thank you for your ongoing support.
+        <br />
+        <br />
+        Your subscription has ensured that our quality journalism remains open
+        for everyone to read and enjoy.
+        <br />
+        Please confirm your cancellation below.
+      </>
+    ),
+    skipFeedback: true
+  },
+  {
+    reasonId: "mma_break_from_news",
+    linkLabel: "I am taking a break from news",
+    saveBody: (
+      <>
+        Thank you for your ongoing support.
+        <br />
+        <br />
+        Your subscription has ensured that our quality journalism remains open
+        for everyone to read and enjoy. You can{" "}
+        <a
           css={{
             textDecoration: "underline",
             color: palette.blue.dark,
             ":visited": { color: palette.blue.dark }
           }}
-          to="/contributions"
+          href="/email-prefs"
         >
-          manage your account
-        </Link>
+          update your email preferences here
+        </a>{" "}
+        if you’d like to reduce communication from us.
       </>
     ),
-    skipFeedback: true
+    alternateFeedbackIntro:
+      "Alternatively we’d love to know more about what we could do better to help provide inspiring and trustworthy news."
+  },
+  {
+    reasonId: "mma_values",
+    linkLabel: "I don’t feel that The Guardian values my support",
+    saveBody: "",
+    alternateFeedbackIntro: inOrderToImproveSubs
+  },
+  {
+    reasonId: "mma_benefits",
+    linkLabel: "None of the subscription benefits are of interest to me",
+    saveBody: "",
+    alternateFeedbackIntro: inOrderToImproveSubs
+  },
+  {
+    reasonId: "mma_time",
+    linkLabel: "I don't have time to use my subscription",
+    saveBody: "",
+    alternateFeedbackIntro: inOrderToImproveSubs
+  },
+  {
+    reasonId: "mma_better_offer",
+    linkLabel: "I've found a better offer with another publisher",
+    saveBody: "",
+    alternateFeedbackIntro: inOrderToImproveSubs
   },
   {
     reasonId: "mma_value_for_money",
-    linkLabel: "I wasn’t getting value for money",
-    saveTitle: "You don’t feel your contribution offers you adequate value",
-    saveBody: standardSaveBody,
-    alternateFeedbackIntro: standardFeedbackIntro
+    linkLabel: "I wasn't getting value for money",
+    saveBody: "",
+    alternateFeedbackIntro: inOrderToImproveSubs
   },
   {
-    reasonId: "mma_payment_issue",
-    linkLabel: "A payment issue",
-    saveTitle: "You have experienced an issue with your payment",
-    saveBody: (
-      <>
-        <p>
-          You can review your payment method and update your details in the{" "}
-          <Link
-            css={{
-              textDecoration: "underline",
-              color: palette.blue.dark,
-              ":visited": { color: palette.blue.dark }
-            }}
-            to={"/contributions"}
-          >
-            manage your account
-          </Link>{" "}
-          section, without the need to cancel your contribution.
-        </p>
-        <p>{standardSaveBody}</p>
-      </>
-    ),
-    alternateFeedbackIntro: standardFeedbackIntro
-  },
-  {
-    reasonId: "mma_direct_debit",
-    linkLabel: "I want to change to Direct Debit",
-    saveTitle: "You would prefer to contribute using Direct Debit",
-    saveBody:
-      "Unfortunately it's not yet possible to switch to paying by Direct Debit online. We’re working on it. To make this change, please contact our customer services team, who will be happy to help you.",
-    skipFeedback: true
-  },
-  {
-    reasonId: "mma_one_off",
-    linkLabel: "I would rather make a single contribution",
-    saveTitle: "You would prefer to make a single contribution",
-    saveBody: (
-      <>
-        <p>
-          After cancelling your monthly or annual contribution, we will show you
-          how to make a single contribution quickly and easily.
-        </p>
-        <p>{standardSaveBody}</p>
-      </>
-    ),
-    alternateFeedbackIntro: standardFeedbackIntro
-  },
-  {
-    reasonId: "mma_wants_annual_contribution",
-    linkLabel: "I would rather make an annual contribution",
-    saveTitle: "You would prefer to make an annual contribution",
-    saveBody: (
-      <>
-        <p>
-          After cancelling your monthly contribution, we will show you how to
-          set up an annual contribution quickly and easily.
-        </p>
-        <p>{standardSaveBody}</p>
-      </>
-    ),
-    alternateFeedbackIntro: standardFeedbackIntro
-  },
-  {
-    reasonId: "mma_wants_monthly_contribution",
-    linkLabel: "I would rather make a monthly contribution",
-    saveTitle: "You would prefer to make a monthly contribution",
-    saveBody: (
-      <>
-        <p>
-          After cancelling your annual contribution, we will show you how to set
-          up an monthly contribution quickly and easily.
-        </p>
-        <p>{standardSaveBody}</p>
-      </>
-    ),
-    alternateFeedbackIntro: standardFeedbackIntro
-  },
-  {
-    reasonId: "mma_health",
-    linkLabel: "Ill-health",
-    saveTitle:
-      "You would like to cancel your contribution due to health reasons",
-    saveBody:
-      "Your contributions have ensured that our quality journalism remains open for everyone to read and enjoy. Please confirm your cancellation below.",
-    skipFeedback: true
+    reasonId: "mma_issue",
+    linkLabel: "I’ve been experiencing technical or service problems",
+    saveBody: "",
+    alternateFeedbackIntro: inOrderToImproveSubs
   },
   {
     reasonId: "mma_other",
     linkLabel: "None of the above",
-    saveTitle: "",
-    saveBody: standardSaveBody,
-    alternateFeedbackIntro: standardFeedbackIntro
+    saveTitle: "Other",
+    saveBody: "",
+    alternateFeedbackIntro: inOrderToImproveSubs
   }
 ];

--- a/app/client/components/cancel/digipack/digipackCancellationReasons.tsx
+++ b/app/client/components/cancel/digipack/digipackCancellationReasons.tsx
@@ -7,7 +7,7 @@ import {
 } from "../cancellationConstants";
 import { CancellationReason } from "../cancellationReason";
 
-export const contributionsCancellationReasons: CancellationReason[] = [
+export const digipackCancellationReasons: CancellationReason[] = [
   {
     reasonId: "mma_article",
     linkLabel: "As a result of a specific article I read",

--- a/app/client/components/cancel/membership/membershipCancellationReasons.tsx
+++ b/app/client/components/cancel/membership/membershipCancellationReasons.tsx
@@ -1,16 +1,7 @@
 import React from "react";
-import { conf } from "../../../../server/config";
 import palette from "../../../colours";
 import { CancellationReason } from "../cancellationReason";
 import { SwitchToContributionPlaceholder } from "./switchToContributionPlaceholder";
-
-// Webpack doesn't like browser globals
-let domain: string;
-if (typeof window !== "undefined" && window.guardian) {
-  domain = window.guardian.domain;
-} else {
-  domain = conf.DOMAIN;
-}
 
 export const membershipCancellationReasons: CancellationReason[] = [
   {
@@ -75,7 +66,7 @@ export const membershipCancellationReasons: CancellationReason[] = [
     reasonId: "mma_support_another_way",
     linkLabel:
       "I am going to support The Guardian in another way, eg. by subscribing",
-    saveTitle: "Thank you for your your ongoing support.",
+    saveTitle: "Thank you for your ongoing support.",
     saveBody: "Please first confirm your membership cancellation below.",
     alternateCallUsPrefix:
       "If you’re not sure what’s best for you or would like help, please contact us",
@@ -100,17 +91,18 @@ export const membershipCancellationReasons: CancellationReason[] = [
       "We understand that sometimes the news cycle can feel a little overwhelming.",
     saveBody: (
       <>
-        You can
+        You can{" "}
         <a
           css={{
             textDecoration: "underline",
             color: palette.blue.dark,
             ":visited": { color: palette.blue.dark }
           }}
-          href={`https://profile.${domain}/consents`}
+          href="/email-prefs"
         >
-          {` click here to manage your communication preferences.`}
+          click here to manage your communication preferences
         </a>
+        .
         <br />
         <br />
         <span>

--- a/app/client/components/cancel/membership/membershipCancellationReasons.tsx
+++ b/app/client/components/cancel/membership/membershipCancellationReasons.tsx
@@ -30,21 +30,36 @@ export const membershipCancellationReasons: CancellationReason[] = [
         <SwitchToContributionPlaceholder />
       </>
     ),
-    experimentTriggerFlag: "showSwitchToContributionPlaceholder",
-    alternateFeedbackThankYouBody:
-      "One of our customer service specialists will be in touch shortly."
+    experimentTriggerFlag: "showSwitchToContributionPlaceholder"
+    // alternateFeedbackThankYouBody: "One of our customer service specialists will be in touch shortly."
   },
   {
     reasonId: "mma_payment_issue",
     linkLabel: "I didn't expect The Guardian to take another payment",
     saveTitle: "We are sorry that you have been charged again",
-    saveBody:
-      "We’d like to know more details to help resolve the issue. One of our customer service specialists will be more than happy to assist.",
-    alternateFeedbackIntro:
-      "Alternatively please provide some more details in the form below and we’ll get back to you as soon as possible",
-    alternateFeedbackThankYouTitle: "Thank you.",
-    alternateFeedbackThankYouBody:
-      "One of our customer service specialists will be in touch shortly."
+    saveBody: (
+      <>
+        Please leave feedback in the box below. Alternatively you can contact us
+        directly to discuss resolving the issue, by emailing{" "}
+        <a
+          css={{
+            textDecoration: "underline",
+            color: palette.blue.dark,
+            ":visited": { color: palette.blue.dark }
+          }}
+          href="mailto:customer.help@theguardian.com"
+        >
+          customer.help@theguardian.com
+        </a>
+        .
+      </>
+    ),
+    // TODO restore commented after Coronavirus
+    // saveBody: "We’d like to know more details to help resolve the issue. One of our customer service specialists will be more than happy to assist.",
+    // alternateFeedbackIntro: "Alternatively please provide some more details in the form below and we’ll get back to you as soon as possible",
+    alternateFeedbackIntro: ""
+    // alternateFeedbackThankYouTitle: "Thank you.",
+    // alternateFeedbackThankYouBody: "One of our customer service specialists will be in touch shortly."
   },
   {
     reasonId: "mma_editorial",
@@ -52,7 +67,7 @@ export const membershipCancellationReasons: CancellationReason[] = [
     saveTitle:
       "In order to improve our journalism, we’d love to know more about why you are thinking of cancelling",
     saveBody:
-      "If there’s anything we can do differently please take a moment to call our customer services team we would be happy to hear from you."
+      "If there’s anything we can do differently please take a moment to contact our customer services team we would be happy to hear from you."
   },
   {
     reasonId: "mma_benefits",
@@ -67,13 +82,13 @@ export const membershipCancellationReasons: CancellationReason[] = [
     linkLabel:
       "I am going to support The Guardian in another way, eg. by subscribing",
     saveTitle: "Thank you for your ongoing support.",
-    saveBody: "Please first confirm your membership cancellation below.",
+    saveBody: "Please confirm your membership cancellation below.",
     alternateCallUsPrefix:
-      "If you’re not sure what’s best for you or would like help, please contact us",
+      "If you’re not sure what’s best for you or would like help, to contact us",
     alternateFeedbackIntro:
-      "Alternatively please provide some more details in the form below and we’ll get back to you as soon as possible",
-    alternateFeedbackThankYouBody:
-      "One of our customer service specialists will be in touch shortly."
+      "Alternatively if you'd like to give us feedback, please enter in the box the below."
+    // "Alternatively please provide some more details in the form below and we’ll get back to you as soon as possible",
+    // alternateFeedbackThankYouBody:  "One of our customer service specialists will be in touch shortly."
   },
   {
     reasonId: "mma_health",
@@ -110,9 +125,8 @@ export const membershipCancellationReasons: CancellationReason[] = [
           customer services team would be happy to set this up for you.
         </span>
       </>
-    ),
-    alternateFeedbackIntro:
-      "Alternatively please provide some more details in the form below and we’ll get back to you as soon as possible"
+    )
+    // alternateFeedbackIntro: "Alternatively please provide some more details in the form below and we’ll get back to you as soon as possible"
   },
   {
     reasonId: "mma_values",

--- a/app/client/components/cancel/stages/genericSaveAttempt.tsx
+++ b/app/client/components/cancel/stages/genericSaveAttempt.tsx
@@ -204,7 +204,7 @@ class FeedbackFormAndContactUs extends React.Component<
         </p>
         <span>
           {reason.alternateFeedbackThankYouBody ||
-            "The Guardian is dedicated to keeping our independent, investigative journalism open to all. We report on the facts, challenging the powerful and holding them to account. Support from our readers makes what we do possible."}
+            "The Guardian is dedicated to keeping our independent, investigative journalism open to all. We report on the facts, challenging the powerful and holding them to account. Support from our readers makes what we do possible and we appreciate hearing from you to help improve our service."}
         </span>
       </div>
     );
@@ -270,7 +270,7 @@ export const GenericSaveAttempt = (props: GenericSaveAttemptProps) => (
               <PageContainerSection>
                 <h3 id="save_title">
                   {props.productType.cancellation.saveTitlePrefix || ""}
-                  {props.reason.saveTitle}
+                  {props.reason.saveTitle || props.reason.linkLabel}
                 </h3>
                 <GoogleOptimiseAwaitFlagWrapper
                   experimentFlagName={props.reason.experimentTriggerFlag}

--- a/app/client/components/cancel/stages/genericSaveAttempt.tsx
+++ b/app/client/components/cancel/stages/genericSaveAttempt.tsx
@@ -264,7 +264,7 @@ export const GenericSaveAttempt = (props: GenericSaveAttemptProps) => (
         >
           <CaseCreationWrapper
             productDetail={productDetail}
-            sfProduct={props.productType.cancellation.sfProduct}
+            sfCaseProduct={props.productType.cancellation.sfCaseProduct}
           >
             <WizardStep routeableStepProps={props} hideBackButton>
               <PageContainerSection>

--- a/app/client/components/genericErrorScreen.tsx
+++ b/app/client/components/genericErrorScreen.tsx
@@ -24,12 +24,11 @@ export const GenericErrorScreen = ({
     <PageContainer>
       <h2>Oops!</h2>
       <p>
-        Sorry, it seems as if our system has made an error.
+        Sorry, it seems as if our system has encountered an error.
         <br />
-        Please try again in 5 minutes. Alternatively, please call to speak to
-        one of our customer service specialists.
+        Please try again in a few minutes.
       </p>
-      <CallCentreNumbers prefixText="To contact us" />
+      <CallCentreNumbers prefixText="Alternatively, to contact us" />
     </PageContainer>
   );
 };

--- a/app/client/components/holiday/holidayReview.tsx
+++ b/app/client/components/holiday/holidayReview.tsx
@@ -81,11 +81,8 @@ const getRenderCreateOrAmendSuccess = (nav: NavigateFn) => (
 const getRenderCreateOrAmendError = (modificationKeyword: string) => () => (
   <div css={{ textAlign: "left", marginTop: "10px" }}>
     <h2>Sorry, {modificationKeyword} your holiday suspension failed.</h2>
-    <p>
-      To try again please go back and re-enter your dates. Alternatively, please
-      call to speak to one of our customer service specialists.
-    </p>
-    <CallCentreNumbers prefixText="To contact us" />
+    <p>To try again please go back and re-enter your dates.</p>
+    <CallCentreNumbers prefixText="Alternatively, to contact us" />
     <LinkButton to=".." text="Back" left />
   </div>
 );

--- a/app/client/components/payment/update/confirmPaymentUpdate.tsx
+++ b/app/client/components/payment/update/confirmPaymentUpdate.tsx
@@ -139,10 +139,8 @@ class ExecutePaymentUpdate extends React.Component<
         <p>
           To try again please go back and re-enter your new{" "}
           {this.props.newPaymentMethodDetail.friendlyName} details.
-          Alternatively, please call to speak to one of our customer service
-          specialists.
         </p>
-        <CallCentreNumbers prefixText="To contact us" />
+        <CallCentreNumbers prefixText="Alternatively, to contact us" />
       </div>
     );
   };

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -110,6 +110,7 @@ export interface Subscription {
   renewalDate: string;
   cancelledAt: boolean;
   nextPaymentDate: string | null;
+  lastPaymentDate: string | null;
   nextPaymentPrice: number | null;
   paymentMethod?: string;
   stripePublicKeyForCardAddition?: string;

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -6,6 +6,8 @@ import {
 } from "../client/components/cancel/cancellationReason";
 import { contributionsCancellationFlowStart } from "../client/components/cancel/contributions/contributionsCancellationFlowStart";
 import { contributionsCancellationReasons } from "../client/components/cancel/contributions/contributionsCancellationReasons";
+import { digipackCancellationFlowStart } from "../client/components/cancel/digipack/digipackCancellationFlowStart";
+import { digipackCancellationReasons } from "../client/components/cancel/digipack/digipackCancellationReasons";
 import { membershipCancellationFlowStart } from "../client/components/cancel/membership/membershipCancellationFlowStart";
 import { membershipCancellationReasons } from "../client/components/cancel/membership/membershipCancellationReasons";
 import { NavItem, navLinks } from "../client/components/nav";
@@ -40,7 +42,10 @@ export type ProductUrlPart =
   | "digital"
   | "guardianweekly"
   | "subscriptions";
-export type SfProduct = "Membership" | "Contribution";
+export type SfCaseProduct =
+  | "Membership"
+  | "Recurring - Contributions"
+  | "Digital Pack Subscriptions";
 export type ProductTitle = "Membership" | "Contributions" | "Subscriptions";
 export type AllProductsProductTypeFilterString =
   | "Weekly"
@@ -54,7 +59,7 @@ export type AllProductsProductTypeFilterString =
 
 export interface CancellationFlowProperties {
   reasons: CancellationReason[];
-  sfProduct: SfProduct;
+  sfCaseProduct: SfCaseProduct;
   linkOnProductPage?: true;
   startPageBody: JSX.Element;
   saveTitlePrefix?: string;
@@ -302,7 +307,7 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
     includeGuardianInTitles: true,
     cancellation: {
       reasons: membershipCancellationReasons,
-      sfProduct: "Membership",
+      sfCaseProduct: "Membership",
       startPageBody: membershipCancellationFlowStart,
       summaryMainPara: (subscription: Subscription) =>
         subscription.end ? (
@@ -338,7 +343,7 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
     cancellation: {
       linkOnProductPage: true,
       reasons: contributionsCancellationReasons,
-      sfProduct: "Contribution",
+      sfCaseProduct: "Recurring - Contributions",
       startPageBody: contributionsCancellationFlowStart,
       saveTitlePrefix: "Reason: ",
       summaryMainPara: () => "Thank you for your valuable support.",
@@ -479,7 +484,44 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
     getOphanProductType: () => "DIGITAL_SUBSCRIPTION",
     showTrialRemainingIfApplicable: true,
     productPage: "subscriptions",
-    alternateTierValue: "Digital Subscription"
+    alternateTierValue: "Digital Subscription",
+    cancellation: {
+      linkOnProductPage: true,
+      reasons: digipackCancellationReasons,
+      sfCaseProduct: "Digital Pack Subscriptions",
+      startPageBody: digipackCancellationFlowStart,
+      saveTitlePrefix: "Reason: ",
+      summaryMainPara: (subscription: Subscription) =>
+        subscription.end ? (
+          <>
+            You will continue to receive the benefits of your digital
+            subscription until <b>{formatDate(subscription.end)}</b>. You will
+            not be charged again.
+          </>
+        ) : (
+          "Your cancellation is effective immediately."
+        ),
+      summaryReasonSpecificPara: () => undefined,
+      onlyShowSupportSectionIfAlternateText: false,
+      alternateSupportButtonText: (reasonId: OptionalCancellationReasonId) => {
+        switch (reasonId) {
+          case "mma_financial_circumstances":
+          case "mma_value_for_money":
+          case "mma_one_off":
+            return "Make a single contribution";
+          case "mma_wants_annual_contribution":
+            return "Make an annual contribution";
+          case "mma_wants_monthly_contribution":
+            return "Make a monthly contribution";
+          default:
+            return undefined;
+        }
+      },
+      alternateSupportButtonUrlSuffix: (
+        reasonId: OptionalCancellationReasonId
+      ) => "/contribute", // TODO tweak the support url to preselect single/monthly/annual once functionality is available
+      swapFeedbackAndContactUs: true
+    }
   },
   contentSubscriptions: {
     friendlyName: "subscription",

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -1,5 +1,6 @@
 import { Link } from "@reach/router";
 import React from "react";
+import palette from "../client/colours";
 import {
   CancellationReason,
   OptionalCancellationReasonId
@@ -496,30 +497,31 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
           <>
             You will continue to receive the benefits of your digital
             subscription until <b>{formatDate(subscription.end)}</b>. You will
-            not be charged again.
+            not be charged again. If you think you’re owed a refund, please
+            contact us at{" "}
+            <a
+              css={{
+                textDecoration: "underline",
+                color: palette.blue.dark,
+                ":visited": { color: palette.blue.dark }
+              }}
+              href="mailto:customer.help@theguardian.com"
+            >
+              customer.help@theguardian.com
+            </a>
+            .
           </>
         ) : (
           "Your cancellation is effective immediately."
         ),
       summaryReasonSpecificPara: () => undefined,
       onlyShowSupportSectionIfAlternateText: false,
-      alternateSupportButtonText: (reasonId: OptionalCancellationReasonId) => {
-        switch (reasonId) {
-          case "mma_financial_circumstances":
-          case "mma_value_for_money":
-          case "mma_one_off":
-            return "Make a single contribution";
-          case "mma_wants_annual_contribution":
-            return "Make an annual contribution";
-          case "mma_wants_monthly_contribution":
-            return "Make a monthly contribution";
-          default:
-            return undefined;
-        }
-      },
+      alternateSupportButtonText: (reasonId: OptionalCancellationReasonId) =>
+        reasonId === "mma_financial_circumstances" ? "/contribute" : undefined,
       alternateSupportButtonUrlSuffix: (
         reasonId: OptionalCancellationReasonId
-      ) => "/contribute", // TODO tweak the support url to preselect single/monthly/annual once functionality is available
+      ) =>
+        reasonId === "mma_financial_circumstances" ? "/contribute" : undefined,
       swapFeedbackAndContactUs: true
     }
   },


### PR DESCRIPTION
## Must be released after https://github.com/guardian/members-data-api/pull/433

This PR introduces a **self-service cancellation flow for the Digital Subscription**, using the same mechanism as we have for membership & contributions.

This PR also includes some tweaks to existing cancellation flows and some call centre related components, which aim to reduce contact to the call centre during this challenging time (Coronavirus 😷).

### Product Page (before cancellation)
![image](https://user-images.githubusercontent.com/19289579/78035217-b3463980-7360-11ea-915a-428b39495bf5.png)
_notice the `Cancel this digital subscription` link at the bottom_

### Step 1
![image](https://user-images.githubusercontent.com/19289579/78035387-f2748a80-7360-11ea-96ca-d53ac88b6caf.png)
_the `Continue` button becomes enabled when user selects a reason option_

### Step 2 (example: `I am unhappy with Guardian journalism`)
![image](https://user-images.githubusercontent.com/19289579/78035504-1d5ede80-7361-11ea-98f6-6dcf588d4354.png)
_... and after having entered & submitted feedback in the box..._
![image](https://user-images.githubusercontent.com/19289579/78035617-3ff0f780-7361-11ea-9b61-cc7a93780f89.png)

### Step 3
![image](https://user-images.githubusercontent.com/19289579/78035682-54cd8b00-7361-11ea-9533-2e56653b4adb.png)

### Product Page (after cancellation)
![image](https://user-images.githubusercontent.com/19289579/78035733-66af2e00-7361-11ea-8ebf-ebe2d3c42e11.png)
_... or if you don't currently have a recurring contribution, you see the 'thrasher' beneath..._


![image](https://user-images.githubusercontent.com/19289579/78035917-9827f980-7361-11ea-9d02-267663389f7c.png)