### PR TITLE
Contact Us form submits to an endpoint

### DIFF
--- a/app/client/components/contactUs/contactUs.tsx
+++ b/app/client/components/contactUs/contactUs.tsx
@@ -3,7 +3,7 @@ import { Button } from "@guardian/src-button";
 import { palette, space } from "@guardian/src-foundations";
 import { headline, textSans } from "@guardian/src-foundations/typography";
 import { RouteComponentProps } from "@reach/router";
-import * as Sentry from "@sentry/browser";
+import { captureException } from "@sentry/browser";
 import React, { useEffect, useState } from "react";
 import { Topic } from "../../../shared/contactUsTypes";
 import { minWidth } from "../../styles/breakpoints";
@@ -196,7 +196,7 @@ const ContactUs = (props: ContactUsPropsWithConfig) => {
         eventAction: "submission_failure",
         eventLabel: errorMsg
       });
-      Sentry.captureException(errorMsg);
+      captureException(errorMsg);
     }
   };
 

--- a/app/client/components/contactUs/contactUs.tsx
+++ b/app/client/components/contactUs/contactUs.tsx
@@ -162,9 +162,15 @@ const ContactUs = (props: ContactUsPropsWithConfig) => {
 
   const subTopics = currentTopic?.subtopics;
 
-  const subSubTopics = subTopics?.find(
+  const currentSubTopic = subTopics?.find(
     subTopic => subTopic.id === contactUsFormState.selectedSubTopic
-  )?.subsubtopics;
+  );
+
+  const subSubTopics = currentSubTopic?.subsubtopics;
+
+  const currentSubSubTopic = subSubTopics?.find(
+    subSubTopic => subSubTopic.id === contactUsFormState.selectedSubSubTopic
+  );
 
   const showSubTopics =
     !!contactUsFormState.selectedTopic &&
@@ -178,12 +184,15 @@ const ContactUs = (props: ContactUsPropsWithConfig) => {
 
   const showForm =
     (!!contactUsFormState.selectedSubSubTopic &&
-      !requireSubSubTopicSubmitButton) ||
+      !requireSubSubTopicSubmitButton &&
+      !currentSubSubTopic?.noForm) ||
     (!!contactUsFormState.selectedSubTopic &&
       !requireSubTopicSubmitButton &&
+      !currentSubTopic?.noForm &&
       !subSubTopics) ||
     (!!contactUsFormState.selectedTopic &&
       !requireTopicSubmitButton &&
+      !currentTopic?.noForm &&
       !subTopics);
 
   const [showSelfServicePrompt, setShowSelfServicePrompt] = useState<boolean>(

--- a/app/client/components/contactUs/contactUs.tsx
+++ b/app/client/components/contactUs/contactUs.tsx
@@ -19,7 +19,7 @@ class ContactUsFormAsyncLoader extends AsyncLoader<ContactUsConfigResponse> {}
 
 type ContactUsConfigResponse = Topic[];
 
-interface ContactUsFormStateSnapshot {
+interface ContactUsFormState {
   selectedTopic: string | undefined;
   selectedSubTopic: string | undefined;
   selectedSubSubTopic: string | undefined;
@@ -59,8 +59,8 @@ const ContactUs = (props: ContactUsPropsWithConfig) => {
     false
   );
 
-  const [contactUsFormStateSnapshot, setContactUsFormStateSnapshot] = useState<
-    ContactUsFormStateSnapshot
+  const [contactUsFormState, setContactUsFormState] = useState<
+    ContactUsFormState
   >({
     selectedTopic: initialTopicSelection,
     selectedSubTopic: validDeepLinkSubTopic?.id,
@@ -82,11 +82,11 @@ const ContactUs = (props: ContactUsPropsWithConfig) => {
   ] = useState<boolean>(!validDeepLinkSubSubTopic);
 
   const setTopic = (newTopicId: string, hasComeFromSubmitButton: boolean) => {
-    setContactUsFormStateSnapshot({
+    setContactUsFormState({
       selectedTopic:
         hasComeFromSubmitButton || !requireTopicSubmitButton
           ? newTopicId
-          : contactUsFormStateSnapshot.selectedTopic,
+          : contactUsFormState.selectedTopic,
       selectedSubTopic: props.config.find(topic => topic.id === newTopicId)
         ?.subtopics?.[0].id,
       selectedSubSubTopic: undefined
@@ -96,8 +96,8 @@ const ContactUs = (props: ContactUsPropsWithConfig) => {
   };
 
   const setSubTopic = (selectedSubTopic: string) => {
-    setContactUsFormStateSnapshot({
-      ...contactUsFormStateSnapshot,
+    setContactUsFormState({
+      ...contactUsFormState,
       selectedSubTopic,
       selectedSubSubTopic: undefined
     });
@@ -105,8 +105,8 @@ const ContactUs = (props: ContactUsPropsWithConfig) => {
   };
 
   const setSubSubTopic = (selectedSubSubTopic: string) =>
-    setContactUsFormStateSnapshot({
-      ...contactUsFormStateSnapshot,
+    setContactUsFormState({
+      ...contactUsFormState,
       selectedSubSubTopic
     });
 
@@ -135,7 +135,7 @@ const ContactUs = (props: ContactUsPropsWithConfig) => {
   };
 
   const subTopicSubmitCallback = () => {
-    if (!!contactUsFormStateSnapshot.selectedSubTopic) {
+    if (!!contactUsFormState.selectedSubTopic) {
       setRequireSubTopicSubmitButton(false);
     }
   };
@@ -151,38 +151,38 @@ const ContactUs = (props: ContactUsPropsWithConfig) => {
   };
 
   const subSubTopicSubmitCallback = () => {
-    if (!!contactUsFormStateSnapshot.selectedSubSubTopic) {
+    if (!!contactUsFormState.selectedSubSubTopic) {
       setRequireSubSubTopicSubmitButton(false);
     }
   };
 
   const currentTopic = props.config.find(
-    topic => topic.id === contactUsFormStateSnapshot.selectedTopic
+    topic => topic.id === contactUsFormState.selectedTopic
   );
 
   const subTopics = currentTopic?.subtopics;
 
   const subSubTopics = subTopics?.find(
-    subTopic => subTopic.id === contactUsFormStateSnapshot.selectedSubTopic
+    subTopic => subTopic.id === contactUsFormState.selectedSubTopic
   )?.subsubtopics;
 
   const showSubTopics =
-    !!contactUsFormStateSnapshot.selectedTopic &&
+    !!contactUsFormState.selectedTopic &&
     !requireTopicSubmitButton &&
     !!subTopics;
 
   const showSubSubTopics =
-    !!contactUsFormStateSnapshot.selectedSubTopic &&
+    !!contactUsFormState.selectedSubTopic &&
     !requireSubTopicSubmitButton &&
     !!subSubTopics;
 
   const showForm =
-    (!!contactUsFormStateSnapshot.selectedSubSubTopic &&
+    (!!contactUsFormState.selectedSubSubTopic &&
       !requireSubSubTopicSubmitButton) ||
-    (!!contactUsFormStateSnapshot.selectedSubTopic &&
+    (!!contactUsFormState.selectedSubTopic &&
       !requireSubTopicSubmitButton &&
       !subSubTopics) ||
-    (!!contactUsFormStateSnapshot.selectedTopic &&
+    (!!contactUsFormState.selectedTopic &&
       !requireTopicSubmitButton &&
       !subTopics);
 
@@ -201,11 +201,10 @@ const ContactUs = (props: ContactUsPropsWithConfig) => {
 
   useEffect(() => {
     const selectedSubtopic = currentTopic?.subtopics?.find(
-      subTopic => subTopic.id === contactUsFormStateSnapshot.selectedSubTopic
+      subTopic => subTopic.id === contactUsFormState.selectedSubTopic
     );
     const selectedSubSubtopic = selectedSubtopic?.subsubtopics?.find(
-      subSubTopic =>
-        subSubTopic.id === contactUsFormStateSnapshot.selectedSubSubTopic
+      subSubTopic => subSubTopic.id === contactUsFormState.selectedSubSubTopic
     );
     setShowSelfServicePrompt(
       (!showSubTopics &&
@@ -238,7 +237,7 @@ const ContactUs = (props: ContactUsPropsWithConfig) => {
       setSubTopicsTitle(currentTopic.subTopicsTitle);
     }
   }, [
-    contactUsFormStateSnapshot,
+    contactUsFormState,
     requireTopicSubmitButton,
     requireSubTopicSubmitButton,
     requireSubSubTopicSubmitButton
@@ -304,9 +303,7 @@ const ContactUs = (props: ContactUsPropsWithConfig) => {
                   {...topic}
                   id={topic.id}
                   updateCallback={topicSelectionCallback}
-                  isSelected={
-                    topic.id === contactUsFormStateSnapshot.selectedTopic
-                  }
+                  isSelected={topic.id === contactUsFormState.selectedTopic}
                   key={topicIndex}
                 />
               ))}
@@ -332,7 +329,7 @@ const ContactUs = (props: ContactUsPropsWithConfig) => {
                 submitButonText="Continue to step 2"
                 showSubmitButton={requireSubTopicSubmitButton}
                 data={subTopics}
-                preSelectedId={contactUsFormStateSnapshot.selectedSubTopic}
+                preSelectedId={contactUsFormState.selectedSubTopic}
                 additionalCss={css`
                   margin-top: ${space[9]}px;
                 `}
@@ -346,7 +343,7 @@ const ContactUs = (props: ContactUsPropsWithConfig) => {
                 submitButonText="Continue to step 3"
                 showSubmitButton={requireSubSubTopicSubmitButton}
                 data={subSubTopics}
-                preSelectedId={contactUsFormStateSnapshot.selectedSubSubTopic}
+                preSelectedId={contactUsFormState.selectedSubSubTopic}
                 additionalCss={css`
                   margin-top: ${space[9]}px;
                 `}
@@ -359,9 +356,9 @@ const ContactUs = (props: ContactUsPropsWithConfig) => {
                 }
                 linkCopy="Go to your account"
                 linkHref="/"
-                topicReferer={`${contactUsFormStateSnapshot.selectedTopic ||
-                  contactUsFormStateSnapshot.selectedSubTopic ||
-                  contactUsFormStateSnapshot.selectedSubSubTopic}`}
+                topicReferer={`${contactUsFormState.selectedTopic ||
+                  contactUsFormState.selectedSubTopic ||
+                  contactUsFormState.selectedSubSubTopic}`}
                 additionalCss={css`
                   margin: ${space[9]}px 0 ${space[6]}px;
                 `}
@@ -376,9 +373,9 @@ const ContactUs = (props: ContactUsPropsWithConfig) => {
                   trackEvent({
                     eventCategory: "contactus_form",
                     eventAction: "submission",
-                    eventLabel: `${contactUsFormStateSnapshot.selectedTopic ||
-                      contactUsFormStateSnapshot.selectedSubTopic ||
-                      contactUsFormStateSnapshot.selectedSubSubTopic}`
+                    eventLabel: `${contactUsFormState.selectedTopic ||
+                      contactUsFormState.selectedSubTopic ||
+                      contactUsFormState.selectedSubSubTopic}`
                   });
                 }}
                 title={`${

--- a/app/client/components/contactUs/contactUs.tsx
+++ b/app/client/components/contactUs/contactUs.tsx
@@ -162,8 +162,8 @@ const ContactUs = (props: ContactUsPropsWithConfig) => {
       ...(contactUsFormState.selectedTopic && {
         topic: contactUsFormState.selectedTopic
       }),
-      ...(contactUsFormState.selectedSubSubTopic && {
-        subtopic: contactUsFormState.selectedSubSubTopic
+      ...(contactUsFormState.selectedSubTopic && {
+        subtopic: contactUsFormState.selectedSubTopic
       }),
       ...(contactUsFormState.selectedSubSubTopic && {
         subsubtopic: contactUsFormState.selectedSubSubTopic

--- a/app/client/components/contactUs/contactUsForm.tsx
+++ b/app/client/components/contactUs/contactUsForm.tsx
@@ -8,14 +8,14 @@ import { Input } from "../input";
 import { ErrorIcon } from "../svgs/errorIcon";
 
 interface ContactUsFormProps {
-  submitCallback: (payload: FormPayload) => void;
+  submitCallback: (payload: FormPayload) => Promise<void>;
   title: string;
   subjectLine: string;
   editableSubjectLine?: boolean;
   additionalCss?: SerializedStyles;
 }
 
-interface FormPayload {
+export interface FormPayload {
   fullName: string;
   email: string;
   subjectLine: string;
@@ -35,6 +35,14 @@ interface FormValidationState {
   details: FormElemValidationObject;
 }
 
+const disabledButtonStyles = css`
+  background: #999999;
+  cursor: not-allowed;
+  &:hover {
+    background: #999999;
+  }
+`;
+
 export const ContactUsForm = (props: ContactUsFormProps) => {
   const [subjectLine, setSubjectLine] = useState<string>(props.subjectLine);
   const [fullName, setFullName] = useState<string>(
@@ -48,6 +56,7 @@ export const ContactUsForm = (props: ContactUsFormProps) => {
     instructionsRemainingCharacters,
     setInstructionsRemainingCharacters
   ] = useState<number>(250);
+  const [submitting, setSubmitting] = useState<boolean>(false);
 
   const mandatoryFieldMessage = "You cannot leave this field empty";
 
@@ -99,12 +108,15 @@ export const ContactUsForm = (props: ContactUsFormProps) => {
       onSubmit={(event: FormEvent) => {
         event.preventDefault();
         if (validateForm()) {
-          props.submitCallback({
-            fullName,
-            subjectLine,
-            email,
-            details
-          });
+          setSubmitting(true);
+          props
+            .submitCallback({
+              fullName,
+              subjectLine,
+              email,
+              details
+            })
+            .then(() => setSubmitting(false));
         }
       }}
       css={css`
@@ -286,7 +298,13 @@ export const ContactUsForm = (props: ContactUsFormProps) => {
           </span>
         </label>
       </fieldset>
-      <Button type="submit">Submit</Button>
+      <Button
+        type="submit"
+        cssOverrides={submitting ? disabledButtonStyles : undefined}
+        disabled={submitting}
+      >
+        Submit
+      </Button>
     </form>
   );
 };

--- a/app/client/components/user.tsx
+++ b/app/client/components/user.tsx
@@ -27,7 +27,7 @@ import {
   ConsentsBanner,
   SuppressConsentBanner
 } from "./consent/consentsBanner";
-import { ContactUsPage } from "./contactUs/contactUs";
+// import { ContactUsPage } from "./contactUs/contactUs";
 import { DeliveryAddressEditConfirmation } from "./delivery/address/deliveryAddressEditConfirmation";
 import { DeliveryAddressForm } from "./delivery/address/deliveryAddressForm";
 import { DeliveryAddressReview } from "./delivery/address/deliveryAddressReview";
@@ -173,10 +173,10 @@ const User = (props: WithOptionalServerPathWithQueryParams) => (
 
       <Help path="/help" />
 
-      <ContactUsPage path="/contact-us" />
+      {/* <ContactUsPage path="/contact-us" />
       <ContactUsPage path="/contact-us/:topicId" />
       <ContactUsPage path="/contact-us/:topicId/:subTopicId" />
-      <ContactUsPage path="/contact-us/:topicId/:subTopicId/:subSubTopicId" />
+      <ContactUsPage path="/contact-us/:topicId/:subTopicId/:subSubTopicId" /> */}
 
       {/* otherwise redirect to root instead of having a "not found page" */}
       <Redirect default from="/*" to="/" noThrow />

--- a/app/client/components/user.tsx
+++ b/app/client/components/user.tsx
@@ -27,7 +27,7 @@ import {
   ConsentsBanner,
   SuppressConsentBanner
 } from "./consent/consentsBanner";
-// import { ContactUsPage } from "./contactUs/contactUs";
+import { ContactUsPage } from "./contactUs/contactUs";
 import { DeliveryAddressEditConfirmation } from "./delivery/address/deliveryAddressEditConfirmation";
 import { DeliveryAddressForm } from "./delivery/address/deliveryAddressForm";
 import { DeliveryAddressReview } from "./delivery/address/deliveryAddressReview";
@@ -173,10 +173,10 @@ const User = (props: WithOptionalServerPathWithQueryParams) => (
 
       <Help path="/help" />
 
-      {/* <ContactUsPage path="/contact-us" />
+      <ContactUsPage path="/contact-us" />
       <ContactUsPage path="/contact-us/:topicId" />
       <ContactUsPage path="/contact-us/:topicId/:subTopicId" />
-      <ContactUsPage path="/contact-us/:topicId/:subTopicId/:subSubTopicId" /> */}
+      <ContactUsPage path="/contact-us/:topicId/:subTopicId/:subSubTopicId" />
 
       {/* otherwise redirect to root instead of having a "not found page" */}
       <Redirect default from="/*" to="/" noThrow />

--- a/app/server/contactUsApi.ts
+++ b/app/server/contactUsApi.ts
@@ -18,6 +18,7 @@ export const contactUsFormHandler = (req: Request, res: Response) => {
 const parseAndValidate = (body: any): ContactUsReq | undefined => {
   try {
     const bodyAsJson = body ? JSON.parse(body) : "{}";
+
     return validateContactUsFormBody(bodyAsJson)
       ? (bodyAsJson as ContactUsReq)
       : undefined;
@@ -26,22 +27,15 @@ const parseAndValidate = (body: any): ContactUsReq | undefined => {
   }
 };
 
-const validateContactUsFormBody = (body: any): boolean => {
-  if (
-    body &&
-    body.topic &&
-    validateTopics(body.topic, body.subtopic, body.subsubtopic) &&
-    body.name &&
-    body.email &&
-    isEmail(body.email) &&
-    body.subject &&
-    body.message
-  ) {
-    return true;
-  }
-
-  return false;
-};
+const validateContactUsFormBody = (body: any): boolean =>
+  body &&
+  body.topic &&
+  validateTopics(body.topic, body.subtopic, body.subsubtopic) &&
+  body.name &&
+  body.email &&
+  isEmail(body.email) &&
+  body.subject &&
+  body.message;
 
 const validateTopics = (
   reqTopic: string | undefined,

--- a/app/server/contactUsApi.ts
+++ b/app/server/contactUsApi.ts
@@ -1,0 +1,5 @@
+import { Request, Response } from "express";
+import { contactUsConfig } from "./contactUsConfig";
+
+export const contactUsConfigHandler = (_: Request, res: Response) =>
+  res.json(contactUsConfig);

--- a/app/server/contactUsApi.ts
+++ b/app/server/contactUsApi.ts
@@ -1,5 +1,97 @@
 import { Request, Response } from "express";
+import { ContactUsReq } from "../shared/contactUsTypes";
 import { contactUsConfig } from "./contactUsConfig";
 
 export const contactUsConfigHandler = (_: Request, res: Response) =>
   res.json(contactUsConfig);
+
+export const contactUsFormHandler = (req: Request, res: Response) => {
+  const validBody = parseAndValidate(req.body);
+
+  if (!validBody) {
+    return res.status(400).send();
+  }
+
+  res.status(201).send();
+};
+
+const parseAndValidate = (body: any): ContactUsReq | undefined => {
+  try {
+    const bodyAsJson = body ? JSON.parse(body) : "{}";
+    return validateContactUsFormBody(bodyAsJson)
+      ? (bodyAsJson as ContactUsReq)
+      : undefined;
+  } catch (error) {
+    return undefined;
+  }
+};
+
+const validateContactUsFormBody = (body: any): boolean => {
+  if (
+    body &&
+    body.topic &&
+    validateTopics(body.topic, body.subtopic, body.subsubtopic) &&
+    body.name &&
+    body.email &&
+    isEmail(body.email) &&
+    body.subject &&
+    body.message
+  ) {
+    return true;
+  }
+
+  return false;
+};
+
+const validateTopics = (
+  reqTopic: string | undefined,
+  reqSubtopic: string | undefined,
+  reqSubsubtopic: string | undefined
+): boolean => {
+  // Validate topic
+  const topicIndex = contactUsConfig.findIndex(topic => topic.id === reqTopic);
+  if (topicIndex === -1 || contactUsConfig[topicIndex].noForm) {
+    return false;
+  }
+
+  // Validate subtopic
+  const subtopics = contactUsConfig[topicIndex].subtopics;
+  if (subtopics) {
+    if (!reqSubtopic) {
+      return false;
+    }
+
+    const subtopicIndex = subtopics.findIndex(
+      subtopic => subtopic.id === reqSubtopic
+    );
+    if (subtopicIndex === -1 || subtopics[subtopicIndex].noForm) {
+      return false;
+    }
+
+    // Validate subsubtopic
+    const subsubtopics = subtopics[subtopicIndex].subsubtopics;
+    if (subsubtopics) {
+      if (!reqSubsubtopic) {
+        return false;
+      }
+
+      const subsubtopicsIndex = subsubtopics.findIndex(
+        subsubtopic => subsubtopic.id === reqSubsubtopic
+      );
+      if (subtopicIndex === -1 || subsubtopics[subsubtopicsIndex].noForm) {
+        return false;
+      }
+    } else if (reqSubsubtopic) {
+      return false;
+    }
+  } else if (reqSubtopic || reqSubsubtopic) {
+    return false;
+  }
+
+  return true;
+};
+
+const isEmail = (email: string): boolean => {
+  const emailSplit = email.split("@");
+  return emailSplit.length === 2 && emailSplit[1].includes(".");
+};

--- a/app/server/contactUsConfig.ts
+++ b/app/server/contactUsConfig.ts
@@ -52,7 +52,8 @@ export const contactUsConfig: Topic[] = [
       },
       {
         id: "s8",
-        name: "I would like to cancel my payment"
+        name: "I would like to cancel my payment",
+        noForm: true
       },
       {
         id: "s9",
@@ -259,6 +260,7 @@ export const contactUsConfig: Topic[] = [
     id: "other",
     name: "Something else",
     enquiryLabel: "your issue",
-    editableSubjectLine: true
+    editableSubjectLine: true,
+    noForm: true
   }
 ];

--- a/app/server/contactUsConfig.ts
+++ b/app/server/contactUsConfig.ts
@@ -96,9 +96,9 @@ export const contactUsConfig: Topic[] = [
               text:
                 "Did you know you can suspend your deliveries online by logging in below and selecting ‘Manage Subscription’? It’s easy to use and means you don’t have to wait for a response.",
               linkText: "Go to your account",
-              href: "/billing",
-              noForm: true
-            }
+              href: "/billing"
+            },
+            noForm: true
           },
           {
             id: "ss2",

--- a/app/server/routes/api.ts
+++ b/app/server/routes/api.ts
@@ -18,7 +18,7 @@ import {
   straightThroughBodyHandler
 } from "../apiProxy";
 import { conf } from "../config";
-import { contactUsConfig } from "../contactUsConfig";
+import { contactUsConfigHandler } from "../contactUsApi";
 import { augmentProductDetailWithDeliveryAddressChangeEffectiveDateForToday } from "../fulfilmentDateCalculatorReader";
 import { log } from "../log";
 import { withIdentity } from "../middleware/identityMiddleware";
@@ -216,6 +216,6 @@ router.get(
   )
 );
 
-router.get("/contact-us-config", (_, res) => res.json(contactUsConfig));
+router.get("/contact-us-config", contactUsConfigHandler);
 
 export default router;

--- a/app/server/routes/api.ts
+++ b/app/server/routes/api.ts
@@ -18,7 +18,7 @@ import {
   straightThroughBodyHandler
 } from "../apiProxy";
 import { conf } from "../config";
-import { contactUsConfigHandler } from "../contactUsApi";
+import { contactUsConfigHandler, contactUsFormHandler } from "../contactUsApi";
 import { augmentProductDetailWithDeliveryAddressChangeEffectiveDateForToday } from "../fulfilmentDateCalculatorReader";
 import { log } from "../log";
 import { withIdentity } from "../middleware/identityMiddleware";
@@ -217,5 +217,7 @@ router.get(
 );
 
 router.get("/contact-us-config", contactUsConfigHandler);
+
+router.post("/contact-us", contactUsFormHandler);
 
 export default router;

--- a/app/shared/contactUsTypes.ts
+++ b/app/shared/contactUsTypes.ts
@@ -3,13 +3,13 @@ interface BaseTopic {
   name: string;
   selfServiceBox?: SelfServiceBox;
   editableSubjectLine?: boolean;
+  noForm?: boolean;
 }
 
 interface SelfServiceBox {
   text: string;
   linkText: string;
   href: string;
-  noForm?: boolean;
 }
 
 export interface SubTopic extends BaseTopic {
@@ -21,4 +21,14 @@ export interface Topic extends BaseTopic {
   enquiryLabel: string;
   subtopics?: SubTopic[];
   subTopicsTitle?: string;
+}
+
+export interface ContactUsReq {
+  topic: string;
+  subtopic?: string;
+  subsubtopic?: string;
+  name: string;
+  email: string;
+  subject: string;
+  message: string;
 }

--- a/app/shared/requiresSignin.ts
+++ b/app/shared/requiresSignin.ts
@@ -1,7 +1,11 @@
 import * as pathLib from "path";
 
 // To avoid security vulnerabilities do no add public paths that do not end in a slash
-const publicPaths = ["/contact-us/", "/api/contact-us-config/"];
+const publicPaths = [
+  "/contact-us/",
+  "/api/contact-us-config/",
+  "/api/contact-us/"
+];
 
 export const requiresSignin = (path: string) => {
   const normalizedPath = pathLib.normalize(path + "/");


### PR DESCRIPTION
## What does this change?
This PR creates an endpoint (`/api/contact-us/`) and changes the Contact Us form so it submits to that endpoint.

This is part of a larger piece of work to release the [Contact Us form](https://trello.com/c/aCi04YJT/1632-integrate-frontend-and-lambda-work-for-contact-us-form-s) and it expands on the code in #511 and #512.

The Contact Us form routes are disabled for now until this feature is ready for release.