### PR TITLE
Do not depend on yarn installed on TC agent even for bootstraping

### DIFF
--- a/build-tc
+++ b/build-tc
@@ -1,9 +1,14 @@
 #!/bin/bash
+shopt -s expand_aliases
 
 set -e
 
 # cd into the app directory where package.json resides
 cd app
+
+# https://classic.yarnpkg.com/en/docs/cli/policies/#toc-policies-set-version
+# This could be removed if all TC agents guaranteed   global yarn installed
+alias yarn='node ../.yarn/releases/yarn-*.js'
 
 # install node
 


### PR DESCRIPTION
## What does this change?

Related PR: https://github.com/guardian/manage-frontend/pull/496

Some TC agents apparently did not have global yarn installed which is needed to boostrap local yarn under `.yarn/releases/` via `yarn-path` in `.yarnrc`. So now we do not depend on agent's installation at all (although this is non-standard way of doing it).

## How to test

- Try to run TC build
- Check build log output for correct version of yarn
