### PR TITLE
Fix holiday stops when termEndDate does not represent anniversary

### DIFF
--- a/app/client/components/holiday/holidayDateChooser.tsx
+++ b/app/client/components/holiday/holidayDateChooser.tsx
@@ -180,8 +180,8 @@ export class HolidayDateChooser extends React.Component<
                   holidayStopsResponse.existingHolidayStopToAmend &&
                   holidayStopsResponse.existingHolidayStopToAmend.id;
 
-                const renewalDateMoment = momentiseDateStr(
-                  productDetail.subscription.renewalDate
+                const anniversaryDateMoment = momentiseDateStr(
+                  productDetail.subscription.anniversaryDate
                 );
 
                 const combinedIssuesImpactedPerYear = calculateIssuesImpactedPerYear(
@@ -190,7 +190,7 @@ export class HolidayDateChooser extends React.Component<
                     .filter(isNotBulkSuspension)
                     .filter(_ => _.id !== existingHolidayStopToAmendId)
                     .flatMap(_ => _.publicationsImpacted),
-                  renewalDateMoment
+                  anniversaryDateMoment
                 );
 
                 const allIssuesImpactedPerYear = calculateIssuesImpactedPerYear(
@@ -198,7 +198,7 @@ export class HolidayDateChooser extends React.Component<
                     .filter(isNotWithdrawn)
                     .filter(isNotBulkSuspension)
                     .flatMap(_ => _.publicationsImpacted),
-                  renewalDateMoment
+                  anniversaryDateMoment
                 );
 
                 return (
@@ -209,7 +209,7 @@ export class HolidayDateChooser extends React.Component<
                       {this.innerContent(
                         holidayStopsResponse,
                         existingHolidayStopToAmendId,
-                        renewalDateMoment,
+                        anniversaryDateMoment,
                         combinedIssuesImpactedPerYear,
                         allIssuesImpactedPerYear,
                         productDetail

--- a/app/client/components/holiday/holidayStopApi.ts
+++ b/app/client/components/holiday/holidayStopApi.ts
@@ -202,20 +202,20 @@ export interface IssuesImpactedPerYear {
 
 export const calculateIssuesImpactedPerYear = (
   publicationsImpacted: HolidayStopDetail[],
-  nextYearStartDate: Moment
+  anniversaryDate: Moment
 ) => {
   return {
     issuesThisYear: publicationsImpacted.filter(
       issue =>
-        issue.publicationDate.isBefore(nextYearStartDate) &&
+        issue.publicationDate.isBefore(anniversaryDate) &&
         issue.publicationDate.isSameOrAfter(
-          nextYearStartDate.clone().subtract(1, "year")
+          anniversaryDate.clone().subtract(1, "year")
         )
     ),
     issuesNextYear: publicationsImpacted.filter(
       issue =>
-        issue.publicationDate.isSameOrAfter(nextYearStartDate) &&
-        issue.publicationDate.isBefore(nextYearStartDate.clone().add(1, "year"))
+        issue.publicationDate.isSameOrAfter(anniversaryDate) &&
+        issue.publicationDate.isBefore(anniversaryDate.clone().add(1, "year"))
     )
   } as IssuesImpactedPerYear;
 };

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -129,6 +129,7 @@ export interface Subscription {
   start?: string;
   end: string;
   renewalDate: string;
+  anniversaryDate: string;
   cancelledAt: boolean;
   nextPaymentDate: string | null;
   lastPaymentDate: string | null;


### PR DESCRIPTION
## What does this change?

* https://trello.com/c/PlKMGmbK/1652-unable-to-apply-holiday-stops-via-mma-if-termstartdate-is-far-enough-in-the-future
* Related PR: https://github.com/guardian/members-data-api/pull/476
* Use dedicate field for anniversary

## How to test

1. Renew subscription few times to push termEndDate
1. Try to schedule holiday stops

## How can we measure success?

For example, the user that raised the case (see trello card) is able to suspend subscription.

## Have we considered potential risks?

Tested end-to-end in DEV.
