### PR TITLE
[RB] - fix contact us buildContactUsReqBody function to stop 400 errors

### DIFF
--- a/app/server/contactUsApi.ts
+++ b/app/server/contactUsApi.ts
@@ -156,10 +156,10 @@ const validateTopics = (
 
 const buildContactUsReqBody = (body: any): ContactUsReq => {
   const attachment =
-    body.attachment.name && body.attachment.contents
+    body.attachment?.name && body.attachment?.contents
       ? {
-          name: body.attachment?.name,
-          contents: body.attachment?.contents
+          name: body.attachment.name,
+          contents: body.attachment.contents
         }
       : undefined;
 


### PR DESCRIPTION
## What does this change?
If the user doesn't attach a file along with the form then the attachment object passed through to the `buildContactUsReqBody` function will be undefined, which is where this bug kicks in, trying to access a property of undefined. 

Solution is to use optional chaining to avoid trying to access property of undefined attachment object.

