### PR TITLE
Add ophan tracking to newsletter preferences

### DIFF
--- a/app/client/__tests__/components/identity/MarketingPreference.tsx
+++ b/app/client/__tests__/components/identity/MarketingPreference.tsx
@@ -11,7 +11,8 @@ describe("MarketingPreference component", () => {
     description: "Test description",
     frequency: "Test frequency",
     title: "Test title",
-    clickHandler: jest.fn()
+    clickHandler: jest.fn(),
+    identityName: "Test-13"
   };
   it("renders correctly and displays marketing information", () => {
     const rendered = create(
@@ -19,6 +20,7 @@ describe("MarketingPreference component", () => {
         id={input.id}
         description={input.description}
         frequency={input.frequency}
+        identityName={input.identityName}
         title={input.title}
         onClick={input.clickHandler}
       />
@@ -32,6 +34,7 @@ describe("MarketingPreference component", () => {
         id={input.id}
         description={input.description}
         frequency={input.frequency}
+        identityName={input.identityName}
         title={input.title}
         selected={true}
         onClick={input.clickHandler}
@@ -41,6 +44,20 @@ describe("MarketingPreference component", () => {
   });
 
   it("will omit the frequency information if it is not supplied", () => {
+    const rendered = create(
+      <MarketingPreference
+        id={input.id}
+        description={input.description}
+        identityName={input.identityName}
+        title={input.title}
+        selected={true}
+        onClick={input.clickHandler}
+      />
+    );
+    expect(rendered.toJSON()).toMatchSnapshot();
+  });
+
+  it("will omit the identityName/data-link-name information if it is not supplied", () => {
     const rendered = create(
       <MarketingPreference
         id={input.id}
@@ -59,6 +76,7 @@ describe("MarketingPreference component", () => {
         id={input.id}
         description={input.description}
         frequency={input.frequency}
+        identityName={input.identityName}
         title={input.title}
         onClick={input.clickHandler}
       />

--- a/app/client/__tests__/components/identity/__snapshots__/MarketingPreference.tsx.snap
+++ b/app/client/__tests__/components/identity/__snapshots__/MarketingPreference.tsx.snap
@@ -16,6 +16,7 @@ exports[`MarketingPreference component renders correctly and displays marketing 
       },
     ]
   }
+  data-link-name="mma-switch : Test-13 : untick"
   onClick={[Function]}
 >
   <div
@@ -192,6 +193,147 @@ exports[`MarketingPreference component will omit the frequency information if it
       },
     ]
   }
+  data-link-name="mma-switch : Test-13 : tick"
+  onClick={[Function]}
+>
+  <div
+    css={
+      Object {
+        "left": 0,
+        "position": "absolute",
+      }
+    }
+  >
+    <label
+      css={
+        Object {
+          ":hover .checkbox": Object {
+            "boxShadow": "0 0 0 3px #ececec",
+          },
+          "cursor": "pointer",
+          "display": "flex",
+          "maxWidth": undefined,
+          "userSelect": "none",
+        }
+      }
+    >
+      <div
+        aria-checked={true}
+        className="checkbox"
+        css={
+          Object {
+            ":focus": Object {
+              "boxShadow": "0 0 0 3px #ffe500",
+            },
+            "background": "#22834D",
+            "border": undefined,
+            "display": "inline-block",
+            "height": "18px",
+            "margin": "3px",
+            "marginRight": "10px",
+            "minWidth": "18px",
+            "outline": 0,
+            "position": "relative",
+            "transition": "all .2s ease-in-out",
+          }
+        }
+        onKeyPress={[Function]}
+        role="checkbox"
+        tabIndex={0}
+      >
+        <input
+          checked={true}
+          css={
+            Object {
+              "opacity": 0,
+              "overflow": "hidden",
+              "position": "absolute",
+              "zIndex": -999999,
+            }
+          }
+          onChange={[Function]}
+          tabIndex={-1}
+          type="checkbox"
+        />
+        <div
+          css={
+            Object {
+              "height": "6px",
+              "left": "3px",
+              "position": "absolute",
+              "textAlign": "right",
+              "top": "5px",
+              "transform": "rotate(-45deg)",
+              "width": "12px",
+            }
+          }
+        >
+          <div
+            css={
+              Object {
+                "borderColor": "#ffffff",
+                "borderStyle": "solid",
+                "borderWidth": "0 0 2px 2px",
+                "height": "6px",
+                "transition": "all .2s ease-in-out",
+                "transitionDelay": ".1s",
+                "width": "12px",
+              }
+            }
+          />
+        </div>
+      </div>
+      <span />
+    </label>
+  </div>
+  <p
+    css={
+      Array [
+        Object {
+          "fontFamily": "\\"Guardian Text Sans Web\\", \\"Helvetica Neue\\", Helvetica, Arial, \\"Lucida Grande\\", sans-serif",
+          "fontSize": "14px",
+        },
+        Object {
+          "cursor": "pointer",
+          "fontFamily": "\\"Guardian Text Sans Web\\", \\"Helvetica Neue\\", Helvetica, Arial, \\"Lucida Grande\\", sans-serif",
+          "fontSize": "14px",
+          "fontWeight": "bold",
+          "lineHeight": "22px",
+          "margin": "0",
+        },
+      ]
+    }
+  >
+    Test title
+  </p>
+  <p
+    css={
+      Object {
+        "padding": "2.88px 0 0 0",
+      }
+    }
+  >
+    Test description
+  </p>
+</div>
+`;
+
+exports[`MarketingPreference component will omit the identityName/data-link-name information if it is not supplied 1`] = `
+<div
+  css={
+    Array [
+      Object {
+        "fontFamily": "\\"Guardian Text Sans Web\\", \\"Helvetica Neue\\", Helvetica, Arial, \\"Lucida Grande\\", sans-serif",
+        "fontSize": "14px",
+      },
+      Object {
+        "lineHeight": "1.333",
+        "marginTop": "12px",
+        "paddingLeft": "30px",
+        "position": "relative",
+      },
+    ]
+  }
   onClick={[Function]}
 >
   <div
@@ -332,6 +474,7 @@ exports[`MarketingPreference component will select the checkbox when the selecte
       },
     ]
   }
+  data-link-name="mma-switch : Test-13 : tick"
   onClick={[Function]}
 >
   <div

--- a/app/client/components/identity/EmailAndMarketing/NewsletterSection.tsx
+++ b/app/client/components/identity/EmailAndMarketing/NewsletterSection.tsx
@@ -27,12 +27,20 @@ const newsletterPreference = (
   newsletter: ConsentOption,
   clickHandler: ClickHandler
 ) => {
-  const { id, name, description, frequency, subscribed } = newsletter;
+  const {
+    id,
+    name,
+    description,
+    frequency,
+    subscribed,
+    identityName
+  } = newsletter;
   return (
     <MarketingPreference
       id={id}
       key={id}
       title={name}
+      identityName={identityName}
       description={description}
       frequency={frequency}
       selected={subscribed}

--- a/app/client/components/identity/MarketingPreference.tsx
+++ b/app/client/components/identity/MarketingPreference.tsx
@@ -6,6 +6,7 @@ import { Checkbox } from "../checkbox";
 interface MarketingPreferenceProps {
   id: string;
   description: string;
+  identityName?: string;
   frequency?: string;
   title?: string;
   selected?: boolean;
@@ -81,7 +82,18 @@ const getFrequency = (frequency: MarketingPreferenceProps["frequency"]) => (
 );
 
 export const MarketingPreference: FC<MarketingPreferenceProps> = props => {
-  const { id, description, frequency, selected, title, onClick } = props;
+  const {
+    id,
+    description,
+    frequency,
+    selected,
+    title,
+    identityName,
+    onClick
+  } = props;
+  const linkName = `mma-switch : ${identityName} : ${
+    selected ? "tick" : "untick"
+  }`;
   return (
     <div
       onClick={e => {
@@ -101,6 +113,7 @@ export const MarketingPreference: FC<MarketingPreferenceProps> = props => {
           position: "relative"
         }
       ]}
+      data-link-name={identityName ? linkName : null}
     >
       <div css={{ position: "absolute", left: 0 }}>
         <Checkbox

--- a/app/client/components/identity/MarketingPreference.tsx
+++ b/app/client/components/identity/MarketingPreference.tsx
@@ -113,7 +113,7 @@ export const MarketingPreference: FC<MarketingPreferenceProps> = props => {
           position: "relative"
         }
       ]}
-      data-link-name={identityName ? linkName : null}
+      data-link-name={identityName ? linkName : undefined}
     >
       <div css={{ position: "absolute", left: 0 }}>
         <Checkbox

--- a/app/client/components/identity/idapi/newsletters.ts
+++ b/app/client/components/identity/idapi/newsletters.ts
@@ -14,7 +14,14 @@ interface NewsletterAPIResponse {
 const newsletterToConsentOption = (
   newsletter: NewsletterAPIResponse
 ): ConsentOption => {
-  const { theme, name, description, frequency, exactTargetListId } = newsletter;
+  const {
+    id: identityName,
+    theme,
+    name,
+    description,
+    frequency,
+    exactTargetListId
+  } = newsletter;
   return {
     id: exactTargetListId.toString(),
     description,
@@ -22,7 +29,8 @@ const newsletterToConsentOption = (
     type: ConsentOptionType.NEWSLETTER,
     name,
     frequency,
-    subscribed: false
+    subscribed: false,
+    identityName
   };
 };
 

--- a/app/client/components/identity/models.ts
+++ b/app/client/components/identity/models.ts
@@ -68,6 +68,7 @@ export interface ConsentOption {
   theme?: string;
   type: ConsentOptionType;
   subscribed: boolean;
+  identityName?: string;
 }
 
 export interface ConsentOptionCollection {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Tracking in Ophan is needed for the newsletters in order to measure impact of upcoming changes as part of the newsletters OKR.

We have added `data-link-name` attributes to the newsletter checkboxes and have used the `identityName` as the identifier. This also means that the `ConsentOptions` model has been updated to include this field.

Co-authored-by: Alex Dufournet <alex.dufournet@theguardian.com>

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
On the marketing preferences page, checking and unchecking a newsletter should trigger an Ophan page click tracking event in the network inspector. This event shouldn't be triggered for normal marketing preferences.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Ophan tracking from the email preferences page.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
I don't think there are any potential risks here, unless there needs to be an update to any privacy information about this being tracked?

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
