### PR TITLE
custom CloudWatch Metric for every `loggingCode`

### DIFF
--- a/app/server/apiProxy.ts
+++ b/app/server/apiProxy.ts
@@ -7,7 +7,7 @@ import { X_GU_ID_FORWARDED_SCOPE } from "../shared/identity";
 import { MDA_TEST_USER_HEADER } from "../shared/productResponse";
 import { isInAccountOverviewTest } from "./accountOverviewRelease";
 import { conf } from "./config";
-import { log } from "./log";
+import { log, putMetric } from "./log";
 import {
   augmentRedirectURL,
   getCookiesOrEmptyString
@@ -120,6 +120,7 @@ export const proxyApiHandler = (
         ...res.locals.loggingDetail,
         responseBody: safeJsonParse(body)
       });
+      putMetric(res.locals.loggingDetail);
       bodyHandler(res, body);
     })
     .catch(error => {
@@ -128,6 +129,7 @@ export const proxyApiHandler = (
         exception: error || "undefined"
       });
       Raven.captureException(error);
+      putMetric(res.locals.loggingDetail);
       res.status(500).send("Something broke!");
     });
 };

--- a/app/server/awsIntegration.ts
+++ b/app/server/awsIntegration.ts
@@ -24,6 +24,8 @@ export const APIGateway = new AWS.APIGateway(standardAwsConfig);
 
 export const CloudFormation = new AWS.CloudFormation(standardAwsConfig);
 
+export const CloudWatch = new AWS.CloudWatch(standardAwsConfig);
+
 export const handleAwsRelatedError = (message: string, detail?: any) => {
   log.error(message, detail);
   Raven.captureMessage(message);
@@ -75,3 +77,25 @@ export const s3FilePromise = <ConfigInterface>(
       s3PromiseResult
     );
   })();
+
+export interface MetricDimensions {
+  [name: string]: string;
+}
+export const putMetricDataPromise = (
+  metricName: string,
+  dimensions: MetricDimensions
+) =>
+  CloudWatch.putMetricData({
+    Namespace: "manage-frontend",
+    MetricData: [
+      {
+        MetricName: metricName,
+        Dimensions: Object.entries(dimensions).map(([Name, Value]) => ({
+          Name,
+          Value
+        })),
+        Value: 1,
+        Unit: "Count"
+      }
+    ]
+  }).promise();

--- a/app/server/log.ts
+++ b/app/server/log.ts
@@ -1,4 +1,5 @@
 import winston from "winston";
+import { putMetricDataPromise } from "./awsIntegration";
 import { conf, Environments } from "./config";
 
 const location =
@@ -14,3 +15,27 @@ export const log = winston.createLogger({
     new winston.transports.Console({ format: winston.format.simple() })
   ]
 });
+
+export interface MetricLoggingFields {
+  loggingCode: string;
+  isOK: boolean;
+  isInAccountOverviewTest: boolean;
+}
+
+export const putMetric = (fields: MetricLoggingFields) => {
+  const dimensions = {
+    Stage: conf.STAGE,
+    outcome: fields.isOK ? "SUCCESS" : "ERROR",
+    variant: fields.isInAccountOverviewTest ? "ACCOUNT OVERVIEW" : "LEGACY"
+  };
+
+  if (fields.loggingCode) {
+    putMetricDataPromise(fields.loggingCode, dimensions).catch(error =>
+      log.error("Failed to putMetricData", {
+        metricName: fields.loggingCode,
+        dimensions,
+        error
+      })
+    );
+  }
+};

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -162,6 +162,13 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !GetAtt ManageFrontendLogGroup.Arn
+        - PolicyName: PushMetrics
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action: cloudwatch:PutMetricData
+                Resource: "*"
         - PolicyName: ReadPrivateCredentials
           PolicyDocument:
             Statement:


### PR DESCRIPTION
Following https://github.com/guardian/manage-frontend/pull/373 (detailed logging) and https://github.com/guardian/manage-frontend/pull/402 (50% mechanism for Account Overview release) we can now put in place metrics to track all our key events for better visibility/monitoring.

The initial purpose is for extra visibility as we roll out Account Overview, but once that's out to 100% **we can begin using these metrics to set alarm thresholds (e.g. _no card updates in the last hour_).**

It uses the [`CloudWatch.putMetricData`](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CloudWatch.html#putMetricData-property) (part of AWS SDK - already a dependency). The metric namespace is fixed as `manage-frontend` and uses the `loggingCode` (e.g. `MDA_UPDATE_PAYMENT_CARD`) as the metric name, and since we're just counting here the `value` is `1` with the `Unit` as `Count`. We use dimensions to parameterise/segregate the metric...
- `Stage` - `DEV`/`CODE`/`PROD`
- `outcome`  - `SUCCESS`/`ERROR` (based on the `isOK` logging field)
- `variant` - `ACCOUNT OVERVIEW`/`LEGACY` (based on the `isInAccountOverviewTest` logging field)

Here's a (non-exhaustive) example of how they look...
![image](https://user-images.githubusercontent.com/19289579/81718664-ed345080-9473-11ea-98d2-83882337ec73.png)
