### PR TITLE
[RB] - remove pesky back tick from the Email and marketting section title

### DIFF
--- a/app/client/components/identity/EmailAndMarketing/index.tsx
+++ b/app/client/components/identity/EmailAndMarketing/index.tsx
@@ -132,7 +132,7 @@ export const EmailAndMarketing = (props: { path?: string }) => {
     <>
       <PageHeaderContainer
         selectedNavItem={navLinks.emailPrefs}
-        title="Emails &amp;` marketing"
+        title="Emails &amp; marketing"
       />
       <PageNavAndContentContainer selectedNavItem={navLinks.emailPrefs}>
         {state.error ? errorMessage : null}


### PR DESCRIPTION
![ronseal](https://user-images.githubusercontent.com/2510683/82894583-b3227e80-9f4a-11ea-9487-f12e70dd88e8.jpg)
 "It does exactly what is says on the tin"