### PR TITLE
Rc/cmp

### DIFF
--- a/app/client/__tests__/__snapshots__/main.tsx.snap
+++ b/app/client/__tests__/__snapshots__/main.tsx.snap
@@ -676,7 +676,12 @@ exports[`Main renders something 1`] = `
   <footer
     css={
       Object {
-        "marginTop": "2rem",
+        "map": undefined,
+        "name": "zpu9mn",
+        "next": undefined,
+        "styles": "
+  margin-top: 2rem;
+",
       }
     }
   >
@@ -684,47 +689,69 @@ exports[`Main renders something 1`] = `
       <div
         css={
           Object {
-            "backgroundColor": "#052962",
-            "color": "#ffffff",
+            "map": undefined,
+            "name": "vck559",
+            "next": undefined,
+            "styles": "
+  background-color: #052962;
+  color: #ffffff;
+",
           }
         }
       >
         <div
           css={
             Object {
-              "margin": "auto",
-              "maxWidth": "1300px",
+              "map": undefined,
+              "name": "1fkn892",
+              "next": undefined,
+              "styles": "
+  max-width: 1300px;
+  margin: auto;
+",
             }
           }
         >
           <div
             css={
               Object {
-                "@media (min-width: 1140px)": Object {
-                  "display": "flex",
-                },
-                "@media (min-width: 980px)": Object {
-                  "padding": "0 20px",
-                },
-                "border": "1px solid rgba(255,255,255,0.3)",
-                "borderTop": 0,
-                "padding": "10px",
+                "map": undefined,
+                "name": "1ku4d2x",
+                "next": undefined,
+                "styles": "
+  padding: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-top: 0;
+
+  @media (min-width: 980px) {
+    padding: 0 20px;
+  }
+
+  @media (min-width: 1140px) {
+    display: flex;
+  }
+",
               }
             }
           >
             <div
               css={
                 Object {
-                  "@media (min-width: 1140px)": Object {
-                    "width": "340px",
-                  },
-                  "@media (min-width: 1300px)": Object {
-                    "width": "460px",
-                  },
-                  "border": 0,
-                  "margin": 0,
-                  "padding": 0,
-                  "width": "100%",
+                  "map": undefined,
+                  "name": "1jqhtyp",
+                  "next": undefined,
+                  "styles": "
+  padding: 0;
+  border: 0;
+  width: 100%;
+  margin: 0;
+  @media (min-width: 1140px) {
+    width: 340px;
+  }
+  @media (min-width: 1300px) {
+    width: 460px;
+  }
+",
                 }
               }
             >
@@ -743,61 +770,86 @@ exports[`Main renders something 1`] = `
             <div
               css={
                 Object {
-                  "@media (min-width: 1300px)": Object {
-                    "borderTop": 0,
-                  },
-                  "borderTop": "1px solid rgba(255,255,255,0.3)",
-                  "display": "flex",
-                  "flexDirection": "row",
-                  "flexWrap": "wrap",
-                  "fontFeatureSettings": "kern",
-                  "fontSize": "16px",
-                  "lineHeight": "16px",
-                  "paddingBottom": "18px",
+                  "map": undefined,
+                  "name": "1x6vqcu",
+                  "next": undefined,
+                  "styles": "
+  font-feature-settings: kern;
+  font-size: 16px;
+  line-height: 16px;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  padding-bottom: 18px;
+  border-top: 1px solid rgba(255, 255, 255, 0.3);
+  @media (min-width: 1300px) {
+    border-top: 0;
+  }
+",
                 }
               }
             >
               <ul
                 css={
                   Object {
-                    "&:nth-of-type(even)": Object {
-                      "borderLeft": "1px solid rgba(255,255,255,0.3)",
-                    },
-                    "@media (min-width: 740px)": Object {
-                      "&:not(:first-of-type)": Object {
-                        "borderLeft": "1px solid rgba(255,255,255,0.3)",
-                      },
-                      "flex": "1 0 0",
-                      "width": "161px",
-                    },
-                    "@media (min-width: 980px)": Object {
-                      "borderLeft": "1px solid rgba(255,255,255,0.3)",
-                    },
-                    "lineHeight": "19.2px",
-                    "listStyle": "none",
-                    "margin": 0,
-                    "padding": "0 10px",
-                    "position": "relative",
-                    "width": "calc(50% - 1.250rem - 1px)",
+                    "map": undefined,
+                    "name": "1hkg2v9",
+                    "next": undefined,
+                    "styles": "
+  line-height: 19.2px;
+  width: calc(50% - 1.25rem - 1px);
+  list-style: none;
+  position: relative;
+  padding: 0 10px;
+  margin: 0;
+
+  &:nth-of-type(even) {
+    border-left: 1px solid rgba(255, 255, 255, 0.3);
+  }
+
+  @media (min-width: 740px) {
+    &:not(:first-of-type) {
+      border-left: 1px solid rgba(255, 255, 255, 0.3);
+    }
+
+    width: 161px;
+    flex: 1 0 0;
+  }
+
+  @media (min-width: 980px) {
+    border-left: 1px solid rgba(255, 255, 255, 0.3);
+  }
+",
                   }
                 }
               >
                 <li
                   css={
                     Object {
-                      "listStyle": "none",
+                      "map": undefined,
+                      "name": "66iazq",
+                      "next": undefined,
+                      "styles": "
+  list-style: none;
+",
                     }
                   }
                 >
                   <a
                     css={
                       Object {
-                        ":hover": Object {
-                          "color": "#ffe500",
-                        },
-                        "color": "#ffffff",
-                        "display": "inline-block",
-                        "padding": "6px 0",
+                        "map": undefined,
+                        "name": "1x52xav",
+                        "next": undefined,
+                        "styles": "
+  display: inline-block;
+  padding: 6px 0;
+  color: #ffffff;
+  :hover {
+    color: #ffe500;
+    cursor: pointer;
+  }
+",
                       }
                     }
                     href="https://thegulocal.com/about"
@@ -808,19 +860,30 @@ exports[`Main renders something 1`] = `
                 <li
                   css={
                     Object {
-                      "listStyle": "none",
+                      "map": undefined,
+                      "name": "66iazq",
+                      "next": undefined,
+                      "styles": "
+  list-style: none;
+",
                     }
                   }
                 >
                   <a
                     css={
                       Object {
-                        ":hover": Object {
-                          "color": "#ffe500",
-                        },
-                        "color": "#ffffff",
-                        "display": "inline-block",
-                        "padding": "6px 0",
+                        "map": undefined,
+                        "name": "1x52xav",
+                        "next": undefined,
+                        "styles": "
+  display: inline-block;
+  padding: 6px 0;
+  color: #ffffff;
+  :hover {
+    color: #ffe500;
+    cursor: pointer;
+  }
+",
                       }
                     }
                     href="https://thegulocal.com/help/contact-us"
@@ -831,19 +894,30 @@ exports[`Main renders something 1`] = `
                 <li
                   css={
                     Object {
-                      "listStyle": "none",
+                      "map": undefined,
+                      "name": "66iazq",
+                      "next": undefined,
+                      "styles": "
+  list-style: none;
+",
                     }
                   }
                 >
                   <a
                     css={
                       Object {
-                        ":hover": Object {
-                          "color": "#ffe500",
-                        },
-                        "color": "#ffffff",
-                        "display": "inline-block",
-                        "padding": "6px 0",
+                        "map": undefined,
+                        "name": "1x52xav",
+                        "next": undefined,
+                        "styles": "
+  display: inline-block;
+  padding: 6px 0;
+  color: #ffffff;
+  :hover {
+    color: #ffe500;
+    cursor: pointer;
+  }
+",
                       }
                     }
                     href="https://thegulocal.com/info/complaints-and-corrections"
@@ -854,19 +928,30 @@ exports[`Main renders something 1`] = `
                 <li
                   css={
                     Object {
-                      "listStyle": "none",
+                      "map": undefined,
+                      "name": "66iazq",
+                      "next": undefined,
+                      "styles": "
+  list-style: none;
+",
                     }
                   }
                 >
                   <a
                     css={
                       Object {
-                        ":hover": Object {
-                          "color": "#ffe500",
-                        },
-                        "color": "#ffffff",
-                        "display": "inline-block",
-                        "padding": "6px 0",
+                        "map": undefined,
+                        "name": "1x52xav",
+                        "next": undefined,
+                        "styles": "
+  display: inline-block;
+  padding: 6px 0;
+  color: #ffffff;
+  :hover {
+    color: #ffe500;
+    cursor: pointer;
+  }
+",
                       }
                     }
                     href="https://thegulocal.com/securedrop"
@@ -877,19 +962,30 @@ exports[`Main renders something 1`] = `
                 <li
                   css={
                     Object {
-                      "listStyle": "none",
+                      "map": undefined,
+                      "name": "66iazq",
+                      "next": undefined,
+                      "styles": "
+  list-style: none;
+",
                     }
                   }
                 >
                   <a
                     css={
                       Object {
-                        ":hover": Object {
-                          "color": "#ffe500",
-                        },
-                        "color": "#ffffff",
-                        "display": "inline-block",
-                        "padding": "6px 0",
+                        "map": undefined,
+                        "name": "1x52xav",
+                        "next": undefined,
+                        "styles": "
+  display: inline-block;
+  padding: 6px 0;
+  color: #ffffff;
+  :hover {
+    color: #ffe500;
+    cursor: pointer;
+  }
+",
                       }
                     }
                     href="https://workforus.thegulocal.com"
@@ -900,19 +996,30 @@ exports[`Main renders something 1`] = `
                 <li
                   css={
                     Object {
-                      "listStyle": "none",
+                      "map": undefined,
+                      "name": "66iazq",
+                      "next": undefined,
+                      "styles": "
+  list-style: none;
+",
                     }
                   }
                 >
                   <a
                     css={
                       Object {
-                        ":hover": Object {
-                          "color": "#ffe500",
-                        },
-                        "color": "#ffffff",
-                        "display": "inline-block",
-                        "padding": "6px 0",
+                        "map": undefined,
+                        "name": "1x52xav",
+                        "next": undefined,
+                        "styles": "
+  display: inline-block;
+  padding: 6px 0;
+  color: #ffffff;
+  :hover {
+    color: #ffe500;
+    cursor: pointer;
+  }
+",
                       }
                     }
                     href="https://thegulocal.com/info/privacy"
@@ -923,19 +1030,30 @@ exports[`Main renders something 1`] = `
                 <li
                   css={
                     Object {
-                      "listStyle": "none",
+                      "map": undefined,
+                      "name": "66iazq",
+                      "next": undefined,
+                      "styles": "
+  list-style: none;
+",
                     }
                   }
                 >
                   <a
                     css={
                       Object {
-                        ":hover": Object {
-                          "color": "#ffe500",
-                        },
-                        "color": "#ffffff",
-                        "display": "inline-block",
-                        "padding": "6px 0",
+                        "map": undefined,
+                        "name": "1x52xav",
+                        "next": undefined,
+                        "styles": "
+  display: inline-block;
+  padding: 6px 0;
+  color: #ffffff;
+  :hover {
+    color: #ffe500;
+    cursor: pointer;
+  }
+",
                       }
                     }
                     href="https://thegulocal.com/info/cookies"
@@ -946,19 +1064,30 @@ exports[`Main renders something 1`] = `
                 <li
                   css={
                     Object {
-                      "listStyle": "none",
+                      "map": undefined,
+                      "name": "66iazq",
+                      "next": undefined,
+                      "styles": "
+  list-style: none;
+",
                     }
                   }
                 >
                   <a
                     css={
                       Object {
-                        ":hover": Object {
-                          "color": "#ffe500",
-                        },
-                        "color": "#ffffff",
-                        "display": "inline-block",
-                        "padding": "6px 0",
+                        "map": undefined,
+                        "name": "1x52xav",
+                        "next": undefined,
+                        "styles": "
+  display: inline-block;
+  padding: 6px 0;
+  color: #ffffff;
+  :hover {
+    color: #ffe500;
+    cursor: pointer;
+  }
+",
                       }
                     }
                     href="https://www.thegulocal.com/help/terms-of-service"
@@ -969,19 +1098,30 @@ exports[`Main renders something 1`] = `
                 <li
                   css={
                     Object {
-                      "listStyle": "none",
+                      "map": undefined,
+                      "name": "66iazq",
+                      "next": undefined,
+                      "styles": "
+  list-style: none;
+",
                     }
                   }
                 >
                   <a
                     css={
                       Object {
-                        ":hover": Object {
-                          "color": "#ffe500",
-                        },
-                        "color": "#ffffff",
-                        "display": "inline-block",
-                        "padding": "6px 0",
+                        "map": undefined,
+                        "name": "1x52xav",
+                        "next": undefined,
+                        "styles": "
+  display: inline-block;
+  padding: 6px 0;
+  color: #ffffff;
+  :hover {
+    color: #ffe500;
+    cursor: pointer;
+  }
+",
                       }
                     }
                     href="https://www.thegulocal.com/help"
@@ -993,44 +1133,64 @@ exports[`Main renders something 1`] = `
               <ul
                 css={
                   Object {
-                    "&:nth-of-type(even)": Object {
-                      "borderLeft": "1px solid rgba(255,255,255,0.3)",
-                    },
-                    "@media (min-width: 740px)": Object {
-                      "&:not(:first-of-type)": Object {
-                        "borderLeft": "1px solid rgba(255,255,255,0.3)",
-                      },
-                      "flex": "1 0 0",
-                      "width": "161px",
-                    },
-                    "@media (min-width: 980px)": Object {
-                      "borderLeft": "1px solid rgba(255,255,255,0.3)",
-                    },
-                    "lineHeight": "19.2px",
-                    "listStyle": "none",
-                    "margin": 0,
-                    "padding": "0 10px",
-                    "position": "relative",
-                    "width": "calc(50% - 1.250rem - 1px)",
+                    "map": undefined,
+                    "name": "1hkg2v9",
+                    "next": undefined,
+                    "styles": "
+  line-height: 19.2px;
+  width: calc(50% - 1.25rem - 1px);
+  list-style: none;
+  position: relative;
+  padding: 0 10px;
+  margin: 0;
+
+  &:nth-of-type(even) {
+    border-left: 1px solid rgba(255, 255, 255, 0.3);
+  }
+
+  @media (min-width: 740px) {
+    &:not(:first-of-type) {
+      border-left: 1px solid rgba(255, 255, 255, 0.3);
+    }
+
+    width: 161px;
+    flex: 1 0 0;
+  }
+
+  @media (min-width: 980px) {
+    border-left: 1px solid rgba(255, 255, 255, 0.3);
+  }
+",
                   }
                 }
               >
                 <li
                   css={
                     Object {
-                      "listStyle": "none",
+                      "map": undefined,
+                      "name": "66iazq",
+                      "next": undefined,
+                      "styles": "
+  list-style: none;
+",
                     }
                   }
                 >
                   <a
                     css={
                       Object {
-                        ":hover": Object {
-                          "color": "#ffe500",
-                        },
-                        "color": "#ffffff",
-                        "display": "inline-block",
-                        "padding": "6px 0",
+                        "map": undefined,
+                        "name": "1x52xav",
+                        "next": undefined,
+                        "styles": "
+  display: inline-block;
+  padding: 6px 0;
+  color: #ffffff;
+  :hover {
+    color: #ffe500;
+    cursor: pointer;
+  }
+",
                       }
                     }
                     href="https://thegulocal.com/index/subjects/a"
@@ -1041,19 +1201,30 @@ exports[`Main renders something 1`] = `
                 <li
                   css={
                     Object {
-                      "listStyle": "none",
+                      "map": undefined,
+                      "name": "66iazq",
+                      "next": undefined,
+                      "styles": "
+  list-style: none;
+",
                     }
                   }
                 >
                   <a
                     css={
                       Object {
-                        ":hover": Object {
-                          "color": "#ffe500",
-                        },
-                        "color": "#ffffff",
-                        "display": "inline-block",
-                        "padding": "6px 0",
+                        "map": undefined,
+                        "name": "1x52xav",
+                        "next": undefined,
+                        "styles": "
+  display: inline-block;
+  padding: 6px 0;
+  color: #ffffff;
+  :hover {
+    color: #ffe500;
+    cursor: pointer;
+  }
+",
                       }
                     }
                     href="https://thegulocal.com/index/contributors"
@@ -1064,19 +1235,30 @@ exports[`Main renders something 1`] = `
                 <li
                   css={
                     Object {
-                      "listStyle": "none",
+                      "map": undefined,
+                      "name": "66iazq",
+                      "next": undefined,
+                      "styles": "
+  list-style: none;
+",
                     }
                   }
                 >
                   <a
                     css={
                       Object {
-                        ":hover": Object {
-                          "color": "#ffe500",
-                        },
-                        "color": "#ffffff",
-                        "display": "inline-block",
-                        "padding": "6px 0",
+                        "map": undefined,
+                        "name": "1x52xav",
+                        "next": undefined,
+                        "styles": "
+  display: inline-block;
+  padding: 6px 0;
+  color: #ffffff;
+  :hover {
+    color: #ffe500;
+    cursor: pointer;
+  }
+",
                       }
                     }
                     href="https://thegulocal.com/info/2016/jul/27/modern-slavery-and-our-supply-chains?INTCMP=NGW_FOOTER_UK_GU_MODERN_SLAVERY_ACT"
@@ -1087,19 +1269,30 @@ exports[`Main renders something 1`] = `
                 <li
                   css={
                     Object {
-                      "listStyle": "none",
+                      "map": undefined,
+                      "name": "66iazq",
+                      "next": undefined,
+                      "styles": "
+  list-style: none;
+",
                     }
                   }
                 >
                   <a
                     css={
                       Object {
-                        ":hover": Object {
-                          "color": "#ffe500",
-                        },
-                        "color": "#ffffff",
-                        "display": "inline-block",
-                        "padding": "6px 0",
+                        "map": undefined,
+                        "name": "1x52xav",
+                        "next": undefined,
+                        "styles": "
+  display: inline-block;
+  padding: 6px 0;
+  color: #ffffff;
+  :hover {
+    color: #ffe500;
+    cursor: pointer;
+  }
+",
                       }
                     }
                     href="https://theguardian.newspapers.com/"
@@ -1110,19 +1303,30 @@ exports[`Main renders something 1`] = `
                 <li
                   css={
                     Object {
-                      "listStyle": "none",
+                      "map": undefined,
+                      "name": "66iazq",
+                      "next": undefined,
+                      "styles": "
+  list-style: none;
+",
                     }
                   }
                 >
                   <a
                     css={
                       Object {
-                        ":hover": Object {
-                          "color": "#ffe500",
-                        },
-                        "color": "#ffffff",
-                        "display": "inline-block",
-                        "padding": "6px 0",
+                        "map": undefined,
+                        "name": "1x52xav",
+                        "next": undefined,
+                        "styles": "
+  display: inline-block;
+  padding: 6px 0;
+  color: #ffffff;
+  :hover {
+    color: #ffe500;
+    cursor: pointer;
+  }
+",
                       }
                     }
                     href="https://www.facebook.com/theguardian"
@@ -1133,19 +1337,30 @@ exports[`Main renders something 1`] = `
                 <li
                   css={
                     Object {
-                      "listStyle": "none",
+                      "map": undefined,
+                      "name": "66iazq",
+                      "next": undefined,
+                      "styles": "
+  list-style: none;
+",
                     }
                   }
                 >
                   <a
                     css={
                       Object {
-                        ":hover": Object {
-                          "color": "#ffe500",
-                        },
-                        "color": "#ffffff",
-                        "display": "inline-block",
-                        "padding": "6px 0",
+                        "map": undefined,
+                        "name": "1x52xav",
+                        "next": undefined,
+                        "styles": "
+  display: inline-block;
+  padding: 6px 0;
+  color: #ffffff;
+  :hover {
+    color: #ffe500;
+    cursor: pointer;
+  }
+",
                       }
                     }
                     href="https://twitter.com/guardian"
@@ -1157,44 +1372,64 @@ exports[`Main renders something 1`] = `
               <ul
                 css={
                   Object {
-                    "&:nth-of-type(even)": Object {
-                      "borderLeft": "1px solid rgba(255,255,255,0.3)",
-                    },
-                    "@media (min-width: 740px)": Object {
-                      "&:not(:first-of-type)": Object {
-                        "borderLeft": "1px solid rgba(255,255,255,0.3)",
-                      },
-                      "flex": "1 0 0",
-                      "width": "161px",
-                    },
-                    "@media (min-width: 980px)": Object {
-                      "borderLeft": "1px solid rgba(255,255,255,0.3)",
-                    },
-                    "lineHeight": "19.2px",
-                    "listStyle": "none",
-                    "margin": 0,
-                    "padding": "0 10px",
-                    "position": "relative",
-                    "width": "calc(50% - 1.250rem - 1px)",
+                    "map": undefined,
+                    "name": "1hkg2v9",
+                    "next": undefined,
+                    "styles": "
+  line-height: 19.2px;
+  width: calc(50% - 1.25rem - 1px);
+  list-style: none;
+  position: relative;
+  padding: 0 10px;
+  margin: 0;
+
+  &:nth-of-type(even) {
+    border-left: 1px solid rgba(255, 255, 255, 0.3);
+  }
+
+  @media (min-width: 740px) {
+    &:not(:first-of-type) {
+      border-left: 1px solid rgba(255, 255, 255, 0.3);
+    }
+
+    width: 161px;
+    flex: 1 0 0;
+  }
+
+  @media (min-width: 980px) {
+    border-left: 1px solid rgba(255, 255, 255, 0.3);
+  }
+",
                   }
                 }
               >
                 <li
                   css={
                     Object {
-                      "listStyle": "none",
+                      "map": undefined,
+                      "name": "66iazq",
+                      "next": undefined,
+                      "styles": "
+  list-style: none;
+",
                     }
                   }
                 >
                   <a
                     css={
                       Object {
-                        ":hover": Object {
-                          "color": "#ffe500",
-                        },
-                        "color": "#ffffff",
-                        "display": "inline-block",
-                        "padding": "6px 0",
+                        "map": undefined,
+                        "name": "1x52xav",
+                        "next": undefined,
+                        "styles": "
+  display: inline-block;
+  padding: 6px 0;
+  color: #ffffff;
+  :hover {
+    color: #ffe500;
+    cursor: pointer;
+  }
+",
                       }
                     }
                     href="https://advertising.thegulocal.com"
@@ -1205,19 +1440,30 @@ exports[`Main renders something 1`] = `
                 <li
                   css={
                     Object {
-                      "listStyle": "none",
+                      "map": undefined,
+                      "name": "66iazq",
+                      "next": undefined,
+                      "styles": "
+  list-style: none;
+",
                     }
                   }
                 >
                   <a
                     css={
                       Object {
-                        ":hover": Object {
-                          "color": "#ffe500",
-                        },
-                        "color": "#ffffff",
-                        "display": "inline-block",
-                        "padding": "6px 0",
+                        "map": undefined,
+                        "name": "1x52xav",
+                        "next": undefined,
+                        "styles": "
+  display: inline-block;
+  padding: 6px 0;
+  color: #ffffff;
+  :hover {
+    color: #ffe500;
+    cursor: pointer;
+  }
+",
                       }
                     }
                     href="https://thegulocal.com/guardian-labs"
@@ -1228,19 +1474,30 @@ exports[`Main renders something 1`] = `
                 <li
                   css={
                     Object {
-                      "listStyle": "none",
+                      "map": undefined,
+                      "name": "66iazq",
+                      "next": undefined,
+                      "styles": "
+  list-style: none;
+",
                     }
                   }
                 >
                   <a
                     css={
                       Object {
-                        ":hover": Object {
-                          "color": "#ffe500",
-                        },
-                        "color": "#ffffff",
-                        "display": "inline-block",
-                        "padding": "6px 0",
+                        "map": undefined,
+                        "name": "1x52xav",
+                        "next": undefined,
+                        "styles": "
+  display: inline-block;
+  padding: 6px 0;
+  color: #ffffff;
+  :hover {
+    color: #ffe500;
+    cursor: pointer;
+  }
+",
                       }
                     }
                     href="https://jobs.thegulocal.com/?INTCMP=NGW_FOOTER_UK_GU_JOBS"
@@ -1251,19 +1508,30 @@ exports[`Main renders something 1`] = `
                 <li
                   css={
                     Object {
-                      "listStyle": "none",
+                      "map": undefined,
+                      "name": "66iazq",
+                      "next": undefined,
+                      "styles": "
+  list-style: none;
+",
                     }
                   }
                 >
                   <a
                     css={
                       Object {
-                        ":hover": Object {
-                          "color": "#ffe500",
-                        },
-                        "color": "#ffffff",
-                        "display": "inline-block",
-                        "padding": "6px 0",
+                        "map": undefined,
+                        "name": "1x52xav",
+                        "next": undefined,
+                        "styles": "
+  display: inline-block;
+  padding: 6px 0;
+  color: #ffffff;
+  :hover {
+    color: #ffe500;
+    cursor: pointer;
+  }
+",
                       }
                     }
                     href="https://soulmates.thegulocal.com/?INTCMP=NGW_FOOTER_UK_GU_SOULMATES"
@@ -1274,19 +1542,30 @@ exports[`Main renders something 1`] = `
                 <li
                   css={
                     Object {
-                      "listStyle": "none",
+                      "map": undefined,
+                      "name": "66iazq",
+                      "next": undefined,
+                      "styles": "
+  list-style: none;
+",
                     }
                   }
                 >
                   <a
                     css={
                       Object {
-                        ":hover": Object {
-                          "color": "#ffe500",
-                        },
-                        "color": "#ffffff",
-                        "display": "inline-block",
-                        "padding": "6px 0",
+                        "map": undefined,
+                        "name": "1x52xav",
+                        "next": undefined,
+                        "styles": "
+  display: inline-block;
+  padding: 6px 0;
+  color: #ffffff;
+  :hover {
+    color: #ffe500;
+    cursor: pointer;
+  }
+",
                       }
                     }
                     href="https://patrons.thegulocal.com/?INTCMP=footer_patrons"
@@ -1297,19 +1576,30 @@ exports[`Main renders something 1`] = `
                 <li
                   css={
                     Object {
-                      "listStyle": "none",
+                      "map": undefined,
+                      "name": "66iazq",
+                      "next": undefined,
+                      "styles": "
+  list-style: none;
+",
                     }
                   }
                 >
                   <a
                     css={
                       Object {
-                        ":hover": Object {
-                          "color": "#ffe500",
-                        },
-                        "color": "#ffffff",
-                        "display": "inline-block",
-                        "padding": "6px 0",
+                        "map": undefined,
+                        "name": "1x52xav",
+                        "next": undefined,
+                        "styles": "
+  display: inline-block;
+  padding: 6px 0;
+  color: #ffffff;
+  :hover {
+    color: #ffe500;
+    cursor: pointer;
+  }
+",
                       }
                     }
                     href="https://discountcode.thegulocal.com/uk?INTCMP=guardian_footer"
@@ -1321,33 +1611,43 @@ exports[`Main renders something 1`] = `
               <div
                 css={
                   Object {
-                    "@media (min-width: 660px)": Object {
-                      "width": "300px",
-                    },
-                    "@media (min-width: 740px)": Object {
-                      "borderTop": 0,
-                    },
-                    "borderLeft": "1px solid rgba(255,255,255,0.3)",
-                    "borderTop": "1px solid rgba(255,255,255,0.3)",
-                    "paddingLeft": "10px",
-                    "width": "50%",
+                    "map": undefined,
+                    "name": "pt8jss",
+                    "next": undefined,
+                    "styles": "
+  width: 50%;
+  border-left: 1px solid rgba(255, 255, 255, 0.3);
+  padding-left: 10px;
+  @media (min-width: 660px) {
+    width: 300px;
+  }
+  border-top: 1px solid rgba(255, 255, 255, 0.3);
+  @media (min-width: 740px) {
+    border-top: 0;
+  }
+",
                   }
                 }
               >
                 <div
                   css={
                     Object {
-                      "@media (min-width: 660px)": Object {
-                        "fontSize": "32px",
-                        "lineHeight": "32px",
-                      },
-                      "color": "#ffe500",
-                      "fontFamily": "GH Guardian Headline, \\"GuardianTextEgyptian\\", Georgia, serif",
-                      "fontSize": "24px",
-                      "fontWeight": "bold",
-                      "lineHeight": "24px",
-                      "marginBottom": "12px",
-                      "marginTop": "3px",
+                      "map": undefined,
+                      "name": "1k0upo6",
+                      "next": undefined,
+                      "styles": "
+  color: #ffe500;
+  font-family: GH Guardian Headline, \\"GuardianTextEgyptian\\", Georgia, serif;
+  font-size: 24px;
+  line-height: 24px;
+  font-weight: bold;
+  margin-top: 3px;
+  margin-bottom: 12px;
+  @media (min-width: 660px) {
+    font-size: 32px;
+    line-height: 32px;
+  }
+",
                     }
                   }
                 >
@@ -1356,9 +1656,14 @@ exports[`Main renders something 1`] = `
                 <div
                   css={
                     Object {
-                      "display": "inline-block",
-                      "marginBottom": "6px",
-                      "marginRight": "10px",
+                      "map": undefined,
+                      "name": "l2bq3g",
+                      "next": undefined,
+                      "styles": "
+  display: inline-block;
+  margin-right: 10px;
+  margin-bottom: 6px;
+",
                     }
                   }
                 >
@@ -1419,27 +1724,37 @@ exports[`Main renders something 1`] = `
           <div
             css={
               Object {
-                "paddingBottom": "24px",
-                "paddingLeft": "20px",
-                "paddingRight": "20px",
-                "position": "relative",
+                "map": undefined,
+                "name": "1wu2ni1",
+                "next": undefined,
+                "styles": "
+  padding-bottom: 24px;
+  padding-left: 20px;
+  padding-right: 20px;
+  position: relative;
+",
               }
             }
           >
             <a
               css={
                 Object {
-                  ":hover": Object {
-                    "color": "#ffe500",
-                  },
-                  "backgroundColor": "#052962",
-                  "color": "#ffffff",
-                  "fontSize": "16px",
-                  "fontWeight": "bold",
-                  "padding": "0 5px",
-                  "position": "absolute",
-                  "right": "20px",
-                  "transform": "translateY(-50%)",
+                  "map": undefined,
+                  "name": "rhcyrc",
+                  "next": undefined,
+                  "styles": "
+  font-size: 16px;
+  color: #ffffff;
+  font-weight: bold;
+  padding: 0 5px;
+  background-color: #052962;
+  :hover {
+    color: #ffe500;
+  }
+  position: absolute;
+  right: 20px;
+  transform: translateY(-50%);
+",
                 }
               }
               href="#top"
@@ -1447,9 +1762,14 @@ exports[`Main renders something 1`] = `
               <span
                 css={
                   Object {
-                    "display": "inline-block",
-                    "paddingRight": "5px",
-                    "paddingTop": "9px",
+                    "map": undefined,
+                    "name": "m3p6yb",
+                    "next": undefined,
+                    "styles": "
+  display: inline-block;
+  padding-right: 5px;
+  padding-top: 9px;
+",
                   }
                 }
               >
@@ -1458,22 +1778,32 @@ exports[`Main renders something 1`] = `
               <span
                 css={
                   Object {
-                    "backgroundColor": "currentColor",
-                    "borderRadius": "100%",
-                    "float": "right",
-                    "height": "42px",
-                    "position": "relative",
-                    "width": "42px",
+                    "map": undefined,
+                    "name": "n17lfs",
+                    "next": undefined,
+                    "styles": "
+  position: relative;
+  float: right;
+  background-color: currentColor;
+  border-radius: 100%;
+  height: 42px;
+  width: 42px;
+",
                   }
                 }
               >
                 <span
                   css={
                     Object {
-                      "fill": "#052962",
-                      "left": "9px",
-                      "position": "absolute",
-                      "top": "9px",
+                      "map": undefined,
+                      "name": "1e08lku",
+                      "next": undefined,
+                      "styles": "
+  position: absolute;
+  fill: #052962;
+  top: 9px;
+  left: 9px;
+",
                     }
                   }
                 >
@@ -1492,11 +1822,16 @@ exports[`Main renders something 1`] = `
             <div
               css={
                 Object {
-                  "@media (min-width: 740px)": Object {
-                    "paddingTop": "6px",
-                  },
-                  "fontSize": "12px",
-                  "paddingTop": "26px",
+                  "map": undefined,
+                  "name": "n9fado",
+                  "next": undefined,
+                  "styles": "
+  @media (min-width: 740px) {
+    padding-top: 6px;
+  }
+  padding-top: 26px;
+  font-size: 12px;
+",
                 }
               }
             >

--- a/app/client/__tests__/cookies.ts
+++ b/app/client/__tests__/cookies.ts
@@ -23,7 +23,7 @@ describe("cookies", () => {
 
   it("getCookie returns the cookie value when a cookie is found", () => {
     // tslint:disable-next-line:no-object-mutation
-    window.document.cookie = `testName=testValue;${cookieName}=${cookieValue}`;
+    window.document.cookie = `testName=testValue; ${cookieName}=${cookieValue}`;
 
     expect(getCookie(cookieName)).toBe(cookieValue);
   });

--- a/app/client/__tests__/cookies.ts
+++ b/app/client/__tests__/cookies.ts
@@ -1,0 +1,30 @@
+import { getCookie } from "../cookies";
+
+const cookieName = "testCookie";
+const cookieValue = "whatever";
+
+describe("cookies", () => {
+  beforeAll(() => {
+    Object.defineProperty(window.document, "cookie", {
+      writable: true,
+      value: ""
+    });
+  });
+  it("getCookie returns null when no cookie exists", () => {
+    expect(getCookie(cookieName)).toBeNull();
+  });
+
+  it("getCookie returns null when no cookie is found", () => {
+    // tslint:disable-next-line:no-object-mutation
+    window.document.cookie = "testName=testValue;";
+
+    expect(getCookie(cookieName)).toBeNull();
+  });
+
+  it("getCookie returns the cookie value when a cookie is found", () => {
+    // tslint:disable-next-line:no-object-mutation
+    window.document.cookie = `testName=testValue;${cookieName}=${cookieValue}`;
+
+    expect(getCookie(cookieName)).toBe(cookieValue);
+  });
+});

--- a/app/client/__tests__/geolocation.ts
+++ b/app/client/__tests__/geolocation.ts
@@ -1,0 +1,26 @@
+import { _, isInUSA } from "../geolocation";
+
+let mockGeoCookieValue: string | null = null;
+
+jest.mock("../cookies", () => ({
+  getCookie: jest.fn(() => mockGeoCookieValue)
+}));
+
+describe("Geolocation", () => {
+  beforeEach(() => {
+    mockGeoCookieValue = null;
+    _.resetModule();
+  });
+
+  it("isInUSA returns true when user geolocation cookie is 'US'", () => {
+    mockGeoCookieValue = "US";
+
+    expect(isInUSA()).toBeTruthy();
+  });
+
+  it("isInUSA returns false when user geolocation cookie is not 'US'", () => {
+    mockGeoCookieValue = "GB";
+
+    expect(isInUSA()).toBeFalsy();
+  });
+});

--- a/app/client/components/consent/consentsBanner.tsx
+++ b/app/client/components/consent/consentsBanner.tsx
@@ -1,6 +1,7 @@
 import { RouteComponentProps } from "@reach/router";
 import React from "react";
 import palette from "../../colours";
+import { getCookie } from "../../cookies";
 import { maxWidth } from "../../styles/breakpoints";
 import { sans } from "../../styles/fonts";
 import { trackEventInOphanOnly } from "../analytics";
@@ -14,11 +15,7 @@ const CONSENTS_BANNER_OPHAN_EVENT_CATEGORY = "consents_banner";
 
 const documentIsAvailable = typeof document !== "undefined" && document;
 
-const requiresConsents = () =>
-  documentIsAvailable &&
-  !document.cookie
-    .split(";")
-    .find(keyValue => keyValue.trim().startsWith(CONSENT_COOKIE_NAME + "="));
+const requiresConsents = () => !getCookie(CONSENT_COOKIE_NAME);
 
 interface ConsentsBannerState {
   requiresConsents: boolean;

--- a/app/client/components/footer/footer.tsx
+++ b/app/client/components/footer/footer.tsx
@@ -231,8 +231,8 @@ export const Footer = () => {
               <div css={footerMenuStyles}>
                 {footerLinks.map((linkList, i) => (
                   <ul key={i} css={footerMenuUlStyles}>
-                    {linkList.map(({ title, link, onClick }) => {
-                      return (
+                    {linkList.map(({ title, link, onClick, USAonly }) => {
+                      return USAonly && !useCCPA ? null : (
                         <li key={title} css={footerMenuLiStyles}>
                           <a
                             href={link}

--- a/app/client/components/footer/footer.tsx
+++ b/app/client/components/footer/footer.tsx
@@ -1,7 +1,8 @@
+import { css } from "@emotion/core";
+import { from } from "@guardian/src-foundations/mq";
 import React, { SyntheticEvent } from "react";
 import { conf } from "../../../server/config";
 import palette from "../../colours";
-import { minWidth } from "../../styles/breakpoints";
 import { headline } from "../../styles/fonts";
 import { SupportTheGuardianButton } from "../supportTheGuardianButton";
 import { footerLinks } from "./footerlinks";
@@ -15,57 +16,197 @@ if (typeof window !== "undefined" && window.guardian) {
 
 const TODAY = new Date();
 
+const footerStyles = css`
+  margin-top: 2rem;
+`;
+
+const footerColourStyles = css`
+  background-color: ${palette.blue.header};
+  color: ${palette.white};
+`;
+
+const footerSizeStyles = css`
+  max-width: 1300px;
+  margin: auto;
+`;
+
+const footerContentStyles = css`
+  padding: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-top: 0;
+
+  ${from.desktop} {
+    padding: 0 20px;
+  }
+
+  ${from.leftCol} {
+    display: flex;
+  }
+`;
+
+const emailSignUpStyles = css`
+  padding: 0;
+  border: 0;
+  width: 100%;
+  margin: 0;
+  ${from.leftCol} {
+    width: 340px;
+  }
+  ${from.wide} {
+    width: 460px;
+  }
+`;
+
+const footerMenuStyles = css`
+  font-feature-settings: kern;
+  font-size: 16px;
+  line-height: 16px;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  padding-bottom: 18px;
+  border-top: 1px solid rgba(255, 255, 255, 0.3);
+  ${from.wide} {
+    border-top: 0;
+  }
+`;
+
+const footerMenuUlStyles = css`
+  line-height: 19.2px;
+  width: calc(50% - 1.25rem - 1px);
+  list-style: none;
+  position: relative;
+  padding: 0 10px;
+  margin: 0;
+
+  &:nth-of-type(even) {
+    border-left: 1px solid rgba(255, 255, 255, 0.3);
+  }
+
+  ${from.tablet} {
+    &:not(:first-of-type) {
+      border-left: 1px solid rgba(255, 255, 255, 0.3);
+    }
+
+    width: 161px;
+    flex: 1 0 0;
+  }
+
+  ${from.desktop} {
+    border-left: 1px solid rgba(255, 255, 255, 0.3);
+  }
+`;
+
+const footerMenuLiStyles = css`
+  list-style: none;
+`;
+
+const footerLinkStyles = css`
+  display: inline-block;
+  padding: 6px 0;
+  color: ${palette.white};
+  :hover {
+    color: ${palette.yellow.medium};
+    cursor: pointer;
+  }
+`;
+
+const supportStyles = css`
+  width: 50%;
+  border-left: 1px solid rgba(255, 255, 255, 0.3);
+  padding-left: 10px;
+  ${from.phablet} {
+    width: 300px;
+  }
+  border-top: 1px solid rgba(255, 255, 255, 0.3);
+  ${from.tablet} {
+    border-top: 0;
+  }
+`;
+
+const supportTitleStyles = css`
+  color: ${palette.yellow.medium};
+  font-family: ${headline};
+  font-size: 24px;
+  line-height: 24px;
+  font-weight: bold;
+  margin-top: 3px;
+  margin-bottom: 12px;
+  ${from.phablet} {
+    font-size: 32px;
+    line-height: 32px;
+  }
+`;
+
+const supportButtonContainerStyles = css`
+  display: inline-block;
+  margin-right: 10px;
+  margin-bottom: 6px;
+`;
+
+const copyrightStyles = css`
+  padding-bottom: 24px;
+  padding-left: 20px;
+  padding-right: 20px;
+  position: relative;
+`;
+
+const backToTopLinkStyles = css`
+  font-size: 16px;
+  color: ${palette.white};
+  font-weight: bold;
+  padding: 0 5px;
+  background-color: ${palette.blue.header};
+  :hover {
+    color: ${palette.yellow.medium};
+  }
+  position: absolute;
+  right: 20px;
+  transform: translateY(-50%);
+`;
+
+const backToTopLabelStyles = css`
+  display: inline-block;
+  padding-right: 5px;
+  padding-top: 9px;
+`;
+
+const backToTopButtonOutterContainerStyles = css`
+  position: relative;
+  float: right;
+  background-color: currentColor;
+  border-radius: 100%;
+  height: 42px;
+  width: 42px;
+`;
+
+const backToTopButtonInnerContainerStyles = css`
+  position: absolute;
+  fill: ${palette.blue.header};
+  top: 9px;
+  left: 9px;
+`;
+
+const copyrightTextStyles = css`
+  ${from.tablet} {
+    padding-top: 6px;
+  }
+  padding-top: 26px;
+  font-size: 12px;
+`;
+
 const fillEmailSignup = (_: SyntheticEvent<HTMLIFrameElement>) => {
   // Placeholder method to autofill user email when the iframe is hosted on the same hostname
   return;
 };
 
 const Footer = () => (
-  <footer
-    css={{
-      marginTop: "2rem"
-    }}
-  >
+  <footer css={footerStyles}>
     <div>
-      <div
-        css={{
-          backgroundColor: palette.blue.header,
-          color: palette.white
-        }}
-      >
-        <div
-          css={{
-            maxWidth: "1300px",
-            margin: "auto"
-          }}
-        >
-          <div
-            css={{
-              padding: "10px",
-              border: "1px solid rgba(255,255,255,0.3)",
-              borderTop: 0,
-              [minWidth.desktop]: {
-                padding: "0 20px"
-              },
-              [minWidth.leftCol]: {
-                display: "flex"
-              }
-            }}
-          >
-            <div
-              css={{
-                padding: 0,
-                border: 0,
-                width: "100%",
-                margin: 0,
-                [minWidth.leftCol]: {
-                  width: "340px"
-                },
-                [minWidth.wide]: {
-                  width: "460px"
-                }
-              }}
-            >
+      <div css={footerColourStyles}>
+        <div css={footerSizeStyles}>
+          <div css={footerContentStyles}>
+            <div css={emailSignUpStyles}>
               <iframe
                 title="Guardian Email Sign-up Form"
                 src={`https://profile.${domain}/email/form/footer/today-uk`}
@@ -79,71 +220,13 @@ const Footer = () => (
               />
             </div>
 
-            <div
-              css={{
-                fontFeatureSettings: "kern",
-                fontSize: "16px",
-                lineHeight: "16px",
-                display: "flex",
-                flexDirection: "row",
-                flexWrap: "wrap",
-                paddingBottom: "18px",
-                borderTop: "1px solid rgba(255,255,255,0.3)",
-                [minWidth.wide]: {
-                  borderTop: 0
-                }
-              }}
-            >
+            <div css={footerMenuStyles}>
               {footerLinks.map((linkList, i) => (
-                <ul
-                  key={i}
-                  css={{
-                    lineHeight: "19.2px",
-                    width: "calc(50% - 1.250rem - 1px)",
-                    listStyle: "none",
-                    position: "relative",
-                    padding: "0 10px",
-                    margin: 0,
-
-                    "&:nth-of-type(even)": {
-                      borderLeft: "1px solid rgba(255,255,255,0.3)"
-                    },
-
-                    [minWidth.tablet]: {
-                      "&:not(:first-of-type)": {
-                        borderLeft: "1px solid rgba(255,255,255,0.3)"
-                      },
-
-                      width: "161px",
-                      flex: "1 0 0"
-                    },
-
-                    [minWidth.desktop]: {
-                      borderLeft: "1px solid rgba(255,255,255,0.3)"
-                    }
-                  }}
-                >
+                <ul key={i} css={footerMenuUlStyles}>
                   {linkList.map(({ title, link, onClick }) => {
                     return (
-                      <li
-                        key={title}
-                        css={{
-                          listStyle: "none"
-                        }}
-                      >
-                        <a
-                          href={link}
-                          onClick={onClick}
-                          css={{
-                            display: "inline-block",
-                            padding: "6px 0",
-                            color: palette.white,
-                            ":hover": {
-                              color: palette.yellow.medium,
-                              cursor: "pointer"
-                            }
-                          }}
-                        >
+                      <li key={title} css={footerMenuLiStyles}>
+                        <a href={link} onClick={onClick} css={footerLinkStyles}>
                           {title}
                         </a>
                       </li>
@@ -151,44 +234,9 @@ const Footer = () => (
                   })}
                 </ul>
               ))}
-              <div
-                css={{
-                  width: "50%",
-                  borderLeft: "1px solid rgba(255,255,255,0.3)",
-                  paddingLeft: "10px",
-                  [minWidth.phablet]: {
-                    width: "300px"
-                  },
-                  borderTop: "1px solid rgba(255,255,255,0.3)",
-                  [minWidth.tablet]: {
-                    borderTop: 0
-                  }
-                }}
-              >
-                <div
-                  css={{
-                    color: palette.yellow.medium,
-                    fontFamily: headline,
-                    fontSize: "24px",
-                    lineHeight: "24px",
-                    fontWeight: "bold",
-                    marginTop: "3px",
-                    marginBottom: "12px",
-                    [minWidth.phablet]: {
-                      fontSize: "32px",
-                      lineHeight: "32px"
-                    }
-                  }}
-                >
-                  Support The&nbsp;Guardian
-                </div>
-                <div
-                  css={{
-                    display: "inline-block",
-                    marginRight: "10px",
-                    marginBottom: "6px"
-                  }}
-                >
+              <div css={supportStyles}>
+                <div css={supportTitleStyles}>Support The&nbsp;Guardian</div>
+                <div css={supportButtonContainerStyles}>
                   <SupportTheGuardianButton
                     urlSuffix="contribute"
                     supportReferer="footer_support_contribute"
@@ -206,72 +254,18 @@ const Footer = () => (
             </div>
           </div>
 
-          <div
-            css={{
-              paddingBottom: "24px",
-              paddingLeft: "20px",
-              paddingRight: "20px",
-              position: "relative"
-            }}
-          >
-            <a
-              href="#top"
-              css={{
-                fontSize: "16px",
-                color: palette.white,
-                fontWeight: "bold",
-                padding: "0 5px",
-                backgroundColor: palette.blue.header,
-                ":hover": {
-                  color: palette.yellow.medium
-                },
-                position: "absolute",
-                right: "20px",
-                transform: "translateY(-50%)"
-              }}
-            >
-              <span
-                css={{
-                  display: "inline-block",
-                  paddingRight: "5px",
-                  paddingTop: "9px"
-                }}
-              >
-                Back to top
-              </span>
-              <span
-                css={{
-                  position: "relative",
-                  float: "right",
-                  backgroundColor: "currentColor",
-                  borderRadius: "100%",
-                  height: "42px",
-                  width: "42px"
-                }}
-              >
-                <span
-                  css={{
-                    position: "absolute",
-                    fill: palette.blue.header,
-                    top: "9px",
-                    left: "9px"
-                  }}
-                >
+          <div css={copyrightStyles}>
+            <a href="#top" css={backToTopLinkStyles}>
+              <span css={backToTopLabelStyles}>Back to top</span>
+              <span css={backToTopButtonOutterContainerStyles}>
+                <span css={backToTopButtonInnerContainerStyles}>
                   <svg width="24" height="18" viewBox="0 0 24 18">
                     <path d="M.4 15.3l10.5-8.4L12 6l1.1.9 10.5 8.4-.5.7L12 9.7.9 16l-.5-.7z" />
                   </svg>
                 </span>
               </span>
             </a>
-            <div
-              css={{
-                [minWidth.tablet]: {
-                  paddingTop: "6px"
-                },
-                paddingTop: "26px",
-                fontSize: "12px"
-              }}
-            >
+            <div css={copyrightTextStyles}>
               © {TODAY.getFullYear()} Guardian News and Media Limited or its
               affiliated companies. All&nbsp;rights&nbsp;reserved.
             </div>

--- a/app/client/components/footer/footer.tsx
+++ b/app/client/components/footer/footer.tsx
@@ -3,7 +3,7 @@ import { from } from "@guardian/src-foundations/mq";
 import React, { SyntheticEvent, useEffect, useState } from "react";
 import { conf } from "../../../server/config";
 import palette from "../../colours";
-import { isInUSA } from "../../geolocation";
+import { isInUSA as isUserInUSA } from "../../geolocation";
 import { headline } from "../../styles/fonts";
 import { SupportTheGuardianButton } from "../supportTheGuardianButton";
 import { footerLinks } from "./footerlinks";
@@ -202,11 +202,11 @@ const fillEmailSignup = (_: SyntheticEvent<HTMLIFrameElement>) => {
 };
 
 export const Footer = () => {
-  const [useCCPA, setUseCCPA] = useState<boolean>(false);
+  const [isInUSA, setIsInUSA] = useState<boolean>(false);
 
   useEffect(() => {
-    setUseCCPA(isInUSA());
-  }, [useCCPA]);
+    setIsInUSA(isUserInUSA());
+  }, [isInUSA]);
 
   return (
     <footer css={footerStyles}>
@@ -232,7 +232,7 @@ export const Footer = () => {
                 {footerLinks.map((linkList, i) => (
                   <ul key={i} css={footerMenuUlStyles}>
                     {linkList.map(({ title, link, onClick, USAonly }) => {
-                      return USAonly && !useCCPA ? null : (
+                      return USAonly && !isInUSA ? null : (
                         <li key={title} css={footerMenuLiStyles}>
                           <a
                             href={link}

--- a/app/client/components/footer/footer.tsx
+++ b/app/client/components/footer/footer.tsx
@@ -123,28 +123,32 @@ const Footer = () => (
                     }
                   }}
                 >
-                  {linkList.map(({ title, link }) => (
-                    <li
-                      key={title}
-                      css={{
-                        listStyle: "none"
-                      }}
-                    >
-                      <a
-                        href={link}
+                  {linkList.map(({ title, link, onClick }) => {
+                    return (
+                      <li
+                        key={title}
                         css={{
-                          display: "inline-block",
-                          padding: "6px 0",
-                          color: palette.white,
-                          ":hover": {
-                            color: palette.yellow.medium
-                          }
+                          listStyle: "none"
                         }}
                       >
-                        {title}
-                      </a>
-                    </li>
-                  ))}
+                        <a
+                          href={link}
+                          onClick={onClick}
+                          css={{
+                            display: "inline-block",
+                            padding: "6px 0",
+                            color: palette.white,
+                            ":hover": {
+                              color: palette.yellow.medium,
+                              cursor: "pointer"
+                            }
+                          }}
+                        >
+                          {title}
+                        </a>
+                      </li>
+                    );
+                  })}
                 </ul>
               ))}
               <div

--- a/app/client/components/footer/footer.tsx
+++ b/app/client/components/footer/footer.tsx
@@ -1,8 +1,9 @@
 import { css } from "@emotion/core";
 import { from } from "@guardian/src-foundations/mq";
-import React, { SyntheticEvent } from "react";
+import React, { SyntheticEvent, useEffect, useState } from "react";
 import { conf } from "../../../server/config";
 import palette from "../../colours";
+import { isInUSA } from "../../geolocation";
 import { headline } from "../../styles/fonts";
 import { SupportTheGuardianButton } from "../supportTheGuardianButton";
 import { footerLinks } from "./footerlinks";
@@ -201,6 +202,12 @@ const fillEmailSignup = (_: SyntheticEvent<HTMLIFrameElement>) => {
 };
 
 export const Footer = () => {
+  const [useCCPA, setUseCCPA] = useState<boolean>(false);
+
+  useEffect(() => {
+    setUseCCPA(isInUSA());
+  }, [useCCPA]);
+
   return (
     <footer css={footerStyles}>
       <div>

--- a/app/client/components/footer/footer.tsx
+++ b/app/client/components/footer/footer.tsx
@@ -200,80 +200,85 @@ const fillEmailSignup = (_: SyntheticEvent<HTMLIFrameElement>) => {
   return;
 };
 
-const Footer = () => (
-  <footer css={footerStyles}>
-    <div>
-      <div css={footerColourStyles}>
-        <div css={footerSizeStyles}>
-          <div css={footerContentStyles}>
-            <div css={emailSignUpStyles}>
-              <iframe
-                title="Guardian Email Sign-up Form"
-                src={`https://profile.${domain}/email/form/footer/today-uk`}
-                scrolling="no"
-                seamless={false}
-                frameBorder="0"
-                data-form-success-desc="We will send you our picks of the most important headlines tomorrow morning."
-                data-node-uid="2"
-                height="86px"
-                onLoad={emailForm => fillEmailSignup(emailForm)}
-              />
-            </div>
+export const Footer = () => {
+  return (
+    <footer css={footerStyles}>
+      <div>
+        <div css={footerColourStyles}>
+          <div css={footerSizeStyles}>
+            <div css={footerContentStyles}>
+              <div css={emailSignUpStyles}>
+                <iframe
+                  title="Guardian Email Sign-up Form"
+                  src={`https://profile.${domain}/email/form/footer/today-uk`}
+                  scrolling="no"
+                  seamless={false}
+                  frameBorder="0"
+                  data-form-success-desc="We will send you our picks of the most important headlines tomorrow morning."
+                  data-node-uid="2"
+                  height="86px"
+                  onLoad={emailForm => fillEmailSignup(emailForm)}
+                />
+              </div>
 
-            <div css={footerMenuStyles}>
-              {footerLinks.map((linkList, i) => (
-                <ul key={i} css={footerMenuUlStyles}>
-                  {linkList.map(({ title, link, onClick }) => {
-                    return (
-                      <li key={title} css={footerMenuLiStyles}>
-                        <a href={link} onClick={onClick} css={footerLinkStyles}>
-                          {title}
-                        </a>
-                      </li>
-                    );
-                  })}
-                </ul>
-              ))}
-              <div css={supportStyles}>
-                <div css={supportTitleStyles}>Support The&nbsp;Guardian</div>
-                <div css={supportButtonContainerStyles}>
+              <div css={footerMenuStyles}>
+                {footerLinks.map((linkList, i) => (
+                  <ul key={i} css={footerMenuUlStyles}>
+                    {linkList.map(({ title, link, onClick }) => {
+                      return (
+                        <li key={title} css={footerMenuLiStyles}>
+                          <a
+                            href={link}
+                            onClick={onClick}
+                            css={footerLinkStyles}
+                          >
+                            {title}
+                          </a>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                ))}
+
+                <div css={supportStyles}>
+                  <div css={supportTitleStyles}>Support The&nbsp;Guardian</div>
+                  <div css={supportButtonContainerStyles}>
+                    <SupportTheGuardianButton
+                      urlSuffix="contribute"
+                      supportReferer="footer_support_contribute"
+                      alternateButtonText="Contribute"
+                      fontWeight="bold"
+                    />
+                  </div>
                   <SupportTheGuardianButton
-                    urlSuffix="contribute"
-                    supportReferer="footer_support_contribute"
-                    alternateButtonText="Contribute"
+                    urlSuffix="subscribe"
+                    supportReferer="footer_support_subscribe"
+                    alternateButtonText="Subscribe"
                     fontWeight="bold"
                   />
                 </div>
-                <SupportTheGuardianButton
-                  urlSuffix="subscribe"
-                  supportReferer="footer_support_subscribe"
-                  alternateButtonText="Subscribe"
-                  fontWeight="bold"
-                />
               </div>
             </div>
-          </div>
 
-          <div css={copyrightStyles}>
-            <a href="#top" css={backToTopLinkStyles}>
-              <span css={backToTopLabelStyles}>Back to top</span>
-              <span css={backToTopButtonOutterContainerStyles}>
-                <span css={backToTopButtonInnerContainerStyles}>
-                  <svg width="24" height="18" viewBox="0 0 24 18">
-                    <path d="M.4 15.3l10.5-8.4L12 6l1.1.9 10.5 8.4-.5.7L12 9.7.9 16l-.5-.7z" />
-                  </svg>
+            <div css={copyrightStyles}>
+              <a href="#top" css={backToTopLinkStyles}>
+                <span css={backToTopLabelStyles}>Back to top</span>
+                <span css={backToTopButtonOutterContainerStyles}>
+                  <span css={backToTopButtonInnerContainerStyles}>
+                    <svg width="24" height="18" viewBox="0 0 24 18">
+                      <path d="M.4 15.3l10.5-8.4L12 6l1.1.9 10.5 8.4-.5.7L12 9.7.9 16l-.5-.7z" />
+                    </svg>
+                  </span>
                 </span>
-              </span>
-            </a>
-            <div css={copyrightTextStyles}>
-              © {TODAY.getFullYear()} Guardian News and Media Limited or its
-              affiliated companies. All&nbsp;rights&nbsp;reserved.
+              </a>
+              <div css={copyrightTextStyles}>
+                © {TODAY.getFullYear()} Guardian News and Media Limited or its
+                affiliated companies. All&nbsp;rights&nbsp;reserved.
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-  </footer>
-);
-
-export default Footer;
+    </footer>
+  );
+};

--- a/app/client/components/footer/footerlinks.tsx
+++ b/app/client/components/footer/footerlinks.tsx
@@ -12,6 +12,7 @@ interface FooterLink {
   title: string;
   link?: string;
   onClick?: () => any;
+  USAonly?: boolean;
 }
 
 export const footerLinks: FooterLink[][] = [
@@ -38,7 +39,8 @@ export const footerLinks: FooterLink[][] = [
     },
     {
       title: "California resident – Do Not Sell",
-      onClick: showPrivacyManager
+      onClick: showPrivacyManager,
+      USAonly: true
     },
     {
       title: "Privacy policy",

--- a/app/client/components/footer/footerlinks.tsx
+++ b/app/client/components/footer/footerlinks.tsx
@@ -11,7 +11,7 @@ if (typeof window !== "undefined" && window.guardian) {
 interface FooterLink {
   title: string;
   link?: string;
-  onClick?: () => any;
+  onClick?: () => void;
   USAonly?: boolean;
 }
 

--- a/app/client/components/footer/footerlinks.tsx
+++ b/app/client/components/footer/footerlinks.tsx
@@ -1,3 +1,4 @@
+import { showPrivacyManager } from "@guardian/consent-management-platform";
 import { conf } from "../../../server/config";
 
 let domain: string;
@@ -9,7 +10,8 @@ if (typeof window !== "undefined" && window.guardian) {
 
 interface FooterLink {
   title: string;
-  link: string;
+  link?: string;
+  onClick?: () => any;
 }
 
 export const footerLinks: FooterLink[][] = [
@@ -33,6 +35,10 @@ export const footerLinks: FooterLink[][] = [
     {
       title: "Work for us",
       link: `https://workforus.${domain}`
+    },
+    {
+      title: "California resident – Do Not Sell",
+      onClick: showPrivacyManager
     },
     {
       title: "Privacy policy",

--- a/app/client/components/main.tsx
+++ b/app/client/components/main.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import palette from "../colours";
 import { serif } from "../styles/fonts";
-import Footer from "./footer/footer";
+import { Footer } from "./footer/footer";
 import Header from "./header";
 
 export class Main extends React.PureComponent<{}> {

--- a/app/client/cookies.ts
+++ b/app/client/cookies.ts
@@ -1,0 +1,7 @@
+export const getCookie = (name: string): string | null => {
+  const cookies: string[] = document?.cookie
+    .split(";")
+    .filter(keyValue => keyValue.trim().startsWith(name + "="));
+
+  return cookies.length ? cookies[0].replace(name + "=", "") : null;
+};

--- a/app/client/cookies.ts
+++ b/app/client/cookies.ts
@@ -3,5 +3,5 @@ export const getCookie = (name: string): string | null => {
     .split(";")
     .filter(keyValue => keyValue.trim().startsWith(name + "="));
 
-  return cookies.length ? cookies[0].replace(name + "=", "") : null;
+  return cookies.length ? cookies[0].trim().replace(name + "=", "") : null;
 };

--- a/app/client/geolocation.ts
+++ b/app/client/geolocation.ts
@@ -1,0 +1,15 @@
+import { getCookie } from "./cookies";
+
+let countryCode: string | null = null;
+
+const getCountryCode = (): string | null => {
+  if (countryCode === null) {
+    countryCode = getCookie("GU_geo_country");
+  }
+
+  return countryCode;
+};
+
+export const isInUSA = (): boolean => getCountryCode() === "US";
+
+export const _ = { resetModule: () => (countryCode = null) };

--- a/app/package.json
+++ b/app/package.json
@@ -127,7 +127,7 @@
   "dependencies": {
     "@emotion/core": "^10.0.14",
     "@emotion/styled": "^10.0.14",
-    "@guardian/consent-management-platform": "1.1.0",
+    "@guardian/consent-management-platform": "^3.4.6",
     "@guardian/src-button": "^0.18.1",
     "@guardian/src-checkbox": "^0.18.1",
     "@guardian/src-foundations": "^0.18.1",

--- a/app/package.json
+++ b/app/package.json
@@ -127,7 +127,7 @@
   "dependencies": {
     "@emotion/core": "^10.0.14",
     "@emotion/styled": "^10.0.14",
-    "@guardian/consent-management-platform": "^3.4.6",
+    "@guardian/consent-management-platform": "^3.4.8",
     "@guardian/src-button": "^0.18.1",
     "@guardian/src-checkbox": "^0.18.1",
     "@guardian/src-foundations": "^0.18.1",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1030,10 +1030,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.3.tgz#dfa0c92efe44a1d1a7974fb49ffeb40ef2da5a27"
   integrity sha512-zVgvPwGK7c1aVdUVc9Qv7SqepOGRDrqCw7KZPSZziWGxSlbII3gmvGLPzLX4d0n0BMbamBacUrN22zOMyFFEkQ==
 
-"@guardian/consent-management-platform@^3.4.6":
-  version "3.4.6"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-3.4.6.tgz#3e2282f88292e9408f8218907da0953301d3c8cd"
-  integrity sha512-mosnZ2J8V/CQvy9ivX7hG/lTOvgt+fDDDqn+MLQ2KlkTHid7M85LcdI1Q4xAIlSx1nnYgYzh7qmizfBJtLx9Fw==
+"@guardian/consent-management-platform@^3.4.8":
+  version "3.4.8"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-3.4.8.tgz#01c8e9894a93ec581024f59d53038ffd915ddc8c"
+  integrity sha512-NZHnq4ayk+tERo72aaTIGJE0uOV/zXFXJUYw2y9M2KKgwqSMQ5ht82jmsLeuEmgVg79EYjKgPWIXU8KeWFShNQ==
   dependencies:
     consent-string "1.5.2"
     js-cookie "2.2.1"

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1030,13 +1030,14 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.3.tgz#dfa0c92efe44a1d1a7974fb49ffeb40ef2da5a27"
   integrity sha512-zVgvPwGK7c1aVdUVc9Qv7SqepOGRDrqCw7KZPSZziWGxSlbII3gmvGLPzLX4d0n0BMbamBacUrN22zOMyFFEkQ==
 
-"@guardian/consent-management-platform@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-1.1.0.tgz#ca93b41c9649f3f90c8075fa1b64065406ea682c"
-  integrity sha512-+C1IzMb+PDCatnmA9B2oNx4KVbaQw/U0fwpIAUC7l/ebDhU2a6b94ha4xTu+iE2gAt/heOMKLs+o3avCNdSGqA==
+"@guardian/consent-management-platform@^3.4.6":
+  version "3.4.6"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-3.4.6.tgz#3e2282f88292e9408f8218907da0953301d3c8cd"
+  integrity sha512-mosnZ2J8V/CQvy9ivX7hG/lTOvgt+fDDDqn+MLQ2KlkTHid7M85LcdI1Q4xAIlSx1nnYgYzh7qmizfBJtLx9Fw==
   dependencies:
-    consent-string "^1.5.1"
-    js-cookie "^2.2.1"
+    consent-string "1.5.2"
+    js-cookie "2.2.1"
+    whatwg-fetch "3.0.0"
 
 "@guardian/src-button@^0.18.1":
   version "0.18.1"
@@ -3947,7 +3948,7 @@ connect-history-api-fallback@^1.6.0:
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz#8b32089359308d111115d81cad3fceab888f97bc"
   integrity sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==
 
-consent-string@^1.5.1:
+consent-string@1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/consent-string/-/consent-string-1.5.2.tgz#cd3615f406a1d7649ebc9722960b5e451cf6a685"
   integrity sha512-xzfHnFzHQSupiamNY93UGn8FggPajHYExI45pzadhVpXVaj3ztnhnA7lYjKXl09pKRQKCT4hvjytt+2eoH7Jaw==
@@ -7213,7 +7214,7 @@ jmespath@0.15.0:
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
   integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
 
-js-cookie@^2.2.1:
+js-cookie@2.2.1, js-cookie@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
   integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
@@ -11659,7 +11660,7 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   dependencies:
     iconv-lite "0.4.24"
 
-whatwg-fetch@>=0.10.0:
+whatwg-fetch@3.0.0, whatwg-fetch@>=0.10.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
   integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==


### PR DESCRIPTION
## What does this change?
This PR makes changes that enable the implementation of the CCPA CMP for our users in the USA.

This includes:
 - Adding logic to check the user's geolocation.
 - Implementing the [CMP NPM package](https://www.npmjs.com/package/@guardian/consent-management-platform)
 - Refactoring the footer component into a stateful component (with react hooks while I was at it). This is to allow having the extra link to the CCPA privacy manager for US users only.

Also update the following wiki resources:
 - [wiki/Geolocation](https://github.com/guardian/manage-frontend/wiki/Geolocation)
 - [wiki/Fastly & Caching](https://github.com/guardian/manage-frontend/wiki/Fastly-&-Caching)
 - [wiki/Cookie Consent Banner](https://github.com/guardian/manage-frontend/wiki/Cookie-Consent-Banner)



## Images
### CCPA CMP banner (on first page load)
![Screenshot 2020-07-08 at 16 29 44](https://user-images.githubusercontent.com/48949546/87019819-008d3f00-c1cb-11ea-9929-7916415706f8.png)

### Footer with CCPA option
![Screenshot 2020-07-08 at 16 30 09](https://user-images.githubusercontent.com/48949546/87019905-16026900-c1cb-11ea-9252-fece3659569c.png)

### CCPA privacy manager (on clicking the footer link)
![Screenshot 2020-07-08 at 16 30 38](https://user-images.githubusercontent.com/48949546/87019974-2c102980-c1cb-11ea-8a03-89a16945c34b.png)
