### PR TITLE
[RB] - add GA tracking for invoice interactions

### DIFF
--- a/app/client/components/billing/billing.tsx
+++ b/app/client/components/billing/billing.tsx
@@ -127,7 +127,8 @@ const BillingRenderer = ([mdaResponse, invoiceResponse]: [
                       ...invoice,
                       pdfPath: `/api/${invoice.pdfPath}`,
                       currency: paidPlan.currency,
-                      currencyISO: paidPlan.currencyISO
+                      currencyISO: paidPlan.currencyISO,
+                      product: specificProductType.productTitle(mainPlan)
                     }));
                   const resultsPerPage = paidPlan.interval?.includes("year")
                     ? productInvoiceData.length

--- a/app/client/components/billing/billing.tsx
+++ b/app/client/components/billing/billing.tsx
@@ -128,7 +128,7 @@ const BillingRenderer = ([mdaResponse, invoiceResponse]: [
                       pdfPath: `/api/${invoice.pdfPath}`,
                       currency: paidPlan.currency,
                       currencyISO: paidPlan.currencyISO,
-                      product: specificProductType.productTitle(mainPlan)
+                      productTitle: specificProductType.urlPart
                     }));
                   const resultsPerPage = paidPlan.interval?.includes("year")
                     ? productInvoiceData.length

--- a/app/client/components/billing/billing.tsx
+++ b/app/client/components/billing/billing.tsx
@@ -128,7 +128,7 @@ const BillingRenderer = ([mdaResponse, invoiceResponse]: [
                       pdfPath: `/api/${invoice.pdfPath}`,
                       currency: paidPlan.currency,
                       currencyISO: paidPlan.currencyISO,
-                      productTitle: specificProductType.urlPart
+                      productUrlPart: specificProductType.urlPart
                     }));
                   const resultsPerPage = paidPlan.interval?.includes("year")
                     ? productInvoiceData.length

--- a/app/client/components/billing/invoiceTableYearSelect.tsx
+++ b/app/client/components/billing/invoiceTableYearSelect.tsx
@@ -4,6 +4,7 @@ import { headline } from "@guardian/src-foundations/typography";
 import { SvgChevronDownSingle } from "@guardian/src-icons";
 import React, { ChangeEvent, Dispatch, SetStateAction } from "react";
 import { maxWidth } from "../../styles/breakpoints";
+import { trackEvent } from "../analytics";
 
 interface InvoiceTableYearSelectProps {
   years: string[];
@@ -48,6 +49,11 @@ export const InvoiceTableYearSelect = (props: InvoiceTableYearSelectProps) => {
             const newYear = event.target.value;
             props.setSelectedYear(newYear);
             props.onDirectUpdate(newYear);
+            trackEvent({
+              eventCategory: "invoice",
+              eventAction: "click",
+              eventLabel: "invoice_year_select"
+            });
           }
         }}
         value={props.selectedYear}

--- a/app/client/components/billing/invoicesTable.tsx
+++ b/app/client/components/billing/invoicesTable.tsx
@@ -32,7 +32,10 @@ interface InvoicesTableProps {
 }
 
 export const InvoicesTable = (props: InvoicesTableProps) => {
-  let trackingPaginationInteractionCount = 1;
+  const [
+    trackingPaginationInteractionCount,
+    setTrackingPaginationInteractionCount
+  ] = useState<number>(1);
   const initialPage = 1;
 
   const [currentPage, setCurrentPage] = useState<number>(initialPage);
@@ -64,8 +67,11 @@ export const InvoicesTable = (props: InvoicesTableProps) => {
       eventCategory: "invoice",
       eventAction: "click",
       eventLabel: "invoice_pagination_select",
-      eventValue: trackingPaginationInteractionCount++
+      eventValue: trackingPaginationInteractionCount
     });
+    setTrackingPaginationInteractionCount(
+      trackingPaginationInteractionCount + 1
+    );
   };
 
   const directYearUpdate = (newYear: string) => {
@@ -304,13 +310,13 @@ export const InvoicesTable = (props: InvoicesTableProps) => {
                     <a
                       css={invoiceLinkCss}
                       href={tableRow.pdfPath}
-                      onClick={() => {
-                        return trackEvent({
+                      onClick={() =>
+                        trackEvent({
                           eventCategory: "invoice",
                           eventAction: "click",
                           eventLabel: `view_${tableRow.productUrlPart}_pdf_invoice`
-                        });
-                      }}
+                        })
+                      }
                     >
                       View invoice (PDF)
                     </a>
@@ -320,13 +326,13 @@ export const InvoicesTable = (props: InvoicesTableProps) => {
                         tableRow.date
                       ).format("YYYY-MM-DD")}.pdf`}
                       href={tableRow.pdfPath}
-                      onClick={() => {
-                        return trackEvent({
+                      onClick={() =>
+                        trackEvent({
                           eventCategory: "invoice",
                           eventAction: "click",
                           eventLabel: `download_${tableRow.productUrlPart}_pdf_invoice`
-                        });
-                      }}
+                        })
+                      }
                     >
                       <DownloadIcon />
                     </a>

--- a/app/client/components/billing/invoicesTable.tsx
+++ b/app/client/components/billing/invoicesTable.tsx
@@ -6,6 +6,7 @@ import React, { useState } from "react";
 import { DATE_INPUT_FORMAT, formatDateStr } from "../../../shared/dates";
 import { InvoiceDataApiItem } from "../../../shared/productResponse";
 import { maxWidth, minWidth } from "../../styles/breakpoints";
+import { trackEvent } from "../analytics";
 import { Pagination } from "../pagination";
 import { CardDisplay } from "../payment/cardDisplay";
 import { DirectDebitDisplay } from "../payment/directDebitDisplay";
@@ -31,6 +32,7 @@ interface InvoicesTableProps {
 }
 
 export const InvoicesTable = (props: InvoicesTableProps) => {
+  let trackingPaginationInteractionCount = 1;
   const initialPage = 1;
 
   const [currentPage, setCurrentPage] = useState<number>(initialPage);
@@ -58,6 +60,12 @@ export const InvoicesTable = (props: InvoicesTableProps) => {
     ).year()}`;
     setCurrentInvoiceYear(targetInvoiceYear);
     setCurrentPage(newPageNumber);
+    trackEvent({
+      eventCategory: "invoice",
+      eventAction: "click",
+      eventLabel: "invoice_pagination_select",
+      eventValue: trackingPaginationInteractionCount++
+    });
   };
 
   const directYearUpdate = (newYear: string) => {
@@ -293,7 +301,20 @@ export const InvoicesTable = (props: InvoicesTableProps) => {
                         )} ${tableRow.currencyISO}`}
                   </div>
                   <div css={tdCss2(index)}>
-                    <a css={invoiceLinkCss} href={tableRow.pdfPath}>
+                    <a
+                      css={invoiceLinkCss}
+                      href={tableRow.pdfPath}
+                      onClick={() => {
+                        return trackEvent({
+                          eventCategory: "invoice",
+                          eventAction: "click",
+                          eventLabel: `view_${tableRow.product?.replace(
+                            /\s+/g,
+                            ""
+                          )}_pdf_invoice`
+                        });
+                      }}
+                    >
                       View invoice (PDF)
                     </a>
                     <a
@@ -302,6 +323,16 @@ export const InvoicesTable = (props: InvoicesTableProps) => {
                         tableRow.date
                       ).format("YYYY-MM-DD")}.pdf`}
                       href={tableRow.pdfPath}
+                      onClick={() => {
+                        return trackEvent({
+                          eventCategory: "invoice",
+                          eventAction: "click",
+                          eventLabel: `download_${tableRow.product?.replace(
+                            /\s+/g,
+                            ""
+                          )}_pdf_invoice`
+                        });
+                      }}
                     >
                       <DownloadIcon />
                     </a>

--- a/app/client/components/billing/invoicesTable.tsx
+++ b/app/client/components/billing/invoicesTable.tsx
@@ -21,7 +21,7 @@ const invoicePaymentMethods = {
 };
 
 interface InvoiceInfo extends InvoiceDataApiItem {
-  productTitle?: string;
+  productUrlPart?: string;
   currencyISO: string;
   currency: string;
 }
@@ -308,7 +308,7 @@ export const InvoicesTable = (props: InvoicesTableProps) => {
                         return trackEvent({
                           eventCategory: "invoice",
                           eventAction: "click",
-                          eventLabel: `view_${tableRow.productTitle}_pdf_invoice`
+                          eventLabel: `view_${tableRow.productUrlPart}_pdf_invoice`
                         });
                       }}
                     >
@@ -324,7 +324,7 @@ export const InvoicesTable = (props: InvoicesTableProps) => {
                         return trackEvent({
                           eventCategory: "invoice",
                           eventAction: "click",
-                          eventLabel: `download_${tableRow.productTitle}_pdf_invoice`
+                          eventLabel: `download_${tableRow.productUrlPart}_pdf_invoice`
                         });
                       }}
                     >

--- a/app/client/components/billing/invoicesTable.tsx
+++ b/app/client/components/billing/invoicesTable.tsx
@@ -21,7 +21,7 @@ const invoicePaymentMethods = {
 };
 
 interface InvoiceInfo extends InvoiceDataApiItem {
-  product?: string;
+  productTitle?: string;
   currencyISO: string;
   currency: string;
 }
@@ -308,10 +308,7 @@ export const InvoicesTable = (props: InvoicesTableProps) => {
                         return trackEvent({
                           eventCategory: "invoice",
                           eventAction: "click",
-                          eventLabel: `view_${tableRow.product?.replace(
-                            /\s+/g,
-                            ""
-                          )}_pdf_invoice`
+                          eventLabel: `view_${tableRow.productTitle}_pdf_invoice`
                         });
                       }}
                     >
@@ -327,10 +324,7 @@ export const InvoicesTable = (props: InvoicesTableProps) => {
                         return trackEvent({
                           eventCategory: "invoice",
                           eventAction: "click",
-                          eventLabel: `download_${tableRow.product?.replace(
-                            /\s+/g,
-                            ""
-                          )}_pdf_invoice`
+                          eventLabel: `download_${tableRow.productTitle}_pdf_invoice`
                         });
                       }}
                     >


### PR DESCRIPTION
## What does this change?
adds GA tracking for the view and download invoice links, clicks on the invoice pagination, and the selection of a year from the invoice year select.

The event labels are as follows:

pagination event: `invoice_pagination_select`
view pdf tracking event: `view_XXXX_pdf_invoice` eg `view_homedelivery_pdf_invoice`
download pdf tracking event: `download_XXXX_pdf_invoice` eg `download_homedelivery_pdf_invoice`
year select event: `invoice_year_select`

## Images
![90876239-3ca2ea80-e39a-11ea-8a23-c6ab2bbfd407](https://user-images.githubusercontent.com/2510683/91835166-ea3ab700-ec40-11ea-80e5-93d76e9f4d58.png)

