### PR TITLE
fix list of affected subs on delivery address update flow when coming into the URL directly (rather than via subscriptions page)

### DIFF
--- a/app/client/components/delivery/address/deliveryAddressForm.tsx
+++ b/app/client/components/delivery/address/deliveryAddressForm.tsx
@@ -20,7 +20,8 @@ import {
 import {
   createProductDetailFetcher,
   ProductFriendlyName,
-  ProductTypes
+  ProductTypes,
+  ProductTypeWithMapGroupedToSpecific
 } from "../../../../shared/productTypes";
 import { COUNTRIES } from "../../identity/models";
 import { PageHeaderContainer, PageNavAndContentContainer } from "../../page";
@@ -753,6 +754,9 @@ export const DeliveryAddressForm = (props: RouteableStepProps) => {
   return (
     <FlowStartMultipleProductDetailHandler
       {...props}
+      overrideProductTypeForFetch={
+        ProductTypes.contentSubscriptions as ProductTypeWithMapGroupedToSpecific
+      }
       headingPrefix={"View delivery address"}
       hideHeading
       hasLeftNav={{

--- a/app/client/components/flowStartMultipleProductDetailHandler.tsx
+++ b/app/client/components/flowStartMultipleProductDetailHandler.tsx
@@ -16,7 +16,8 @@ import {
 } from "../../shared/productResponse";
 import {
   createProductDetailFetcher,
-  hasProductPageProperties
+  hasProductPageProperties,
+  ProductTypeWithMapGroupedToSpecific
 } from "../../shared/productTypes";
 import palette from "../colours";
 import { minWidth } from "../styles/breakpoints";
@@ -92,7 +93,16 @@ const getProductDetailSelector = (
   selectProductDetail: (productDetail: ProductDetail) => void,
   supportRefererSuffix: string
 ) => (data: MembersDataApiItem[]) => {
-  const sortedList = data.filter(isProduct).sort(sortByJoinDate);
+  const sortedList = data
+    .filter(isProduct)
+    .filter(
+      productDetail =>
+        !props.overrideProductTypeForFetch ||
+        props.overrideProductTypeForFetch.mapGroupedToSpecific(
+          productDetail
+        ) === props.productType
+    )
+    .sort(sortByJoinDate);
   if (sortedList.length > 0) {
     const first = sortedList[0];
     if (sortedList.length === 1 && isProduct(first)) {
@@ -256,6 +266,7 @@ export interface FlowStartMultipleProductDetailHandlerProps
     productDetail: ProductDetail
   ) => React.ReactNode;
   allowCancelledSubscription?: true;
+  overrideProductTypeForFetch?: ProductTypeWithMapGroupedToSpecific;
 }
 
 export interface FlowStartMultipleProductDetailHandlerState {
@@ -324,7 +335,7 @@ export class FlowStartMultipleProductDetailHandler extends React.Component<
         <MembersDatApiAsyncLoader
           fetch={
             createProductDetailFetcher(
-              this.props.productType
+              this.props.overrideProductTypeForFetch || this.props.productType
             ) /*TODO reload on 'back' to page*/
           }
           render={this.preWiredProductDetailSelector}

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -197,6 +197,9 @@ export interface ProductTypeWithDeliveryRecordsProperties extends ProductType {
     records: DeliveryRecordsProperties;
   };
 }
+export interface ProductTypeWithMapGroupedToSpecific extends ProductType {
+  mapGroupedToSpecific: (productDetail: ProductDetail) => ProductType;
+}
 
 export const hasDeliveryRecordsFlow = (
   productType: ProductType


### PR DESCRIPTION
When going to `/delivery/<PRODUCT TYPE>/address` it invokes the `FlowStartMultipleProductDetailHandler` (much like all the other flows) which exists to handle multiple subs of the same type (think of it as an interstitial product picker specifically for the product type in the URL. If the user comes from the product page the specific sub they chose is passed through via 'browser history state' to avoid additional unnecessary calls.

The delivery address update flow needs ALL subs to form the list of 'affected subscriptions', so previously if user had gone directly to say `/delivery/voucher/address` they would have only seen voucher in the list of affected subs (which is incorrect).

This change passes through a product type override for the fetch this does, such that for the delivery address update flow, this thing fetches all subscriptions but then for the list of choices filters out those which don't match the product type in the URL, but still has the detail it need s to display ALL the 'affected subscriptions'.