### PR TITLE
[cancellation flow] don't bother calling `sf-cancellation-cases-api` on confirmation page if we have no caseId (was bad UX)

### DIFF
--- a/app/client/components/cancel/stages/executeCancellation.tsx
+++ b/app/client/components/cancel/stages/executeCancellation.tsx
@@ -62,7 +62,7 @@ const getCaseUpdateWithCancelOutcomeFunc = (
 const getCancellationSummaryWithReturnButton = (
   productType: ProductTypeWithCancellationFlow,
   productDetail: ProductDetail
-) => (
+) => () => (
   <div>
     {getCancellationSummary(productType)(productDetail)}
     <div css={{ height: "20px" }} />
@@ -71,18 +71,23 @@ const getCancellationSummaryWithReturnButton = (
 );
 
 const getCaseUpdatingCancellationSummary = (
-  caseId: string,
+  caseId: string | "",
   productType: ProductTypeWithCancellationFlow
 ) => (productDetails: ProductDetail[]) => {
   const productDetail = productDetails[0] || { subscription: {} };
-  return (
+  const render = getCancellationSummaryWithReturnButton(
+    productType,
+    productDetail
+  );
+  return caseId ? (
     <CaseUpdateAsyncLoader
       fetch={getCaseUpdateWithCancelOutcomeFunc(caseId, productDetail)}
-      render={() =>
-        getCancellationSummaryWithReturnButton(productType, productDetail)
-      }
+      render={render}
+      errorRender={render} // ignore errors because bad UX for user, and we will hear about it other ways
       loadingMessage="Finalising your cancellation..."
     />
+  ) : (
+    render()
   );
 };
 


### PR DESCRIPTION
No longer bother calling `sf-cancellation-cases-api` on confirmation page (to update the case) if we don't have a `caseId` (because it failed to create one earlier in the flow), because it would obviously always fail and was therefore obscuring the success/failure of their actual cancellation call. 

### Background (https://trello.com/c/SKGQAXDb)
With the increase in failures from `cancellation-sf-cases-api` (because of sync slowness - see https://trello.com/c/oAZ1nzrk/1066-consider-a-queue-for-the-cancellation-cases-mechanism) users will be seeing errors on the confirmation screen even though they in fact do succeed in cancelling their product - bad UX essentially.

Note, this is already handled gracefully on 'Step 2' by not showing the feedback box.