### PR TITLE
[holiday-stops] add support for bulk suspensions

### DIFF
--- a/app/client/components/holiday/existingHolidayStopActions.tsx
+++ b/app/client/components/holiday/existingHolidayStopActions.tsx
@@ -44,6 +44,19 @@ export class ExistingHolidayStopActions extends React.Component<
       );
     }
 
+    if (this.props.bulkSuspensionReason) {
+      return (
+        <span css={{ maxWidth: "225px" }}>
+          Imposed suspension ({this.props.bulkSuspensionReason})
+          <br />
+          <small>
+            This does not count towards your annual limit, but you will still
+            receive credit.
+          </small>
+        </span>
+      );
+    }
+
     if (
       this.props.reloadParent &&
       this.props.mutabilityFlags &&

--- a/app/client/components/holiday/holidayDateChooser.tsx
+++ b/app/client/components/holiday/holidayDateChooser.tsx
@@ -37,6 +37,7 @@ import {
   HolidayStopDetail,
   HolidayStopsResponseContext,
   isHolidayStopsResponse,
+  isNotBulkSuspension,
   isNotWithdrawn,
   IssuesImpactedPerYear,
   PotentialHolidayStopsResponse,
@@ -182,6 +183,7 @@ export class HolidayDateChooser extends React.Component<
                 const combinedIssuesImpactedPerYear = calculateIssuesImpactedPerYear(
                   holidayStopsResponse.existing
                     .filter(isNotWithdrawn)
+                    .filter(isNotBulkSuspension)
                     .filter(_ => _.id !== existingHolidayStopToAmendId)
                     .flatMap(_ => _.publicationsImpacted),
                   renewalDateMoment
@@ -190,6 +192,7 @@ export class HolidayDateChooser extends React.Component<
                 const allIssuesImpactedPerYear = calculateIssuesImpactedPerYear(
                   holidayStopsResponse.existing
                     .filter(isNotWithdrawn)
+                    .filter(isNotBulkSuspension)
                     .flatMap(_ => _.publicationsImpacted),
                   renewalDateMoment
                 );

--- a/app/client/components/holiday/holidayStopApi.ts
+++ b/app/client/components/holiday/holidayStopApi.ts
@@ -33,6 +33,7 @@ export interface RawHolidayStopRequest {
   publicationsImpacted: RawHolidayStopDetail[];
   mutabilityFlags: MutabilityFlags;
   withdrawnTime?: string;
+  bulkSuspensionReason?: string;
 }
 
 export interface RawPotentialHolidayStopDetail {
@@ -59,6 +60,7 @@ export interface MinimalHolidayStopRequest {
   dateRange: DateRange;
   mutabilityFlags?: MutabilityFlags;
   withdrawnDate?: Moment;
+  bulkSuspensionReason?: string;
 }
 
 export interface HolidayStopRequest extends MinimalHolidayStopRequest {
@@ -148,6 +150,9 @@ export function isHolidayStopsResponse(
 
 export const isNotWithdrawn = (holidayStopRequest: HolidayStopRequest) =>
   !holidayStopRequest.withdrawnDate;
+
+export const isNotBulkSuspension = (holidayStopRequest: HolidayStopRequest) =>
+  !holidayStopRequest.bulkSuspensionReason;
 
 const embellishRawHolidayStop = (
   rawHolidayStopRequest: RawHolidayStopRequest

--- a/app/client/components/holiday/holidaysOverview.tsx
+++ b/app/client/components/holiday/holidaysOverview.tsx
@@ -40,6 +40,7 @@ import {
   GetHolidayStopsResponse,
   HolidayStopRequest,
   HolidayStopsResponseContext,
+  isNotBulkSuspension,
   isNotWithdrawn
 } from "./holidayStopApi";
 import { SummaryTable } from "./summaryTable";
@@ -87,6 +88,7 @@ const renderHolidayStopsOverview = (
   const combinedIssuesImpactedPerYear = calculateIssuesImpactedPerYear(
     holidayStopsResponse.existing
       .filter(isNotWithdrawn)
+      .filter(isNotBulkSuspension)
       .flatMap(existing => existing.publicationsImpacted),
     renewalDateMoment
   );

--- a/app/client/components/holiday/summaryTable.tsx
+++ b/app/client/components/holiday/summaryTable.tsx
@@ -187,8 +187,8 @@ export const SummaryTable = (props: SummaryTableProps) => {
       >
         <tbody>
           <tr>
-            <th>Duration</th>
-            <th css={{ minWidth: "250px" }}>
+            <th css={{ minWidth: "225px" }}>Duration</th>
+            <th css={{ minWidth: "225px" }}>
               {props.alternateSuspendedColumnHeading || "Suspended"}
             </th>
             {isOperatingOnNewHolidayStop ? (


### PR DESCRIPTION
## MUST be released after https://github.com/guardian/support-service-lambdas/pull/648

#### Holiday Stop Overview
Note explainer text in place of usual 'actions' and note that the Summary doesn't include these issues in the count/limit.
![image](https://user-images.githubusercontent.com/19289579/80230676-2c783a00-864a-11ea-8b1b-6282a8ed47bd.png)

#### Holiday Stop Creation
Note again that the imposed holiday stop isn't included in the count/limit (57 remaining).
![image](https://user-images.githubusercontent.com/19289579/80230891-75c88980-864a-11ea-848a-d35d36847fa6.png)
