### PR TITLE
Duplicate invoices

### DIFF
--- a/app/client/components/billing/invoicesTable.tsx
+++ b/app/client/components/billing/invoicesTable.tsx
@@ -286,9 +286,11 @@ export const InvoicesTable = (props: InvoicesTableProps) => {
                     </div>
                   </div>
                   <div css={tdCss2(index, tableHeadings[2])}>
-                    {`${tableRow.currency}${Number(tableRow.price).toFixed(
-                      2
-                    )} ${tableRow.currencyISO}`}
+                    {tableRow.hasMultipleSubs
+                      ? "Multiple prices"
+                      : `${tableRow.currency}${Number(tableRow.price).toFixed(
+                          2
+                        )} ${tableRow.currencyISO}`}
                   </div>
                   <div css={tdCss2(index)}>
                     <a css={invoiceLinkCss} href={tableRow.pdfPath}>

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -17,6 +17,7 @@ export interface InvoiceDataApiItem {
   pdfPath: string;
   price: string;
   paymentMethod: string;
+  hasMultipleSubs: boolean;
   last4?: string;
   cardType?: string;
 }


### PR DESCRIPTION
## What does this change?
For invoices that span multiple subscriptions display the string "Multiple prices" instead of the price in the invoice table.

reliant on the 2 following prs:
https://github.com/guardian/manage-frontend/pull/477
https://github.com/guardian/invoicing-api/pull/15

## Images
Before            |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/2510683/91154097-fd85d980-e6b8-11ea-9a7e-4e49562d35af.png)  |  ![](https://user-images.githubusercontent.com/2510683/91154143-0c6c8c00-e6b9-11ea-820e-ca10eabe1ef1.png)


