### PR TITLE
[RB TR] - payment failure alert refactor

### DIFF
--- a/app/client/components/accountoverview/accountOverview.tsx
+++ b/app/client/components/accountoverview/accountOverview.tsx
@@ -8,7 +8,6 @@ import {
   MembersDataApiItem,
   MembersDatApiAsyncLoader,
   ProductDetail,
-  replaceAlertTextCTA,
   sortByJoinDate
 } from "../../../shared/productResponse";
 import {
@@ -20,7 +19,7 @@ import { maxWidth } from "../../styles/breakpoints";
 import { isCancelled } from "../cancel/cancellationSummary";
 import { NAV_LINKS } from "../nav/navConfig";
 import { PageContainer } from "../page";
-import { ProblemAlert } from "../ProblemAlert";
+import { PaymentFailureAlertIfApplicable } from "../payment/paymentFailureAlertIfApplicable";
 import {
   SupportTheGuardianButton,
   SupportTheGuardianButtonProps
@@ -50,7 +49,7 @@ const AccountOverviewRenderer = (apiResponse: MembersDataApiItem[]) => {
     return <EmptyAccountOverview />;
   }
 
-  const firstPaymentFailure = allProductDetails.find(_ => _.alertText);
+  const maybeFirstPaymentFailure = allProductDetails.find(_ => _.alertText);
 
   const subHeadingCss = css`
     margin: ${space[12]}px 0 ${space[6]}px;
@@ -64,24 +63,9 @@ const AccountOverviewRenderer = (apiResponse: MembersDataApiItem[]) => {
 
   return (
     <>
-      {firstPaymentFailure?.alertText && (
-        <ProblemAlert
-          title="A payment needs your attention"
-          message={replaceAlertTextCTA(firstPaymentFailure.alertText)}
-          button={{
-            title: "Update payment method",
-            link: `/payment/${
-              GROUPED_PRODUCT_TYPES[
-                firstPaymentFailure.mmaCategory
-              ].mapGroupedToSpecific(firstPaymentFailure).urlPart
-            }`,
-            state: firstPaymentFailure
-          }}
-          additionalcss={css`
-            margin-top: 30px;
-          `}
-        />
-      )}
+      <PaymentFailureAlertIfApplicable
+        productDetail={maybeFirstPaymentFailure}
+      />
 
       {Object.entries(mmaCategoryToProductDetails).map(
         ([mmaCategory, productDetails]) => {

--- a/app/client/components/accountoverview/manageProduct.tsx
+++ b/app/client/components/accountoverview/manageProduct.tsx
@@ -12,8 +12,7 @@ import {
   isGift,
   isPaidSubscriptionPlan,
   isSixForSix,
-  ProductDetail,
-  replaceAlertTextCTA
+  ProductDetail
 } from "../../../shared/productResponse";
 import {
   hasDeliveryRecordsFlow,
@@ -27,8 +26,8 @@ import { FlowWrapper } from "../FlowWrapper";
 import { NAV_LINKS } from "../nav/navConfig";
 import { CardDisplay } from "../payment/cardDisplay";
 import { DirectDebitDisplay } from "../payment/directDebitDisplay";
+import { PaymentFailureAlertIfApplicable } from "../payment/paymentFailureAlertIfApplicable";
 import { PayPalDisplay } from "../payment/paypalDisplay";
-import { ProblemAlert } from "../ProblemAlert";
 import { ProductDescriptionListTable } from "../productDescriptionListTable";
 import { SupportTheGuardianButton } from "../supportTheGuardianButton";
 import { ErrorIcon } from "../svgs/errorIcon";
@@ -79,20 +78,7 @@ const InnerContent = ({ props, productDetail }: InnerContentProps) => {
 
   return (
     <>
-      {productDetail.alertText && (
-        <ProblemAlert
-          title="A payment needs your attention"
-          message={replaceAlertTextCTA(productDetail.alertText)}
-          button={{
-            title: "Update payment method",
-            link: `/payment/${specificProductType.urlPart}`,
-            state: productDetail
-          }}
-          additionalcss={css`
-            margin-top: 30px;
-          `}
-        />
-      )}
+      <PaymentFailureAlertIfApplicable productDetail={productDetail} />
       <div
         css={css`
           ${subHeadingBorderTopCss}

--- a/app/client/components/payment/paymentFailureAlertIfApplicable.tsx
+++ b/app/client/components/payment/paymentFailureAlertIfApplicable.tsx
@@ -1,0 +1,34 @@
+import { css } from "@emotion/core";
+import React from "react";
+import { ProductDetail } from "../../../shared/productResponse";
+import { GROUPED_PRODUCT_TYPES } from "../../../shared/productTypes";
+import { ProblemAlert } from "../ProblemAlert";
+
+interface PaymentFailureAlertIfApplicableProps {
+  productDetail: ProductDetail | undefined;
+}
+
+export const PaymentFailureAlertIfApplicable = ({
+  productDetail
+}: PaymentFailureAlertIfApplicableProps) =>
+  productDetail?.alertText ? (
+    <ProblemAlert
+      title="A payment needs your attention"
+      message={augmentPaymentFailureAlertText(productDetail.alertText)}
+      button={{
+        title: "Update payment method",
+        link: `/payment/${
+          GROUPED_PRODUCT_TYPES[productDetail.mmaCategory].mapGroupedToSpecific(
+            productDetail
+          ).urlPart
+        }`,
+        state: productDetail
+      }}
+      additionalcss={css`
+        margin-top: 30px;
+      `}
+    />
+  ) : null;
+
+export const augmentPaymentFailureAlertText = (alertText: string) =>
+  `${alertText} Please check that the payment details shown are up to date.`;

--- a/app/client/components/payment/update/updatePaymentFlow.tsx
+++ b/app/client/components/payment/update/updatePaymentFlow.tsx
@@ -8,7 +8,6 @@ import React from "react";
 import {
   MembersDataApiItemContext,
   ProductDetail,
-  replaceAlertTextCTA,
   Subscription
 } from "../../../../shared/productResponse";
 import { maxWidth } from "../../../styles/breakpoints";
@@ -22,6 +21,7 @@ import {
   RouteableStepProps,
   WizardStep
 } from "../../wizardRouterAdapter";
+import { augmentPaymentFailureAlertText } from "../paymentFailureAlertIfApplicable";
 import { PayPalDisplay } from "../paypalDisplay";
 import { CardInputForm } from "./card/cardInputForm";
 import { CurrentPaymentDetails } from "./currentPaymentDetails";
@@ -197,7 +197,9 @@ class PaymentUpdaterStep extends React.Component<
               <div>
                 <h3 css={{ marginBottom: "7px" }}>Why am I here?</h3>
                 <span>
-                  {replaceAlertTextCTA(this.props.productDetail.alertText)}
+                  {augmentPaymentFailureAlertText(
+                    this.props.productDetail.alertText
+                  )}
                 </span>
               </div>
             )}

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -27,12 +27,6 @@ export const formatDate = (shortForm: string) => {
 
 export const MDA_TEST_USER_HEADER = "X-Gu-Membership-Test-User";
 
-export const replaceAlertTextCTA = (alertText: string) =>
-  alertText.replace(
-    /Please check .*/g,
-    "Please check that the payment details shown are up to date."
-  );
-
 export const sortByJoinDate = (a: ProductDetail, b: ProductDetail) =>
   b.joinDate.localeCompare(a.joinDate);
 


### PR DESCRIPTION
## What does this change?

- Add paymentFailureAlertIfApplicable component to remove duplication
- Following https://github.com/guardian/members-data-api/pull/461 removed the nasty replace function in favour of simply appending the `Please check that the payment details shown are up to date.` sentence

## Images
![Screenshot 2020-06-19 at 15 06 17](https://user-images.githubusercontent.com/2510683/85141457-b6a1e080-b23e-11ea-84a8-2b48783f1c7d.png)
