### PR TITLE
Remove public profile information from manage

### DIFF
--- a/app/client/components/identity/PublicProfile/ProfileFormSection.tsx
+++ b/app/client/components/identity/PublicProfile/ProfileFormSection.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import * as Yup from "yup";
 import { Button } from "../../buttons";
 import { WithStandardTopMargin } from "../../page";
-import { FormTextAreaField, FormTextField } from "../Form/FormField";
+import { FormTextField } from "../Form/FormField";
 import { ErrorTypes, User } from "../models";
 import { PageSection } from "../PageSection";
 import { textSmall } from "../sharedStyles";
@@ -15,15 +15,10 @@ interface ProfileFormSectionProps {
   onSuccess: (user: User) => void;
 }
 
-const hasUsername = (user: User) => !!user.username;
-
 const formValidationSchema = Yup.object().shape({
   username: Yup.string()
     .min(6, "Must be 6 characters minimum")
-    .max(20, "Must be 20 characters or less"),
-  location: Yup.string().max(255, "Maximum length is 255"),
-  aboutMe: Yup.string().max(1500, "Maximum length is 1500"),
-  interests: Yup.string().max(255, "Maximum length is 255")
+    .max(20, "Must be 20 characters or less")
 });
 
 const usernameInput = (formikProps: FormikProps<User>) => (
@@ -45,14 +40,7 @@ const fieldSetCss = {
 const ProfileForm = (props: FormikProps<User> & ProfileFormSectionProps) => (
   <Form>
     <fieldset css={fieldSetCss} disabled={props.isSubmitting}>
-      {!hasUsername(props.user) ? usernameInput(props) : null}
-      <FormTextField name="location" label="Location" formikProps={props} />
-      <FormTextAreaField name="aboutMe" label="About Me" formikProps={props} />
-      <FormTextAreaField
-        name="interests"
-        label="Interests"
-        formikProps={props}
-      />
+      {usernameInput(props)}
       <Button
         disabled={props.isSubmitting}
         text="Save changes"

--- a/app/client/components/identity/PublicProfile/index.tsx
+++ b/app/client/components/identity/PublicProfile/index.tsx
@@ -71,6 +71,21 @@ export const PublicProfile = (_: { path?: string }) => {
     </>
   );
 
+  const usernameInputForm = (u: User) => (
+    <>
+      <ProfileFormSection
+        user={u}
+        saveUser={values => saveUser(u, values)}
+        onError={handleGeneralError}
+        onSuccess={setUser}
+      />
+
+      <WithStandardTopMargin>
+        <Lines n={1} />
+      </WithStandardTopMargin>
+    </>
+  );
+
   const content = (u: User) => (
     <>
       <WithStandardTopMargin>
@@ -86,16 +101,7 @@ export const PublicProfile = (_: { path?: string }) => {
       <WithStandardTopMargin>
         <Lines n={1} />
       </WithStandardTopMargin>
-      {hasUsername(u) ? usernameDisplay(u) : null}
-      <ProfileFormSection
-        user={u}
-        saveUser={values => saveUser(u, values)}
-        onError={handleGeneralError}
-        onSuccess={setUser}
-      />
-      <WithStandardTopMargin>
-        <Lines n={1} />
-      </WithStandardTopMargin>
+      {hasUsername(u) ? usernameDisplay(u) : usernameInputForm(u)}
       <WithStandardTopMargin>
         <AvatarSection userId={u.id} />
       </WithStandardTopMargin>

--- a/app/client/components/identity/idapi/user.ts
+++ b/app/client/components/identity/idapi/user.ts
@@ -7,9 +7,9 @@ import {
   localFetch
 } from "./fetch";
 
-type UserPublicFields = Partial<
-  Pick<User, "aboutMe" | "interests" | "location" | "username">
-> & { displayName?: string };
+type UserPublicFields = Partial<Pick<User, "username">> & {
+  displayName?: string;
+};
 
 type UserPrivateFields = Partial<
   Pick<
@@ -77,9 +77,6 @@ const toUserApiRequest = (user: Partial<User>): UserAPIRequest => {
 
   return {
     publicFields: {
-      aboutMe: user.aboutMe,
-      interests: user.interests,
-      location: user.location,
       username: user.username,
       // Currently displayname and username must be set to the same value, but this is not enforced on IDAPI
       // and clients are expected to implement this logic for the time being.
@@ -108,9 +105,6 @@ const toUser = (response: UserAPIResponse): User => {
   return {
     id: user.id,
     primaryEmailAddress: user.primaryEmailAddress,
-    location: getFromUser("publicFields.location"),
-    aboutMe: getFromUser("publicFields.aboutMe"),
-    interests: getFromUser("publicFields.interests"),
     username: getFromUser("publicFields.username"),
     title: getFromUser("privateFields.title"),
     firstName: getFromUser("privateFields.firstName"),

--- a/app/client/components/identity/models.ts
+++ b/app/client/components/identity/models.ts
@@ -24,9 +24,6 @@ export enum ConsentOptionType {
 export interface User {
   id: string;
   primaryEmailAddress: string;
-  location: string;
-  aboutMe: string;
-  interests: string;
   consents: string[];
   username: string;
   validated: boolean;
@@ -46,9 +43,6 @@ export interface User {
 export interface UserError {
   type: ErrorTypes.VALIDATION;
   error: {
-    aboutMe: string;
-    location: string;
-    interests: string;
     username: string;
   };
 }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

A decisions has been made to remove public profile information from user profiles for about me, location and interests.

This PR removes it from manage-frontend. We will eventually delete the data from IDAPI

https://trello.com/c/ALpVrAu3/2340-removing-about-me-location-interests-just-the-ui-m

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Tested locally running manage

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Users can no longer see or enter these details

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

![Screenshot 2020-09-16 at 15 08 09](https://user-images.githubusercontent.com/29203769/93349701-b9a57080-f82f-11ea-95be-70159ecebc3b.png)
![Screenshot 2020-09-16 at 14 51 49](https://user-images.githubusercontent.com/29203769/93349705-bad69d80-f82f-11ea-8779-c93eb1ea4dff.png)

