### PR TITLE
Refactor Contact Us form components

### DIFF
--- a/app/client/components/contactUs/contactUs.tsx
+++ b/app/client/components/contactUs/contactUs.tsx
@@ -15,9 +15,9 @@ import { SubTopicForm } from "./subTopicForm";
 import { TopicForm } from "./topicForm";
 
 interface ContactUsState {
-  selectedTopic: string | undefined;
-  selectedSubTopic: string | undefined;
-  selectedSubSubTopic: string | undefined;
+  topicId: string | undefined;
+  subTopicId: string | undefined;
+  subSubTopicId: string | undefined;
 }
 
 interface ContactUsProps extends RouteComponentProps {
@@ -29,31 +29,31 @@ interface ContactUsProps extends RouteComponentProps {
 type ContactUsFormStatus = "form" | "success";
 
 export const ContactUs = (props: ContactUsProps) => {
-  const validDeepLinkTopic = contactUsConfig.find(
+  const validUrlTopicId = contactUsConfig.find(
     topic => topic.id === props.urlTopicId
   );
 
-  const validDeepLinkSubTopic = validDeepLinkTopic?.subtopics?.find(
+  const validUrlSubTopicId = validUrlTopicId?.subtopics?.find(
     subTopic => subTopic.id === props.urlSubTopicId
   );
 
-  const validDeepLinkSubSubTopic = validDeepLinkSubTopic?.subsubtopics?.find(
+  const validUrlSubSubTopicId = validUrlSubTopicId?.subsubtopics?.find(
     subSubTopic => subSubTopic.id === props.urlSubSubTopicId
   );
 
   const [formStatus, setFormStatus] = useState<ContactUsFormStatus>("form");
 
   const [contactUsState, setContactUsState] = useState<ContactUsState>({
-    selectedTopic: validDeepLinkTopic?.id,
-    selectedSubTopic: validDeepLinkSubTopic?.id,
-    selectedSubSubTopic: validDeepLinkSubSubTopic?.id
+    topicId: validUrlTopicId?.id,
+    subTopicId: validUrlSubTopicId?.id,
+    subSubTopicId: validUrlSubSubTopicId?.id
   });
 
   const setTopic = (selectedTopic: string) => {
     setContactUsState({
-      selectedTopic,
-      selectedSubTopic: undefined,
-      selectedSubSubTopic: undefined
+      topicId: selectedTopic,
+      subTopicId: undefined,
+      subSubTopicId: undefined
     });
 
     trackEvent({
@@ -66,8 +66,8 @@ export const ContactUs = (props: ContactUsProps) => {
   const setSubTopic = (selectedSubTopic: string) => {
     setContactUsState({
       ...contactUsState,
-      selectedSubTopic,
-      selectedSubSubTopic: undefined
+      subTopicId: selectedSubTopic,
+      subSubTopicId: undefined
     });
 
     trackEvent({
@@ -80,7 +80,7 @@ export const ContactUs = (props: ContactUsProps) => {
   const setSubSubTopic = (selectedSubSubTopic: string) => {
     setContactUsState({
       ...contactUsState,
-      selectedSubSubTopic
+      subSubTopicId: selectedSubSubTopic
     });
 
     trackEvent({
@@ -92,14 +92,14 @@ export const ContactUs = (props: ContactUsProps) => {
 
   const submitForm = async (formData: FormPayload): Promise<boolean> => {
     const body = JSON.stringify({
-      ...(contactUsState.selectedTopic && {
-        topic: contactUsState.selectedTopic
+      ...(contactUsState.topicId && {
+        topic: contactUsState.topicId
       }),
-      ...(contactUsState.selectedSubTopic && {
-        subtopic: contactUsState.selectedSubTopic
+      ...(contactUsState.subTopicId && {
+        subtopic: contactUsState.subTopicId
       }),
-      ...(contactUsState.selectedSubSubTopic && {
-        subsubtopic: contactUsState.selectedSubSubTopic
+      ...(contactUsState.subSubTopicId && {
+        subsubtopic: contactUsState.subSubTopicId
       }),
       name: formData.fullName,
       email: formData.email,
@@ -115,9 +115,9 @@ export const ContactUs = (props: ContactUsProps) => {
         eventCategory: "ContactUs",
         eventAction: "submission_success",
         eventLabel:
-          `${contactUsState.selectedTopic} - ` +
-          `${contactUsState.selectedSubTopic} - ` +
-          `${contactUsState.selectedSubSubTopic}`
+          `${contactUsState.topicId} - ` +
+          `${contactUsState.subTopicId} - ` +
+          `${contactUsState.subSubTopicId}`
       });
       return true;
     } else {
@@ -134,17 +134,17 @@ export const ContactUs = (props: ContactUsProps) => {
   };
 
   const currentTopic = contactUsConfig.find(
-    topic => topic.id === contactUsState.selectedTopic
+    topic => topic.id === contactUsState.topicId
   );
 
   const subTopics = currentTopic?.subtopics;
   const currentSubTopic = subTopics?.find(
-    subTopic => subTopic.id === contactUsState.selectedSubTopic
+    subTopic => subTopic.id === contactUsState.subTopicId
   );
 
   const subSubTopics = currentSubTopic?.subsubtopics;
   const currentSubSubTopic = subSubTopics?.find(
-    subSubTopic => subSubTopic.id === contactUsState.selectedSubSubTopic
+    subSubTopic => subSubTopic.id === contactUsState.subSubTopicId
   );
 
   const subTopicsTitle = currentTopic?.subTopicsTitle || "";
@@ -206,26 +206,26 @@ export const ContactUs = (props: ContactUsProps) => {
             <>
               <TopicForm
                 data={contactUsConfig}
-                preSelectedId={contactUsState.selectedTopic}
+                preSelectedId={contactUsState.topicId}
                 submitCallback={setTopic}
               />
               {subTopics && (
                 <SubTopicForm
-                  key={`subtopic-${contactUsState.selectedTopic}`}
+                  key={`subtopic-${contactUsState.topicId}`}
                   title={subTopicsTitle}
                   submitButonText="Continue to step 2"
                   data={subTopics}
-                  preSelectedId={contactUsState.selectedSubTopic}
+                  preSelectedId={contactUsState.subTopicId}
                   submitCallback={setSubTopic}
                 />
               )}
               {subSubTopics && (
                 <SubTopicForm
-                  key={`subsubtopic-${contactUsState.selectedSubTopic}`}
+                  key={`subsubtopic-${contactUsState.subTopicId}`}
                   title={subSubTopicsTitle}
                   submitButonText="Continue to step 3"
                   data={subSubTopics}
-                  preSelectedId={contactUsState.selectedSubSubTopic}
+                  preSelectedId={contactUsState.subSubTopicId}
                   submitCallback={setSubSubTopic}
                 />
               )}
@@ -237,9 +237,9 @@ export const ContactUs = (props: ContactUsProps) => {
                   linkAsButton={!showForm}
                   showContacts={!showForm}
                   topicReferer={
-                    `${contactUsState.selectedTopic} - ` +
-                    `${contactUsState.selectedSubTopic} - ` +
-                    `${contactUsState.selectedSubSubTopic}`
+                    `${contactUsState.topicId} - ` +
+                    `${contactUsState.subTopicId} - ` +
+                    `${contactUsState.subSubTopicId}`
                   }
                   additionalCss={css`
                     margin: ${space[9]}px 0 ${space[6]}px;
@@ -249,7 +249,7 @@ export const ContactUs = (props: ContactUsProps) => {
 
               {showForm && (
                 <ContactUsForm
-                  key={`${contactUsState.selectedTopic}-${contactUsState.selectedSubTopic}-${contactUsState.selectedSubSubTopic}`}
+                  key={`${contactUsState.topicId}-${contactUsState.subTopicId}-${contactUsState.subSubTopicId}`}
                   submitCallback={submitForm}
                   title={`${
                     subTopics || subSubTopics

--- a/app/client/components/contactUs/contactUs.tsx
+++ b/app/client/components/contactUs/contactUs.tsx
@@ -249,7 +249,7 @@ export const ContactUs = (props: ContactUsProps) => {
 
               {showForm && (
                 <ContactUsForm
-                  key={subjectLine}
+                  key={`${contactUsState.selectedTopic}-${contactUsState.selectedSubTopic}-${contactUsState.selectedSubSubTopic}`}
                   submitCallback={submitForm}
                   title={`${
                     subTopics || subSubTopics

--- a/app/client/components/contactUs/contactUsForm.tsx
+++ b/app/client/components/contactUs/contactUsForm.tsx
@@ -173,7 +173,7 @@ export const ContactUsForm = (props: ContactUsFormProps) => {
         }
       }}
       css={css`
-        ${props.additionalCss}
+        margin-top: ${space[9]}px;
       `}
     >
       <fieldset

--- a/app/client/components/contactUs/subTopicForm.tsx
+++ b/app/client/components/contactUs/subTopicForm.tsx
@@ -8,11 +8,11 @@ import { SubTopic } from "../../../shared/contactUsTypes";
 import { minWidth } from "../../styles/breakpoints";
 
 interface SubTopicFormProps {
-  submitCallback: (subTopicId: string) => void;
   title: string;
   submitButonText: string;
   data: SubTopic[];
   preSelectedId?: string;
+  submitCallback: (subTopicId: string) => void;
 }
 
 export const SubTopicForm = (props: SubTopicFormProps) => {

--- a/app/client/components/contactUs/subTopicForm.tsx
+++ b/app/client/components/contactUs/subTopicForm.tsx
@@ -1,38 +1,47 @@
-import { css, SerializedStyles } from "@emotion/core";
+import { css } from "@emotion/core";
 import { Button } from "@guardian/src-button";
 import { palette, space } from "@guardian/src-foundations";
 import { textSans } from "@guardian/src-foundations/typography";
 import { Radio, RadioGroup } from "@guardian/src-radio";
-import React, { FormEvent } from "react";
+import React, { FormEvent, useState } from "react";
 import { SubTopic } from "../../../shared/contactUsTypes";
 import { minWidth } from "../../styles/breakpoints";
 
 interface SubTopicFormProps {
-  updateCallback: (subTopicId: string) => void;
-  submitCallback: () => void;
+  submitCallback: (subTopicId: string) => void;
   title: string;
   submitButonText: string;
-  showSubmitButton: boolean;
-  additionalCss?: SerializedStyles;
-  data?: SubTopic[];
+  data: SubTopic[];
   preSelectedId?: string;
 }
 
 export const SubTopicForm = (props: SubTopicFormProps) => {
+  const [selectedId, setSelectedId] = useState<string>(
+    props.preSelectedId || props.data[0].id
+  );
+
+  const [requiresSubmitButton, setRequiresSubmitButton] = useState<boolean>(
+    true
+  );
+
   return (
     <form
       onSubmit={(event: FormEvent) => {
         event.preventDefault();
-        props.submitCallback();
+        setRequiresSubmitButton(false);
+        props.submitCallback(selectedId);
       }}
       css={css`
-        ${props.additionalCss}
+        margin-top: ${space[9]}px;
       `}
     >
       <fieldset
         onChange={(event: FormEvent<HTMLFieldSetElement>) => {
           const target: HTMLInputElement = event.target as HTMLInputElement;
-          props.updateCallback(target.value);
+          setSelectedId(target.value);
+          if (!requiresSubmitButton) {
+            props.submitCallback(target.value);
+          }
         }}
         css={css`
           border: 1px solid ${palette.neutral["86"]};
@@ -75,7 +84,7 @@ export const SubTopicForm = (props: SubTopicFormProps) => {
               }
             `}
           >
-            {props.data?.map((subTopic, index) => (
+            {props.data.map((subTopic, index) => (
               <li
                 key={`deliveryProblemRadio-${index}`}
                 css={css`
@@ -85,9 +94,7 @@ export const SubTopicForm = (props: SubTopicFormProps) => {
                 <Radio
                   value={subTopic.id}
                   label={subTopic.name}
-                  checked={
-                    !!props.preSelectedId && subTopic.id === props.preSelectedId
-                  }
+                  checked={subTopic.id === selectedId}
                   css={css`
                     vertical-align: top;
                     text-transform: lowercase;
@@ -101,7 +108,7 @@ export const SubTopicForm = (props: SubTopicFormProps) => {
           </ul>
         </RadioGroup>
       </fieldset>
-      {props.showSubmitButton && (
+      {requiresSubmitButton && (
         <Button type="submit">{props.submitButonText}</Button>
       )}
     </form>

--- a/app/client/components/contactUs/subTopicForm.tsx
+++ b/app/client/components/contactUs/subTopicForm.tsx
@@ -84,9 +84,9 @@ export const SubTopicForm = (props: SubTopicFormProps) => {
               }
             `}
           >
-            {props.data.map((subTopic, index) => (
+            {props.data.map(subTopic => (
               <li
-                key={`deliveryProblemRadio-${index}`}
+                key={subTopic.id}
                 css={css`
                   ${textSans.medium()};
                 `}

--- a/app/client/components/contactUs/topicForm.tsx
+++ b/app/client/components/contactUs/topicForm.tsx
@@ -1,0 +1,78 @@
+import { css } from "@emotion/core";
+import { Button } from "@guardian/src-button";
+import { palette, space } from "@guardian/src-foundations";
+import { headline } from "@guardian/src-foundations/typography";
+import React, { useState } from "react";
+import { Topic } from "../../../shared/contactUsTypes";
+import { minWidth } from "../../styles/breakpoints";
+import { TopicButton } from "./topicButton";
+
+interface TopicFormProps {
+  submitCallback: (topicId: string) => void;
+  data: Topic[];
+  preSelectedId?: string;
+}
+
+export const TopicForm = (props: TopicFormProps) => {
+  const [selectedId, setSelectedId] = useState<string>(
+    props.preSelectedId || props.data[0].id
+  );
+
+  const [requiresSubmitButton, setRequiresSubmitButton] = useState<boolean>(
+    true
+  );
+
+  return (
+    <>
+      <h2
+        css={css`
+          ${headline.xxsmall({ fontWeight: "bold" })};
+          border-top: 1px solid ${palette.neutral[86]};
+          margin-top: ${space[6]}px;
+          padding: ${space[1]}px 0;
+          ${minWidth.desktop} {
+            margin-top: ${space[9]}px;
+          }
+        `}
+      >
+        Choose a topic you would like to discuss
+      </h2>
+      <div
+        css={css`
+          display: flex;
+          flex-wrap: wrap;
+          align-items: stretch;
+          justify-content: space-between;
+        `}
+      >
+        {props.data.map((topic, topicIndex) => (
+          <TopicButton
+            key={topicIndex}
+            {...topic}
+            id={topic.id}
+            updateCallback={(newId: string) => {
+              setSelectedId(newId);
+              if (!requiresSubmitButton) {
+                props.submitCallback(newId);
+              }
+            }}
+            isSelected={topic.id === selectedId}
+          />
+        ))}
+      </div>
+      {requiresSubmitButton && (
+        <Button
+          css={css`
+            margin-top: ${space[6]}px;
+          `}
+          onClick={() => {
+            setRequiresSubmitButton(false);
+            props.submitCallback(selectedId);
+          }}
+        >
+          Begin form
+        </Button>
+      )}
+    </>
+  );
+};

--- a/app/client/components/contactUs/topicForm.tsx
+++ b/app/client/components/contactUs/topicForm.tsx
@@ -45,9 +45,9 @@ export const TopicForm = (props: TopicFormProps) => {
           justify-content: space-between;
         `}
       >
-        {props.data.map((topic, topicIndex) => (
+        {props.data.map(topic => (
           <TopicButton
-            key={topicIndex}
+            key={topic.id}
             {...topic}
             id={topic.id}
             updateCallback={(newId: string) => {


### PR DESCRIPTION
## What does this change?
This PR refactors the Contact Us React components. The goal is to make the main Contact Us component more lean.

## Why?
The main Contact Us component was getting quite big. This made it more difficult to work on. It also affects the ease with which someone new to the code would be able to pick it up. Both of these negatively impact the team's speed of delivery.

## How?
The goal was achieved mainly by delegating minor responsibilities from the main component to its children. This opened up the possibility for some abstraction at the main component level, which in turn allowed the simplification of a big chunk of its logic.

## Results
The main Contact Us component went from **_~450 lines_** of code to only **_~285 lines_**. Components are better encapsulated and provide better abstraction.

## Other improvements in this PR
- Removes the use of indexes and non-unique values as React component keys according to [React recommendations](https://reactjs.org/docs/lists-and-keys.html#keys)
- Some variables now have more meaningful names