### PR TITLE
Rework page flow tweak

### DIFF
--- a/app/client/components/analytics.tsx
+++ b/app/client/components/analytics.tsx
@@ -130,10 +130,6 @@ export class AnalyticsTracker extends React.PureComponent<{}> {
       <Location>
         {({ location }) => {
           if (location && typeof window !== "undefined") {
-            // tslint:disable-next-line:no-object-mutation
-            document.body.scrollTop = 0; // For Safari
-            // tslint:disable-next-line:no-object-mutation
-            document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
             if (
               window.guardian &&
               window.guardian.ophan &&

--- a/app/client/components/analytics.tsx
+++ b/app/client/components/analytics.tsx
@@ -130,12 +130,10 @@ export class AnalyticsTracker extends React.PureComponent<{}> {
       <Location>
         {({ location }) => {
           if (location && typeof window !== "undefined") {
-            setTimeout(() => {
-              // tslint:disable-next-line:no-object-mutation
-              document.body.scrollTop = 0; // For Safari
-              // tslint:disable-next-line:no-object-mutation
-              document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
-            }, 250);
+            // tslint:disable-next-line:no-object-mutation
+            document.body.scrollTop = 0; // For Safari
+            // tslint:disable-next-line:no-object-mutation
+            document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
             if (
               window.guardian &&
               window.guardian.ophan &&

--- a/app/client/components/consent/consentsBanner.tsx
+++ b/app/client/components/consent/consentsBanner.tsx
@@ -33,6 +33,8 @@ export class ConsentsBanner extends React.Component<
     requiresConsents: false
   };
 
+  private bannerRef = React.createRef<HTMLDivElement>();
+
   public componentDidMount = () => {
     if (isInUSA()) {
       initCMP({ useCcpa: true });
@@ -48,6 +50,8 @@ export class ConsentsBanner extends React.Component<
 
     return documentIsAvailable && !useCCPA && requiresConsents ? (
       <div
+        ref={this.bannerRef}
+        tabIndex={-1}
         css={{
           zIndex: 99,
           position: "fixed",
@@ -146,7 +150,7 @@ export class ConsentsBanner extends React.Component<
   };
 
   private updateStateWithConsents = () =>
-    this.setState({ requiresConsents: requiresConsents() });
+    this.setState({ requiresConsents: requiresConsents() }, this.focusBanner);
 
   private writeConsents = () => {
     const newGuTkCookieValue = `1.${Date.now()}`;
@@ -160,6 +164,15 @@ export class ConsentsBanner extends React.Component<
       `expires=${expires.toUTCString()};domain=.${window.guardian.domain}`;
 
     this.updateStateWithConsents();
+  };
+
+  private focusBanner = () => {
+    // tslint:disable-next-line:no-shadowed-variable
+    const { useCCPA, requiresConsents } = this.state;
+
+    if (documentIsAvailable && !useCCPA && requiresConsents) {
+      this.bannerRef.current?.focus();
+    }
   };
 }
 

--- a/app/client/components/scrollToTop.tsx
+++ b/app/client/components/scrollToTop.tsx
@@ -1,16 +1,23 @@
 import { Location } from "@reach/router";
 import React from "react";
 
+const exceptions: string[] = [];
+
 export const ScrollToTop = () => (
   <Location>
     {({ location }) => {
       if (location && document) {
-        // tslint:disable-next-line:no-object-mutation
-        document.body.scrollTop = 0; // For Safari
-        // tslint:disable-next-line:no-object-mutation
-        document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
+        if (shouldScrollToTop(location.pathname)) {
+          // tslint:disable-next-line:no-object-mutation
+          document.body.scrollTop = 0; // For Safari
+          // tslint:disable-next-line:no-object-mutation
+          document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
+        }
       }
       return null;
     }}
   </Location>
 );
+
+const shouldScrollToTop = (path: string) =>
+  !exceptions.some(exception => path.startsWith(exception));

--- a/app/client/components/scrollToTop.tsx
+++ b/app/client/components/scrollToTop.tsx
@@ -1,0 +1,16 @@
+import { Location } from "@reach/router";
+import React from "react";
+
+export const ScrollToTop = () => (
+  <Location>
+    {({ location }) => {
+      if (location && document) {
+        // tslint:disable-next-line:no-object-mutation
+        document.body.scrollTop = 0; // For Safari
+        // tslint:disable-next-line:no-object-mutation
+        document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
+      }
+      return null;
+    }}
+  </Location>
+);

--- a/app/client/components/user.tsx
+++ b/app/client/components/user.tsx
@@ -46,6 +46,7 @@ import { Main, WithOptionalServerPathWithQueryParams } from "./main";
 import { ConfirmPaymentUpdate } from "./payment/update/confirmPaymentUpdate";
 import { PaymentUpdated } from "./payment/update/paymentUpdated";
 import { PaymentUpdateFlow } from "./payment/update/updatePaymentFlow";
+import { ScrollToTop } from "./scrollToTop";
 
 const User = (props: WithOptionalServerPathWithQueryParams) => (
   <Main {...props}>
@@ -197,6 +198,7 @@ export const ServerUser = (serverPathWithQueryParams: string) => (
 export const BrowserUser = (
   <>
     <AnalyticsTracker />
+    <ScrollToTop />
     <User />
   </>
 );

--- a/app/client/components/user.tsx
+++ b/app/client/components/user.tsx
@@ -53,7 +53,7 @@ const User = (props: WithOptionalServerPathWithQueryParams) => (
     <Global styles={css(`${global}`)} />
     <Global styles={css(`${fonts}`)} />
 
-    <Router primary={false} css={{ height: "100%" }}>
+    <Router primary={true} css={{ height: "100%" }}>
       <AccountOverview path="/" />
       <Billing path="/billing" />
 
@@ -198,7 +198,7 @@ export const ServerUser = (serverPathWithQueryParams: string) => (
 export const BrowserUser = (
   <>
     <AnalyticsTracker />
-    <ScrollToTop />
     <User />
+    <ScrollToTop />
   </>
 );

--- a/app/client/components/user.tsx
+++ b/app/client/components/user.tsx
@@ -52,7 +52,7 @@ const User = (props: WithOptionalServerPathWithQueryParams) => (
     <Global styles={css(`${global}`)} />
     <Global styles={css(`${fonts}`)} />
 
-    <Router css={{ height: "100%" }}>
+    <Router primary={false} css={{ height: "100%" }}>
       <AccountOverview path="/" />
       <Billing path="/billing" />
 
@@ -181,7 +181,7 @@ const User = (props: WithOptionalServerPathWithQueryParams) => (
       {/* otherwise redirect to root instead of having a "not found page" */}
       <Redirect default from="/*" to="/" noThrow />
     </Router>
-    <Router>
+    <Router primary={false}>
       <SuppressConsentBanner path="/payment/*" />
       <ConsentsBanner default />
     </Router>


### PR DESCRIPTION
## What does this change?
This PR improves a tweak that was introduced in #133 to make all page navigations scroll to the top (as they would if it wasn't a single page app). It is now smoother. It also tweaks `@reach/router` settings so we can make the most of its accessibility features.

## Details
When a user navigates to a different page within the SPA `@reach/router` will focus the new component. This needs to happen for accessibility reasons (eg: not confusing screen readers). When this components is focused the browsers scrolls to it.

Because we're adding our header outside the client side routing (`Main` component) when the router focuses the element the scroll will hide part of the page. PR #133 fixes this by scrolling the page back to top shortly after navigation.
In cases where the user comes from a long page that has been scrolled down, the jump to the new component in the router and then to the top of the page is noticeable for the user. Removing the delay and moving the code to the end of the page fixes this visual glitch. I also added a way to easily declare paths as exceptions to this behaviour.

Because we have two client side routers we also weren't taking advantage of the accessibility features that `@reach/router` offers by default. This is because upon page load the `@reach/router` will focus on the component returned by the first router (our actual content) and then immediately on the component returned by the second router (our consent banner). If there is no consent banner this focuses a non-visible component at the bottom of the page, misleading accessibility software. Setting the `primary` property on the second router to `false` will prevent it from focusing on the component it returns.

The problem then becomes that screen readers will not focus on the consent banner when it is displayed anymore. Having the consent banner manage its own focus and focus itself when the banner is displayed fixes that too.


## Screenshots

| Before        | After           |
| ------------- |:-------------:|
| ![mmajumpglitch](https://user-images.githubusercontent.com/48949546/98854692-cb337f00-2452-11eb-83f6-74cf1952a61b.gif) | ![mmajumpglitchfixed](https://user-images.githubusercontent.com/48949546/98847119-bef5f480-2447-11eb-8c70-d09ceb16e8a6.gif) |


## Other issues
We currently do not focus the consent banner when we show a Sourcepoint banner (US users, for now). This should be looked at more closely when we update to using only the Sourcepoint banner.