### PR TITLE
[RB TR] - Account overview product card refactor

### DIFF
--- a/app/client/components/accountoverview/accountOverview.tsx
+++ b/app/client/components/accountoverview/accountOverview.tsx
@@ -22,8 +22,8 @@ import {
   SupportTheGuardianButton,
   SupportTheGuardianButtonProps
 } from "../supportTheGuardianButton";
+import { AccountOverviewCard } from "./accountOverviewCard";
 import { EmptyAccountOverview } from "./emptyAccountOverview";
-import { Product } from "./product";
 
 const AccountOverviewRenderer = (apiResponse: MembersDataApiItem[]) => {
   const productDetailList = apiResponse
@@ -92,10 +92,9 @@ const AccountOverviewRenderer = (apiResponse: MembersDataApiItem[]) => {
             My subscriptions
           </h2>
           {subscriptionData.map(item => (
-            <Product
+            <AccountOverviewCard
               key={item.productDetail.subscription.subscriptionId}
               {...item}
-              productCategory="subscription"
             />
           ))}
           {subscriptionData.some(item =>
@@ -126,10 +125,9 @@ const AccountOverviewRenderer = (apiResponse: MembersDataApiItem[]) => {
             My membership
           </h2>
           {membershipData.map(item => (
-            <Product
+            <AccountOverviewCard
               key={item.productDetail.subscription.subscriptionId}
               {...item}
-              productCategory="membership"
             />
           ))}
           {membershipData.some(item =>
@@ -159,10 +157,9 @@ const AccountOverviewRenderer = (apiResponse: MembersDataApiItem[]) => {
           </h2>
           {contributorData.map(item => {
             return (
-              <Product
+              <AccountOverviewCard
                 key={item.productDetail.subscription.subscriptionId}
                 {...item}
-                productCategory="contribution"
               />
             );
           })}

--- a/app/client/components/accountoverview/manageMembership.tsx
+++ b/app/client/components/accountoverview/manageMembership.tsx
@@ -53,9 +53,6 @@ export const ManageMembership = (props: RouteableStepProps) => {
         routeableStepProps: RouteableStepProps,
         productDetail: ProductDetail
       ) => {
-        const membershipTier =
-          props.productType.alternateTierValue || productDetail.tier;
-
         const mainPlan = getMainPlan(productDetail.subscription);
 
         const hasCancellationPending = productDetail.subscription.cancelledAt;
@@ -125,7 +122,7 @@ export const ManageMembership = (props: RouteableStepProps) => {
                 content={[
                   {
                     title: "Membership tier",
-                    value: membershipTier
+                    value: productDetail.tier
                   },
                   {
                     title: "Start date",

--- a/app/client/components/accountoverview/manageSubscription.tsx
+++ b/app/client/components/accountoverview/manageSubscription.tsx
@@ -69,8 +69,6 @@ export const ManageSubscription = (props: RouteableStepProps) => {
         const productType =
           ProductTypes.subscriptions.mapGroupedToSpecific?.(productDetail) ||
           props.productType;
-        const productName =
-          productType.alternateTierValue || productDetail.tier;
 
         const hasCancellationPending = productDetail.subscription.cancelledAt;
 
@@ -112,10 +110,7 @@ export const ManageSubscription = (props: RouteableStepProps) => {
                   ${subHeadingCss}
                 `}
               >
-                {productName}
-                {mainPlan.name &&
-                  !isSixForSix(mainPlan.name) &&
-                  ` - ${mainPlan.name}`}
+                {productType.productTitle(mainPlan)}
               </h2>
               {hasCancellationPending && (
                 <p

--- a/app/client/components/productPage.tsx
+++ b/app/client/components/productPage.tsx
@@ -267,8 +267,7 @@ const getProductDetailRenderer = (
                 </h2>
               ) : (
                 <h2>
-                  {productType.alternateTierValue || productDetail.tier}
-                  {mainPlan.name && <i>&nbsp;({mainPlan.name})</i>}
+                  {productType.productTitle(mainPlan)}
                   {isGift(subscription) && giftFlag}
                 </h2>
               )}
@@ -331,8 +330,7 @@ const getProductDetailRenderer = (
                       {productPageProperties.tierChangeable ? (
                         <div css={wrappingContainerCSS}>
                           <div css={{ marginRight: "15px" }}>
-                            {productType.alternateTierValue ||
-                              productDetail.tier}
+                            {productDetail.tier}
                           </div>
                           {/*TODO add a !=="Patron" condition around the Change tier button once we have a direct journey to cancellation*/}
                           <a
@@ -346,7 +344,7 @@ const getProductDetailRenderer = (
                           </a>
                         </div>
                       ) : (
-                        productType.alternateTierValue || productDetail.tier
+                        productType.productTitle(mainPlan)
                       )}
                       {mainPlan.name && <i>&nbsp;({mainPlan.name})</i>}
                       {isGift(subscription) && giftFlag}

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -79,7 +79,7 @@ export const augmentInterval = (interval: string) =>
   interval === "6 weeks" ? "one-off" : `${interval}ly`;
 
 export const isSixForSix = (planName: string | null) =>
-  planName && planName.indexOf("6 for 6") !== -1;
+  !!planName && planName.indexOf("6 for 6") !== -1;
 
 export interface PaidSubscriptionPlan
   extends SubscriptionPlan,

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -503,7 +503,7 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
     productPage: "subscriptions"
   },
   guardianweekly: {
-    productTitle: calculateProductTitle("Guardian Weekly"),
+    productTitle: () => "Guardian Weekly",
     friendlyName: "Guardian Weekly subscription",
     shortFriendlyName: "Guardian Weekly",
     allProductsProductTypeFilterString: "Weekly",

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -33,6 +33,7 @@ import {
   isGift,
   ProductDetail,
   Subscription,
+  SubscriptionPlan,
   SubscriptionWithDeliveryAddress
 } from "./productResponse";
 
@@ -152,6 +153,7 @@ export interface DeliveryProperties {
 }
 
 export interface ProductType {
+  productTitle: (mainPlan?: SubscriptionPlan) => string;
   friendlyName: ProductFriendlyName;
   shortFriendlyName?: string;
   allProductsProductTypeFilterString: AllProductsProductTypeFilterString;
@@ -160,8 +162,9 @@ export interface ProductType {
   getOphanProductType?: (
     productDetail: ProductDetail
   ) => OphanProduct | undefined;
+  shouldRevealSubscriptionId?: boolean;
+  tierLabel?: string;
   includeGuardianInTitles?: true;
-  alternateTierValue?: string;
   renewalMetadata?: SupportTheGuardianButtonProps;
   noProductSupportUrlSuffix?: string;
   productPage?: ProductPageProperties | ProductUrlPart; // undefined 'productPage' means no product page
@@ -175,6 +178,8 @@ export interface ProductType {
     productFilenamePart: string;
     explicitSingleDayOfWeek?: string;
   };
+  cancelledCopy?: string;
+  shouldShowJoinDateNotStartDate?: true;
 }
 
 export interface ProductTypeWithCancellationFlow extends ProductType {
@@ -294,6 +299,10 @@ const showDeliveryAddressCheck = (
 ): subscription is SubscriptionWithDeliveryAddress =>
   !isGift(subscription) && !!subscription.deliveryAddress;
 
+const calculateProductTitle = (baseProductTtile: string) => (
+  mainPlan?: SubscriptionPlan
+) => baseProductTtile + (mainPlan?.name ? ` - ${mainPlan.name}` : "");
+
 export type ProductTypeKeys =
   | "membership"
   | "contributions"
@@ -306,6 +315,7 @@ export type ProductTypeKeys =
 
 export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
   membership: {
+    productTitle: () => "Guardian membership",
     friendlyName: "membership",
     allProductsProductTypeFilterString: "Membership",
     urlPart: "membership",
@@ -341,9 +351,14 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
       onlyShowSupportSectionIfAlternateText: false,
       alternateSupportButtonText: () => undefined,
       alternateSupportButtonUrlSuffix: () => undefined
-    }
+    },
+    cancelledCopy:
+      "Your membership has been cancelled. You will continue to receive the benefits of your membership until",
+    tierLabel: "Membership tier",
+    shouldShowJoinDateNotStartDate: true
   },
   contributions: {
+    productTitle: () => "Recurring contribution",
     friendlyName: "recurring contribution",
     allProductsProductTypeFilterString: "Contribution",
     urlPart: "contributions",
@@ -400,8 +415,9 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
       swapFeedbackAndContactUs: true
     }
   },
+  // FIXME: DEPRECATED: once Braze templates have been updated to use voucher/homedelivery, then replace with redirect to /subscriptions for anything with 'paper' in the URL
   newspaper: {
-    // FIXME: DEPRECATED: once Braze templates have been updated to use voucher/homedelivery, then replace with redirect to /subscriptions for anything with 'paper' in the URL
+    productTitle: calculateProductTitle("Newspaper subscription"),
     friendlyName: "newspaper subscription",
     allProductsProductTypeFilterString: "Paper",
     urlPart: "paper",
@@ -414,6 +430,7 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
     productPage: "subscriptions"
   },
   homedelivery: {
+    productTitle: calculateProductTitle("Newspaper Delivery"),
     friendlyName: "home delivery subscription",
     shortFriendlyName: "home delivery",
     allProductsProductTypeFilterString: "HomeDelivery",
@@ -443,6 +460,7 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
     }
   },
   voucher: {
+    productTitle: calculateProductTitle("Newspaper Voucher"),
     friendlyName: "newspaper voucher subscription",
     allProductsProductTypeFilterString: "Voucher",
     urlPart: "voucher",
@@ -485,6 +503,7 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
     productPage: "subscriptions"
   },
   guardianweekly: {
+    productTitle: calculateProductTitle("Guardian Weekly"),
     friendlyName: "Guardian Weekly subscription",
     shortFriendlyName: "Guardian Weekly",
     allProductsProductTypeFilterString: "Weekly",
@@ -495,7 +514,6 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
       urlSuffix: "subscribe/weekly",
       supportReferer: "gw_renewal"
     },
-    alternateTierValue: "Guardian Weekly",
     holidayStops: {
       issueKeyword: "issue"
     },
@@ -533,13 +551,13 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
     }
   },
   digipack: {
+    productTitle: () => "Digital Subscription",
     friendlyName: "digital subscription",
     allProductsProductTypeFilterString: "Digipack",
     urlPart: "digital",
     legacyUrlPart: "digitalpack",
     getOphanProductType: () => "DIGITAL_SUBSCRIPTION",
     showTrialRemainingIfApplicable: true,
-    alternateTierValue: "Digital Subscription",
     cancellation: {
       linkOnProductPage: true,
       reasons: digipackCancellationReasons,
@@ -558,6 +576,7 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
     productPage: "subscriptions"
   },
   subscriptions: {
+    productTitle: () => "", // this is just a top level product type
     friendlyName: "subscription",
     allProductsProductTypeFilterString: "ContentSubscription",
     urlPart: "subscriptions",
@@ -583,6 +602,9 @@ export const ProductTypes: { [productKey in ProductTypeKeys]: ProductType } = {
         return ProductTypes.guardianweekly;
       }
       return ProductTypes.subscriptions; // This should never happen!
-    }
+    },
+    cancelledCopy:
+      "Your subscription has been cancelled. You are able to access your subscription until",
+    shouldRevealSubscriptionId: true
   }
 };


### PR DESCRIPTION
## What does this change?
rename product.tsx to accountOverviewCard.tsx. Move away from string comparisons for branching logic and use properties in productType object (config)

## TODO

- [ ] replace this TODO section with a link to Wiki page about `ProductTypes` once written