### PR TITLE
[RB TR] - improve redirect efficiency

### DIFF
--- a/app/client/components/accountoverview/manageProduct.tsx
+++ b/app/client/components/accountoverview/manageProduct.tsx
@@ -499,6 +499,7 @@ export const ManageProduct = (props: RouteableStepProps) => (
     {...props}
     loadingMessagePrefix="Retrieving details of your"
     allowCancelledSubscription
+    forceRedirectToAccountOverviewIfNoBrowserHistoryState
   >
     {productDetail => (
       <InnerContent props={props} productDetail={productDetail} />

--- a/app/client/components/productDetailProvider.tsx
+++ b/app/client/components/productDetailProvider.tsx
@@ -15,6 +15,7 @@ interface ProductDetailProviderProps extends RouteableStepProps {
   children: (productDetail: ProductDetail) => JSX.Element;
   allowCancelledSubscription?: true;
   loadingMessagePrefix: string;
+  forceRedirectToAccountOverviewIfNoBrowserHistoryState?: true;
 }
 
 export const ProductDetailProvider = (props: ProductDetailProviderProps) => {
@@ -40,7 +41,9 @@ export const ProductDetailProvider = (props: ProductDetailProviderProps) => {
   }
   // ie definitely no browser history state
   else if (selectedProductDetail === null) {
-    return (
+    return props.forceRedirectToAccountOverviewIfNoBrowserHistoryState ? (
+      visuallyNavigateToParent(props, true)
+    ) : (
       <MembersDatApiAsyncLoader
         fetch={createProductDetailFetcher(props.productType)}
         render={renderSingleProductOrReturnToAccountOverview(

--- a/app/client/components/user.tsx
+++ b/app/client/components/user.tsx
@@ -76,7 +76,7 @@ const User = () => (
           <Redirect
             key={productType.urlPart}
             from={"/" + productType.urlPart}
-            to={"/" + productType.productPage}
+            to={"/"}
             noThrow
           />
         ))}


### PR DESCRIPTION
- Add ability to force redirect to account overview from productDetailProvider via prop called `forceRedirectToAccountOverviewIfNoBrowserHistoryState` used by `manageProduct`
- Remove redundant redirect for specific product types
