### PR TITLE
[RB] - input component should only return a number on update if the i…

### DIFF
--- a/app/client/components/input.tsx
+++ b/app/client/components/input.tsx
@@ -110,7 +110,13 @@ export const Input = (props: InputProps) => {
           ref={inputEl}
           onChange={(e: React.ChangeEvent<HTMLInputElement>): void =>
             props.changeSetState &&
-            props.changeSetState(`${e.target.valueAsNumber}`)
+            props.changeSetState(
+              `${
+                props.type === "number"
+                  ? e.target.valueAsNumber
+                  : e.target.value
+              }`
+            )
           }
           onFocus={(e: React.FocusEvent<HTMLInputElement>): void =>
             props.onFocus && props.onFocus(e)


### PR DESCRIPTION
## What does this change?
input component should only return a number on update if the input type is number, otherwise it simply returns target.value

## How to test
The input fields in the contact us form (Name, email) should now be editable. Similarly the contribution "other" amount input field should also be editable (example where the input update should return a number) 

## Images
![bugpr](https://user-images.githubusercontent.com/2510683/98377820-30dfcf80-203d-11eb-9950-901557dca720.png)

