### PR TITLE
Give permission to invoke API Gateway needed for AWS signature

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -199,6 +199,15 @@ Resources:
               - Effect: Allow
                 Action: apigateway:GET
                 Resource: !Sub arn:aws:apigateway:${AWS::Region}::/apikeys/*
+        - PolicyName: InvokeApiGateway
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action: execute-api:Invoke
+                Resource:
+                  - !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:*/DEV/*
+                  - !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:*/CODE/*
+                  - !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:*/${Stage}/* # avoids PROD resources being available to lower environments
 
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile


### PR DESCRIPTION
## What does this change?

Without this policy, Invoicing API which requires IAM authorization https://github.com/guardian/manage-frontend/pull/465, responds with 403

```
User: arn:aws:sts::*********:assumed-role/support-CODE-manage-frontend-AppRole-********/i-******* 
is not authorized to perform: execute-api:Invoke 
on resource: arn:aws:execute-api:eu-west-1:************:********/DEV/GET/invoices"}
```

## How to test

Go to 

```
https://manage.code.dev-theguardian.com/billing
```

 and tail with

```
awslogs get --profile membership support-manage-frontend-CODE --watch | grep -i LIST_INVOICES
```

should respond with

```
"status":200,"isOK"
```

## Have we considered potential risks?

As mentioned in https://github.com/guardian/manage-frontend/pull/465 we should alarm on 403 because it should never occur.

Due to environment switching design we have to hardcode stages

```
Resource:
  - !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:*/DEV/*
  - !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:*/CODE/*
  - !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:*/${Stage}/* # avoids PROD resources being available to lower environments
```

however note that lower environments will not be granted PROD permissions.