### PR TITLE
[RB] - only load stripe SDK on intent

### DIFF
--- a/app/client/components/payment/update/card/cardInputForm.tsx
+++ b/app/client/components/payment/update/card/cardInputForm.tsx
@@ -74,9 +74,7 @@ export const CardInputForm = (props: CardInputFormProps) => {
   };
 
   const loadSetupIntent = (recaptchaToken: string) => {
-    if (stripePromise === null) {
-      loadStripe();
-    }
+    loadStripe();
 
     setDidCompleteRecaptcha(true);
 

--- a/app/client/components/payment/update/card/cardInputForm.tsx
+++ b/app/client/components/payment/update/card/cardInputForm.tsx
@@ -1,6 +1,6 @@
 import * as Sentry from "@sentry/browser";
 import { Elements } from "@stripe/react-stripe-js";
-import { loadStripe } from "@stripe/stripe-js";
+import { Stripe } from "@stripe/stripe-js";
 import React, { useEffect, useState } from "react";
 import {
   STRIPE_PUBLIC_KEY_HEADER,
@@ -38,7 +38,10 @@ export const CardInputForm = (props: CardInputFormProps) => {
   >();
   const [stripeSetupIntentError, setstripeSetupIntentError] = useState<Error>();
 
-  const stripePromise = loadStripe(props.stripeApiKey);
+  const [
+    stripePromise,
+    setStripePromise
+  ] = useState<Promise<Stripe | null> | null>(null);
 
   useEffect(() => {
     if (window.grecaptcha) {
@@ -64,7 +67,17 @@ export const CardInputForm = (props: CardInputFormProps) => {
     });
   };
 
+  const loadStripe = () => {
+    import("@stripe/stripe-js").then(StripeAsync => {
+      setStripePromise(StripeAsync.loadStripe(props.stripeApiKey));
+    });
+  };
+
   const loadSetupIntent = (recaptchaToken: string) => {
+    if (stripePromise === null) {
+      loadStripe();
+    }
+
     setDidCompleteRecaptcha(true);
 
     fetch("/api/payment/card", {


### PR DESCRIPTION
## What does this change?
only load the stripe sdk when the user explicitly decides to update their payment details:

![Screenshot 2020-08-24 at 10 36 28](https://user-images.githubusercontent.com/2510683/91045924-80525a00-e60f-11ea-99eb-583f96ac4ec1.png)


I've taken some screenshots in order to explain the approach here ...

The first image is the default route (account overview) on the existing master branch
![01_master](https://user-images.githubusercontent.com/2510683/91311704-4ae27380-e7ab-11ea-8693-c9692ec50f83.png)


The 2nd image is if we move the loadStripe call within the useEffect hook but keep the existing stripe imports (again on the default route - account overview):
![02_loadstripeInUseEffect](https://user-images.githubusercontent.com/2510683/91311826-6f3e5000-e7ab-11ea-8966-c91a040ec7a4.png)

The 3rd and 4th images are the approach taken in this pr (the 1st image being the default route and the 2nd being the update payment page after capthca is complete)
![03_asyncLoadStripeImport](https://user-images.githubusercontent.com/2510683/91312146-d2c87d80-e7ab-11ea-96a4-9cb20e375315.png)

update payment page:
![04_asyncLoadStripeImport](https://user-images.githubusercontent.com/2510683/91312180-dbb94f00-e7ab-11ea-9266-a0a41cfa3297.png)

