### PR TITLE
Update newsletter footer embed src

### DIFF
--- a/app/client/__tests__/__snapshots__/main.tsx.snap
+++ b/app/client/__tests__/__snapshots__/main.tsx.snap
@@ -818,7 +818,7 @@ exports[`Main renders something 1`] = `
                 onLoad={[Function]}
                 scrolling="no"
                 seamless={false}
-                src="https://profile.thegulocal.com/email/form/footer/today-uk"
+                src="https://www.theguardian.com/email/form/footer/today-uk"
                 title="Guardian Email Sign-up Form"
               />
             </div>

--- a/app/client/components/footer/footer.tsx
+++ b/app/client/components/footer/footer.tsx
@@ -1,19 +1,11 @@
 import { css } from "@emotion/core";
 import { from } from "@guardian/src-foundations/mq";
 import React, { SyntheticEvent, useEffect, useState } from "react";
-import { conf } from "../../../server/config";
 import palette from "../../colours";
 import { isInUSA as isUserInUSA } from "../../geolocation";
 import { headline } from "../../styles/fonts";
 import { SupportTheGuardianButton } from "../supportTheGuardianButton";
 import { footerLinks } from "./footerlinks";
-
-let domain: string;
-if (typeof window !== "undefined" && window.guardian) {
-  domain = window.guardian.domain;
-} else {
-  domain = conf.DOMAIN;
-}
 
 const TODAY = new Date();
 
@@ -221,7 +213,7 @@ export const Footer = () => {
               <div css={emailSignUpStyles}>
                 <iframe
                   title="Guardian Email Sign-up Form"
-                  src={`https://profile.${domain}/email/form/footer/today-uk`}
+                  src={`https://www.theguardian.com/email/form/footer/today-uk`}
                   scrolling="no"
                   seamless={false}
                   frameBorder="0"


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Following a refactor of how the newsletter embeds will work, there won't be an iframe hosted at `profile.guardian.co.uk`. Instead I'm moving this to using `www.theguardian.com` directly, and we'll be implementing some changes to make sure that things like autofilling email addresses for logged in users will be implemented in a way that is suitable across platforms.

### Related PRs:
 - https://github.com/guardian/frontend/pull/23051 (Reverted pending some work on the router, but the code will be the same following these changes)
