### PR TITLE
GW renewal link

### DIFF
--- a/app/client/components/accountoverview/manageSubscription.tsx
+++ b/app/client/components/accountoverview/manageSubscription.tsx
@@ -19,6 +19,7 @@ import {
 } from "../../../shared/productTypes";
 import { maxWidth } from "../../styles/breakpoints";
 import { LinkButton } from "../buttons";
+import { CallCentreEmailAndNumbers } from "../callCenterEmailAndNumbers";
 import { DeliveryAddressDisplay } from "../delivery/address/deliveryAddressDisplay";
 import { FlowStartMultipleProductDetailHandler } from "../flowStartMultipleProductDetailHandler";
 import { navLinks } from "../nav";
@@ -28,6 +29,7 @@ import { DirectDebitDisplay } from "../payment/directDebitDisplay";
 import { PayPalDisplay } from "../payment/paypalDisplay";
 import { ProblemAlert } from "../ProblemAlert";
 import { ProductDescriptionListTable } from "../productDescriptionListTable";
+import { SupportTheGuardianButton } from "../supportTheGuardianButton";
 import { ErrorIcon } from "../svgs/errorIcon";
 import { RouteableStepProps } from "../wizardRouterAdapter";
 
@@ -350,6 +352,35 @@ export const ManageSubscription = (props: RouteableStepProps) => {
                       text="Manage suspensions"
                       to={`/suspend/${productType.urlPart}`}
                       state={productDetail}
+                    />
+                  </>
+                )}
+              {!productDetail.subscription.autoRenew &&
+                productType.renewalMetadata && (
+                  <>
+                    <h2
+                      css={css`
+                        ${subHeadingCss}
+                      `}
+                    >
+                      Renewal
+                    </h2>
+                    <p>
+                      To renew your one-off {productType.friendlyName}, please
+                      contact us.
+                    </p>
+                    <CallCentreEmailAndNumbers />
+                    <p>
+                      Alternatively, if you would prefer to start a recurring{" "}
+                      {productType.friendlyName} you can do so by clicking the
+                      button below.
+                    </p>
+                    <SupportTheGuardianButton
+                      {...productType.renewalMetadata}
+                      fontWeight="bold"
+                      textColour={palette.neutral[100]}
+                      colour={palette.brand[400]}
+                      notPrimary
                     />
                   </>
                 )}

--- a/app/client/components/accountoverview/manageSubscription.tsx
+++ b/app/client/components/accountoverview/manageSubscription.tsx
@@ -372,8 +372,8 @@ export const ManageSubscription = (props: RouteableStepProps) => {
                     <CallCentreEmailAndNumbers />
                     <p>
                       Alternatively, if you would prefer to start a recurring{" "}
-                      {productType.friendlyName} you can do so by clicking the
-                      button below.
+                      {productType.friendlyName} you can explore payment options
+                      and subscribe online by clicking the button below.
                     </p>
                     <SupportTheGuardianButton
                       {...productType.renewalMetadata}

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -241,9 +241,6 @@ const getProductDetailRenderer = (
   const productType = originalProductType.mapGroupedToSpecific
     ? originalProductType.mapGroupedToSpecific(productDetail)
     : originalProductType;
-  const alternateManagementCtaLabel =
-    productType.alternateManagementCtaLabel &&
-    productType.alternateManagementCtaLabel(productDetail);
   const subscription = productDetail.subscription;
   const mainPlan = getMainPlan(subscription);
   return (
@@ -437,23 +434,13 @@ const getProductDetailRenderer = (
                 }
               />
             )}
-            {productType.alternateManagementUrl &&
-              alternateManagementCtaLabel &&
-              (productDetailList.length > 1 ? (
+            {productType.renewalMetadata &&
+              !productDetail.subscription.autoRenew && (
                 <div css={{ fontWeight: "bold" }}>
-                  To {alternateManagementCtaLabel}, please <InlineContactUs />
+                  To renew your one-off {productType.friendlyName}, please{" "}
+                  <InlineContactUs />
                 </div>
-              ) : (
-                <a href={productType.alternateManagementUrl}>
-                  <Button
-                    text={
-                      alternateManagementCtaLabel.substr(0, 1).toUpperCase() +
-                      alternateManagementCtaLabel.substr(1)
-                    }
-                    right
-                  />
-                </a>
-              ))}
+              )}
             {productType.cancellation &&
               productType.cancellation.linkOnProductPage && (
                 <Link

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -22,6 +22,7 @@ import {
 import { voucherCancellationFlowStart } from "../client/components/cancel/voucher/voucherCancellationFlowStart";
 import { voucherCancellationReasons } from "../client/components/cancel/voucher/voucherCancellationReasons";
 import { NavItem, navLinks } from "../client/components/nav";
+import { SupportTheGuardianButtonProps } from "../client/components/supportTheGuardianButton";
 import { RouteableStepProps } from "../client/components/wizardRouterAdapter";
 import {
   getScopeFromRequestPathOrEmptyString,
@@ -161,10 +162,7 @@ export interface ProductType {
   ) => OphanProduct | undefined;
   includeGuardianInTitles?: true;
   alternateTierValue?: string;
-  alternateManagementUrl?: string;
-  alternateManagementCtaLabel?: (
-    productDetail: ProductDetail
-  ) => string | undefined;
+  renewalMetadata?: SupportTheGuardianButtonProps;
   noProductSupportUrlSuffix?: string;
   productPage?: ProductPageProperties | ProductUrlPart; // undefined 'productPage' means no product page
   cancellation?: CancellationFlowProperties; // undefined 'cancellation' means no cancellation flow
@@ -266,12 +264,6 @@ export const allProductsDetailFetcher = () =>
       )
     }
   });
-
-const domainSpecificSubsManageURL = `https://subscribe.${
-  typeof window !== "undefined" && window.guardian && window.guardian.domain
-    ? window.guardian.domain
-    : "theguardian.com"
-}/manage`;
 
 const getNoProductInTabCopy = (links: NavItem[]) => {
   return (
@@ -498,12 +490,12 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
     allProductsProductTypeFilterString: "Weekly",
     urlPart: "guardianweekly",
     getOphanProductType: () => "PRINT_SUBSCRIPTION", // TODO create a GUARDIAN_WEEKLY Product in Ophan data model
+    renewalMetadata: {
+      alternateButtonText: "Subscribe here",
+      urlSuffix: "subscribe/weekly",
+      supportReferer: "gw_renewal"
+    },
     alternateTierValue: "Guardian Weekly",
-    alternateManagementUrl: domainSpecificSubsManageURL,
-    alternateManagementCtaLabel: (productDetail: ProductDetail) =>
-      productDetail.subscription.autoRenew
-        ? undefined
-        : "renew your one-off Guardian Weekly subscription",
     holidayStops: {
       issueKeyword: "issue"
     },


### PR DESCRIPTION
Adds renewal section to manage subscription page if not auto renewing and if enabled in productTypes (currently only Guardian weekly).
![Screenshot 2020-06-03 at 12 27 34](https://user-images.githubusercontent.com/2510683/83631767-f2c61780-a595-11ea-9b96-3590a1c3d270.png)

## NOTE by @twrichards 
The old behaviour for GW renewal was to link to the `/manage` section of the old subs platform, if (and only if) the customer had a single subscription (because the old subs platform could only display one at once) or otherwise display instructions to contact the call centre. The manual renewals mechanism in the old platform...

- is super ugly
- credit card appears to be broken
- was the only outstanding link from manage.theguardian.com to that platform

... plus detecting multiple subs when within 'manage subscription' page of the newer style design of MMA would be nasty. SO, **I decided to kill that last linkage to the old platform** and always prompt customers to contact the call centre if they want to manually renew (i.e. not to recurring) but also provide a link to take out a new recurring subscription by linking to `support.theguardian.com/subscribe/weekly`