### PR TITLE
Fix early redirection to root due to productDetail existing at different levels in location.state

### DIFF
--- a/app/client/components/accountoverview/accountOverviewCard.tsx
+++ b/app/client/components/accountoverview/accountOverviewCard.tsx
@@ -281,7 +281,7 @@ export const AccountOverviewCard = (props: AccountOverviewCardProps) => {
             <LinkButton
               to={`/${groupedProductType.urlPart}`}
               text={`Manage ${groupedProductType.friendlyName}`}
-              state={{ productDetail: props.productDetail }}
+              state={props.productDetail}
               colour={palette.brand[800]}
               textColour={palette.brand[400]}
               fontWeight={"bold"}
@@ -381,7 +381,7 @@ export const AccountOverviewCard = (props: AccountOverviewCardProps) => {
                 >
                   <LinkButton
                     to={`/payment/${specificProductType.urlPart}`}
-                    state={{ productDetail: props.productDetail }}
+                    state={props.productDetail}
                     text={"Manage payment method"}
                     colour={
                       hasPaymentFailure

--- a/app/client/components/accountoverview/manageProduct.tsx
+++ b/app/client/components/accountoverview/manageProduct.tsx
@@ -184,7 +184,7 @@ const InnerContent = ({ props, productDetail }: InnerContentProps) => {
           alert={!!productDetail.alertText}
           text="Update payment method"
           to={`/payment/${specificProductType.urlPart}`}
-          state={{ productDetail }}
+          state={productDetail}
         />
       )}
 
@@ -233,7 +233,7 @@ const InnerContent = ({ props, productDetail }: InnerContentProps) => {
               fontWeight="bold"
               text="Manage delivery address"
               to={`/delivery/${specificProductType.urlPart}/address`}
-              state={{ productDetail }}
+              state={productDetail}
             />
           </>
         )}
@@ -260,7 +260,7 @@ const InnerContent = ({ props, productDetail }: InnerContentProps) => {
             fontWeight="bold"
             text="Manage delivery history"
             to={`/delivery/${specificProductType.urlPart}/records`}
-            state={{ productDetail }}
+            state={productDetail}
           />
         </>
       )}
@@ -292,7 +292,7 @@ const InnerContent = ({ props, productDetail }: InnerContentProps) => {
               fontWeight="bold"
               text="Manage suspensions"
               to={`/suspend/${specificProductType.urlPart}`}
-              state={{ productDetail }}
+              state={productDetail}
             />
           </>
         )}

--- a/app/client/components/buttons.tsx
+++ b/app/client/components/buttons.tsx
@@ -36,7 +36,7 @@ interface LinkButtonState {
 
 interface LinkButtonProps extends ButtonProps {
   to: string;
-  state?: LinkButtonState;
+  state?: LinkButtonState | ProductDetail;
 }
 
 const applyIconStyleIfApplicable = (

--- a/app/client/components/productDetailProvider.tsx
+++ b/app/client/components/productDetailProvider.tsx
@@ -31,10 +31,18 @@ export const ProductDetailProvider = (props: ProductDetailProviderProps) => {
 
   // Browser history state is inspected inside this hook to avoid race condition with server side rendering
   useEffect(() => {
-    const productDetailFromBrowserHistoryState =
+    const productDetailNestedFromBrowserHistoryState =
       isProduct(props.location?.state?.productDetail) &&
       props.location?.state?.productDetail;
-    setSelectedProductDetail(productDetailFromBrowserHistoryState || null);
+
+    const productDetailDirectFromBrowserHistoryState =
+      isProduct(props.location?.state) && props.location?.state;
+
+    setSelectedProductDetail(
+      productDetailNestedFromBrowserHistoryState ||
+        productDetailDirectFromBrowserHistoryState ||
+        null
+    );
   }, []); // Equivalent to componentDidMount (ie only happens on the client)
 
   if (selectedProductDetail) {


### PR DESCRIPTION
## What does this change?

`ProductDetails` is sometimes passed directly as the `state` object of Reach Router [Link](https://reach.tech/router/api/Link) component

```
<Link
  state={props.productDetail}
  ...
>
```

and other times nested inside another object 

```
<LinkButton
  state={
    {
      productDetail,
      flowReferrer: {
        title: NAV_LINKS.billing.title,
        link: NAV_LINKS.billing.link
      }
    }
  }
  ...
/>
``` 

so this PR accounts for both possibilities in `ProductDetailProvider` component. This fixes the bug where  `ProductDetailProvider` would think there is nothing in the state, and then re-request from MMA, however MMA could respond with less precise information, for example, there could be two subscriptions of the same kind, and `ProductDetailProvider` would not have enough information to know which the user has picked, so it would simply redirect back to the `Account Overview` with the intention of user picking the correct one. The user would then get stuck in redirection loop.

## How to test

To reproduce the bug acquire two subscriptions of the same kind, for example two separate subscriptions of Guardian Weekly, and then try to complete cancellation flow.

## How can we measure success?

It is rare that users would have duplicate products, however this bug was also interfering with development as we often create many subscriptions during testing.

## Have we considered potential risks?

- There is no major behavioural change in this PR
- It was tested end-to-end
