### PR TITLE
simplify first time set-up and day-to-day running of manage-frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Manage Frontend - manage.theguardian.com
+# manage.theguardian.com
 
-Frontend of `manage.theguardian.com`
+This README contains mainly set-up information.
+
+[SEE THE WIKI FOR MAIN DOCUMENTATION!](https://github.com/guardian/manage-frontend/wiki)
 
 ## Technologies
 
@@ -9,39 +11,69 @@ Frontend of `manage.theguardian.com`
 - [Emotion](https://emotion.sh)
 - [React](https://reactjs.org/)
 - [TypeScript](https://www.typescriptlang.org)
+
+DEV only Dependencies
+
 - [Jest](https://facebook.github.io/jest/)
-
-## Dependencies
-
-- [Members data API](https://github.com/guardian/members-data-api)
-- [NVM](https://github.com/creationix/nvm)
 - [Yarn](https://yarnpkg.com/lang/en/)
 - [NGINX](https://www.nginx.com)
 
-## Setup DEV environment
+## Dependencies
+
+- [`identity-frontend`](https://github.com/guardian/identity-frontend)
+- [IDAPI](https://github.com/guardian/identity)
+- [`members-data-api`](https://github.com/guardian/members-data-api)
+- [`holiday-stop-api` ](https://github.com/guardian/support-service-lambdas/tree/master/handlers/holiday-stop-api)
+- [`delivery-records-api`](https://github.com/guardian/support-service-lambdas/tree/master/handlers/delivery-records-api)
+- [`cancellation-sf-cases-api`](https://github.com/guardian/support-service-lambdas/tree/master/handlers/cancellation-sf-cases-api)
+- Stripe
+- Google ReCaptcha
+
+## Basic DEV environment
+
+NOTE nginx proxies CODE instances of [`identity-frontend`](https://github.com/guardian/identity-frontend) for sign-in and [`members-data-api`](https://github.com/guardian/members-data-api) **if they're not running locally**. See sections further down if you need to actually develop either of those services in parallel with `manage-frontend`.
+
+#### One-off setup
 
 1. Follow the [Nginx steps for manage-frontend](https://github.com/guardian/manage-frontend/blob/master/nginx/README.md)
-1. Follow the [nginx steps for identity-platform](https://github.com/guardian/identity-platform/blob/master/nginx/README.md#setup-nginx-with-ssl-for-dev).
-1. Follow the [identity-frontend configuration steps](https://github.com/guardian/identity-frontend#configuration).
-1. Follow the [setup instructions for members-data-api](https://github.com/guardian/members-data-api#setting-it-up-locally).
-1. In `./nginx` run `./setup.sh`.
-1. In `./app`, run `nvm use` and `yarn`.
+1. Ensure you have `nvm` installed (DO NOT install via Brew, instead use [nvm's installation instructions](https://github.com/nvm-sh/nvm#installing-and-updating))
+1. In `./app`...
+   1. run `nvm use`
+   1. run `yarn`
+   1. authenticate snyk [with your token](https://support.snyk.io/hc/en-us/articles/360004008258-Authenticate-the-CLI-with-your-account) `npx snyk config set api=XXXXXXXX`
 
-**Running locally**
+#### Running locally (each day you need use it)
 
 1.  First fetch credentials from [Janus](https://janus.gutools.co.uk/) for the `membership` profile.
-2.  You will need to have [identity-frontend](https://github.com/guardian/identity-frontend) running (`./start-frontend.sh`), to allow you to sign in (the sign-in cookies are required).
-3.  You will also need to have [members-data-api](https://github.com/guardian/members-data-api) (`./start-api.sh`) running, to get CODE subscription data.
-4.  You will need to have nginx running (`sudo nginx`), if it's not running already.
-5.  In `./app`, run `yarn watch`.
-6.  Then go to https://manage.thegulocal.com/
-7.  To execute `yarn test` first authenticate snyk [with your token](https://support.snyk.io/hc/en-us/articles/360004008258-Authenticate-the-CLI-with-your-account)
-    ```
-    cd app
-    npx snyk config set api=XXXXXXXX
-    ```
 
-### SSH
+1.  You will need to have nginx running (`sudo nginx`), if it's not running already.
+1.  In `./app`, run `yarn watch`.
+1.  Which should open https://manage.thegulocal.com/ in the browser (you may need to refresh if you see an error, whilst the it catches up)
+1.  You will very likely be redirected to `profile.thegulocal.com` (as you need to be signed in, in the last hour, to use MMA - see [wiki/IDAPI-Integration](https://github.com/guardian/manage-frontend/wiki/IDAPI-Integration)). You can use the same login as you would use in CODE, and you can create new subs by visiting https://support.code.dev-theguardian.com (when sign-in there with the same account). _Social sign-in (Google, Facebook etc.) doesn't appear to work via the proxy unfortunately._
+
+### To develop `members-data-api` in parallel
+
+#### One-off setup
+
+1. Follow the [setup instructions for members-data-api](https://github.com/guardian/members-data-api#setting-it-up-locally).
+
+#### Running locally (each day you need use it)
+
+1.  You will also need to have [members-data-api](https://github.com/guardian/members-data-api) (`./start-api.sh`) running, to get subscription data (from DEV Zuora/Salesforce).
+1.  You will probably also need the tunnel to the `contributions-store`, see point 2 of [members-data-api#running-locally](https://github.com/guardian/members-data-api#running-locally)
+
+### To develop `identity-frontend` in parallel (very unlikely)
+
+#### One-off setup
+
+1. Follow the [nginx steps for identity-platform](https://github.com/guardian/identity-platform/blob/master/nginx/README.md#setup-nginx-with-ssl-for-dev).
+1. Follow the [identity-frontend configuration steps](https://github.com/guardian/identity-frontend#configuration).
+
+#### Running locally (each day you need use it)
+
+2.  Start [identity-frontend](https://github.com/guardian/identity-frontend) with `./start-frontend.sh`.
+
+## SSH into running instances in AWS
 
 You must ssh via the bastion, e.g. using [ssm-scala](https://github.com/guardian/ssm-scala):
 `ssm ssh --profile membership --bastion-tags contributions-store-bastion,support,PROD --tags manage-frontend,support,CODE -a -x --newest`

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -1,19 +1,14 @@
 # Setup Nginx with valid TLS certificate in DEV
 
-1. Old nginx configuration files were in `/usr/local/etc/nginx/sites-enabled`, however the new
-   ones end up in `/usr/local/etc/nginx/servers`, so backup and remove `sites-enabled`
-1. Install [dev-nginx](https://github.com/guardian/dev-nginx)
+nginx proxies CODE instances of [`identity-frontend`](https://github.com/guardian/identity-frontend) for sign-in and [`members-data-api`](https://github.com/guardian/members-data-api) **if they're not running locally**.
+
+_Old nginx configuration files were in `/usr/local/etc/nginx/sites-enabled`, however the new
+ones end up in `/usr/local/etc/nginx/servers`, so backup and remove`sites-enabled`_
+
+1. Ensure you have [dev-nginx](https://github.com/guardian/dev-nginx) installed, if not...
    ```bash
    brew tap "guardian/devtools"
    brew install dev-nginx
    ```
-1. Add the following to `/etc/hosts`
-   ```
-   127.0.0.1   manage.thegulocal.com               # https://github.com/guardian/manage-frontend
-   127.0.0.1   profile.thegulocal.com              # https://github.com/guardian/identity-frontend
-   127.0.0.1   members-data-api.thegulocal.com     # https://github.com/guardian/members-data-api
-   ```
-1. Run `setup.sh`
-1. Enter sudo password
+1. Inside the `nginx` directory, run `./setup.sh` (which creates/installs certs for manage.thegulocal.com, members-data-api.thegulocal.com and profile.thegulocal.com, then installs the nginx config for each and (re)starts nginx) - you will need to enter your machine password (for the `sudo`)
 1. Check `/usr/local/etc/nginx/servers/manage-frontend.conf` exists
-1. Start nginx with `sudo nginx`

--- a/nginx/identity-frontend-CODE-fallback.conf
+++ b/nginx/identity-frontend-CODE-fallback.conf
@@ -1,0 +1,38 @@
+upstream identity_services { # avoids naming clash with Identity's own nginx config if already installed
+  server localhost:9009; # Dotcom Identity Frontend
+  server localhost:8860; # Identity Frontend
+  server localhost:8800; # IDAPI ??
+}
+
+server {
+    listen 443 ssl;
+    server_name profile.thegulocal.com;
+    proxy_http_version 1.1; # this is essential for chunked responses to work
+
+    ssl_certificate profile.thegulocal.com.crt;
+    ssl_certificate_key profile.thegulocal.com.key;
+    ssl_session_timeout 5m;
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    ssl_prefer_server_ciphers on;
+
+    location / {
+        proxy_pass http://identity_services;
+        proxy_set_header Host $http_host;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+
+        proxy_intercept_errors on;
+        error_page 404 502 503 504 = @fallback;
+    }
+
+    location @fallback {
+        proxy_pass https://profile.code.dev-theguardian.com;
+        proxy_set_header Host profile.code.dev-theguardian.com;
+        proxy_set_header Origin https://profile.code.dev-theguardian.com;
+        proxy_hide_header Content-Security-Policy;
+        proxy_cookie_domain profile.code.dev-theguardian.com profile.thegulocal.com;
+        proxy_cookie_domain .code.dev-theguardian.com .thegulocal.com;
+    }
+}

--- a/nginx/members-data-api-CODE-fallback.conf
+++ b/nginx/members-data-api-CODE-fallback.conf
@@ -1,0 +1,29 @@
+server {
+    listen 443 ssl;
+    server_name members-data-api.thegulocal.com;
+    proxy_http_version 1.1; # this is essential for chunked responses to work
+
+    ssl_certificate members-data-api.thegulocal.com.crt;
+    ssl_certificate_key members-data-api.thegulocal.com.key;
+    ssl_session_timeout 5m;
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    ssl_prefer_server_ciphers on;
+
+    location / {
+        proxy_pass http://localhost:9400/;
+        proxy_set_header Host $http_host;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+
+        proxy_intercept_errors on;
+        error_page 404 502 503 504 = @fallback;
+    }
+
+    location @fallback {
+        proxy_pass https://members-data-api.code.dev-theguardian.com;
+        proxy_set_header Host members-data-api.code.dev-theguardian.com;
+    }
+
+}

--- a/nginx/setup.sh
+++ b/nginx/setup.sh
@@ -1,15 +1,21 @@
 #!/bin/bash
 #Clean up legacy config
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-NGINX_HOME=$(nginx -V 2>&1 | grep 'configure arguments:' | sed 's#.*conf-path=\([^ ]*\)/nginx\.conf.*#\1#g')
+NGINX_HOME=$(dev-nginx locate-nginx)
 sudo rm -f $NGINX_HOME/sites-enabled/manage-frontend.conf
 
 # Setup Nginx proxies for local development with valid SSL
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $( dirname "${BASH_SOURCE[0]}" )
 
-SITE_CONF=${SCRIPT_DIR}/manage-frontend.conf
-
+dev-nginx add-to-hosts-file manage.thegulocal.com
 dev-nginx setup-cert manage.thegulocal.com
+dev-nginx link-config $(pwd)/manage-frontend.conf
 
-dev-nginx link-config ${SITE_CONF}
+dev-nginx add-to-hosts-file profile.thegulocal.com
+dev-nginx setup-cert profile.thegulocal.com
+dev-nginx link-config $(pwd)/identity-frontend-CODE-fallback.conf
+
+dev-nginx add-to-hosts-file members-data-api.thegulocal.com
+dev-nginx setup-cert members-data-api.thegulocal.com
+dev-nginx link-config $(pwd)/members-data-api-CODE-fallback.conf
+
 dev-nginx restart-nginx


### PR DESCRIPTION
add nginx configs to proxy CODE instances of `identity-frontend` and `members-data-api` **as a fallback** if not running locally (to develop those services in parallel one has to simply run them locally and it will use instead of CODE).

The set-up instructions were quite involved for new starters previously - now just one set-up script for nginx, plus a couple of simple commands for manage itself.

Also day-to-day (for all devs) having to start various other services locally was not only a faff but a distraction when debugging (if one crashed or didn't have some config etc).

README changes cover this