### PR TITLE
Contact Us form length validation

### DIFF
--- a/app/client/components/contactUs/contactUsForm.tsx
+++ b/app/client/components/contactUs/contactUsForm.tsx
@@ -261,7 +261,7 @@ export const ContactUsForm = (props: ContactUsFormProps) => {
         <Input
           label="Full Name"
           width={50}
-          changeSetState={setFullName}
+          changeSetState={newFullName => setFullName(newFullName.substr(0, 50))}
           value={fullName}
           additionalCss={css`
             margin: ${space[5]}px;
@@ -277,7 +277,7 @@ export const ContactUsForm = (props: ContactUsFormProps) => {
           secondaryLabel="If you are contacting us regarding an account you hold with us you must use the email you registered with"
           type="email"
           width={50}
-          changeSetState={setEmail}
+          changeSetState={newEmail => setEmail(newEmail.substr(0, 50))}
           value={email}
           additionalCss={css`
             margin: ${space[5]}px;
@@ -293,7 +293,9 @@ export const ContactUsForm = (props: ContactUsFormProps) => {
             label="Subject of enquiry"
             type="text"
             width={50}
-            changeSetState={setSubjectLine}
+            changeSetState={newSubjectLine =>
+              setSubjectLine(newSubjectLine.substr(0, 50))
+            }
             value={subjectLine}
             additionalCss={css`
               margin: ${space[5]}px;

--- a/app/server/contactUsApi.ts
+++ b/app/server/contactUsApi.ts
@@ -162,10 +162,10 @@ const buildContactUsReqBody = (body: any): ContactUsReq => ({
   ...(body.subsubtopic && {
     subsubtopic: body.subsubtopic
   }),
-  name: body.name,
-  email: body.email,
-  subject: body.subject,
-  message: body.message,
+  name: (body.name as string).substr(0, 50),
+  email: (body.email as string).substr(0, 50),
+  subject: (body.subject as string).substr(0, 50),
+  message: (body.message as string).substr(0, 255),
   ...(body.attachment && {
     attachment: body.attachment
   })


### PR DESCRIPTION
## What does this change?
Adds length validation to the Contact Us form and endpoint. [Trello card](https://trello.com/c/9UUZDKq9/1778-alarm-5xx-rate-from-contact-us-api-prod).

On the client-side it makes it so the user is unable to go over the allowed length for the name, email and subject fields.

On the endpoint it trims the name, email, subject and message fields so they do no go over the allowed length.