### PR TITLE
GW cancellation flow

### DIFF
--- a/app/client/components/cancel/cancellationContexts.tsx
+++ b/app/client/components/cancel/cancellationContexts.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { DeliveryRecordDetail } from "../delivery/records/deliveryRecordsApi";
 import { OutstandingHolidayStop } from "../holiday/holidayStopApi";
 import { OptionalCancellationReasonId } from "./cancellationReason";
 
@@ -21,7 +22,8 @@ export const CancellationPolicyContext: React.Context<OptionalCancellationPolicy
 export type OptionalOutstandingCredits =
   | undefined
   | {
-      holidayStops: OutstandingHolidayStop[];
+      holidayStops?: OutstandingHolidayStop[];
+      deliveryCredits?: DeliveryRecordDetail[];
     };
 export const CancellationOutstandingCreditsContext: React.Context<OptionalOutstandingCredits> = React.createContext(
   undefined as OptionalOutstandingCredits

--- a/app/client/components/cancel/cancellationFlowEscalationCheck.tsx
+++ b/app/client/components/cancel/cancellationFlowEscalationCheck.tsx
@@ -15,9 +15,13 @@ export interface VoucherCancellationFlowEscalationCheckProps
 const generateEscalationCausesList = (_: {
   isEffectiveToday: boolean;
   hasOutstandingHolidayStops: boolean;
+  hasOutstandingDeliveryProblemCredits: boolean;
 }) => [
   ...(_.isEffectiveToday ? ["Requested Effective Today"] : []),
-  ...(_.hasOutstandingHolidayStops ? ["Outstanding Holiday Stop Credits"] : [])
+  ...(_.hasOutstandingHolidayStops ? ["Outstanding Holiday Stop Credits"] : []),
+  ...(_.hasOutstandingDeliveryProblemCredits
+    ? ["Outstanding Delivery Problem Credits"]
+    : [])
 ];
 
 export const CancellationFlowEscalationCheck = (
@@ -36,7 +40,12 @@ export const CancellationFlowEscalationCheck = (
                   cancellationPolicy === cancellationEffectiveToday,
                 hasOutstandingHolidayStops:
                   !!outstandingCredits &&
-                  outstandingCredits.holidayStops.length > 0
+                  !!outstandingCredits.holidayStops &&
+                  outstandingCredits.holidayStops.length > 0,
+                hasOutstandingDeliveryProblemCredits:
+                  !!outstandingCredits &&
+                  !!outstandingCredits.deliveryCredits &&
+                  outstandingCredits.deliveryCredits.length > 0
               })
             )
           }

--- a/app/client/components/cancel/cancellationReason.ts
+++ b/app/client/components/cancel/cancellationReason.ts
@@ -13,6 +13,7 @@ export interface CancellationReason {
 }
 
 export type CancellationReasonId =
+  | "mma_autorenew"
   | "mma_covid"
   | "mma_delivery_issue"
   | "mma_redemption_issue"

--- a/app/client/components/cancel/cancellationSummary.tsx
+++ b/app/client/components/cancel/cancellationSummary.tsx
@@ -2,7 +2,11 @@ import { css } from "@emotion/core";
 import { palette } from "@guardian/src-foundations";
 import { Link } from "@reach/router";
 import React from "react";
-import { ProductDetail, Subscription } from "../../../shared/productResponse";
+import {
+  formatDate,
+  ProductDetail,
+  Subscription
+} from "../../../shared/productResponse";
 import {
   hasDeliveryRecordsFlow,
   ProductType
@@ -11,6 +15,7 @@ import { GenericErrorScreen } from "../genericErrorScreen";
 import { PageContainer } from "../page";
 import { ResubscribeThrasher } from "../resubscribeThrasher";
 import { SupportTheGuardianButton } from "../supportTheGuardianButton";
+import { hrefStyle } from "./cancellationConstants";
 import { CancellationReasonContext } from "./cancellationContexts";
 
 const actuallyCancelled = (
@@ -18,15 +23,31 @@ const actuallyCancelled = (
   productDetail: ProductDetail
 ) => {
   const deliveryRecordsLink: string = `/delivery/${productType.urlPart}/records`;
+  const subscription = productDetail.subscription;
   return (
     <>
       <PageContainer>
         <h3>Your {productType.friendlyName} is cancelled.</h3>
         {productType.cancellation && (
           <p>
-            {productType.cancellation.summaryMainPara(
-              productDetail.subscription
-            )}
+            {productType.cancellation?.alternateSummaryMainPara ||
+              (subscription.end ? (
+                <>
+                  You will continue to receive the benefits of your{" "}
+                  {productType.friendlyName} until{" "}
+                  <b>{formatDate(subscription.end)}</b>. You will not be charged
+                  again. If you think you’re owed a refund, please contact us at{" "}
+                  <a
+                    css={hrefStyle}
+                    href="mailto:customer.help@theguardian.com"
+                  >
+                    customer.help@theguardian.com
+                  </a>
+                  .
+                </>
+              ) : (
+                "Your cancellation is effective immediately."
+              ))}
           </p>
         )}
       </PageContainer>

--- a/app/client/components/cancel/contributions/contributionsCancellationFlowStart.tsx
+++ b/app/client/components/cancel/contributions/contributionsCancellationFlowStart.tsx
@@ -11,8 +11,8 @@ export const contributionsCancellationFlowStart = () => (
       Your support means The Guardian can remain editorially independent, free
       from the influence of billionaire owners and politicians. This enables us
       to give a voice to the voiceless, challenge the powerful and hold them to
-      account. Our readers’ support helps us to keep our journalism free of a
-      paywall, so it’s open and accessible to all.
+      account. The support from our readers helps us to keep our journalism free
+      of a paywall, so it’s open and accessible to all.
     </p>
 
     <p>Please could you take a moment to tell us why you want to cancel?</p>

--- a/app/client/components/cancel/digipack/digipackCancellationFlowStart.tsx
+++ b/app/client/components/cancel/digipack/digipackCancellationFlowStart.tsx
@@ -11,8 +11,8 @@ export const digipackCancellationFlowStart = () => (
       Your support means The Guardian can remain editorially independent, free
       from the influence of billionaire owners and politicians. This enables us
       to give a voice to the voiceless, challenge the powerful and hold them to
-      account. Our readers’ support helps us to keep our journalism free of a
-      paywall, so it’s open and accessible to all.
+      account. The support from our readers helps us to keep our journalism free
+      of a paywall, so it’s open and accessible to all.
     </p>
 
     <p>Please could you take a moment to tell us why you want to cancel?</p>

--- a/app/client/components/cancel/gw/gwCancellationFlowStart.tsx
+++ b/app/client/components/cancel/gw/gwCancellationFlowStart.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { trackEvent } from "../../analytics";
+import { PageContainerSection } from "../../page";
+import { hrefStyle } from "../cancellationConstants";
+
+const trackCancellationClickEvent = (eventLabel: string) => () =>
+  trackEvent({
+    eventCategory: "cancellation",
+    eventAction: "click",
+    eventLabel
+  });
+
+export const gwCancellationFlowStart = () => (
+  <PageContainerSection>
+    <h3>
+      We’re sorry to hear you’re thinking of cancelling your Guardian Weekly
+      subscription.
+    </h3>
+
+    <p>
+      Your support means The Guardian can remain editorially independent, free
+      from the influence of billionaire owners and politicians. This enables us
+      to give a voice to the voiceless, challenge the powerful and hold them to
+      account. Our readers’ support helps us to keep our journalism free of a
+      paywall, so it’s open and accessible to all.
+    </p>
+
+    <p>
+      If you’re looking to take a break- it’s possible to take a suspension from
+      your subscription. You can suspend up to 6 issues per year. This pauses
+      delivery and you will receive the money for any suspended issues off your
+      next bill.{" "}
+      <a
+        css={hrefStyle}
+        href="/suspend/guardianweekly"
+        onClick={trackCancellationClickEvent("gw_holiday_suspension")}
+      >
+        Suspend your subscription here
+      </a>
+      .
+    </p>
+
+    <p>Please could you take a moment to tell us why you want to cancel?</p>
+  </PageContainerSection>
+);

--- a/app/client/components/cancel/gw/gwCancellationFlowStart.tsx
+++ b/app/client/components/cancel/gw/gwCancellationFlowStart.tsx
@@ -21,12 +21,12 @@ export const gwCancellationFlowStart = () => (
       Your support means The Guardian can remain editorially independent, free
       from the influence of billionaire owners and politicians. This enables us
       to give a voice to the voiceless, challenge the powerful and hold them to
-      account. Our readers’ support helps us to keep our journalism free of a
-      paywall, so it’s open and accessible to all.
+      account. The support from our readers helps us to keep our journalism free
+      of a paywall, so it’s open and accessible to all.
     </p>
 
     <p>
-      If you’re looking to take a break- it’s possible to take a suspension from
+      If you’re looking to take a break, it’s possible to take a suspension from
       your subscription. You can suspend up to 6 issues per year. This pauses
       delivery and you will receive the money for any suspended issues off your
       next bill.{" "}

--- a/app/client/components/cancel/gw/gwCancellationReasons.tsx
+++ b/app/client/components/cancel/gw/gwCancellationReasons.tsx
@@ -1,0 +1,138 @@
+import React from "react";
+import {
+  hrefStyle,
+  inOrderToImproveSubs,
+  standardAlternateFeedbackIntro
+} from "../cancellationConstants";
+import { CancellationReason } from "../cancellationReason";
+
+export const gwCancellationReasons: CancellationReason[] = [
+  {
+    reasonId: "mma_editorial",
+    linkLabel: "I am unhappy with Guardian journalism",
+    saveBody:
+      "In order to improve our journalism, we’d love to know more about why you are thinking of cancelling.",
+    alternateFeedbackIntro: standardAlternateFeedbackIntro
+  },
+  {
+    reasonId: "mma_financial_circumstances",
+    linkLabel: "A change in my financial circumstances",
+    saveBody: (
+      <>
+        We understand that financial circumstances can change from time to time.
+        <br />
+        Making a smaller contribution to the Guardian can be an inexpensive way
+        of keeping journalism open for everyone to read and enjoy. Once you’ve
+        completed your cancellation below, we hope you’ll consider a small
+        one&nbsp;off or recurring contribution in the future.
+      </>
+    ),
+    escalationSaveBody: "",
+    skipFeedback: true
+  },
+  {
+    reasonId: "mma_support_another_way",
+    linkLabel:
+      "I am going to support The Guardian in another way, eg. by subscribing",
+    saveBody: (
+      <>
+        Thank you for your ongoing support.
+        <br />
+        <br />
+        Once you’ve completed your cancellation below, you can set up a new
+        product via our online checkouts.
+      </>
+    ),
+    escalationSaveBody: "",
+    skipFeedback: true
+  },
+  {
+    reasonId: "mma_health",
+    linkLabel: "Ill-health",
+    saveBody: (
+      <>
+        Thank you for your ongoing support.
+        <br />
+        <br />
+        Your subscription has ensured that our quality journalism remains open
+        for everyone to read and enjoy.
+        <br />
+        Please confirm your cancellation below.
+      </>
+    ),
+    escalationSaveBody: "",
+    skipFeedback: true
+  },
+  {
+    reasonId: "mma_break_from_news",
+    linkLabel: "I am taking a break from news",
+    saveBody: (
+      <>
+        Thank you for your ongoing support.
+        <br />
+        <br />
+        Your subscription has ensured that our quality journalism remains open
+        for everyone to read and enjoy. You can{" "}
+        <a css={hrefStyle} href="/email-prefs">
+          update your email preferences here
+        </a>{" "}
+        if you’d like to reduce communication from us.
+        <br />
+        <br />
+        Alternatively we’d love to know more about what we could do better to
+        help provide inspiring and trustworthy news.
+      </>
+    ),
+    escalationSaveBody:
+      "We’d love to know more about what we could do better to help provide inspiring and trustworthy news."
+  },
+  {
+    reasonId: "mma_values",
+    linkLabel: "I don’t feel that The Guardian values my support",
+    saveBody: "",
+    alternateFeedbackIntro: inOrderToImproveSubs
+  },
+  {
+    reasonId: "mma_time",
+    linkLabel: "I don't have time to use my subscription",
+    saveBody: "",
+    alternateFeedbackIntro: inOrderToImproveSubs
+  },
+  {
+    reasonId: "mma_better_offer",
+    linkLabel: "I've found a better offer with another publisher",
+    saveBody: "",
+    alternateFeedbackIntro: inOrderToImproveSubs
+  },
+  {
+    reasonId: "mma_value_for_money",
+    linkLabel: "I wasn't getting value for money",
+    saveBody: "",
+    alternateFeedbackIntro: inOrderToImproveSubs
+  },
+  {
+    reasonId: "mma_covid",
+    linkLabel: "My subscription use is disrupted due to COVID-19",
+    saveBody: "",
+    alternateFeedbackIntro: inOrderToImproveSubs
+  },
+  {
+    reasonId: "mma_delivery_issue",
+    linkLabel: "I’ve had repeated delivery issues",
+    saveBody: "",
+    alternateFeedbackIntro: inOrderToImproveSubs
+  },
+  {
+    reasonId: "mma_autorenew",
+    linkLabel: "I don’t want an auto-renewing subscription",
+    saveBody: "",
+    skipFeedback: true
+  },
+  {
+    reasonId: "mma_other",
+    linkLabel: "None of the above",
+    saveTitle: "Other",
+    saveBody: "",
+    alternateFeedbackIntro: inOrderToImproveSubs
+  }
+];

--- a/app/client/components/cancel/physicalSubsCancellationFlowWrapper.tsx
+++ b/app/client/components/cancel/physicalSubsCancellationFlowWrapper.tsx
@@ -16,7 +16,7 @@ import {
 } from "./cancellationContexts";
 
 type CombinedOutstandingCreditsResponse = [
-  OutstandingHolidayStopsResponse | undefined,
+  OutstandingHolidayStopsResponse,
   DeliveryRecordsResponse | undefined
 ];
 
@@ -81,7 +81,7 @@ const getContextualRestOfFlowRenderer = (
 ]: CombinedOutstandingCreditsResponse) => (
   <CancellationOutstandingCreditsContext.Provider
     value={{
-      holidayStops: outstandingHolidayStops?.publicationsToRefund,
+      holidayStops: outstandingHolidayStops.publicationsToRefund,
       deliveryCredits: outstandingDeliveryProblemCredits?.results
     }}
   >

--- a/app/client/components/cancel/stages/genericSaveAttempt.tsx
+++ b/app/client/components/cancel/stages/genericSaveAttempt.tsx
@@ -265,7 +265,10 @@ export const GenericSaveAttempt = (props: GenericSaveAttemptProps) => {
     <MembersDataApiItemContext.Consumer>
       {productDetail =>
         isProduct(productDetail) ? (
-          flowWrapper(productDetail)(
+          flowWrapper(
+            productDetail,
+            props.productType
+          )(
             <CancellationReasonContext.Provider
               value={props.path as CancellationReasonId}
             >

--- a/app/client/components/cancel/voucher/voucherCancellationFlowStart.tsx
+++ b/app/client/components/cancel/voucher/voucherCancellationFlowStart.tsx
@@ -31,7 +31,7 @@ export const voucherCancellationFlowStart = (subscription: Subscription) => {
         <a
           css={hrefStyle}
           href="/suspend/voucher"
-          onClick={trackCancellationClickEvent("holiday_suspension")}
+          onClick={trackCancellationClickEvent("voucher_holiday_suspension")}
         >
           online
         </a>

--- a/app/server/routes/api.ts
+++ b/app/server/routes/api.ts
@@ -171,6 +171,14 @@ router.get(
     "subscriptionName"
   )
 );
+router.get(
+  "/delivery-records/:subscriptionName/cancel",
+  deliveryRecordsAPI(
+    "delivery-records/:subscriptionName/cancel",
+    "DELIVERY_RECORDS_CANCELLATION_PREVIEW",
+    "subscriptionName"
+  )
+);
 router.post(
   "/delivery-records/:subscriptionName",
   deliveryRecordsAPI(

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -1,6 +1,5 @@
 import { Link } from "@reach/router";
 import React, { ReactNode } from "react";
-import { hrefStyle } from "../client/components/cancel/cancellationConstants";
 import {
   CancellationReason,
   OptionalCancellationReasonId
@@ -9,6 +8,8 @@ import { contributionsCancellationFlowStart } from "../client/components/cancel/
 import { contributionsCancellationReasons } from "../client/components/cancel/contributions/contributionsCancellationReasons";
 import { digipackCancellationFlowStart } from "../client/components/cancel/digipack/digipackCancellationFlowStart";
 import { digipackCancellationReasons } from "../client/components/cancel/digipack/digipackCancellationReasons";
+import { gwCancellationFlowStart } from "../client/components/cancel/gw/gwCancellationFlowStart";
+import { gwCancellationReasons } from "../client/components/cancel/gw/gwCancellationReasons";
 import { membershipCancellationFlowStart } from "../client/components/cancel/membership/membershipCancellationFlowStart";
 import { membershipCancellationReasons } from "../client/components/cancel/membership/membershipCancellationReasons";
 import {
@@ -24,7 +25,6 @@ import {
 } from "./identity";
 import { OphanProduct } from "./ophanTypes";
 import {
-  formatDate,
   isGift,
   ProductDetail,
   Subscription,
@@ -53,6 +53,7 @@ export type SfCaseProduct =
   | "Membership"
   | "Recurring - Contributions"
   | "Voucher Subscriptions"
+  | "Guardian Weekly"
   | "Digital Pack Subscriptions";
 export type ProductTitle = "Membership" | "Contributions" | "Subscriptions";
 export type AllProductsProductTypeFilterString =
@@ -75,7 +76,7 @@ export interface CancellationFlowProperties {
   startPageBody: (subscription: Subscription) => JSX.Element;
   startPageOfferEffectiveDateOptions?: true;
   hideReasonTitlePrefix?: true;
-  summaryMainPara: (subscription: Subscription) => JSX.Element | string; // TODO should probably have a good default and make this optional
+  alternateSummaryMainPara?: string;
   summaryReasonSpecificPara: (
     reasonId: OptionalCancellationReasonId
   ) => string | undefined;
@@ -326,16 +327,6 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
       sfCaseProduct: "Membership",
       startPageBody: membershipCancellationFlowStart,
       hideReasonTitlePrefix: true,
-      summaryMainPara: (subscription: Subscription) =>
-        subscription.end ? (
-          <>
-            You will continue to receive the benefits of your membership until{" "}
-            <b>{formatDate(subscription.end)}</b>. You will not be charged
-            again.
-          </>
-        ) : (
-          "Your cancellation is effective immediately."
-        ),
       summaryReasonSpecificPara: () => undefined,
       onlyShowSupportSectionIfAlternateText: false,
       alternateSupportButtonText: () => undefined,
@@ -362,7 +353,7 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
       reasons: contributionsCancellationReasons,
       sfCaseProduct: "Recurring - Contributions",
       startPageBody: contributionsCancellationFlowStart,
-      summaryMainPara: () => "Thank you for your valuable support.",
+      alternateSummaryMainPara: "Thank you for your valuable support.",
       summaryReasonSpecificPara: (reasonId: OptionalCancellationReasonId) => {
         switch (reasonId) {
           case "mma_financial_circumstances":
@@ -470,21 +461,6 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
       flowWrapper: physicalSubsCancellationFlowWrapper,
       startPageBody: voucherCancellationFlowStart,
       startPageOfferEffectiveDateOptions: true,
-      summaryMainPara: (subscription: Subscription) =>
-        subscription.end ? (
-          <>
-            You will continue to receive the benefits of your voucher
-            subscription until <b>{formatDate(subscription.end)}</b>. You will
-            not be charged again. If you think you’re owed a refund, please
-            contact us at{" "}
-            <a css={hrefStyle} href="mailto:customer.help@theguardian.com">
-              customer.help@theguardian.com
-            </a>
-            .
-          </>
-        ) : (
-          "Your cancellation is effective immediately."
-        ),
       summaryReasonSpecificPara: () => undefined,
       onlyShowSupportSectionIfAlternateText: false,
       alternateSupportButtonText: (reasonId: OptionalCancellationReasonId) =>
@@ -522,6 +498,23 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
         availableProblemTypes: commonDeliveryProblemTypes
       }
     },
+    cancellation: {
+      linkOnProductPage: true,
+      reasons: gwCancellationReasons,
+      sfCaseProduct: "Guardian Weekly",
+      flowWrapper: physicalSubsCancellationFlowWrapper,
+      startPageBody: gwCancellationFlowStart,
+      startPageOfferEffectiveDateOptions: true,
+      summaryReasonSpecificPara: () => undefined,
+      onlyShowSupportSectionIfAlternateText: false,
+      alternateSupportButtonText: (reasonId: OptionalCancellationReasonId) =>
+        reasonId === "mma_financial_circumstances" ? "/contribute" : undefined,
+      alternateSupportButtonUrlSuffix: (
+        reasonId: OptionalCancellationReasonId
+      ) =>
+        reasonId === "mma_financial_circumstances" ? "/contribute" : undefined,
+      swapFeedbackAndContactUs: true
+    },
     productPage: "subscriptions",
     fulfilmentDateCalculator: {
       productFilenamePart: "Guardian Weekly",
@@ -541,21 +534,6 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
       reasons: digipackCancellationReasons,
       sfCaseProduct: "Digital Pack Subscriptions",
       startPageBody: digipackCancellationFlowStart,
-      summaryMainPara: (subscription: Subscription) =>
-        subscription.end ? (
-          <>
-            You will continue to receive the benefits of your digital
-            subscription until <b>{formatDate(subscription.end)}</b>. You will
-            not be charged again. If you think you’re owed a refund, please
-            contact us at{" "}
-            <a css={hrefStyle} href="mailto:customer.help@theguardian.com">
-              customer.help@theguardian.com
-            </a>
-            .
-          </>
-        ) : (
-          "Your cancellation is effective immediately."
-        ),
       summaryReasonSpecificPara: () => undefined,
       onlyShowSupportSectionIfAlternateText: false,
       alternateSupportButtonText: (reasonId: OptionalCancellationReasonId) =>

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -71,7 +71,8 @@ export interface CancellationFlowProperties {
   sfCaseProduct: SfCaseProduct;
   linkOnProductPage?: true;
   flowWrapper?: (
-    productDetail: ProductDetail
+    productDetail: ProductDetail,
+    productType: ProductType
   ) => (restOfFlow: RestOfCancellationFlow) => ReactNode;
   startPageBody: (subscription: Subscription) => JSX.Element;
   startPageOfferEffectiveDateOptions?: true;


### PR DESCRIPTION
## MUST be released after https://github.com/guardian/support-service-lambdas/pull/643

**Similar to recent voucher cancellation flow (https://github.com/guardian/manage-frontend/pull/384) in terms of the notion of an 'escalation route' etc. The key differences are...**

- of course, different copy and slightly different reasons
- an additional call to the [`/cancel` endpoint of `delivery-records-api`](https://github.com/guardian/support-service-lambdas/pull/643) which wasn't required for voucher. This is done in parallel with the equivalent `holiday-stops-api` call, which required some refactoring of `AsyncLoader` to support multiple `Response`s.