### PR TITLE
Sign AWS API Gateway requests for AWS_IAM authorization

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -87,6 +87,7 @@
     "@types/webpack-merge": "^4.1.3",
     "@types/webpack-node-externals": "^1.6.3",
     "@types/yup": "^0.26.23",
+    "@types/aws4": "^1.5.1",
     "assets-webpack-plugin": "^3.9.5",
     "babel-jest": "^24.9.0",
     "babel-loader": "^8.0.6",
@@ -163,7 +164,8 @@
     "url-parse": "^1.4.4",
     "webpack-node-externals": "^1.7.2",
     "winston": "^3.2.1",
-    "yup": "^0.27.0"
+    "yup": "^0.27.0",
+    "aws4": "^1.10.0"
   },
   "license": "UNLICENSED",
   "snyk": true

--- a/app/server/awsIntegration.ts
+++ b/app/server/awsIntegration.ts
@@ -23,20 +23,20 @@ const standardAwsConfig = {
 const S3 = new AWS.S3(standardAwsConfig);
 
 // Returns AWS signature version 4 headers to be used for AWS_IAM authorization in API Gateway
-export const signAwsRequest = async (
-  host: string,
-  path: string,
-  body: string,
-  apiKey: string,
+export const getAwsSignature = async (
+  host: string, // foo.execute-api.eu-west-1.amazonaws.com
+  path: string, // DEV/bar
+  body: string, // '{"foo": "bar"}'
+  apiKey: string, // x-api-key
   credentials: CredentialProviderChain = CREDENTIAL_PROVIDER
 ) => {
   const creds: Credentials = await credentials.resolvePromise();
   const opts = {
     region: AWS_REGION,
     service: "execute-api",
-    host, // foo.execute-api.eu-west-1.amazonaws.com
-    path, // DEV/bar
-    body, // '{"foo": "bar"}'
+    host,
+    path,
+    body,
     headers: {
       "Content-Type": "application/json",
       "x-api-key": apiKey // it is not actually necessary for signature

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1626,6 +1626,11 @@
   dependencies:
     "@types/webpack" "*"
 
+"@types/aws4@^1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@types/aws4/-/aws4-1.5.1.tgz#361fadab198a030ab398269183ae3fa86e958ed9"
+  integrity sha1-Nh+tqxmKAwqzmCaRg64/qG6Vjtk=
+
 "@types/babel__core@^7.1.0":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.3.tgz#e441ea7df63cd080dfcd02ab199e6d16a735fc30"
@@ -2584,6 +2589,11 @@ aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
   integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
+
+aws4@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.0.tgz#a17b3a8ea811060e74d47d306122400ad4497ae2"
+  integrity sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==
 
 aws4@^1.8.0:
   version "1.8.0"


### PR DESCRIPTION
## What does this change?

https://trello.com/c/YlnL1eOP/1523-secure-invoicing-api

This PR provides the ability to use any HTTP client to send AWS [signed](https://docs.aws.amazon.com/apigateway/api-reference/signing-requests/) requests to API Gateway resources which require AWS_IAM authorisation. The function `getAwsSignature` by default uses `CredentialProviderChain` defined in `awsIntegration.ts` to resolve AWS credentials.

## How to test

### Example HTTP request:

```http
POST /DEV/refund HTTP/1.1
Host: ${apiId}.execute-api.${region}.amazonaws.com
Content-Type: application/json
x-api-key: ********
X-Amz-Content-Sha256: ******
X-Amz-Security-Token: ****
X-Amz-Date: ****
Authorization: ****

{ "foo": "bar" }
```

### Example code snippet

```typescript
import {getAwsSignature} from "./awsIntegration";

const body = JSON.stringify({ "foo": "bar" })
const host = `${apiId}.execute-api.${region}.amazonaws.com`
const path = "/DEV/foo"
const apiKey = "**********"

getAwsSignature(host, path, body, apiKey)
    .then(headers => fetch(`https://${host}${path}`, {method: "POST", headers, body}))
```

### Postman configuration

Postman provides `AWS Signature` under `Auth` tab.

## How can we measure success?

Respond with 403 for user without the `x-api-key` and AWS credentials.

## Have we considered potential risks?

Given that AWS authenticated user will always be manage-fronted, that is, a service user, we should never see 403.  Failure to authenticate would represent misconfiguration of the app so we should alarm to fix ASAP.
