### PR TITLE
[RB] - display cancelled products in the account overview page for 3 months

### DIFF
--- a/app/.snyk
+++ b/app/.snyk
@@ -28,16 +28,6 @@ ignore:
     - node-pre-gyp > rc > minimist:
         reason: cannot be upgraded
         expires: '2020-10-17T17:00:51.079Z'
-  SNYK-JS-NODEFETCH-674311:
-    - formik > create-react-context > fbjs > isomorphic-fetch > node-fetch:
-        reason: Can be upgraded but will require code changes
-        expires: '2020-10-11T22:24:44.022Z'
-    - react-daterange-picker > create-react-class > fbjs > isomorphic-fetch > node-fetch:
-        reason: Cannot be upgraded; repo seems inactive
-        expires: '2020-10-11T22:24:44.022Z'
-    - react-daterange-picker > react-addons-pure-render-mixin > fbjs > isomorphic-fetch > node-fetch:
-        reason: Cannot be upgraded; repo seems inactive
-        expires: '2020-10-11T22:24:44.022Z'
   SNYK-JS-UAPARSERJS-610226:
     - formik > create-react-context > fbjs > ua-parser-js:
         reason: No upgrade available
@@ -48,6 +38,16 @@ ignore:
     - react-daterange-picker > react-addons-pure-render-mixin > fbjs > ua-parser-js:
         reason: No upgrade available
         expires: '2020-10-17T17:00:51.079Z'
+  SNYK-JS-NODEFETCH-674311:
+    - formik > create-react-context > fbjs > isomorphic-fetch > node-fetch:
+        reason: fix in seperate pr
+        expires: '2020-11-13T10:41:08.711Z'
+    - react-daterange-picker > create-react-class > fbjs > isomorphic-fetch > node-fetch:
+        reason: no fix available
+        expires: '2020-11-13T10:41:08.711Z'
+    - react-daterange-picker > react-addons-pure-render-mixin > fbjs > isomorphic-fetch > node-fetch:
+        reason: no fix available
+        expires: '2020-11-13T10:41:08.711Z'
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   SNYK-JS-LODASH-450202:

--- a/app/client/components/accountoverview/accountOverviewCancelledCard.tsx
+++ b/app/client/components/accountoverview/accountOverviewCancelledCard.tsx
@@ -1,0 +1,250 @@
+import { css } from "@emotion/core";
+import { palette, space } from "@guardian/src-foundations";
+import { textSans } from "@guardian/src-foundations/typography";
+import React from "react";
+import { formatDateStr } from "../../../shared/dates";
+import {
+  CancelledProductDetail,
+  isGift
+} from "../../../shared/productResponse";
+import { GROUPED_PRODUCT_TYPES } from "../../../shared/productTypes";
+import { maxWidth, minWidth } from "../../styles/breakpoints";
+import { titlepiece } from "../../styles/fonts";
+import { trackEvent } from "../analytics";
+import { Button } from "../buttons";
+import { ErrorIcon } from "../svgs/errorIcon";
+import { GiftIcon } from "../svgs/giftIcon";
+
+interface AccountOverviewCancelledCardProps {
+  product: CancelledProductDetail;
+}
+
+export const AccountOverviewCancelledCard = (
+  props: AccountOverviewCancelledCardProps
+) => {
+  const groupedProductType = GROUPED_PRODUCT_TYPES[props.product.mmaCategory];
+
+  const specificProductType = groupedProductType.mapGroupedToSpecific(
+    props.product
+  );
+
+  const showSubscribeAgainButton =
+    props.product.mmaCategory !== "membership" &&
+    props.product.mmaCategory !== "contributions";
+
+  const shouldShowJoinDateNotStartDate =
+    groupedProductType.shouldShowJoinDateNotStartDate;
+
+  const keyValuePairCss = css`
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  `;
+
+  const keyCss = css`
+    ${textSans.medium({ fontWeight: "bold" })};
+    margin: 0 0 16px 0;
+    padding: 0 ${space[2]}px 0 0;
+    display: inline-block;
+    vertical-align: top;
+    width: 14ch;
+  `;
+
+  const valueCss = css`
+    ${textSans.medium()};
+    margin: 0 0 16px 0;
+    padding: 0;
+    display: inline-block;
+    vertical-align: top;
+    width: calc(100% - 15ch);
+  `;
+
+  return (
+    <div
+      css={css`
+        border: 1px solid ${palette.neutral[86]};
+        margin-bottom: ${space[6]}px;
+      `}
+    >
+      <div
+        css={css`
+          display: flex;
+          justify-content: space-between;
+          align-items: start;
+          background-color: ${palette.neutral[97]};
+          ${minWidth.mobileLandscape} {
+            align-items: center;
+          }
+        `}
+      >
+        <h2
+          css={css`
+            margin: 0;
+            padding: ${space[3]}px;
+            color: ${palette.neutral[7]};
+            ${titlepiece.small()};
+            font-weight: bold;
+            font-size: 17px;
+            ${maxWidth.mobileLandscape} {
+              padding: ${space[3]}px;
+            }
+            ${minWidth.tablet} {
+              font-size: 20px;
+              padding: ${space[3]}px ${space[5]}px;
+            }
+          `}
+        >
+          {specificProductType.productTitle()}
+        </h2>
+        <div
+          css={css`
+            display: flex;
+            align-items: center;
+            padding: ${space[3]}px 0;
+            ${maxWidth.mobileLandscape} {
+              flex-direction: column;
+              align-items: end;
+            }
+          `}
+        >
+          <div
+            css={css`
+              margin-right: ${space[3]}px;
+              white-space: nowrap;
+              transform: translateY(1px);
+              ${maxWidth.mobileLandscape} {
+                ${isGift(props.product.subscription)
+                  ? "margin: 0 5px 6px 0;"
+                  : ""};
+              }
+              ${minWidth.tablet} {
+                margin-right: ${space[5]}px;
+              }
+            `}
+          >
+            <ErrorIcon
+              fill={palette.brandAlt[200]}
+              additionalCss={css`
+                transform: translateY(1px);
+              `}
+            />
+            <span
+              css={css`
+                ${textSans.medium({ fontWeight: "bold" })};
+                line-height: 1;
+                margin-left: 6px;
+              `}
+            >
+              Cancelled
+            </span>
+          </div>
+          {isGift(props.product.subscription) && (
+            <GiftIcon alignArrowToThisSide={"left"} />
+          )}
+        </div>
+      </div>
+      <div
+        css={css`
+          padding: ${space[5]}px ${space[3]}px;
+          ${minWidth.tablet} {
+            padding: ${space[5]}px;
+            display: flex;
+          }
+        `}
+      >
+        <div
+          css={css`
+            margin: 0;
+            padding: 0;
+            ${minWidth.tablet} {
+              flex: 1;
+              display: flex;
+              flex-flow: column nowrap;
+            }
+            ul:last-of-type li {
+              margin-bottom: ${showSubscribeAgainButton ? `${space[5]}px` : 0};
+            }
+          `}
+        >
+          {groupedProductType.shouldRevealSubscriptionId && (
+            <ul css={keyValuePairCss}>
+              <li css={keyCss}>Subscription ID</li>
+              <li css={valueCss}>
+                {props.product.subscription.subscriptionId}
+              </li>
+            </ul>
+          )}
+          {groupedProductType.tierLabel && (
+            <ul css={keyValuePairCss}>
+              <li css={keyCss}>{groupedProductType.tierLabel}</li>
+              <li css={valueCss}>{props.product.tier}</li>
+            </ul>
+          )}
+          {showSubscribeAgainButton && (
+            <div
+              css={css`
+                margin-top: auto;
+              `}
+            >
+              <a
+                href="https://support.theguardian.com/uk/subscribe"
+                onClick={() => {
+                  trackEvent({
+                    eventCategory: "href",
+                    eventAction: "click",
+                    eventLabel: "subscribe_again"
+                  });
+                }}
+              >
+                <Button
+                  text="Subscribe again"
+                  fontWeight="bold"
+                  colour={palette.brand[800]}
+                  textColour={palette.brand[400]}
+                  height="36px"
+                />
+              </a>
+            </div>
+          )}
+        </div>
+        <div
+          css={css`
+            margin: ${space[6]}px 0 0 0;
+            padding: ${space[6]}px 0 0 0;
+            border-top: 1px solid ${palette.neutral[86]};
+            ${minWidth.tablet} {
+              flex: 1;
+              display: flex;
+              flex-flow: column nowrap;
+              padding: 0 0 0 ${space[5]}px;
+              border-top: none;
+              border-left: 1px solid ${palette.neutral[86]};
+              margin: 0;
+              padding: 0 0 0 ${space[5]}px;
+            }
+            ul:last-of-type li {
+              margin-bottom: ${showSubscribeAgainButton ? `${space[5]}px` : 0};
+            }
+          `}
+        >
+          {props.product.subscription.start && (
+            <ul css={keyValuePairCss}>
+              <li css={keyCss}>
+                {shouldShowJoinDateNotStartDate ? "Join" : "Start"} date
+              </li>
+              <li css={valueCss}>
+                {formatDateStr(props.product.subscription.start)}
+              </li>
+            </ul>
+          )}
+          <ul css={keyValuePairCss}>
+            <li css={keyCss}>End date</li>
+            <li css={valueCss}>
+              {formatDateStr(props.product.subscription.end)}
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/app/client/components/accountoverview/supportTheGuardianSection.tsx
+++ b/app/client/components/accountoverview/supportTheGuardianSection.tsx
@@ -1,0 +1,35 @@
+import { css } from "@emotion/core";
+import { palette, space } from "@guardian/src-foundations";
+import { textSans } from "@guardian/src-foundations/typography";
+import React from "react";
+import {
+  SupportTheGuardianButton,
+  SupportTheGuardianButtonProps
+} from "../supportTheGuardianButton";
+
+export interface SupportTheGuardianSectionProps
+  extends SupportTheGuardianButtonProps {
+  message: string;
+}
+
+export const SupportTheGuardianSection = (
+  props: SupportTheGuardianSectionProps
+) => (
+  <>
+    <p
+      css={css`
+        ${textSans.medium()}
+        margin-top: ${space[6]}px;
+      `}
+    >
+      {props.message}
+    </p>
+    <SupportTheGuardianButton
+      fontWeight="bold"
+      textColour={palette.neutral[100]}
+      colour={palette.brand[400]}
+      notPrimary
+      {...props}
+    />
+  </>
+);

--- a/app/package.json
+++ b/app/package.json
@@ -60,6 +60,7 @@
     "@emotion/babel-preset-css-prop": "^10.0.27",
     "@testing-library/react": "^8.0.1",
     "@types/assets-webpack-plugin": "^3.9.0",
+    "@types/aws4": "^1.5.1",
     "@types/base-64": "^0.1.2",
     "@types/bunyan": "^1.8.4",
     "@types/color": "^3.0.0",
@@ -87,7 +88,6 @@
     "@types/webpack-merge": "^4.1.5",
     "@types/webpack-node-externals": "^1.7.1",
     "@types/yup": "^0.26.23",
-    "@types/aws4": "^1.5.1",
     "assets-webpack-plugin": "^3.10.0",
     "babel-jest": "^26.3.0",
     "babel-loader": "^8.0.6",
@@ -143,6 +143,7 @@
     "@stripe/react-stripe-js": "^1.1.2",
     "@stripe/stripe-js": "^1.7.0",
     "aws-sdk": "^2.746.0",
+    "aws4": "^1.10.1",
     "base-64": "^0.1.0",
     "color": "^3.0.0",
     "cookie-parser": "^1.4.4",
@@ -154,6 +155,7 @@
     "lodash": "^4.17.20",
     "moment": "^2.18.1",
     "moment-range": "^3.0.3",
+    "node-fetch": "^2.6.1",
     "number-to-words": "^1.2.4",
     "ophan-tracker-js": "^1.3.16",
     "react": "^16.13.1",
@@ -164,8 +166,7 @@
     "url-parse": "^1.4.4",
     "webpack-node-externals": "^1.7.2",
     "winston": "^3.2.1",
-    "yup": "^0.28.2",
-    "aws4": "^1.10.1"
+    "yup": "^0.28.2"
   },
   "license": "UNLICENSED",
   "snyk": true

--- a/app/server/routes/api.ts
+++ b/app/server/routes/api.ts
@@ -207,4 +207,12 @@ router.get(
   )
 );
 
+router.get(
+  "/cancelled",
+  membersDataApiHandler(
+    "user-attributes/me/cancelled-subscriptions",
+    "MDA_CANCELLED_SUBSCRIPTIONS"
+  )
+);
+
 export default router;

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -59,11 +59,22 @@ export interface ProductDetail extends WithSubscription {
   selfServiceCancellation: SelfServiceCancellation;
 }
 
+export interface CancelledProductDetail {
+  mmaCategory: GroupedProductTypeKeys;
+  tier: string;
+  joinDate: string;
+  subscription: CancelledSubscription;
+}
+
 export function isProduct(
   data: MembersDataApiItem | undefined
 ): data is ProductDetail {
   return !!data && data.hasOwnProperty("tier");
 }
+
+export const isCancelledProduct = (
+  data: CancelledProductDetail | ProductDetail | undefined
+) => !!data && !data.hasOwnProperty("joinDate");
 
 export interface Card extends CardProps {
   stripePublicKeyForUpdate: string;
@@ -153,6 +164,15 @@ export interface Subscription {
   cancellationEffectiveDate?: string;
 }
 
+export interface CancelledSubscription {
+  subscriptionId: string;
+  cancellationEffectiveDate: string;
+  start: string;
+  end: string;
+  readerType: ReaderType;
+  accountId: string;
+}
+
 export interface SubscriptionWithDeliveryAddress extends Subscription {
   deliveryAddress: DeliveryAddress;
 }
@@ -161,7 +181,7 @@ export interface WithSubscription {
   subscription: Subscription;
 }
 
-export const isGift = (subscription: Subscription) =>
+export const isGift = (subscription: { readerType: string }) =>
   subscription.readerType === "Gift";
 
 export const getMainPlan: (subscription: Subscription) => SubscriptionPlan = (

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -63,6 +63,7 @@ export interface CancelledProductDetail {
   mmaCategory: GroupedProductTypeKeys;
   tier: string;
   joinDate: string;
+  isCancelledAndEnded: string;
   subscription: CancelledSubscription;
 }
 
@@ -74,7 +75,7 @@ export function isProduct(
 
 export const isCancelledProduct = (
   data: CancelledProductDetail | ProductDetail | undefined
-) => !!data && !data.hasOwnProperty("joinDate");
+) => !!data && data.hasOwnProperty("isCancelledAndEnded");
 
 export interface Card extends CardProps {
   stripePublicKeyForUpdate: string;

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -63,7 +63,6 @@ export interface CancelledProductDetail {
   mmaCategory: GroupedProductTypeKeys;
   tier: string;
   joinDate: string;
-  isCancelledAndEnded: string;
   subscription: CancelledSubscription;
 }
 
@@ -72,10 +71,6 @@ export function isProduct(
 ): data is ProductDetail {
   return !!data && data.hasOwnProperty("tier");
 }
-
-export const isCancelledProduct = (
-  data: CancelledProductDetail | ProductDetail | undefined
-) => !!data && data.hasOwnProperty("isCancelledAndEnded");
 
 export interface Card extends CardProps {
   stripePublicKeyForUpdate: string;

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from "react";
-import { SupportTheGuardianSectionProps } from "../client/components/accountoverview/accountOverview";
+import { SupportTheGuardianSectionProps } from "../client/components/accountoverview/supportTheGuardianSection";
 import {
   CancellationReason,
   OptionalCancellationReasonId
@@ -29,7 +29,8 @@ import {
   ProductDetail,
   Subscription,
   SubscriptionPlan,
-  SubscriptionWithDeliveryAddress
+  SubscriptionWithDeliveryAddress,
+  CancelledProductDetail
 } from "./productResponse";
 
 type ProductFriendlyName =
@@ -168,7 +169,9 @@ export interface ProductType {
 }
 
 export interface GroupedProductType extends ProductType {
-  mapGroupedToSpecific: (productDetail: ProductDetail) => ProductType;
+  mapGroupedToSpecific: (
+    productDetail: ProductDetail | CancelledProductDetail
+  ) => ProductType;
   groupFriendlyName: string;
   supportTheGuardianSectionProps: SupportTheGuardianSectionProps;
 }
@@ -555,7 +558,9 @@ export const GROUPED_PRODUCT_TYPES: {
     groupFriendlyName: "subscriptions",
     allProductsProductTypeFilterString: "ContentSubscription",
     urlPart: "subscriptions",
-    mapGroupedToSpecific: (productDetail: ProductDetail) => {
+    mapGroupedToSpecific: (
+      productDetail: ProductDetail | CancelledProductDetail
+    ) => {
       if (productDetail.tier === "Digital Pack") {
         return PRODUCT_TYPES.digipack;
       } else if (productDetail.tier === "Newspaper Delivery") {

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -25,12 +25,12 @@ import {
 } from "./identity";
 import { OphanProduct } from "./ophanTypes";
 import {
+  CancelledProductDetail,
   isGift,
   ProductDetail,
   Subscription,
   SubscriptionPlan,
-  SubscriptionWithDeliveryAddress,
-  CancelledProductDetail
+  SubscriptionWithDeliveryAddress
 } from "./productResponse";
 
 type ProductFriendlyName =

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -9878,6 +9878,11 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
 node-forge@0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.9.0.tgz#d624050edbb44874adca12bb9a52ec63cb782579"


### PR DESCRIPTION
## What does this change?

Related PR: https://github.com/guardian/members-data-api/pull/478

Cancelled products should show in the account overview page for 3 months after they were cancelled.

A new `/cancelled` endpoint has been created (see [here](https://github.com/guardian/members-data-api/pull/478/commits/f350544476ecefaf0c9a240cc546a3ed014deabd)) which is called alongside the existing `/me/mma` members-data-api request.

A new `accountOverviewCancelledCard` component has been created to handle the response from the `/cancelled` endpoint. The response from the `/cancelled` endpoint is a slimmed down version of the `/me/mma` response and as such the component does not currently show payment information, a slightly slimmed down product title (`Newspaper Voucher` instead of `Newspaper Voucher - Everyday` for example) and no 6for6 explainer.

If the cancelled product was a subscription, then a button to subscribe again is displayed at the bottom of the product box. If the product was a contribution or a membership then a message is displayed at the bottom of the list of contributions or memberships with a custom message and cta.

## Images
![Screenshot_2020-10-14 My Account The Guardian](https://user-images.githubusercontent.com/2510683/95970758-3bc18e80-0e08-11eb-8df4-80079460a0f7.png)


