### PR TITLE
Cancellation contact us

### DIFF
--- a/app/client/components/accountoverview/manageProduct.tsx
+++ b/app/client/components/accountoverview/manageProduct.tsx
@@ -17,6 +17,7 @@ import {
 } from "../../../shared/productResponse";
 import {
   hasDeliveryRecordsFlow,
+  ProductType,
   shouldHaveHolidayStopsFlow
 } from "../../../shared/productTypes";
 import { maxWidth } from "../../styles/breakpoints";
@@ -446,27 +447,49 @@ const InnerContent = ({ props, productDetail }: InnerContentProps) => {
           </>
         )}
 
-      {specificProductType.cancellation && !hasCancellationPending && (
-        <Link
-          css={css`
-                  display: block;
-                  float: right;
-                  margin: ${space[24]}px 0 0 auto;
-                  ${textSans.medium()}
-                  color: ${palette.brand["500"]};
-                  border-bottom: 1px solid ${palette.neutral["100"]};
-                  transition: border-color .15s ease-out;
-                  :hover: {
-                    borderBottom: 1px solid ${palette.brand["400"]};
-                  }
-                `}
-          to={"/cancel/" + specificProductType.urlPart}
-          state={productDetail}
-        >
-          Cancel {groupedProductType.friendlyName}
-        </Link>
+      {!hasCancellationPending && (
+        <CancellationCTA
+          productDetail={productDetail}
+          friendlyName={groupedProductType.friendlyName}
+          specificProductType={specificProductType}
+        />
       )}
     </>
+  );
+};
+
+interface CancellationCTAProps {
+  productDetail: ProductDetail;
+  friendlyName: string;
+  specificProductType: ProductType;
+}
+
+const CancellationCTA = (props: CancellationCTAProps) => {
+  const shouldContactUsToCancel =
+    !props.productDetail.selfServiceCancellation.isAllowed ||
+    !props.specificProductType.cancellation;
+  return (
+    <div
+      css={css`
+        margin: ${space[24]}px 0 0 auto;
+        ${textSans.medium()}
+        color: ${palette.neutral[46]};
+      `}
+    >
+      {shouldContactUsToCancel &&
+        "Would you like to cancel your subscription? "}
+      <Link
+        css={css`
+          color: ${palette.brand["500"]};
+        `}
+        to={"/cancel/" + props.specificProductType.urlPart}
+        state={props.productDetail}
+      >
+        {shouldContactUsToCancel
+          ? "Contact us"
+          : `Cancel ${props.friendlyName}`}
+      </Link>
+    </div>
   );
 };
 

--- a/app/client/components/accountoverview/manageProduct.tsx
+++ b/app/client/components/accountoverview/manageProduct.tsx
@@ -493,31 +493,29 @@ const CancellationCTA = (props: CancellationCTAProps) => {
   );
 };
 
-export const ManageProduct = (props: RouteableStepPropsForGrouped) => {
-  const pageTitle = `Manage ${props.groupedProductType.friendlyName}`;
-  return (
-    <FlowWrapper
-      {...props}
-      productType={props.groupedProductType}
-      loadingMessagePrefix="Retrieving details of your"
-      allowCancelledSubscription
-      forceRedirectToAccountOverviewIfNoBrowserHistoryState
-      selectedNavItem={NAV_LINKS.accountOverview}
-      pageTitle={pageTitle}
-      breadcrumbs={[
-        {
-          title: NAV_LINKS.accountOverview.title,
-          link: NAV_LINKS.accountOverview.link
-        },
-        {
-          title: pageTitle,
-          currentPage: true
-        }
-      ]}
-    >
-      {productDetail => (
-        <InnerContent props={props} productDetail={productDetail} />
-      )}
-    </FlowWrapper>
-  );
-};
+export const ManageProduct = (props: RouteableStepPropsForGrouped) => (
+  <FlowWrapper
+    {...props}
+    productType={props.groupedProductType}
+    loadingMessagePrefix="Retrieving details of your"
+    allowCancelledSubscription
+    forceRedirectToAccountOverviewIfNoBrowserHistoryState
+    selectedNavItem={NAV_LINKS.accountOverview}
+    pageTitle={`Manage ${props.groupedProductType.shortFriendlyName ||
+      props.groupedProductType.friendlyName}`}
+    breadcrumbs={[
+      {
+        title: NAV_LINKS.accountOverview.title,
+        link: NAV_LINKS.accountOverview.link
+      },
+      {
+        title: `Manage ${props.groupedProductType.friendlyName}`,
+        currentPage: true
+      }
+    ]}
+  >
+    {productDetail => (
+      <InnerContent props={props} productDetail={productDetail} />
+    )}
+  </FlowWrapper>
+);

--- a/app/client/components/callCenterEmailAndNumbers.tsx
+++ b/app/client/components/callCenterEmailAndNumbers.tsx
@@ -205,6 +205,7 @@ export const CallCentreEmailAndNumbers = (
                 >
                   {phoneRegion.phoneNumbers.map(({ phoneNumber, suffix }) => (
                     <span
+                      key={phoneNumber}
                       css={css`
                         ${innerSectionBlockSpanCss}
                       `}

--- a/app/client/components/callCenterEmailAndNumbers.tsx
+++ b/app/client/components/callCenterEmailAndNumbers.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/core";
-import { palette } from "@guardian/src-foundations";
+import { palette, space } from "@guardian/src-foundations";
 import { textSans } from "@guardian/src-foundations/typography";
 import React, { useState } from "react";
 import { CallCentreNumbersProps } from "./callCentreNumbers";
@@ -90,7 +90,7 @@ export const CallCentreEmailAndNumbers = (
   const sectionTitleCss = (isOpen: boolean, isNotFirstOption: boolean) => `
     ${textSans.medium()};
     margin: 0;
-    padding: 12px 17px 12px 12px;
+    padding: ${space[3]}px ${space[3] * 2 + 15}px ${space[3]}px ${space[3]}px;
     position: relative;
     cursor: pointer;
     :after {

--- a/app/client/components/callCenterEmailAndNumbers.tsx
+++ b/app/client/components/callCenterEmailAndNumbers.tsx
@@ -17,24 +17,82 @@ const callCenterStyles = css({
   fontWeight: "normal"
 });
 
-export const CallCentreEmailAndNumbers = (props: CallCentreNumbersProps) => {
-  const [accordianStatus, setAccordianStatus] = useState([
-    {
-      isOpen: true
-    },
-    {
-      isOpen: false
-    },
-    {
-      isOpen: false
-    }
-  ]);
+export type PhoneRegionKey = "US" | "AUS" | "UK & ROW";
 
-  const sectionTitleCss = (sectionNum: number) => `
+interface PhoneRegion {
+  key: PhoneRegionKey;
+  title: string;
+  openingHours: string;
+  phoneNumbers: Array<{ phoneNumber: string; suffix?: string }>;
+}
+
+const EMAIL_ADDRESS: string = "customer.help@theguardian.com";
+
+const PHONE_DATA: PhoneRegion[] = [
+  {
+    key: "UK & ROW",
+    title: "United Kingdom, Europe and rest of world",
+    openingHours: "8am - 8pm on weekdays, 8am - 6pm at weekends (GMP/BST)",
+    phoneNumbers: [
+      {
+        phoneNumber: "+44 (0) 330 333 6790"
+      }
+    ]
+  },
+  {
+    key: "AUS",
+    title: "Australia, New Zealand, and Asia Pacific",
+    openingHours: "9am - 5pm Monday - Friday (AEDT)",
+    phoneNumbers: [
+      {
+        phoneNumber: "1800 773 766",
+        suffix: "(within Australia)"
+      },
+      {
+        phoneNumber: "+61 28076 8599",
+        suffix: "(outside Australia)"
+      }
+    ]
+  },
+  {
+    key: "US",
+    title: "Canada and USA",
+    openingHours: "9am - 5pm on weekdays (EST/EDT)",
+    phoneNumbers: [
+      {
+        phoneNumber: "1-844-632-2010",
+        suffix: "(toll free USA)"
+      },
+      {
+        phoneNumber: "+1 917-900-4663",
+        suffix: "(outside USA)"
+      }
+    ]
+  }
+];
+
+interface CallCentreEmailAndNumbersProps extends CallCentreNumbersProps {
+  hideEmailAddress?: boolean;
+  phoneRegionFilterKeys?: PhoneRegionKey[];
+}
+
+export const CallCentreEmailAndNumbers = (
+  props: CallCentreEmailAndNumbersProps
+) => {
+  const [indexOfOpenSection, setIndexOfOpenSection] = useState<number>(0);
+
+  const filteredPhoneData = PHONE_DATA.filter(
+    phoneRegion =>
+      !props.phoneRegionFilterKeys ||
+      props.phoneRegionFilterKeys.includes(phoneRegion.key)
+  );
+
+  const sectionTitleCss = (isOpen: boolean, isNotFirstOption: boolean) => `
     ${textSans.medium()};
     margin: 0;
     padding: 12px 17px 12px 12px;
     position: relative;
+    cursor: pointer;
     :after {
       content: "";
       display: block;
@@ -45,12 +103,12 @@ export const CallCentreEmailAndNumbers = (props: CallCentreNumbersProps) => {
       position: absolute;
       top: 50%;
       transform: translateY(-50%) ${
-        accordianStatus[sectionNum].isOpen ? "rotate(-45deg)" : "rotate(135deg)"
+        isOpen ? "rotate(-45deg)" : "rotate(135deg)"
       };
       transition: transform 0.4s;
       right: 17px;
     }
-    ${sectionNum > 0 &&
+    ${isNotFirstOption &&
       `
       :before {
         content: "";
@@ -80,19 +138,13 @@ export const CallCentreEmailAndNumbers = (props: CallCentreNumbersProps) => {
       font-weight: bold;
   `;
 
-  const innerSectionTitleCss = (isTopTitle: boolean) => `
+  const innerSectionTitleCss = `
     ${textSans.medium()};
-    margin: ${isTopTitle ? "6px 0 4px" : "20px 0 4px"};
+    margin: 6px 0 4px;
   `;
 
   const handleSectionClick = (sectionNum: number) => () => {
-    setAccordianStatus(
-      accordianStatus.map((section, sectionIndex) =>
-        sectionIndex === sectionNum
-          ? { isOpen: !section.isOpen }
-          : { isOpen: false }
-      )
-    );
+    setIndexOfOpenSection(indexOfOpenSection === sectionNum ? -1 : sectionNum);
   };
   return (
     <div css={callCenterStyles}>
@@ -103,201 +155,79 @@ export const CallCentreEmailAndNumbers = (props: CallCentreNumbersProps) => {
           border: 1px solid ${palette.neutral["86"]};
         `}
       >
-        <div css={css`subsectionCss`}>
-          <h2
-            css={css`
-              ${sectionTitleCss(0)}
-            `}
-            onClick={handleSectionClick(0)}
-          >
-            United Kingdom, Europe and rest of world
-          </h2>
-          <div
-            css={css`
-              ${innerSectionCss(accordianStatus[0].isOpen)}
-            `}
-          >
-            <h4
-              css={css`
-                ${innerSectionTitleCss(true)}
-              `}
-            >
-              Email:
-            </h4>
-            <span
-              css={css`
-                ${textSans.medium({ fontWeight: "bold" })};
-              `}
-            >
-              customer.help@theguardian.com
-            </span>
-            <h4
-              css={css`
-                ${innerSectionTitleCss(true)}
-              `}
-            >
-              Phone:
-            </h4>
-            <p
-              css={css`
-                ${innerSectionPCss}
-              `}
-            >
-              <span
+        {filteredPhoneData.map((phoneRegion, index) => {
+          const isOpen = index === indexOfOpenSection;
+          const isNotFirstOption = index > 0;
+          return (
+            <div css={css`subsectionCss`} key={phoneRegion.key}>
+              <h2
                 css={css`
-                  ${innerSectionBlockSpanCss}
+                  ${sectionTitleCss(isOpen, isNotFirstOption)}
+                `}
+                onClick={handleSectionClick(index)}
+              >
+                {phoneRegion.title}
+              </h2>
+              <div
+                css={css`
+                  ${innerSectionCss(isOpen)}
                 `}
               >
-                +44 (0) 330 333 6790
-              </span>
-              8am - 8pm on weekdays, 8am - 6pm at weekends (GMP/BST)
-            </p>
-          </div>
-        </div>
-        <div css={css`subsectionCss`}>
-          <h2
-            css={css`
-              ${sectionTitleCss(1)}
-            `}
-            onClick={handleSectionClick(1)}
-          >
-            Australia, New Zealand, and Asia Pacific
-          </h2>
-          <div
-            css={css`
-              ${innerSectionCss(accordianStatus[1].isOpen)}
-            `}
-          >
-            <h4
-              css={css`
-                ${innerSectionTitleCss(true)}
-              `}
-            >
-              Email:
-            </h4>
-            <span
-              css={css`
-                ${textSans.medium({ fontWeight: "bold" })};
-              `}
-            >
-              customer.help@theguardian.com
-            </span>
-            <h4
-              css={css`
-                ${innerSectionTitleCss(true)}
-              `}
-            >
-              Phone:
-            </h4>
-            <p
-              css={css`
-                ${innerSectionPCss}
-              `}
-            >
-              <span
-                css={css`
-                  ${innerSectionBlockSpanCss}
-                `}
-              >
-                1800 773 766{" "}
-                <span
+                {!props.hideEmailAddress && (
+                  <>
+                    <h4
+                      css={css`
+                        ${innerSectionTitleCss}
+                      `}
+                    >
+                      Email:
+                    </h4>
+                    <span
+                      css={css`
+                        ${textSans.medium({ fontWeight: "bold" })};
+                      `}
+                    >
+                      {EMAIL_ADDRESS}
+                    </span>
+                  </>
+                )}
+                <h4
                   css={css`
-                    font-weight: normal;
+                    ${innerSectionTitleCss}
                   `}
                 >
-                  (within Australia)
-                </span>
-              </span>
-              <span
-                css={css`
-                  ${innerSectionBlockSpanCss}
-                `}
-              >
-                +61 28076 8599{" "}
-                <span
+                  Phone:
+                </h4>
+                <p
                   css={css`
-                    font-weight: normal;
+                    ${innerSectionPCss}
                   `}
                 >
-                  (outside Australia)
-                </span>
-              </span>
-              9am - 5pm Monday - Friday (AEDT)
-            </p>
-          </div>
-        </div>
-        <div css={css`subsectionCss`}>
-          <h2
-            css={css`
-              ${sectionTitleCss(2)}
-            `}
-            onClick={handleSectionClick(2)}
-          >
-            Canada and USA
-          </h2>
-          <div
-            css={css`
-              ${innerSectionCss(accordianStatus[2].isOpen)}
-            `}
-          >
-            <h4
-              css={css`
-                ${innerSectionTitleCss(true)}
-              `}
-            >
-              Email:
-            </h4>
-            <span
-              css={css`
-                ${textSans.medium({ fontWeight: "bold" })};
-              `}
-            >
-              customer.help@theguardian.com
-            </span>
-            <h4
-              css={css`
-                ${innerSectionTitleCss(true)}
-              `}
-            >
-              Phone:
-            </h4>
-            <p
-              css={css`
-                ${innerSectionPCss}
-              `}
-            >
-              <span
-                css={css`
-                  ${innerSectionBlockSpanCss}
-                `}
-              >
-                1-844-632-2010{" "}
-                <span
-                  css={css`
-                    font-weight: normal;
-                  `}
-                >
-                  (toll free USA)
-                </span>
-              </span>
-              <span
-                css={css`
-                  ${innerSectionBlockSpanCss}
-                `}
-              >
-                +1 917-900-4663{" "}
-                <span
-                  css={css`
-                    font-weight: normal;
-                  `}
-                >
-                  (outside USA)
-                </span>
-              </span>
-              9am - 5pm on weekdays (EST/EDT)
-            </p>
-          </div>
-        </div>
+                  {phoneRegion.phoneNumbers.map(({ phoneNumber, suffix }) => (
+                    <span
+                      css={css`
+                        ${innerSectionBlockSpanCss}
+                      `}
+                    >
+                      {phoneNumber}
+                      {suffix && (
+                        <span
+                          css={css`
+                            font-weight: normal;
+                          `}
+                        >
+                          {" "}
+                          {suffix}
+                        </span>
+                      )}
+                    </span>
+                  ))}
+                  {phoneRegion.openingHours}
+                </p>
+              </div>
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/app/client/components/cancel/cancellationFlow.tsx
+++ b/app/client/components/cancel/cancellationFlow.tsx
@@ -193,7 +193,8 @@ export const CancellationFlow = (props: RouteableStepProps) => (
     {...props}
     loadingMessagePrefix="Checking the status of your"
     selectedNavItem={NAV_LINKS.accountOverview}
-    pageTitle={`Cancel ${props.productType.friendlyName}`} // TODO: rethink title as too long with hd sub
+    pageTitle={`Cancel ${props.productType.shortFriendlyName ||
+      props.productType.friendlyName}`}
     breadcrumbs={[
       {
         title: NAV_LINKS.accountOverview.title,
@@ -216,6 +217,7 @@ export const CancellationFlow = (props: RouteableStepProps) => (
       ) : (
         <ContactUsToCancel
           selfServiceCancellation={productDetail.selfServiceCancellation}
+          subscriptionId={productDetail.subscription.subscriptionId}
           productType={props.productType}
         />
       )

--- a/app/client/components/cancel/cancellationFlow.tsx
+++ b/app/client/components/cancel/cancellationFlow.tsx
@@ -9,7 +9,10 @@ import {
   MembersDataApiItemContext,
   ProductDetail
 } from "../../../shared/productResponse";
-import { ProductTypeWithCancellationFlow } from "../../../shared/productTypes";
+import {
+  hasCancellationFlow,
+  ProductTypeWithCancellationFlow
+} from "../../../shared/productTypes";
 import { maxWidth } from "../../styles/breakpoints";
 import { LinkButton } from "../buttons";
 import { FlowWrapper } from "../FlowWrapper";
@@ -28,6 +31,7 @@ import {
   cancellationEffectiveToday,
   CancellationPolicyContext
 } from "./cancellationContexts";
+import { ContactUsToCancel } from "./contactUsToCancel";
 
 export interface RouteableStepPropsWithCancellationFlow
   extends RouteableStepProps {
@@ -184,14 +188,12 @@ class ReasonPicker extends React.Component<
   }
 }
 
-export const CancellationFlow = (
-  props: RouteableStepPropsWithCancellationFlow
-) => (
+export const CancellationFlow = (props: RouteableStepProps) => (
   <FlowWrapper
     {...props}
     loadingMessagePrefix="Checking the status of your"
     selectedNavItem={NAV_LINKS.accountOverview}
-    pageTitle={`Cancel ${props.productType.friendlyName}`}
+    pageTitle={`Cancel ${props.productType.friendlyName}`} // TODO: rethink title as too long with hd sub
     breadcrumbs={[
       {
         title: NAV_LINKS.accountOverview.title,
@@ -203,6 +205,20 @@ export const CancellationFlow = (
       }
     ]}
   >
-    {productDetail => <ReasonPicker {...props} productDetail={productDetail} />}
+    {productDetail =>
+      productDetail.selfServiceCancellation.isAllowed &&
+      hasCancellationFlow(props.productType) ? (
+        <ReasonPicker
+          {...props}
+          productType={props.productType}
+          productDetail={productDetail}
+        />
+      ) : (
+        <ContactUsToCancel
+          selfServiceCancellation={productDetail.selfServiceCancellation}
+          productType={props.productType}
+        />
+      )
+    }
   </FlowWrapper>
 );

--- a/app/client/components/cancel/contactUsToCancel.tsx
+++ b/app/client/components/cancel/contactUsToCancel.tsx
@@ -8,9 +8,11 @@ import { ProductType } from "../../../shared/productTypes";
 import { maxWidth, minWidth } from "../../styles/breakpoints";
 import { CallCentreEmailAndNumbers } from "../callCenterEmailAndNumbers";
 import { NAV_LINKS } from "../nav/navConfig";
+import { ProductDescriptionListTable } from "../productDescriptionListTable";
 
 interface ContactUsToCancelProps {
   selfServiceCancellation: SelfServiceCancellation;
+  subscriptionId: string;
   productType: ProductType;
 }
 
@@ -40,6 +42,14 @@ export const ContactUsToCancel = (props: ContactUsToCancelProps) => {
       >
         Contact us to cancel
       </h2>
+      <ProductDescriptionListTable
+        content={[
+          {
+            title: "Subscription ID",
+            value: props.subscriptionId
+          }
+        ]}
+      />
       <p
         css={css`
           ${textSans.medium()}

--- a/app/client/components/cancel/contactUsToCancel.tsx
+++ b/app/client/components/cancel/contactUsToCancel.tsx
@@ -7,7 +7,6 @@ import { SelfServiceCancellation } from "../../../shared/productResponse";
 import { ProductType } from "../../../shared/productTypes";
 import { maxWidth, minWidth } from "../../styles/breakpoints";
 import { CallCentreEmailAndNumbers } from "../callCenterEmailAndNumbers";
-import { InfoSection } from "../infoSection";
 import { NAV_LINKS } from "../nav/navConfig";
 
 interface ContactUsToCancelProps {
@@ -49,12 +48,6 @@ export const ContactUsToCancel = (props: ContactUsToCancelProps) => {
         Please contact our Customer Service team. You can find the contact
         details for your region below.
       </p>
-      {props.productType.cancellationContactUsWarningSuffix && (
-        <InfoSection>
-          <strong>Please remember</strong>{" "}
-          {props.productType.cancellationContactUsWarningSuffix}
-        </InfoSection>
-      )}
       <CallCentreEmailAndNumbers
         hideEmailAddress={!props.selfServiceCancellation.shouldDisplayEmail}
         phoneRegionFilterKeys={
@@ -75,6 +68,4 @@ export const ContactUsToCancel = (props: ContactUsToCancelProps) => {
       </LinkButton>
     </>
   );
-  // TODO: Ask jian about displaying subscription id
-  // Do everything else! (will need new key on productType for warning text about cancellation notice)
 };

--- a/app/client/components/cancel/contactUsToCancel.tsx
+++ b/app/client/components/cancel/contactUsToCancel.tsx
@@ -1,0 +1,80 @@
+import { css } from "@emotion/core";
+import { LinkButton } from "@guardian/src-button";
+import { palette, space } from "@guardian/src-foundations";
+import { headline, textSans } from "@guardian/src-foundations/typography";
+import React from "react";
+import { SelfServiceCancellation } from "../../../shared/productResponse";
+import { ProductType } from "../../../shared/productTypes";
+import { maxWidth, minWidth } from "../../styles/breakpoints";
+import { CallCentreEmailAndNumbers } from "../callCenterEmailAndNumbers";
+import { InfoSection } from "../infoSection";
+import { NAV_LINKS } from "../nav/navConfig";
+
+interface ContactUsToCancelProps {
+  selfServiceCancellation: SelfServiceCancellation;
+  productType: ProductType;
+}
+
+export const ContactUsToCancel = (props: ContactUsToCancelProps) => {
+  const subHeadingTitleCss = `
+    ${headline.small()};
+    font-weight: bold;
+    ${maxWidth.tablet} {
+      font-size: 1.25rem;
+      line-height: 1.6;
+    };
+  `;
+  const subHeadingBorderTopCss = `
+    border-top: 1px solid ${palette.neutral["86"]};
+    margin: 50px 0 ${space[5]}px;
+  `;
+  const subHeadingCss = `
+    ${subHeadingBorderTopCss}
+    ${subHeadingTitleCss}
+  `;
+  return (
+    <>
+      <h2
+        css={css`
+          ${subHeadingCss}
+        `}
+      >
+        Contact us to cancel
+      </h2>
+      <p
+        css={css`
+          ${textSans.medium()}
+        `}
+      >
+        Please contact our Customer Service team. You can find the contact
+        details for your region below.
+      </p>
+      {props.productType.cancellationContactUsWarningSuffix && (
+        <InfoSection>
+          <strong>Please remember</strong>{" "}
+          {props.productType.cancellationContactUsWarningSuffix}
+        </InfoSection>
+      )}
+      <CallCentreEmailAndNumbers
+        hideEmailAddress={!props.selfServiceCancellation.shouldDisplayEmail}
+        phoneRegionFilterKeys={
+          props.selfServiceCancellation.phoneRegionsToDisplay
+        }
+      />
+      <LinkButton
+        css={css`
+          margin-top: ${space[3]}px;
+          ${minWidth.tablet} {
+            margin-top: ${space[5]}px;
+          }
+        `}
+        href={NAV_LINKS.accountOverview.link}
+        showIcon={false}
+      >
+        Return to your account
+      </LinkButton>
+    </>
+  );
+  // TODO: Ask jian about displaying subscription id
+  // Do everything else! (will need new key on productType for warning text about cancellation notice)
+};

--- a/app/client/components/delivery/address/deliveryAddressForm.tsx
+++ b/app/client/components/delivery/address/deliveryAddressForm.tsx
@@ -34,6 +34,7 @@ import { maxWidth, minWidth } from "../../../styles/breakpoints";
 import { flattenEquivalent } from "../../../utils";
 import { CallCentreEmailAndNumbers } from "../../callCenterEmailAndNumbers";
 import { CallCentreNumbers } from "../../callCentreNumbers";
+import { InfoSection } from "../../infoSection";
 import { NAV_LINKS } from "../../nav/navConfig";
 import { PageContainer } from "../../page";
 import {
@@ -333,29 +334,10 @@ const FormContainer = (props: FormContainerProps) => {
                 {Object.values(
                   props.contactIdToArrayOfProductDetailAndProductType
                 ).flatMap(flattenEquivalent).length > 1 && (
-                  <p
-                    css={css`
-                      ${textSans.medium()};
-                      background-color: ${palette.neutral[97]};
-                      padding: ${space[5]}px ${space[5]}px ${space[5]}px 49px;
-                      margin-bottom: 12px;
-                      position: relative;
-                    `}
-                  >
-                    <i
-                      css={css`
-                        width: 17px;
-                        height: 17px;
-                        position: absolute;
-                        top: ${space[5]}px;
-                        left: ${space[5]}px;
-                      `}
-                    >
-                      <InfoIconDark fillColor={palette.brand[500]} />
-                    </i>
+                  <InfoSection>
                     Please note that changing your address here will update the
                     delivery address for all of your subscriptions.
-                  </p>
+                  </InfoSection>
                 )}
                 {(formStatus === formStates.INIT ||
                   formStatus === formStates.PENDING ||

--- a/app/client/components/delivery/address/deliveryAddressReview.tsx
+++ b/app/client/components/delivery/address/deliveryAddressReview.tsx
@@ -6,9 +6,9 @@ import { Link, navigate } from "@reach/router";
 import React, { useContext, useState } from "react";
 import { maxWidth, minWidth } from "../../../styles/breakpoints";
 import { CallCentreEmailAndNumbers } from "../../callCenterEmailAndNumbers";
+import { InfoSection } from "../../infoSection";
 import { ProductDescriptionListTable } from "../../productDescriptionListTable";
 import { ProgressIndicator } from "../../progressIndicator";
-import { InfoIconDark } from "../../svgs/infoIconDark";
 import {
   RouteableStepProps,
   visuallyNavigateToParent,
@@ -85,29 +85,10 @@ const DeliveryAddressReviewFC = (props: RouteableStepProps) => {
       </h2>
       <div>
         {addressChangedInformationContext.length > 1 && (
-          <p
-            css={css`
-              ${textSans.medium()};
-              background-color: ${palette.neutral[97]};
-              padding: ${space[5]}px ${space[5]}px ${space[5]}px 49px;
-              margin-bottom: 12px;
-              position: relative;
-            `}
-          >
-            <i
-              css={css`
-                width: 17px;
-                height: 17px;
-                position: absolute;
-                top: ${space[5]}px;
-                left: ${space[5]}px;
-              `}
-            >
-              <InfoIconDark fillColor={palette.brand[500]} />
-            </i>
+          <InfoSection>
             Please note that changing your address here will update the delivery
             address for all of your subscriptions.
-          </p>
+          </InfoSection>
         )}
         <section
           css={css`

--- a/app/client/components/delivery/records/deliveryAddressStep.tsx
+++ b/app/client/components/delivery/records/deliveryAddressStep.tsx
@@ -29,6 +29,7 @@ import { flattenEquivalent } from "../../../utils";
 import AsyncLoader from "../../asyncLoader";
 import { CallCentreEmailAndNumbers } from "../../callCenterEmailAndNumbers";
 import { COUNTRIES } from "../../identity/models";
+import { InfoSection } from "../../infoSection";
 import {
   ProductDescriptionListKeyValue,
   ProductDescriptionListTable
@@ -169,29 +170,10 @@ export const DeliveryAddressStep = (props: DeliveryAddressStepProps) => {
     return (
       <>
         {productsAffected.length > 1 && (
-          <p
-            css={css`
-              ${textSans.medium()};
-              background-color: ${palette.neutral[97]};
-              padding: ${space[5]}px ${space[5]}px ${space[5]}px 49px;
-              margin-bottom: 12px;
-              position: relative;
-            `}
-          >
-            <i
-              css={css`
-                width: 17px;
-                height: 17px;
-                position: absolute;
-                top: ${space[5]}px;
-                left: ${space[5]}px;
-              `}
-            >
-              <InfoIconDark fillColor={palette.brand[500]} />
-            </i>
+          <InfoSection>
             Please note that changing your address here will update the delivery
             address for all of your subscriptions.
-          </p>
+          </InfoSection>
         )}
         <form
           action="#"

--- a/app/client/components/delivery/records/deliveryRecordsProblemConfirmation.tsx
+++ b/app/client/components/delivery/records/deliveryRecordsProblemConfirmation.tsx
@@ -229,7 +229,8 @@ const DeliveryRecordsProblemConfirmationFC = (
             <div>
               <dt css={dtCss}>Product:</dt>
               <dd css={ddCss}>
-                {props.routeableStepProps.productType.shortFriendlyName}
+                {props.routeableStepProps.productType.shortFriendlyName ||
+                  props.routeableStepProps.productType.friendlyName}
               </dd>
             </div>
             <div>

--- a/app/client/components/infoSection.tsx
+++ b/app/client/components/infoSection.tsx
@@ -1,0 +1,34 @@
+import { css } from "@emotion/core";
+import { palette, space } from "@guardian/src-foundations";
+import { textSans } from "@guardian/src-foundations/typography";
+import React from "react";
+import { InfoIconDark } from "./svgs/infoIconDark";
+
+interface InfoSectionProps {
+  children: React.ReactNode;
+}
+
+export const InfoSection = (props: InfoSectionProps) => (
+  <p
+    css={css`
+      ${textSans.medium()};
+      background-color: ${palette.neutral[97]};
+      padding: ${space[5]}px ${space[5]}px ${space[5]}px 49px;
+      margin-bottom: 12px;
+      position: relative;
+    `}
+  >
+    <i
+      css={css`
+        width: 17px;
+        height: 17px;
+        position: absolute;
+        top: ${space[5]}px;
+        left: ${space[5]}px;
+      `}
+    >
+      <InfoIconDark fillColor={palette.brand[500]} />
+    </i>
+    {props.children}
+  </p>
+);

--- a/app/client/components/user.tsx
+++ b/app/client/components/user.tsx
@@ -9,7 +9,6 @@ import {
   hasDeliveryRecordsFlow,
   PRODUCT_TYPES,
   ProductType,
-  ProductTypeWithCancellationFlow,
   ProductTypeWithDeliveryRecordsProperties,
   ProductTypeWithHolidayStopsFlow,
   shouldHaveHolidayStopsFlow
@@ -64,15 +63,14 @@ const User = () => (
           />
         )
       )}
-      {Object.values(PRODUCT_TYPES)
-        .filter(hasCancellationFlow)
-        .map((productType: ProductTypeWithCancellationFlow) => (
-          <CancellationFlow
-            key={productType.urlPart}
-            path={"/cancel/" + productType.urlPart}
-            productType={productType}
-          >
-            {productType.cancellation.reasons.map(
+      {Object.values(PRODUCT_TYPES).map((productType: ProductType) => (
+        <CancellationFlow
+          key={productType.urlPart}
+          path={"/cancel/" + productType.urlPart}
+          productType={productType}
+        >
+          {hasCancellationFlow(productType) &&
+            productType.cancellation.reasons.map(
               (reason: CancellationReason) => (
                 <GenericSaveAttempt
                   path={reason.reasonId}
@@ -88,8 +86,8 @@ const User = () => (
                 </GenericSaveAttempt>
               )
             )}
-          </CancellationFlow>
-        ))}
+        </CancellationFlow>
+      ))}
 
       {Object.values(PRODUCT_TYPES).map((productType: ProductType) => (
         <PaymentUpdateFlow

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -1,6 +1,7 @@
 import * as Sentry from "@sentry/browser";
 import React from "react";
 import AsyncLoader from "../client/components/asyncLoader";
+import { PhoneRegionKey } from "../client/components/callCenterEmailAndNumbers";
 import { DeliveryRecordDetail } from "../client/components/delivery/records/deliveryRecordsApi";
 import { CardProps } from "../client/components/payment/cardDisplay";
 import { GroupedProductTypeKeys } from "./productTypes";
@@ -36,6 +37,11 @@ export const replaceAlertTextCTA = (alertText: string) =>
 export const sortByJoinDate = (a: ProductDetail, b: ProductDetail) =>
   b.joinDate.localeCompare(a.joinDate);
 
+export interface SelfServiceCancellation {
+  isAllowed: boolean;
+  shouldDisplayEmail: boolean;
+  phoneRegionsToDisplay: PhoneRegionKey[];
+}
 export interface ProductDetail extends WithSubscription {
   isTestUser: boolean; // THIS IS NOT PART OF THE members-data-api RESPONSE (but inferred from a header)
   isPaidTier: boolean;
@@ -44,6 +50,7 @@ export interface ProductDetail extends WithSubscription {
   joinDate: string;
   mmaCategory: GroupedProductTypeKeys;
   alertText?: string;
+  selfServiceCancellation: SelfServiceCancellation;
 }
 
 export function isProduct(

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -154,7 +154,6 @@ export interface ProductType {
   renewalMetadata?: SupportTheGuardianButtonProps;
   noProductSupportUrlSuffix?: string;
   cancellation?: CancellationFlowProperties; // undefined 'cancellation' means no cancellation flow
-  cancellationContactUsWarningSuffix?: string;
   cancelledCopy?: string;
   showTrialRemainingIfApplicable?: true;
   updateAmountMdaEndpoint?: string;
@@ -425,9 +424,7 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
       ) =>
         reasonId === "mma_financial_circumstances" ? "/contribute" : undefined,
       swapFeedbackAndContactUs: true
-    },
-    cancellationContactUsWarningSuffix:
-      "that you must call us at least 6 weeks in advance before the date printed on the last voucher in your voucher book."
+    }
   },
   digitalvoucher: {
     productTitle: calculateProductTitle("Newspaper Subscription Card"),

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -154,6 +154,8 @@ export interface ProductType {
   renewalMetadata?: SupportTheGuardianButtonProps;
   noProductSupportUrlSuffix?: string;
   cancellation?: CancellationFlowProperties; // undefined 'cancellation' means no cancellation flow
+  cancellationContactUsWarningSuffix?: string;
+  cancelledCopy?: string;
   showTrialRemainingIfApplicable?: true;
   updateAmountMdaEndpoint?: string;
   holidayStops?: HolidayStopFlowProperties;
@@ -162,7 +164,6 @@ export interface ProductType {
     productFilenamePart: string;
     explicitSingleDayOfWeek?: string;
   };
-  cancelledCopy?: string;
   shouldShowJoinDateNotStartDate?: true;
 }
 
@@ -424,7 +425,9 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
       ) =>
         reasonId === "mma_financial_circumstances" ? "/contribute" : undefined,
       swapFeedbackAndContactUs: true
-    }
+    },
+    cancellationContactUsWarningSuffix:
+      "that you must call us at least 6 weeks in advance before the date printed on the last voucher in your voucher book."
   },
   digitalvoucher: {
     productTitle: calculateProductTitle("Newspaper Subscription Card"),


### PR DESCRIPTION
Following https://github.com/guardian/members-data-api/pull/459 we now get a new top level object with key `selfServiceCancellation` on our `ProductDetail` type, for example...

  ![image](https://user-images.githubusercontent.com/19289579/85270295-fcde8600-b470-11ea-976c-4d762ef2e35e.png)

... which we use to drive...

- a new `CancellationCTA` component (part of `manageProduct.tsx`) which, depending on what we get from the API, shows either... 
![image](https://user-images.githubusercontent.com/19289579/85272233-ceae7580-b473-11ea-82f0-86d18321bd9e.png)
...OR... 
![image](https://user-images.githubusercontent.com/19289579/85272697-6f9d3080-b474-11ea-8d90-849ad6b437b1.png)
 ...OR nothing if the sub is already cancelled. 

The above both link to cancellation flow regardless and then the cancellation flow either displays the existing 3-step self-service flow OR...

- a new `ContactUsToCancel` component which displays contact details (filtered by the properties in the new `selfServiceCancellation` from the API - which required a refactor of `callCenterEmailAndNumbers.tsx`)...
![Screenshot 2020-06-19 at 16 28 36](https://user-images.githubusercontent.com/2510683/85150077-fc17db00-b249-11ea-930a-633b427af1ad.png)

#### PLUS
At one point we thought we were going to need in 'info section' on this new `ContactUsToCancel` component and so we refactored three similar instances in the delivery address update flow into a re-usable `InfoSection` component, which although we didn't up using directly the refactors are still in this PR (as they're still a nice reduction in duplication).