### PR TITLE
[RB TR] - fix redirect from wild card path

### DIFF
--- a/app/client/components/user.tsx
+++ b/app/client/components/user.tsx
@@ -174,11 +174,11 @@ const User = () => (
       <Help path="/help" />
 
       {/* otherwise redirect to root instead of having a "not found page" */}
-      <Redirect default={true} to="/" />
+      <Redirect default from="/*" to="/" noThrow />
     </Router>
     <Router>
       <SuppressConsentBanner path="/payment/*" />
-      <ConsentsBanner default={true} />
+      <ConsentsBanner default />
     </Router>
   </Main>
 );


### PR DESCRIPTION
## What does this change?
fix redirect from wild card path

reach router requires a from property. Also when using a wildcard you need to prepend a `/` eg `/*`
