### PR TITLE
[RB] - use https instead of http

### DIFF
--- a/app/server/apiGatewayDiscovery.ts
+++ b/app/server/apiGatewayDiscovery.ts
@@ -211,5 +211,5 @@ export const getContactUsAPIHostAndKey = async () => {
     return undefined;
   }
 
-  return { host: `http://${host}/${stage}/`, apiKey };
+  return { host: `https://${host}/${stage}/`, apiKey };
 };


### PR DESCRIPTION
## What does this change?
use https instead of http for the contact us api url. The load balancer only supports https.

## How can we measure success?
No more timeouts when submitting the contact us form
