### PR TITLE
escalate cancellation errors (now the underlying error scenario is fixed in members-data-api)

### DIFF
--- a/app/client/components/cancel/stages/executeCancellation.tsx
+++ b/app/client/components/cancel/stages/executeCancellation.tsx
@@ -57,7 +57,9 @@ const getCaseUpdateWithCancelOutcomeFunc = (
           Subject: "Online Cancellation Completed"
         }
       : {
-          Subject: "Online Cancellation Error"
+          Subject: "Online Cancellation Error",
+          Status: "New",
+          Priority: "High"
         }
   );
 


### PR DESCRIPTION
Now the underlying cancellation error scenario is fixed (https://github.com/guardian/members-data-api/pull/437) we should escalate error cases so the CSRs can take a look.