### PR TITLE
fix problem with logging of non-OK responses

### DIFF
--- a/app/server/apiProxy.ts
+++ b/app/server/apiProxy.ts
@@ -113,9 +113,7 @@ export const proxyApiHandler = (
       return intermediateResponse.text();
     })
     .then(body => {
-      const suitableLog = res.locals.loggingDetail.isOK
-        ? log.info
-        : log.warning;
+      const suitableLog = res.locals.loggingDetail.isOK ? log.info : log.warn;
       suitableLog("proxying", {
         ...res.locals.loggingDetail,
         responseBody: safeJsonParse(body)
@@ -126,7 +124,7 @@ export const proxyApiHandler = (
     .catch(error => {
       log.error("ERROR proxying", {
         ...res.locals.loggingDetail,
-        exception: error || "undefined"
+        exception: error ? error.toString() : "undefined"
       });
       Raven.captureException(error);
       putMetric(res.locals.loggingDetail);


### PR DESCRIPTION
Caught by server-side Sentry errors...
![image](https://user-images.githubusercontent.com/19289579/83058133-ca975f80-a04f-11ea-9d57-7a2c8019da4f.png)

Really pernicious problem, caused by using `log.warning` rather than `log.warn`  - introduced in https://github.com/guardian/manage-frontend/pull/373 - the exception was fortunately being caught by the `.catch` on the promise, and so no real difference for users (since this only affected non-OK responses anyway).
![image](https://user-images.githubusercontent.com/19289579/83057378-be5ed280-a04e-11ea-92e4-2f66c2d742a5.png)

This also explains why, in the logs, we had no visibility on the `responseBody` for all non-OK responses.