### PR TITLE
Resolve incorrect peer dependency

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -131,7 +131,7 @@
     "@guardian/consent-management-platform": "^3.4.8",
     "@guardian/src-button": "^1.8.0",
     "@guardian/src-checkbox": "^1.8.0",
-    "@guardian/src-foundations": "^1.8.0",
+    "@guardian/src-foundations": "^1.9.1",
     "@guardian/src-icons": "^1.8.0",
     "@guardian/src-inline-error": "^1.9.1",
     "@guardian/src-radio": "^1.8.0",


### PR DESCRIPTION
Fix 

```
warning " > @guardian/src-inline-error@1.9.1" has incorrect peer dependency "@guardian/src-foundations@^1.9.1".
```