### PR TITLE
Contact Us: Fix email validation

### DIFF
--- a/app/client/components/contactUs/contactUsForm.tsx
+++ b/app/client/components/contactUs/contactUsForm.tsx
@@ -95,7 +95,7 @@ export const ContactUsForm = (props: ContactUsFormProps) => {
     },
     email: {
       isValid: true,
-      message: mandatoryFieldMessage
+      message: "Please insert a valid email address."
     },
     subjectLine: {
       isValid: true,

--- a/app/client/components/contactUs/contactUsForm.tsx
+++ b/app/client/components/contactUs/contactUsForm.tsx
@@ -275,7 +275,6 @@ export const ContactUsForm = (props: ContactUsFormProps) => {
         <Input
           label="Email address"
           secondaryLabel="If you are contacting us regarding an account you hold with us you must use the email you registered with"
-          type="email"
           width={50}
           changeSetState={newEmail => setEmail(newEmail.substr(0, 50))}
           value={email}

--- a/app/client/components/contactUs/contactUsForm.tsx
+++ b/app/client/components/contactUs/contactUsForm.tsx
@@ -162,7 +162,7 @@ export const ContactUsForm = (props: ContactUsFormProps) => {
       ...formValidationState,
       inValidationMode: !isFormInValidState,
       fullName: { ...formValidationState.fullName, isValid: isFullNameValid },
-      email: { ...formValidationState.fullName, isValid: isEmailValid },
+      email: { ...formValidationState.email, isValid: isEmailValid },
       subjectLine: {
         ...formValidationState.subjectLine,
         isValid: isSubjectLineValid


### PR DESCRIPTION
## What does this change?
This PR makes 3 changes.
- Uses the correct variable for email when updating the validation state on `ContactUsForm`. This bug hasn't had impact in the wild because the `isValid` is being set correctly and the error message in the fullName and email fields are the same.
- Changes the email error message to more descriptive of the issue.
- Removes the email type from the email input as it interferes with our validation code and presents our users with an inconsistent experience (example in the screenshot below).



| Before        | After           |
| ------------- |:-------------:|
| ![image](https://user-images.githubusercontent.com/48949546/99789944-49f77e80-2b1b-11eb-87f8-80fb3868c81c.png) | ![image](https://user-images.githubusercontent.com/48949546/99790277-c7bb8a00-2b1b-11eb-9863-ea911854be00.png) |
