### PR TITLE
[RB] - styling housekeeping

### DIFF
--- a/app/client/components/page.tsx
+++ b/app/client/components/page.tsx
@@ -240,7 +240,7 @@ export const PageHeaderContainer: React.SFC<PageHeaderContainerProps> = (
             color: ${palette.neutral["100"]};
             ${headline.medium({ fontWeight: "bold" })};
             font-size: 1.5rem;
-            padding: 0 8px 8px 8px;
+            padding: 8px;
             border: 1px solid ${palette.brand.pastel};
             border-bottom: 0;
             ${minWidth.tablet} {

--- a/app/client/components/productDescriptionListTable.tsx
+++ b/app/client/components/productDescriptionListTable.tsx
@@ -52,6 +52,9 @@ export const ProductDescriptionListTable = (
     tableEntry => !!tableEntry.value
   );
 
+  const showAlternativeTableRowBgColours =
+    props.alternateRowBgColors && filteredContent.length > 2;
+
   interface ContentRowMapEntry {
     row: number;
     isFirstCollum: boolean;
@@ -120,7 +123,7 @@ export const ProductDescriptionListTable = (
             }px;
               margin: 0;
               background-color: ${
-                props.alternateRowBgColors && currentRow % 2 === 0
+                showAlternativeTableRowBgColours && currentRow % 2 === 0
                   ? palette.neutral[97]
                   : "transparent"
               };
@@ -139,7 +142,7 @@ export const ProductDescriptionListTable = (
                 padding: ${
                   isFirstTableRow
                     ? space[5]
-                    : props.alternateRowBgColors
+                    : showAlternativeTableRowBgColours
                     ? space[5]
                     : space[5] * 0.5
                 }px
@@ -147,7 +150,7 @@ export const ProductDescriptionListTable = (
                 ${
                   isLastTableRow
                     ? space[5]
-                    : props.alternateRowBgColors
+                    : showAlternativeTableRowBgColours
                     ? space[5]
                     : space[5] * 0.5
                 }px;


### PR DESCRIPTION
## What does this change?
on ProductDescriptionListTable  component only show the alternate row background colours if there is enough data to render more than 1 row.

Increase the padding-top slightly for the page header on Mobile breakpoints

## Images
![Screenshot 2020-06-05 at 15 12 29](https://user-images.githubusercontent.com/2510683/83886533-17112800-a73f-11ea-888a-84946cd6d804.png)


![Screenshot 2020-06-05 at 15 10 14](https://user-images.githubusercontent.com/2510683/83886227-ea5d1080-a73e-11ea-8436-706aff23f57e.png)

