### PR TITLE
[RB] - page header title space

### DIFF
--- a/app/client/components/page.tsx
+++ b/app/client/components/page.tsx
@@ -251,31 +251,37 @@ export const PageHeaderContainer: React.SFC<PageHeaderContainerProps> = (
 
             ${props.breadcrumbs
               ? `
-            ${gridItemPlacementv2(2, 1, 1, 3)};
-            ${minWidth.tablet} {
-              ${gridItemPlacementv2(2, 1, 1, 10)};
-            };
-            ${minWidth.desktop} {
-              ${gridItemPlacementv2(2, 1, 5, 8)};
-              font-size: 2.625rem;
-            };
-            ${minWidth.wide} {
-              ${gridItemPlacementv2(2, 1, 6, 10)};
-            };  
-          `
+                ${gridItemPlacementv2(2, 1, 1, 4)};
+                ${minWidth.mobileMedium} {
+                  ${gridItemPlacementv2(2, 1, 1, 3)};
+                };
+                ${minWidth.tablet} {
+                  ${gridItemPlacementv2(2, 1, 1, 10)};
+                };
+                ${minWidth.desktop} {
+                  ${gridItemPlacementv2(2, 1, 5, 8)};
+                  font-size: 2.625rem;
+                };
+                ${minWidth.wide} {
+                  ${gridItemPlacementv2(2, 1, 6, 10)};
+                };  
+              `
               : `
-            ${gridItemPlacementv2(1, 1, 1, 3)};
-            ${minWidth.tablet} {
-              ${gridItemPlacementv2(1, 1, 1, 10)};
-            };
-            ${minWidth.desktop} {
-              ${gridItemPlacementv2(1, 1, 5, 8)};
-              font-size: 2.625rem;
-            };
-            ${minWidth.wide} {
-              ${gridItemPlacementv2(1, 1, 6, 10)};
-            };
-          `}
+                ${gridItemPlacementv2(1, 1, 1, 4)};
+                ${minWidth.mobileMedium} {
+                  ${gridItemPlacementv2(1, 1, 1, 3)};
+                };
+                ${minWidth.tablet} {
+                  ${gridItemPlacementv2(1, 1, 1, 10)};
+                };
+                ${minWidth.desktop} {
+                  ${gridItemPlacementv2(1, 1, 5, 8)};
+                  font-size: 2.625rem;
+                };
+                ${minWidth.wide} {
+                  ${gridItemPlacementv2(1, 1, 6, 10)};
+                };
+              `}
           `}
         >
           {props.title}


### PR DESCRIPTION

## What does this change?
Make page header title holder wider on small mobile breakpoints (320 - 374px) to stop title from wrapping


## Images
![Screenshot_2020-06-03 My Account The Guardian(5)](https://user-images.githubusercontent.com/2510683/83687566-d781f900-a5e3-11ea-9662-46a6ddf7248f.png)