### PR TITLE
Get cancellation effective date from dedicated endpoint in MDAPI

### DIFF
--- a/app/client/components/accountoverview/accountOverviewCard.tsx
+++ b/app/client/components/accountoverview/accountOverviewCard.tsx
@@ -2,7 +2,7 @@ import { css } from "@emotion/core";
 import { palette, space } from "@guardian/src-foundations";
 import { textSans } from "@guardian/src-foundations/typography";
 import React from "react";
-import { formatDateStr } from "../../../shared/dates";
+import { cancellationFormatDate, formatDateStr } from "../../../shared/dates";
 import {
   getMainPlan,
   isGift,
@@ -203,7 +203,9 @@ export const AccountOverviewCard = (props: AccountOverviewCardProps) => {
                 font-weight: bold;
               `}
             >
-              {formatDateStr(props.productDetail.subscription.end)}
+              {cancellationFormatDate(
+                props.productDetail.subscription.cancellationEffectiveDate
+              )}
             </span>
             .
           </p>

--- a/app/client/components/accountoverview/manageProduct.tsx
+++ b/app/client/components/accountoverview/manageProduct.tsx
@@ -4,7 +4,7 @@ import { palette, space } from "@guardian/src-foundations";
 import { headline, textSans } from "@guardian/src-foundations/typography";
 import { Link } from "@reach/router";
 import React, { useState } from "react";
-import { formatDateStr } from "../../../shared/dates";
+import { cancellationFormatDate } from "../../../shared/dates";
 import {
   getMainPlan,
   isGift,
@@ -123,7 +123,11 @@ const InnerContent = ({ props, productDetail }: InnerContentProps) => {
             `}
           >
             {cancelledCopy}{" "}
-            <strong>{formatDateStr(productDetail.subscription.end)}</strong>
+            <strong>
+              {cancellationFormatDate(
+                productDetail.subscription.cancellationEffectiveDate
+              )}
+            </strong>
           </span>
           .
         </p>

--- a/app/client/components/cancel/cancellationDateResponse.ts
+++ b/app/client/components/cancel/cancellationDateResponse.ts
@@ -1,8 +1,8 @@
-import AsyncLoader from "../asyncLoader";
 import {
-  X_GU_ID_FORWARDED_SCOPE,
-  getScopeFromRequestPathOrEmptyString
+  getScopeFromRequestPathOrEmptyString,
+  X_GU_ID_FORWARDED_SCOPE
 } from "../../../shared/identity";
+import AsyncLoader from "../asyncLoader";
 
 export interface CancellationDateResponse {
   cancellationEffectiveDate: string;

--- a/app/client/components/cancel/cancellationDateResponse.ts
+++ b/app/client/components/cancel/cancellationDateResponse.ts
@@ -1,0 +1,24 @@
+import AsyncLoader from "../asyncLoader";
+import {
+  X_GU_ID_FORWARDED_SCOPE,
+  getScopeFromRequestPathOrEmptyString
+} from "../../../shared/identity";
+
+export interface CancellationDateResponse {
+  cancellationEffectiveDate: string;
+}
+
+export class CancellationDateAsyncLoader extends AsyncLoader<
+  CancellationDateResponse
+> {}
+
+export const cancellationDateFetcher = (subscriptionName: string) => () =>
+  fetch("/api/cancellation-date/" + subscriptionName, {
+    credentials: "include",
+    mode: "same-origin",
+    headers: {
+      [X_GU_ID_FORWARDED_SCOPE]: getScopeFromRequestPathOrEmptyString(
+        window.location.href
+      )
+    }
+  });

--- a/app/client/components/cancel/cancellationFlow.tsx
+++ b/app/client/components/cancel/cancellationFlow.tsx
@@ -31,12 +31,12 @@ import {
   cancellationEffectiveToday,
   CancellationPolicyContext
 } from "./cancellationContexts";
-import { ContactUsToCancel } from "./contactUsToCancel";
 import {
   CancellationDateAsyncLoader,
   cancellationDateFetcher,
   CancellationDateResponse
 } from "./cancellationDateResponse";
+import { ContactUsToCancel } from "./contactUsToCancel";
 
 export interface RouteableStepPropsWithCancellationFlow
   extends RouteableStepProps {

--- a/app/client/components/cancel/cancellationFlow.tsx
+++ b/app/client/components/cancel/cancellationFlow.tsx
@@ -62,9 +62,10 @@ class ReasonPicker extends React.Component<
   };
 
   public render(): React.ReactNode {
-    const showCancellationDateOptions = !isNaN(
-      Date.parse(this.props.chargedThroughCancellationDate)
-    );
+    // offer choice if not trial period or lead time, and startPageOfferEffectiveDateOptions config set to true
+    const showCancellationDateOptions =
+      !isNaN(Date.parse(this.props.chargedThroughCancellationDate)) &&
+      this.props.productType.cancellation.startPageOfferEffectiveDateOptions;
 
     const chargedThroughDateStr =
       showCancellationDateOptions &&
@@ -114,19 +115,6 @@ class ReasonPicker extends React.Component<
               </h4>
               <form css={css({ marginBottom: "30px" })}>
                 <RadioButton
-                  value="Today"
-                  label="Today"
-                  checked={
-                    this.state.cancellationPolicy === cancellationEffectiveToday
-                  }
-                  groupName="cancellationPolicy"
-                  onChange={() =>
-                    this.setState({
-                      cancellationPolicy: cancellationEffectiveToday
-                    })
-                  }
-                />
-                <RadioButton
                   value="EndOfLastInvoicePeriod"
                   label={`On ${chargedThroughDateStr}, which is the end of your current billing period (you should not be charged again)`}
                   checked={
@@ -137,6 +125,19 @@ class ReasonPicker extends React.Component<
                   onChange={() =>
                     this.setState({
                       cancellationPolicy: cancellationEffectiveEndOfLastInvoicePeriod
+                    })
+                  }
+                />
+                <RadioButton
+                  value="Today"
+                  label="Today"
+                  checked={
+                    this.state.cancellationPolicy === cancellationEffectiveToday
+                  }
+                  groupName="cancellationPolicy"
+                  onChange={() =>
+                    this.setState({
+                      cancellationPolicy: cancellationEffectiveToday
                     })
                   }
                 />

--- a/app/client/components/cancel/cancellationFlow.tsx
+++ b/app/client/components/cancel/cancellationFlow.tsx
@@ -63,12 +63,12 @@ class ReasonPicker extends React.Component<
 
   public render(): React.ReactNode {
     // offer choice if not trial period or lead time, and startPageOfferEffectiveDateOptions config set to true
-    const showCancellationDateOptions =
+    const shouldOfferEffectiveDateOptions =
       !isNaN(Date.parse(this.props.chargedThroughCancellationDate)) &&
       this.props.productType.cancellation.startPageOfferEffectiveDateOptions;
 
     const chargedThroughDateStr =
-      showCancellationDateOptions &&
+      shouldOfferEffectiveDateOptions &&
       momentiseDateStr(this.props.chargedThroughCancellationDate).format(
         friendlyLongDateFormat
       );
@@ -108,7 +108,7 @@ class ReasonPicker extends React.Component<
             ))}
           </form>
 
-          {showCancellationDateOptions && (
+          {shouldOfferEffectiveDateOptions && (
             <>
               <h4>
                 When would you like your cancellation to become effective?
@@ -166,7 +166,7 @@ class ReasonPicker extends React.Component<
                 to={this.state.reasonPath}
                 disabled={
                   !this.state.reasonPath ||
-                  (showCancellationDateOptions &&
+                  (shouldOfferEffectiveDateOptions &&
                     !this.state.cancellationPolicy)
                 }
                 right

--- a/app/client/components/cancel/cancellationSummary.tsx
+++ b/app/client/components/cancel/cancellationSummary.tsx
@@ -2,11 +2,8 @@ import { css } from "@emotion/core";
 import { palette } from "@guardian/src-foundations";
 import { Link } from "@reach/router";
 import React from "react";
-import {
-  formatDate,
-  ProductDetail,
-  Subscription
-} from "../../../shared/productResponse";
+import { cancellationFormatDate } from "../../../shared/dates";
+import { ProductDetail, Subscription } from "../../../shared/productResponse";
 import {
   hasDeliveryRecordsFlow,
   ProductType
@@ -35,8 +32,13 @@ const actuallyCancelled = (
                 <>
                   You will continue to receive the benefits of your{" "}
                   {productType.friendlyName} until{" "}
-                  <b>{formatDate(subscription.end)}</b>. You will not be charged
-                  again. If you think you’re owed a refund, please contact us at{" "}
+                  <b>
+                    {cancellationFormatDate(
+                      subscription.cancellationEffectiveDate
+                    )}
+                  </b>
+                  . You will not be charged again. If you think you’re owed a
+                  refund, please contact us at{" "}
                   <a
                     css={hrefStyle}
                     href="mailto:customer.help@theguardian.com"

--- a/app/server/routes/api.ts
+++ b/app/server/routes/api.ts
@@ -69,6 +69,15 @@ router.get(
   )
 );
 
+router.get(
+  "/cancellation-date/:subscriptionName",
+  membersDataApiHandler(
+    "user-attributes/me/cancel/:subscriptionName",
+    "MDA_CANCEL",
+    ["subscriptionName"]
+  )
+);
+
 router.post(
   "/cancel/:subscriptionName?",
   membersDataApiHandler(

--- a/app/server/routes/api.ts
+++ b/app/server/routes/api.ts
@@ -72,7 +72,7 @@ router.get(
 router.get(
   "/cancellation-date/:subscriptionName",
   membersDataApiHandler(
-    "user-attributes/me/cancel/:subscriptionName",
+    "user-attributes/me/cancellation-date/:subscriptionName",
     "MDA_CANCEL",
     ["subscriptionName"]
   )

--- a/app/shared/dates.ts
+++ b/app/shared/dates.ts
@@ -9,3 +9,9 @@ export const momentiseDateStr = (dateStr: string) =>
 
 export const formatDateStr = (dateStr: string, outputFormat?: string) =>
   momentiseDateStr(dateStr).format(outputFormat || "D MMM YYYY");
+
+export const cancellationFormatDate = (cancellationEffectiveDate?: string) => {
+  return cancellationEffectiveDate === undefined
+    ? "today"
+    : formatDateStr(cancellationEffectiveDate);
+};

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -149,6 +149,7 @@ export interface Subscription {
   contactId?: string;
   // THIS IS NOT PART OF THE members-data-api RESPONSE (it's injected server-side - see server/routes/api.ts)
   deliveryAddressChangeEffectiveDate?: string;
+  cancellationEffectiveDate?: string;
 }
 
 export interface SubscriptionWithDeliveryAddress extends Subscription {


### PR DESCRIPTION
## What does this change?

- https://trello.com/c/b8Rx4P6u/1642-manage-frontend-cancellation-flow-give-user-choice-of-date-of-cancellation-but-the-date-is-never-used-s
- https://trello.com/c/IIlIyWzB/1636-self-service-cancellation-effective-date-bug
- Related PR: https://github.com/guardian/members-data-api/pull/472
- MMA will now make use of dedicated endpoint in MDAPI to first determine effective cancellation date
  - If subscription is in trial period or lead time, then it will cancel now without CSR manual intervention
  - If subscription is in invoiced period, then MDAPI will respond with end of last invoice period date, and user will be presented with options to cancel now or at the end of invoice. If user chooses now, then case will be raised to CSR for manual intervention
- Showing of options can be entirely skipped with `startPageOfferEffectiveDateOptions` as is currently the case for Contributions.
- `cancellationEffectiveDate` decided by MDAPI, and part of `me/mma` response, will now be displayed on confirmation page and account overview instead of `subscription.end`

## How to test

Follow the instructions in https://github.com/guardian/membership-common/pull/629

## How can we measure success?

- GW+6for6 incorrect cancellation effective date resolved
- User is not presented with misleading cancellation dates
- Improved correctness of churn reporting
- Free trial and lead time cancellations fully automated

## Have we considered potential risks?

This PR is intended to only fix bugs, that is, there should be no behavioural  changes.

## Images

Choice

![image](https://user-images.githubusercontent.com/13835317/94252326-ad9a6c80-ff1b-11ea-986b-0771979c9407.png)

Account overview

![image](https://user-images.githubusercontent.com/13835317/94252386-c014a600-ff1b-11ea-8d22-1ff64e12aebd.png)

Cancellation confirmation page
![image](https://user-images.githubusercontent.com/13835317/94259919-34087b80-ff27-11ea-8f9c-963fb9f7cb65.png)



