### PR TITLE
Update snyk policy

### DIFF
--- a/app/.snyk
+++ b/app/.snyk
@@ -6,6 +6,9 @@ ignore:
     - '@emotion/core > @emotion/css > babel-plugin-emotion > @babel/helper-module-imports > @babel/types > lodash':
         reason: no upgrade or patch available
         expires: '2020-12-16T11:03:52.659Z'
+      formik > lodash:
+        reason: No remediation available
+        expires: '2020-12-20T10:37:44.000Z'
     - '@emotion/styled > babel-plugin-emotion > @babel/helper-module-imports > @babel/types > lodash':
         reason: no upgrade or patch available
         expires: '2020-12-16T11:03:52.660Z'
@@ -37,7 +40,7 @@ ignore:
   SNYK-JS-UAPARSERJS-610226:
     - formik > create-react-context > fbjs > ua-parser-js:
         reason: No remediation available
-        expires: '2020-11-18T15:43:00.924Z'
+        expires: '2020-12-20T10:37:44.000Z'
     - react-daterange-picker > create-react-class > fbjs > ua-parser-js:
         reason: No remediation available
         expires: '2020-11-18T15:43:00.924Z'


### PR DESCRIPTION
## What does this change?
Snyk is blocking the build due to a 2 security vulnerabilities introduced by formik that aren't patched yet. Ignored for 30 days to allows the build to complete. This is yet another reason why we should work toward getting rid of formik.

```
   ✗ Prototype Pollution [High Severity][https://snyk.io/vuln/SNYK-JS-LODASH-590103] in lodash@4.17.19
      introduced by formik@1.5.8 > lodash@4.17.19
    This issue was fixed in versions: 4.17.20

    ✗ Regular Expression Denial of Service (ReDoS) [High Severity][https://snyk.io/vuln/SNYK-JS-UAPARSERJS-610226] in ua-parser-js@0.7.19
      introduced by formik@1.5.8 > create-react-context@0.2.3 > fbjs@0.8.17 > ua-parser-js@0.7.19
    This issue was fixed in versions: 0.7.22
```

## Risks
We **_may_** be vulnerable to denial of service attacks in our pages that use formik (Settings page). 