### PR TITLE
Investigate users being re-directed back to root before flow is completed

### DIFF
--- a/app/client/components/accountoverview/manageProduct.tsx
+++ b/app/client/components/accountoverview/manageProduct.tsx
@@ -376,7 +376,12 @@ const CancellationCTA = (props: CancellationCTAProps) => {
         css={css`
           color: ${palette.brand["500"]};
         `}
-        to={"/cancel/" + props.specificProductType.urlPart}
+        to={
+          "/cancel/" +
+          props.specificProductType.urlPart +
+          "/" +
+          props.productDetail.subscription.subscriptionId
+        }
         state={props.productDetail}
       >
         {shouldContactUsToCancel

--- a/app/client/components/productDetailProvider.tsx
+++ b/app/client/components/productDetailProvider.tsx
@@ -16,6 +16,7 @@ export interface ProductDetailProviderProps extends RouteableStepProps {
   allowCancelledSubscription?: true;
   loadingMessagePrefix: string;
   forceRedirectToAccountOverviewIfNoBrowserHistoryState?: true;
+  subscriptionId?: string;
 }
 
 export const ProductDetailProvider = (props: ProductDetailProviderProps) => {
@@ -46,7 +47,10 @@ export const ProductDetailProvider = (props: ProductDetailProviderProps) => {
       visuallyNavigateToParent(props, true)
     ) : (
       <MembersDatApiAsyncLoader
-        fetch={createProductDetailFetcher(props.productType)}
+        fetch={createProductDetailFetcher(
+          props.productType,
+          props.subscriptionId
+        )}
         render={renderSingleProductOrReturnToAccountOverview(
           props,
           setSelectedProductDetail
@@ -76,8 +80,8 @@ const renderSingleProductOrReturnToAccountOverview = (
     );
 
   if (filteredProductDetails.length === 1) {
-    setSelectedProductDetail(filteredProductDetails[0]);
+    setSelectedProductDetail(filteredProductDetails[0]); // FIXME: Could this filtering be more precise on subscriptionId?
     return null;
   }
-  return visuallyNavigateToParent(props, true);
+  return visuallyNavigateToParent(props, true); // FIXME: This seems to happen silently currently. Should some error feedback be provided, as we have users reporting they are stuck in a loop.
 };

--- a/app/client/components/user.tsx
+++ b/app/client/components/user.tsx
@@ -68,7 +68,7 @@ const User = () => (
       {Object.values(PRODUCT_TYPES).map((productType: ProductType) => (
         <CancellationFlow
           key={productType.urlPart}
-          path={"/cancel/" + productType.urlPart}
+          path={"/cancel/" + productType.urlPart + "/:subscriptionId"}
           productType={productType}
         >
           {hasCancellationFlow(productType) &&


### PR DESCRIPTION
## What does this change?

* https://trello.com/c/zGUa33yd/1639-manage-frontend-redirects-to-account-overview-before-user-flow-is-completed-s
* This is just an exploratory draft PR to server as discussion point
* Currently `ProductDetailProvider` component requests `/me/mma`, which might return multiple products, and then has a guard `if (filteredProductDetails.length === 1) setSelectedProductDetail(filteredProductDetails[0])`. Perhaps instead we should be more specific, and somehow pass specific `subscriptionId` we are interested in thus `ProductDetailProvider` would request `/me/mma/A-S00060454`. [`createProductDetailFetcher`](https://github.com/guardian/manage-frontend/blob/fd7fb46cf73fab9737eca7b1c0517d10eea3ad8e/app/shared/productTypes.tsx#L215) already accounts for this possibility 
* How would we pass the `subscriptionId` down to all the components that need it? Currently just for cancellation flow I pass it via Router path parameter, which does seem to allow me to escape from the redirection loop.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
