### PR TITLE
Remove delivery instructions for GW

### DIFF
--- a/app/client/components/delivery/records/deliveryRecordCard.tsx
+++ b/app/client/components/delivery/records/deliveryRecordCard.tsx
@@ -21,6 +21,7 @@ interface DeliveryRecordCardProps {
   productName?: string;
   recordCurrency?: string;
   isChecked?: boolean;
+  showDeliveryInstructions?: boolean;
   addRecordToDeliveryProblem?: (id: string) => void;
   removeRecordFromDeliveryProblem?: (id: string) => void;
 }
@@ -258,33 +259,35 @@ export const DeliveryRecordCard = (props: DeliveryRecordCardProps) => {
           </div>
         </>
       )}
-      <div
-        css={css`
-          ${recordRowCss}
-        `}
-      >
-        <dt
+      {props.showDeliveryInstructions && (
+        <div
           css={css`
-            ${dtCss()}
+            ${recordRowCss}
           `}
         >
-          Instructions:
-        </dt>
-        <dd
-          css={css`
-            ${ddCss}
-          `}
-        >
-          {props.deliveryRecord.deliveryInstruction &&
-          !props.deliveryRecord.hasHolidayStop ? (
-            <DeliveryRecordInstructions
-              message={props.deliveryRecord.deliveryInstruction}
-            />
-          ) : (
-            "N/A"
-          )}
-        </dd>
-      </div>
+          <dt
+            css={css`
+              ${dtCss()}
+            `}
+          >
+            Instructions:
+          </dt>
+          <dd
+            css={css`
+              ${ddCss}
+            `}
+          >
+            {props.deliveryRecord.deliveryInstruction &&
+            !props.deliveryRecord.hasHolidayStop ? (
+              <DeliveryRecordInstructions
+                message={props.deliveryRecord.deliveryInstruction}
+              />
+            ) : (
+              "N/A"
+            )}
+          </dd>
+        </div>
+      )}
     </dl>
   );
 };

--- a/app/client/components/delivery/records/deliveryRecords.tsx
+++ b/app/client/components/delivery/records/deliveryRecords.tsx
@@ -544,6 +544,9 @@ export const DeliveryRecordsFC = (props: DeliveryRecordsFCProps) => {
                 removeRecordFromDeliveryProblem={
                   removeRecordFromDeliveryProblem
                 }
+                showDeliveryInstructions={
+                  productType.delivery.records.showDeliveryInstructions
+                }
                 recordCurrency={props.subscriptionCurrency}
                 isChecked={selectedProblemRecords.includes(deliveryRecord.id)}
                 productName={capitalize(

--- a/app/client/components/delivery/records/deliveryRecordsProblemConfirmation.tsx
+++ b/app/client/components/delivery/records/deliveryRecordsProblemConfirmation.tsx
@@ -278,6 +278,10 @@ const DeliveryRecordsProblemConfirmationFC = (
                     deliveryRecord={deliveryRecord}
                     listIndex={listIndex}
                     pageStatus={PageStatus.REPORT_ISSUE_CONFIRMATION}
+                    showDeliveryInstructions={
+                      props.routeableStepProps.productType.delivery?.records
+                        ?.showDeliveryInstructions
+                    }
                     deliveryProblemMap={props.data.deliveryProblemMap}
                     recordCurrency={props.subscriptionCurrency}
                   />

--- a/app/client/components/delivery/records/deliveryRecordsProblemReview.tsx
+++ b/app/client/components/delivery/records/deliveryRecordsProblemReview.tsx
@@ -387,6 +387,10 @@ const DeliveryRecordsProblemReviewFC = (
                         deliveryRecord={deliveryRecord}
                         listIndex={listIndex}
                         pageStatus={PageStatus.READ_ONLY}
+                        showDeliveryInstructions={
+                          props.productType.delivery.records
+                            .showDeliveryInstructions
+                        }
                         deliveryProblemMap={
                           deliveryProblemContext.deliveryProblemMap
                         }


### PR DESCRIPTION
## What does this change?
Delivery instructions are currently only guaranteed to be forwarded on to newspaper subscription delivery partners. This does not include Guardian Weekly subscriptions.

This pr is to remove the delivery instructions from the delivery history/record problem reporting journey. The delivery instructions are only shown if the `showDeliveryInstructions` property is set to true in `productTypes`

[ticket](https://trello.com/c/jOtYGBz2/959-task-remove-instructions-for-guardian-weekly-on-delivery-history-display)

## Images
Before             |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/2510683/86806471-ce67ca00-c070-11ea-9a16-7cb0b2747451.png)  |  ![](https://user-images.githubusercontent.com/2510683/86806463-cb6cd980-c070-11ea-8a83-6fe65e0d955f.png)