### PR TITLE
add missing calls to putMetric for things outside of the proxy

### DIFF
--- a/app/server/stripeSetupIntentsHandler.ts
+++ b/app/server/stripeSetupIntentsHandler.ts
@@ -6,7 +6,7 @@ import {
   StripeSetupIntent
 } from "../shared/stripeSetupIntent";
 import { isInAccountOverviewTest } from "./accountOverviewRelease";
-import { log } from "./log";
+import { log, putMetric } from "./log";
 import {
   recaptchaConfigPromise,
   stripeSetupIntentConfigPromise
@@ -29,10 +29,15 @@ export const stripeSetupIntentHandler = async (
   ).json();
 
   if (!recaptchaResult?.success) {
-    log.error("failed server-side reCaptcha verification", {
+    const loggingDetail = {
       loggingCode: "RECAPTURE_FAILURE",
       isInAccountOverviewTest: isInAccountOverviewTest(response),
       recaptchaResult
+    };
+    log.error("failed server-side reCaptcha verification", loggingDetail);
+    putMetric({
+      ...loggingDetail,
+      isOK: false
     });
     response.status(400).send("reCaptcha missing/failed");
     return;
@@ -102,7 +107,7 @@ export const stripeSetupIntentHandler = async (
             ? log.info
             : log.warning;
           suitableLog("fetching", response.locals.loggingDetail);
-
+          putMetric(response.locals.loggingDetail);
           response.json({
             id: setupIntent.id,
             client_secret: setupIntent.client_secret
@@ -119,5 +124,6 @@ const handleTerminalError = (response: express.Response) => (error: Error) => {
     ...response.locals.loggingDetail,
     exception: error || "undefined"
   });
+  putMetric(response.locals.loggingDetail);
   response.status(500).send();
 };


### PR DESCRIPTION
Following on from https://github.com/guardian/manage-frontend/pull/404 - missed an additional place that doesn't use the proxy but needed metrics.