### PR TITLE
Contact Us form fixes and tweaks

### DIFF
--- a/app/client/components/contactUs/contactUs.tsx
+++ b/app/client/components/contactUs/contactUs.tsx
@@ -5,9 +5,10 @@ import { navigate, RouteComponentProps } from "@reach/router";
 import { captureException } from "@sentry/browser";
 import React from "react";
 import { contactUsConfig } from "../../../shared/contactUsConfig";
+import { ContactUsFormPayload } from "../../../shared/contactUsTypes";
 import { minWidth } from "../../styles/breakpoints";
 import { trackEvent } from "../analytics";
-import { ContactUsForm, FormPayload } from "./contactUsForm";
+import { ContactUsForm } from "./contactUsForm";
 import { ContactUsHeader } from "./contactUsHeader";
 import { ContactUsPageContainer } from "./contactUsPageContainer";
 import { SelfServicePrompt } from "./selfServicePrompt";
@@ -59,16 +60,16 @@ export const ContactUs = (props: ContactUsProps) => {
     (currentSubTopic && !currentSubTopic?.noForm && !subSubTopics) ||
     (currentTopic && !currentTopic?.noForm && !subTopics);
 
-  const subjectLine = `${currentTopic ? currentTopic.name : ""}${
+  const subject = `${currentTopic ? currentTopic.name : ""}${
     currentSubSubTopic ? ` - ${currentSubSubTopic.name}` : ""
   }${
     !currentSubSubTopic && currentSubTopic ? ` - ${currentSubTopic.name}` : ""
   }`;
 
-  const isSubjectLineEditable = !!(
-    currentSubSubTopic?.editableSubjectLine ||
-    currentSubTopic?.editableSubjectLine ||
-    currentTopic?.editableSubjectLine
+  const isSubjectEditable = !!(
+    currentSubSubTopic?.editableSubject ||
+    currentSubTopic?.editableSubject ||
+    currentTopic?.editableSubject
   );
 
   const setTopic = (selectedTopic: string) => {
@@ -108,7 +109,9 @@ export const ContactUs = (props: ContactUsProps) => {
     );
   };
 
-  const submitForm = async (formData: FormPayload): Promise<boolean> => {
+  const submitForm = async (
+    formData: ContactUsFormPayload
+  ): Promise<boolean> => {
     const body = JSON.stringify({
       ...(currentTopic?.id && {
         topic: currentTopic?.id
@@ -119,12 +122,7 @@ export const ContactUs = (props: ContactUsProps) => {
       ...(currentSubSubTopic?.id && {
         subsubtopic: currentSubSubTopic?.id
       }),
-      name: formData.fullName,
-      email: formData.email,
-      subject: formData.subjectLine,
-      message: formData.details,
-      captchaToken: formData.captchaToken,
-      attachment: formData.attachment
+      ...formData
     });
 
     const res = await fetch("/api/contact-us/", { method: "POST", body });
@@ -245,8 +243,8 @@ export const ContactUs = (props: ContactUsProps) => {
                       ? `Step ${subSubTopics ? "3" : "2"}:`
                       : ""
                   } Tell us more`}
-                  subjectLine={subjectLine}
-                  editableSubjectLine={isSubjectLineEditable}
+                  subject={subject}
+                  editableSubject={isSubjectEditable}
                 />
               )}
             </>

--- a/app/client/components/contactUs/contactUsForm.tsx
+++ b/app/client/components/contactUs/contactUsForm.tsx
@@ -283,8 +283,8 @@ export const ContactUsForm = (props: ContactUsFormProps) => {
           <Input
             label="Subject of enquiry"
             type="text"
-            width={50}
-            changeSetState={newSubject => setSubject(newSubject.substr(0, 50))}
+            width={100}
+            changeSetState={newSubject => setSubject(newSubject.substr(0, 100))}
             value={subject}
             additionalCss={css`
               margin: ${space[5]}px;

--- a/app/client/components/contactUs/contactUsForm.tsx
+++ b/app/client/components/contactUs/contactUsForm.tsx
@@ -283,7 +283,7 @@ export const ContactUsForm = (props: ContactUsFormProps) => {
           <Input
             label="Subject of enquiry"
             type="text"
-            width={100}
+            width={50}
             changeSetState={newSubject => setSubject(newSubject.substr(0, 100))}
             value={subject}
             additionalCss={css`

--- a/app/client/components/contactUs/contactUsForm.tsx
+++ b/app/client/components/contactUs/contactUsForm.tsx
@@ -62,8 +62,8 @@ export const ContactUsForm = (props: ContactUsFormProps) => {
       window.guardian?.identityDetails?.email) ||
       ""
   );
-  const [message, setDetails] = useState<string>("");
-  const [messageRemainingCharacters, setDetailsRemainingCharacters] = useState<
+  const [message, setMessage] = useState<string>("");
+  const [messageRemainingCharacters, setMessageRemainingCharacters] = useState<
     number
   >(2500);
 
@@ -352,8 +352,8 @@ export const ContactUsForm = (props: ContactUsFormProps) => {
             maxLength={2500}
             value={message}
             onChange={(e: ChangeEvent<HTMLTextAreaElement>) => {
-              setDetails(e.target.value);
-              setDetailsRemainingCharacters(2500 - e.target.value.length);
+              setMessage(e.target.value);
+              setMessageRemainingCharacters(2500 - e.target.value.length);
             }}
             css={css`
               width: 100%;

--- a/app/client/components/contactUs/contactUsForm.tsx
+++ b/app/client/components/contactUs/contactUsForm.tsx
@@ -87,7 +87,7 @@ export const ContactUsForm = (props: ContactUsFormProps) => {
     },
     email: {
       isValid: true,
-      message: "Please insert a valid email address."
+      errorMessage: "Please insert a valid email address."
     },
     subject: {
       isValid: true,

--- a/app/server/contactUsApi.ts
+++ b/app/server/contactUsApi.ts
@@ -173,7 +173,7 @@ const buildContactUsReqBody = (body: any): ContactUsReq => {
     }),
     name: (body.name as string).substr(0, 50),
     email: (body.email as string).substr(0, 50),
-    subject: (body.subject as string).substr(0, 50),
+    subject: (body.subject as string).substr(0, 100),
     message: (body.message as string).substr(0, 2500),
     ...(attachment && {
       attachment

--- a/app/server/contactUsApi.ts
+++ b/app/server/contactUsApi.ts
@@ -159,7 +159,7 @@ const buildContactUsReqBody = (body: any): ContactUsReq => {
     body.attachment.name && body.attachment.contents
       ? {
           name: body.attachment?.name,
-          contents: body.attachment?.name
+          contents: body.attachment?.contents
         }
       : undefined;
 

--- a/app/server/contactUsApi.ts
+++ b/app/server/contactUsApi.ts
@@ -154,19 +154,29 @@ const validateTopics = (
   return true;
 };
 
-const buildContactUsReqBody = (body: any): ContactUsReq => ({
-  topic: body.topic,
-  ...(body.subtopic && {
-    subtopic: body.subtopic
-  }),
-  ...(body.subsubtopic && {
-    subsubtopic: body.subsubtopic
-  }),
-  name: (body.name as string).substr(0, 50),
-  email: (body.email as string).substr(0, 50),
-  subject: (body.subject as string).substr(0, 50),
-  message: (body.message as string).substr(0, 2500),
-  ...(body.attachment && {
-    attachment: body.attachment
-  })
-});
+const buildContactUsReqBody = (body: any): ContactUsReq => {
+  const attachment =
+    body.attachment.name && body.attachment.contents
+      ? {
+          name: body.attachment?.name,
+          contents: body.attachment?.name
+        }
+      : undefined;
+
+  return {
+    topic: body.topic,
+    ...(body.subtopic && {
+      subtopic: body.subtopic
+    }),
+    ...(body.subsubtopic && {
+      subsubtopic: body.subsubtopic
+    }),
+    name: (body.name as string).substr(0, 50),
+    email: (body.email as string).substr(0, 50),
+    subject: (body.subject as string).substr(0, 50),
+    message: (body.message as string).substr(0, 2500),
+    ...(attachment && {
+      attachment
+    })
+  };
+};

--- a/app/shared/contactUsConfig.ts
+++ b/app/shared/contactUsConfig.ts
@@ -43,7 +43,7 @@ export const contactUsConfig: Topic[] = [
       {
         id: "s4",
         name: "Something else",
-        editableSubjectLine: true
+        editableSubject: true
       }
     ]
   },
@@ -102,7 +102,7 @@ export const contactUsConfig: Topic[] = [
       {
         id: "s9",
         name: "Something else",
-        editableSubjectLine: true
+        editableSubject: true
       }
     ]
   },
@@ -119,7 +119,7 @@ export const contactUsConfig: Topic[] = [
       {
         id: "s11",
         name: "Something else",
-        editableSubjectLine: true
+        editableSubject: true
       }
     ]
   },
@@ -175,7 +175,7 @@ export const contactUsConfig: Topic[] = [
           {
             id: "ss5",
             name: "Something else",
-            editableSubjectLine: true
+            editableSubject: true
           }
         ]
       },
@@ -229,7 +229,7 @@ export const contactUsConfig: Topic[] = [
           {
             id: "ss11",
             name: "Something else",
-            editableSubjectLine: true
+            editableSubject: true
           }
         ]
       },
@@ -261,7 +261,7 @@ export const contactUsConfig: Topic[] = [
           {
             id: "ss15",
             name: "Something else",
-            editableSubjectLine: true
+            editableSubject: true
           }
         ]
       }
@@ -308,7 +308,7 @@ export const contactUsConfig: Topic[] = [
       {
         id: "s20",
         name: "Something else",
-        editableSubjectLine: true
+        editableSubject: true
       }
     ]
   },
@@ -337,7 +337,7 @@ export const contactUsConfig: Topic[] = [
       {
         id: "s25",
         name: "Something else",
-        editableSubjectLine: true
+        editableSubject: true
       }
     ]
   },
@@ -350,6 +350,6 @@ export const contactUsConfig: Topic[] = [
     id: "other",
     name: "Something else",
     enquiryLabel: "your query",
-    editableSubjectLine: true
+    editableSubject: true
   }
 ];

--- a/app/shared/contactUsTypes.ts
+++ b/app/shared/contactUsTypes.ts
@@ -2,7 +2,7 @@ interface BaseTopic {
   id: string;
   name: string;
   selfServiceBox?: SelfServiceBox;
-  editableSubjectLine?: boolean;
+  editableSubject?: boolean;
   noForm?: boolean;
 }
 
@@ -23,12 +23,20 @@ export interface Topic extends BaseTopic {
   subTopicsTitle?: string;
 }
 
-export interface ContactUsReq {
-  topic: string;
-  subtopic?: string;
-  subsubtopic?: string;
+interface BaseContactUsReqPayload {
   name: string;
   email: string;
   subject: string;
   message: string;
+  attachment?: { name: string; contents: string };
+}
+
+export interface ContactUsFormPayload extends BaseContactUsReqPayload {
+  captchaToken: string;
+}
+
+export interface ContactUsReq extends BaseContactUsReqPayload {
+  topic: string;
+  subtopic?: string;
+  subsubtopic?: string;
 }


### PR DESCRIPTION
## What does this change?
This PR makes a few changes to the Contact Us form.
- Renames variables so they are common across all the Contact Us components (client-side, json requests, server-side) and consolidates the types.
- Ensures selective field forwarding happens for attachment fields. Currently a malicious user can manipulate our code to add any number of of fields (spam) inside the attachment request and this would be forwarded to the contact-us-api lambda.
- increases the character limit for the subject. Longer subjects were getting clipped leading to some confusion for our CSRs.