### PR TITLE
Standardise event tracking info for Contact Us form

### DIFF
--- a/app/client/components/contactUs/contactUs.tsx
+++ b/app/client/components/contactUs/contactUs.tsx
@@ -119,8 +119,8 @@ const ContactUs = (props: ContactUsPropsWithConfig) => {
     setTransientTopicSelection(newTopicId);
     setTopic(newTopicId, requireTopicSubmitButton);
     trackEvent({
-      eventCategory: "contact_us_topic",
-      eventAction: "click",
+      eventCategory: "ContactUs",
+      eventAction: "topic_click",
       eventLabel: newTopicId
     });
   };
@@ -129,8 +129,8 @@ const ContactUs = (props: ContactUsPropsWithConfig) => {
     setSubTopic(newSubTopicId);
 
     trackEvent({
-      eventCategory: "contact_us_subtopic",
-      eventAction: "click",
+      eventCategory: "ContactUs",
+      eventAction: "subtopic_click",
       eventLabel: newSubTopicId
     });
   };
@@ -145,8 +145,8 @@ const ContactUs = (props: ContactUsPropsWithConfig) => {
     setSubSubTopic(newSubSubTopicId);
 
     trackEvent({
-      eventCategory: "contact_us_subsubtopic",
-      eventAction: "click",
+      eventCategory: "ContactUs",
+      eventAction: "subsubtopic_click",
       eventLabel: newSubSubTopicId
     });
   };
@@ -181,7 +181,6 @@ const ContactUs = (props: ContactUsPropsWithConfig) => {
         eventCategory: "ContactUs",
         eventAction: "submission_success",
         eventLabel:
-          "Succeeded in submiting form with topics " +
           `${contactUsFormState.selectedTopic} - ` +
           `${contactUsFormState.selectedSubTopic} - ` +
           `${contactUsFormState.selectedSubSubTopic}`
@@ -409,9 +408,11 @@ const ContactUs = (props: ContactUsPropsWithConfig) => {
                 }
                 linkCopy="Go to your account"
                 linkHref="/"
-                topicReferer={`${contactUsFormState.selectedTopic ||
-                  contactUsFormState.selectedSubTopic ||
-                  contactUsFormState.selectedSubSubTopic}`}
+                topicReferer={
+                  `${contactUsFormState.selectedTopic} - ` +
+                  `${contactUsFormState.selectedSubTopic} - ` +
+                  `${contactUsFormState.selectedSubSubTopic}`
+                }
                 additionalCss={css`
                   margin: ${space[9]}px 0 ${space[6]}px;
                 `}

--- a/app/client/components/contactUs/selfServicePrompt.tsx
+++ b/app/client/components/contactUs/selfServicePrompt.tsx
@@ -24,6 +24,13 @@ export const SelfServicePrompt = (props: SelfServicePromptProps) => {
     color: ${palette.brand[500]};
   `;
 
+  const onServicelinkClick = () =>
+    trackEvent({
+      eventCategory: "ContactUs",
+      eventAction: "servicelink_click",
+      eventLabel: props.topicReferer
+    });
+
   return (
     <p
       css={css`
@@ -51,13 +58,7 @@ export const SelfServicePrompt = (props: SelfServicePromptProps) => {
       {isSignedIn ? (
         <Link
           to={props.linkHref}
-          onClick={() =>
-            trackEvent({
-              eventCategory: "selfservice_link",
-              eventAction: "click",
-              eventLabel: `signed in: ${props.topicReferer}`
-            })
-          }
+          onClick={onServicelinkClick}
           css={css`
             ${linkCss}
           `}
@@ -67,13 +68,7 @@ export const SelfServicePrompt = (props: SelfServicePromptProps) => {
       ) : (
         <a
           href={props.linkHref}
-          onClick={() =>
-            trackEvent({
-              eventCategory: "selfservice_link",
-              eventAction: "click",
-              eventLabel: `signed out: ${props.topicReferer}`
-            })
-          }
+          onClick={onServicelinkClick}
           css={css`
             ${linkCss}
           `}


### PR DESCRIPTION
## What does this change?
This PR standardises the information submitted to GA in the Contact Us form for improved clarity and easier reporting.

This is part of a larger piece of work to release the [Contact Us form](https://trello.com/c/aCi04YJT/1632-integrate-frontend-and-lambda-work-for-contact-us-form-s) and it expands on the code in #511, #512 and #513.