### PR TITLE
Migrate legacy colour names to new colour names

### DIFF
--- a/app/client/components/accountoverview/accountOverviewCard.tsx
+++ b/app/client/components/accountoverview/accountOverviewCard.tsx
@@ -151,7 +151,7 @@ export const AccountOverviewCard = (props: AccountOverviewCardProps) => {
               `}
             >
               <ErrorIcon
-                fill={palette.brandYellow[200]}
+                fill={palette.brandAlt[200]}
                 additionalCss={css`
                   transform: translateY(1px);
                 `}

--- a/app/client/components/accountoverview/manageProduct.tsx
+++ b/app/client/components/accountoverview/manageProduct.tsx
@@ -120,7 +120,7 @@ const InnerContent = ({ props, productDetail }: InnerContentProps) => {
             ${textSans.medium()};
           `}
         >
-          <ErrorIcon fill={palette.brandYellow[200]} />
+          <ErrorIcon fill={palette.brandAlt[200]} />
           <span
             css={css`
               margin-left: ${space[2]}px;

--- a/app/client/components/delivery/address/deliveryAddressEditConfirmation.tsx
+++ b/app/client/components/delivery/address/deliveryAddressEditConfirmation.tsx
@@ -294,7 +294,7 @@ export const SuccessMessage = (props: SuccessMessageProps) => (
       position: relative;
       width: 100%;
       text-align: left;
-      border: 4px solid ${palette.success.main};
+      border: 4px solid ${palette.success[400]};
       box-sizing: border-box;
       padding: 14px 14px 14px 50px;
       margin-bottom: 50px;

--- a/app/client/components/delivery/address/deliveryAddressForm.tsx
+++ b/app/client/components/delivery/address/deliveryAddressForm.tsx
@@ -662,7 +662,7 @@ const Form = (props: FormProps) => {
               ${textSans.medium()};
               font-weight: bold;
               margin-left: 22px;
-              color: ${palette.brand.main};
+              color: ${palette.brand[400]};
             `}
           >
             Cancel

--- a/app/client/components/delivery/address/deliveryAddressReview.tsx
+++ b/app/client/components/delivery/address/deliveryAddressReview.tsx
@@ -215,7 +215,7 @@ const DeliveryAddressReviewFC = (props: RouteableStepProps) => {
               ${textSans.medium()};
               font-weight: bold;
               margin-left: 22px;
-              color: ${palette.brand.main};
+              color: ${palette.brand[400]};
             `}
           >
             Go back

--- a/app/client/components/delivery/address/input.tsx
+++ b/app/client/components/delivery/address/input.tsx
@@ -61,7 +61,7 @@ export const Input = (props: InputProps) => {
           css={css`
             display: block;
             font-weight: normal;
-            color: ${palette.error.main};
+            color: ${palette.error[400]};
           `}
         >
           <ErrorIcon
@@ -109,7 +109,7 @@ export const Input = (props: InputProps) => {
           padding: 0 8px;
           background-color: ${palette.neutral["100"]};
           border: ${props.inErrorState ? 4 : 2}px solid ${
-            props.inErrorState ? palette.error.main : palette.neutral["60"]
+            props.inErrorState ? palette.error[400] : palette.neutral["60"]
           };
           ${props.prefixValue &&
             `

--- a/app/client/components/delivery/address/select.tsx
+++ b/app/client/components/delivery/address/select.tsx
@@ -37,7 +37,7 @@ export const Select = (props: SelectProps) => (
       <span
         css={css`
           display: block;
-          color: ${palette.error.main};
+          color: ${palette.error[400]};
         `}
       >
         <ErrorIcon />
@@ -61,7 +61,7 @@ export const Select = (props: SelectProps) => (
           margin-top: 4px;
           padding: 8px 0 8px 4px;
           border: ${props.inErrorState ? 4 : 2}px solid ${
-        props.inErrorState ? palette.error.main : palette.neutral["60"]
+        props.inErrorState ? palette.error[400] : palette.neutral["60"]
       };
           &:focus {
             ${focusHalo};

--- a/app/client/components/delivery/records/deliveryAddressStep.tsx
+++ b/app/client/components/delivery/records/deliveryAddressStep.tsx
@@ -412,10 +412,10 @@ export const DeliveryAddressStep = (props: DeliveryAddressStepProps) => {
             <Button
               type="submit"
               css={css`
-                color: ${palette.brand.main};
-                background-color: ${palette.brand.faded};
+                color: ${palette.brand[400]};
+                background-color: ${palette.brand[800]};
                 :hover {
-                  background-color: ${Color(palette.brand.faded, "hex")
+                  background-color: ${Color(palette.brand[800], "hex")
                     .darken(0.1)
                     .string()};
                 }
@@ -433,7 +433,7 @@ export const DeliveryAddressStep = (props: DeliveryAddressStepProps) => {
               }}
               css={css`
                 margin-top: ${space[5]}px;
-                color: ${palette.brand.main};
+                color: ${palette.brand[400]};
                 background-color: transparent;
                 :hover {
                   background-color: transparent;

--- a/app/client/components/delivery/records/deliveryRecordInstructions.tsx
+++ b/app/client/components/delivery/records/deliveryRecordInstructions.tsx
@@ -33,7 +33,7 @@ export const DeliveryRecordInstructions = (
             : "none"};
           text-align: left;
           ${textSans.small({ italic: true })};
-          color: ${palette.brand.bright};
+          color: ${palette.brand[500]};
           cursor: pointer;
         `}
         onClick={() => {

--- a/app/client/components/delivery/records/deliveryRecordStatus.tsx
+++ b/app/client/components/delivery/records/deliveryRecordStatus.tsx
@@ -130,7 +130,7 @@ export const RecordStatus = (props: RecordStatusProps) => {
               left: 0;
             `}
           >
-            <InfoIconDark fillColor={palette.brand.bright} size={22} />
+            <InfoIconDark fillColor={palette.brand[500]} size={22} />
           </i>
           {changesMessage}
         </span>

--- a/app/client/components/delivery/records/deliveryRecords.tsx
+++ b/app/client/components/delivery/records/deliveryRecords.tsx
@@ -405,7 +405,7 @@ export const DeliveryRecordsFC = (props: DeliveryRecordsFCProps) => {
                         left: ${space[3]}px;
                       `}
                     >
-                      <InfoIconDark fillColor={palette.brand.bright} />
+                      <InfoIconDark fillColor={palette.brand[500]} />
                     </i>
                     You don't have any available delivery history to report.
                     Your deliveries may be too far in the past or have already
@@ -617,7 +617,7 @@ export const DeliveryRecordsFC = (props: DeliveryRecordsFCProps) => {
                         position: relative;
                         padding: ${space[5]}px ${space[5]}px ${space[5]}px 50px;
                         ${textSans.medium()};
-                        border: 4px solid ${palette.news.main};
+                        border: 4px solid ${palette.news[400]};
                       `}
                     >
                       <i
@@ -713,7 +713,7 @@ export const DeliveryRecordsFC = (props: DeliveryRecordsFCProps) => {
                     font-weight: bold;
                     margin-left: 22px;
                     padding: 0;
-                    color: ${palette.brand.main};
+                    color: ${palette.brand[400]};
                     :hover {
                       background-color: transparent;
                     }

--- a/app/client/components/delivery/records/deliveryRecordsAddress.tsx
+++ b/app/client/components/delivery/records/deliveryRecordsAddress.tsx
@@ -53,7 +53,7 @@ export const RecordAddress = (props: DeliveryAddress) => {
           display: block;
           text-align: left;
           ${textSans.small({ italic: true })};
-          color: ${palette.brand.bright};
+          color: ${palette.brand[500]};
           font-style: normal;
           text-decoration: underline;
           cursor: pointer;
@@ -70,8 +70,8 @@ export const RecordAddress = (props: DeliveryAddress) => {
             height: 6px;
             margin-left: 6px;
             margin-bottom: ${showAddress ? -1 : 2}px;
-            border-top: 1px solid ${palette.brand.bright};
-            border-right: 1px solid ${palette.brand.bright};
+            border-top: 1px solid ${palette.brand[500]};
+            border-right: 1px solid ${palette.brand[500]};
             transform: rotate(${showAddress ? -45 : 135}deg);
           `}
         />

--- a/app/client/components/delivery/records/deliveryRecordsProblemConfirmation.tsx
+++ b/app/client/components/delivery/records/deliveryRecordsProblemConfirmation.tsx
@@ -152,7 +152,7 @@ const DeliveryRecordsProblemConfirmationFC = (
               left: ${space[3]}px;
             `}
           >
-            <InfoIconDark fillColor={palette.brand.bright} />
+            <InfoIconDark fillColor={palette.brand[500]} />
           </i>
           {deliveryProblemCredit?.showCredit
             ? `Thank you for reporting your delivery problem${

--- a/app/client/components/delivery/records/deliveryRecordsProblemForm.tsx
+++ b/app/client/components/delivery/records/deliveryRecordsProblemForm.tsx
@@ -191,7 +191,7 @@ export const DeliveryRecordProblemForm = (
                             <span
                               css={css`
                                 display: block;
-                                color: ${palette.news.main};
+                                color: ${palette.news[400]};
                               `}
                             >
                               <i
@@ -219,7 +219,7 @@ export const DeliveryRecordProblemForm = (
                             ${props.inValidationState &&
                             deliveryProblemRadioOption.messageIsMandatory &&
                             !selectedDeliveryProblem.message
-                              ? palette.news.main
+                              ? palette.news[400]
                               : palette.neutral["60"]};
                           width: 100%;
                           padding: 12px;
@@ -243,7 +243,7 @@ export const DeliveryRecordProblemForm = (
             display: block;
             position: relative;
             padding: ${space[5]}px ${space[5]}px ${space[5]}px 50px;
-            border: 4px solid ${palette.news.main};
+            border: 4px solid ${palette.news[400]};
             margin-bottom: ${space[5]}px;
           `}
         >
@@ -269,7 +269,7 @@ export const DeliveryRecordProblemForm = (
               font-weight: bold;
               margin-left: 22px;
               padding: 0;
-              color: ${palette.brand.main};
+              color: ${palette.brand[400]};
               :hover {
                 background-color: transparent;
               }

--- a/app/client/components/delivery/records/deliveryRecordsProblemReview.tsx
+++ b/app/client/components/delivery/records/deliveryRecordsProblemReview.tsx
@@ -500,7 +500,7 @@ const DeliveryRecordsProblemReviewFC = (
                         left: 0;
                       `}
                     >
-                      <InfoIconDark fillColor={palette.brand.bright} />
+                      <InfoIconDark fillColor={palette.brand[500]} />
                     </i>
                     Once you submit your report, your case will be marked as
                     high priority. Our customer service team will try their best
@@ -540,7 +540,7 @@ const DeliveryRecordsProblemReviewFC = (
                   font-weight: bold;
                   margin-left: 22px;
                   padding: 0;
-                  color: ${palette.brand.main};
+                  color: ${palette.brand[400]};
                   :hover {
                     background-color: transparent;
                   }

--- a/app/client/components/delivery/records/readOnlyAddressDisplay.tsx
+++ b/app/client/components/delivery/records/readOnlyAddressDisplay.tsx
@@ -68,10 +68,10 @@ export const ReadOnlyAddressDisplay = (props: ReadOnlyAddressDisplayProps) => {
               css={css`
                 display: block;
                 margin-top: ${space[5]}px;
-                color: ${palette.brand.main};
-                background-color: ${palette.brand.faded};
+                color: ${palette.brand[400]};
+                background-color: ${palette.brand[800]};
                 :hover {
-                  background-color: ${Color(palette.brand.faded, "hex")
+                  background-color: ${Color(palette.brand[800], "hex")
                     .darken(0.1)
                     .string()};
                 }
@@ -107,10 +107,10 @@ export const ReadOnlyAddressDisplay = (props: ReadOnlyAddressDisplayProps) => {
                 css={css`
                   display: block;
                   margin-top: ${space[5]}px;
-                  color: ${palette.brand.main};
-                  background-color: ${palette.brand.faded};
+                  color: ${palette.brand[400]};
+                  background-color: ${palette.brand[800]};
                   :hover {
-                    background-color: ${Color(palette.brand.faded, "hex")
+                    background-color: ${Color(palette.brand[800], "hex")
                       .darken(0.1)
                       .string()};
                   }

--- a/app/client/components/delivery/records/userPhoneNumber.tsx
+++ b/app/client/components/delivery/records/userPhoneNumber.tsx
@@ -255,7 +255,7 @@ export const UserPhoneNumber = (props: UserPhoneNumberProps) => {
                 left: 0;
               `}
             >
-              <InfoIconDark fillColor={palette.brand.bright} />
+              <InfoIconDark fillColor={palette.brand[500]} />
             </i>
             Your number will be updated when you submit your report.
           </span>

--- a/app/client/components/header.tsx
+++ b/app/client/components/header.tsx
@@ -10,11 +10,11 @@ const Header = () => {
   return (
     <header
       css={{
-        backgroundColor: palette.brand.main,
+        backgroundColor: palette.brand[400],
         minHeight: "50px",
         overflow: "visible",
         position: "relative",
-        boxShadow: `0 2px 1px -1px ${palette.brand.pastel}`,
+        boxShadow: `0 2px 1px -1px ${palette.brand[600]}`,
         zIndex: 1070,
         [minWidth.desktop]: {
           minHeight: "82px"
@@ -56,7 +56,7 @@ const Header = () => {
         <DropdownNav />
         <GridRoundel
           fillMain={palette.neutral["100"]}
-          fillG={palette.brand.main}
+          fillG={palette.brand[400]}
         />
       </div>
     </header>

--- a/app/client/components/help.tsx
+++ b/app/client/components/help.tsx
@@ -263,15 +263,15 @@ export const Help = (_: RouteComponentProps) => (
                   height: 36px;
                   border-radius: 18px;
                   padding: 0 16px;
-                  color: ${palette.brand.main};
-                  background-color: ${palette.brand.faded};
+                  color: ${palette.brand[400]};
+                  background-color: ${palette.brand[800]};
                   :hover {
-                    background-color: ${Color(palette.brand.faded, "hex")
+                    background-color: ${Color(palette.brand[800], "hex")
                       .darken(0.1)
                       .string()};
                   }
                   :visited {
-                    color: ${palette.brand.main};
+                    color: ${palette.brand[400]};
                   }
                 `}
                 onClick={() => {
@@ -327,7 +327,7 @@ export const Help = (_: RouteComponentProps) => (
       <Button
         text={reportTechnicalIssue.title}
         fontWeight="bold"
-        colour={palette.brand.main}
+        colour={palette.brand[400]}
         textColour={palette.neutral[100]}
         height="36px"
         right

--- a/app/client/components/nav/dropdownNav.tsx
+++ b/app/client/components/nav/dropdownNav.tsx
@@ -10,8 +10,8 @@ import { MenuSpecificNavItem, NAV_LINKS } from "./navConfig";
 const dropdownNavCss = (showMenu: boolean) =>
   css({
     display: `${showMenu ? "block" : "none"}`,
-    background: palette.brand.main,
-    borderTop: `1px solid ${palette.brand.pastel}`,
+    background: palette.brand[400],
+    borderTop: `1px solid ${palette.brand[600]}`,
     position: "absolute",
     top: "50px",
     left: 0,
@@ -68,7 +68,7 @@ const dropdownNavItemCss = css({
   display: "flex",
   alignItems: "center",
   ":hover, :focus": {
-    backgroundColor: palette.brand.dark,
+    backgroundColor: palette.brand[300],
     textDecoration: "none"
   },
   ":focus": {
@@ -83,7 +83,7 @@ const dropdownNavItemCss = css({
     right: 0,
     width: "calc(100% - 46px)",
     height: "1px",
-    backgroundColor: `${palette.brand.pastel}`
+    backgroundColor: `${palette.brand[600]}`
   },
   [minWidth.desktop]: {
     padding: "18px 14px",

--- a/app/client/components/nav/leftSideNav.tsx
+++ b/app/client/components/nav/leftSideNav.tsx
@@ -37,11 +37,11 @@ const leftNavLinkCss = (isSelected: boolean | undefined) =>
     whiteSpace: "nowrap",
     textOverflow: "ellipsis",
     background: palette.neutral["100"],
-    color: palette.brand.main,
+    color: palette.brand[400],
 
     [minWidth.desktop]: {
       borderLeft: `${space[2]}px solid ${
-        isSelected ? palette.brandYellow.main : palette.neutral["46"]
+        isSelected ? palette.brandAlt[400] : palette.neutral["46"]
       }`,
       boxShadow: isSelected ? "0 1px 0 white" : undefined,
       minHeight: 0,

--- a/app/client/components/page.tsx
+++ b/app/client/components/page.tsx
@@ -177,7 +177,7 @@ const PageHeaderContainer: React.SFC<PageHeaderContainerProps> = (
             ${headline.medium({ fontWeight: "bold" })};
             font-size: 1.5rem;
             padding: 8px;
-            border: 1px solid ${palette.brand.pastel};
+            border: 1px solid ${palette.brand[600]};
             border-bottom: 0;
             ${minWidth.tablet} {
               line-height: 57px;


### PR DESCRIPTION
## What does this change?

Source's [global colour names](https://www.theguardian.design/2a1e5182b/p/492a30-light-palette) have changed from semantic words to numbers representing approximate lightness values. This approach was considered more scalable. The word-based names are deprecated and the number-based names have been available for some time.

With 2.0.0 we have decided to declutter the API and delete the old names. This change migrates manage-frontend from the old naming system to the new one.

## How to test

Difficult, as the change spans a large number of files and flows. You can read the [colour mapping spreadsheet](https://docs.google.com/spreadsheets/d/1rcBqHDJmNFnS0NavpotpEvg-dW3ONxvWDL7eSWyfPPY/edit?usp=sharing) I used to ensure I didnt make any typos. This is derived from mappings in the [global colours module](https://github.com/guardian/source/blob/3e34d126e89d2544fbbb505f134bad55ed6271df/src/core/foundations/src/palette/global.ts) in Source.

## How can we measure success?

Upgrading to Source v2.0.0 should be less of a hassle!

## Have we considered potential risks?

Typecheck passed so the colours I have used here at least exist! The worst case is that I have mistakenly replaced a colour with a colour that makes content less accessible or less aesthetically pleasing.

## Images

There should be no UI changes
