### PR TITLE
[RB TR] - Hide membership benefits during cancellation for friend tier

### DIFF
--- a/app/client/components/cancel/cancellationFlow.tsx
+++ b/app/client/components/cancel/cancellationFlow.tsx
@@ -85,7 +85,7 @@ class ReasonPicker extends React.Component<
           `}
         />
         {this.props.productType.cancellation.startPageBody(
-          this.props.productDetail.subscription
+          this.props.productDetail
         )}
         <WithStandardTopMargin>
           <h4>Please select a reason</h4>

--- a/app/client/components/cancel/membership/membershipCancellationFlowStart.tsx
+++ b/app/client/components/cancel/membership/membershipCancellationFlowStart.tsx
@@ -1,5 +1,6 @@
 import { css } from "@emotion/core";
 import React from "react";
+import { ProductDetail } from "../../../../shared/productResponse";
 import palette from "../../../colours";
 import { trackEvent } from "../../analytics";
 import { WithStandardTopMargin } from "../../page";
@@ -40,37 +41,39 @@ const clickHereToFindOutMoreAboutOurNewFeatures = (
   </a>
 );
 
-export const membershipCancellationFlowStart = () => (
+export const membershipCancellationFlowStart = ({ tier }: ProductDetail) => (
   <>
-    <div
-      css={{
-        backgroundColor: palette.neutral["6"],
-        padding: "10px 20px",
-        marginBottom: "40px"
-      }}
-    >
-      <h4
+    {tier !== "Friend" && (
+      <div
         css={{
-          marginTop: "0",
-          marginBottom: "10px"
+          backgroundColor: palette.neutral["6"],
+          padding: "10px 20px",
+          marginBottom: "40px"
         }}
       >
-        If you cancel your Membership you will miss out on:
-      </h4>
-      <ul css={benefitsCss}>
-        <li css={cssBullet()}>Access to events tickets</li>
-        <li css={cssBullet()}>Exclusive emails from our membership editor</li>
-        <li
+        <h4
           css={{
-            ...cssBullet("100%"),
-            paddingTop: "5px"
+            marginTop: "0",
+            marginBottom: "10px"
           }}
         >
-          Free access to the premium tier of the Guardian app -{" "}
-          {clickHereToFindOutMoreAboutOurNewFeatures}
-        </li>
-      </ul>
-    </div>
+          If you cancel your Membership you will miss out on:
+        </h4>
+        <ul css={benefitsCss}>
+          <li css={cssBullet()}>Access to events tickets</li>
+          <li css={cssBullet()}>Exclusive emails from our membership editor</li>
+          <li
+            css={{
+              ...cssBullet("100%"),
+              paddingTop: "5px"
+            }}
+          >
+            Free access to the premium tier of the Guardian app -{" "}
+            {clickHereToFindOutMoreAboutOurNewFeatures}
+          </li>
+        </ul>
+      </div>
+    )}
     <WithStandardTopMargin>
       <p
         css={{

--- a/app/client/components/cancel/voucher/voucherCancellationFlowStart.tsx
+++ b/app/client/components/cancel/voucher/voucherCancellationFlowStart.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { getMainPlan, Subscription } from "../../../../shared/productResponse";
+import { getMainPlan, ProductDetail } from "../../../../shared/productResponse";
 import { trackEvent } from "../../analytics";
 import { WithStandardTopMargin } from "../../page";
 import { hrefStyle } from "../cancellationConstants";
@@ -11,7 +11,9 @@ const trackCancellationClickEvent = (eventLabel: string) => () =>
     eventLabel
   });
 
-export const voucherCancellationFlowStart = (subscription: Subscription) => {
+export const voucherCancellationFlowStart = ({
+  subscription
+}: ProductDetail) => {
   const mainPlan = getMainPlan(subscription);
 
   const isEligibleForFreeDigipackAccess =

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -77,7 +77,7 @@ interface CancellationFlowProperties {
     productDetail: ProductDetail,
     productType: ProductType
   ) => (restOfFlow: RestOfCancellationFlow) => ReactNode;
-  startPageBody: (subscription: Subscription) => JSX.Element;
+  startPageBody: (productDetail: ProductDetail) => JSX.Element;
   startPageOfferEffectiveDateOptions?: true;
   hideReasonTitlePrefix?: true;
   alternateSummaryMainPara?: string;


### PR DESCRIPTION
## What does this change?
Only show membership benefits for people cancelling if they are not on Friend tier

## Images
![Screenshot 2020-06-22 at 11 22 55](https://user-images.githubusercontent.com/2510683/85277378-3fa55b80-b47b-11ea-9526-7df1a7a703d4.png)

