### PR TITLE
[RB] - add gift icon to manage sunscription header if applicable

### DIFF
--- a/app/client/components/accountoverview/manageSubscription.tsx
+++ b/app/client/components/accountoverview/manageSubscription.tsx
@@ -8,6 +8,7 @@ import {
   augmentInterval,
   getFuturePlanIfVisible,
   getMainPlan,
+  isGift,
   isPaidSubscriptionPlan,
   isSixForSix,
   ProductDetail
@@ -31,18 +32,25 @@ import { ProblemAlert } from "../ProblemAlert";
 import { ProductDescriptionListTable } from "../productDescriptionListTable";
 import { SupportTheGuardianButton } from "../supportTheGuardianButton";
 import { ErrorIcon } from "../svgs/errorIcon";
+import { GiftIcon } from "../svgs/giftIcon";
 import { RouteableStepProps } from "../wizardRouterAdapter";
 
 export const ManageSubscription = (props: RouteableStepProps) => {
-  const subHeadingCss = `
-    border-top: 1px solid ${palette.neutral["86"]};
+  const subHeadingTitleCss = `
     ${headline.small()};
     font-weight: bold;
-    margin-top: 50px;
     ${maxWidth.tablet} {
       font-size: 1.25rem;
       line-height: 1.6;
     };
+  `;
+  const subHeadingBorderTopCss = `
+    border-top: 1px solid ${palette.neutral["86"]};
+    margin-top: 50px;
+  `;
+  const subHeadingCss = `
+    ${subHeadingBorderTopCss}
+    ${subHeadingTitleCss}
   `;
 
   return (
@@ -107,16 +115,35 @@ export const ManageSubscription = (props: RouteableStepProps) => {
                   `}
                 />
               )}
-              <h2
+              <div
                 css={css`
-                  ${subHeadingCss}
+                  ${subHeadingBorderTopCss}
+                  display: flex;
+                  align-items: start;
+                  justify-content: space-between;
                 `}
               >
-                {productName}
-                {mainPlan.name &&
-                  !isSixForSix(mainPlan.name) &&
-                  ` - ${mainPlan.name}`}
-              </h2>
+                <h2
+                  css={css`
+                    ${subHeadingTitleCss}
+                    margin: 0;
+                  `}
+                >
+                  {productName}
+                  {mainPlan.name &&
+                    !isSixForSix(mainPlan.name) &&
+                    ` - ${mainPlan.name}`}
+                </h2>
+                {isGift(productDetail.subscription) && (
+                  <i
+                    css={css`
+                      margin: 4px 0 0 ${space[3]}px;
+                    `}
+                  >
+                    <GiftIcon alignArrowToThisSide={"left"} />
+                  </i>
+                )}
+              </div>
               {hasCancellationPending && (
                 <p
                   css={css`

--- a/app/client/components/accountoverview/manageSubscription.tsx
+++ b/app/client/components/accountoverview/manageSubscription.tsx
@@ -128,9 +128,6 @@ export const ManageSubscription = (props: RouteableStepProps) => {
                   `}
                 >
                   {productType.productTitle(mainPlan)}
-                  {mainPlan.name &&
-                    !isSixForSix(mainPlan.name) &&
-                    ` - ${mainPlan.name}`}
                 </h2>
                 {isGift(productDetail.subscription) && (
                   <i


### PR DESCRIPTION
## What does this change?
Adds the gift icon to the right hand side of the product title in the manage subscription page if the subscription is a gift.

## Images
Desktop breakpoint             |  Mobile breakpoint (320px)
:-------------------------:|:-------------------------:
![Screenshot_2020-06-03 My Account The Guardian(4)](https://user-images.githubusercontent.com/2510683/83685540-be2b7d80-a5e0-11ea-90ab-b5364d2a1d5f.png)  |  ![](https://user-images.githubusercontent.com/2510683/83685444-963c1a00-a5e0-11ea-8247-52f95bcd4679.png)

