### PR TITLE
Enable holiday stops for Subscription Card (Digital Voucher)

### DIFF
--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -440,6 +440,13 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
     legacyUrlPart: "digitalvoucher",
     getOphanProductType: () => "PRINT_SUBSCRIPTION",
     restrictedNewsletterIDs: [FRONT_PAGE_NEWSLETTER_ID],
+    holidayStops: {
+      issueKeyword: "issue",
+      alternateNoticeString: "one day's notice",
+      additionalHowAdvice:
+        "Please note you will not be able to redeem your paper on any days that you have a suspension in place.",
+      hideDeliveryRedirectionHelpBullet: true
+    },
     delivery: {
       showAddress: showDeliveryAddressCheck
     }


### PR DESCRIPTION
## What does this change?

- Related service-layer PR: https://github.com/guardian/support-service-lambdas/pull/692
- Related Salesforce PR: https://github.com/guardian/salesforce/pull/278
- Enable users to self-service their Subscription Card holiday suspensions

## How to test

In DEV:

1. Until `Subscription Card` has been properly released, enable its acquisition like so
   1. Change `val useDigitalVoucher = true` in [support-frontend](https://github.com/guardian/support-frontend/blob/920e638c35430cc260acdb1878f37bffa1d12fae/support-models/src/main/scala/com/gu/support/catalog/Product.scala#L93)
   1. Deploy branch with above change to CODE by deploying `support:support-workers-mono` and `support:frontend-mono`
   1. Acquire Subscription Card without using test user at https://support.code.dev-theguardian.com/uk/subscribe/paper
1. Fetch fresh Janus credentials
1. `yarn watch` within `app/`
1. Go to https://manage.thegulocal.com/suspend/subscriptioncard
1. Make sure latest `holiday-stop-api` and `holiday-stop-processor` are deployed in DEV
1. Complete holiday suspension flow
1. Check Salesforce DEV has the corresponding HolidayStopRequest
1. Run `holiday-stop-processor` with date override as Stopped Publication Date, for example, `2020-09-27`
1. Check Zuora Dev subscription has correct holiday stop product applied

## How can we measure success?

Decreased load on call centre.

## Have we considered potential risks?

No major risks apparent.

## Images

![image](https://user-images.githubusercontent.com/13835317/93234619-6cb09400-f774-11ea-9c33-f2d24e822f0b.png)


