### PR TITLE
[RB TR] - fix direct debit svg height on chrome

### DIFF
--- a/app/client/components/payment/directDebitLogo.tsx
+++ b/app/client/components/payment/directDebitLogo.tsx
@@ -12,7 +12,6 @@ export const DirectDebitLogo = (props: DirectDebitLogoProps) => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 603.094 195.188"
     width="65"
-    height="auto"
     css={css`
       ${props.additionalCss}
     `}


### PR DESCRIPTION
Remove height auto attribute from direct debit logo (not needed and looks whack on chrome

## Before
![image](https://user-images.githubusercontent.com/2510683/83867669-b6272700-a721-11ea-8647-8e2c828630e7.png)


## After
![Screenshot_2020-06-05 My Account The Guardian](https://user-images.githubusercontent.com/2510683/83867614-9abc1c00-a721-11ea-8bf5-4069284722f5.png)

