### PR TITLE
[RB] - remove old help page content. Replace with help centre context

### DIFF
--- a/app/client/components/help.tsx
+++ b/app/client/components/help.tsx
@@ -1,34 +1,14 @@
 import { css } from "@emotion/core";
-import { palette } from "@guardian/src-foundations";
+import { palette, space } from "@guardian/src-foundations";
 import { headline, textSans } from "@guardian/src-foundations/typography";
 import { RouteComponentProps } from "@reach/router";
-import Color from "color";
-import React from "react";
-import { conf } from "../../server/config";
+import React, { useState } from "react";
 import { minWidth } from "../styles/breakpoints";
 import { trackEvent } from "./analytics";
-import { Button } from "./buttons";
+import { LinkButton } from "./buttons";
 import { CallCentreEmailAndNumbers } from "./callCenterEmailAndNumbers";
-import { NAV_LINKS, NavItem } from "./nav/navConfig";
+import { NAV_LINKS } from "./nav/navConfig";
 import { PageContainer } from "./page";
-import { getHelpSectionIcon } from "./svgs/helpSectionIcons";
-
-let domain: string;
-if (typeof window !== "undefined" && window.guardian) {
-  domain = window.guardian.domain;
-} else {
-  domain = conf.DOMAIN;
-}
-
-const reportTechnicalIssue: NavItem = {
-  title: "Report technical issue",
-  link: `https://www.${domain}/info/tech-feedback`
-};
-
-interface FaqLink {
-  title: string;
-  link: string;
-}
 
 export type FaqSectionNames =
   | "Delivery"
@@ -36,306 +16,191 @@ export type FaqSectionNames =
   | "Print subscriptions"
   | "Account";
 
-interface SectionFaq {
+interface Question {
   id: string;
-  links: FaqLink[];
-  seeAll: FaqLink;
+  title: string;
+  link: string;
 }
 
-type Faqs = {
-  [key in FaqSectionNames]: SectionFaq;
-};
-const faqs: Faqs = {
-  Delivery: {
-    id: "delivery",
-    links: [
-      {
-        title: "Can my delivery be suspended while I'm on holiday?",
-        link:
-          "https://www.theguardian.com/help/2017/dec/11/help-if-you-are-going-on-holiday"
-      },
-      {
-        title: "Can my delivery be redirected?",
-        link: "https://www.theguardian.com/help/2017/dec/11/help-with-delivery"
-      },
-      {
-        title: "How do I change my delivery address?",
-        link: "https://www.theguardian.com/help/2017/dec/11/help-with-delivery"
-      },
-      {
-        title: "My delivery is late or missing",
-        link: "https://www.theguardian.com/help/2017/dec/11/help-with-delivery"
-      }
-    ],
-    seeAll: {
-      title: "See all delivery FAQs",
-      link: "https://www.theguardian.com/help/2017/dec/11/help-with-delivery"
-    }
+const highlightedQuestions: Question[] = [
+  {
+    id: "q1",
+    title: "Can my delivery be suspended while I'm on holiday?",
+    link:
+      "https://www.theguardian.com/help/2020/nov/17/i-need-to-pause-my-delivery"
   },
-  "Billing and payments": {
-    id: "billing",
-    links: [
-      {
-        title: "How do I update my payment details?",
-        link: "https://www.theguardian.com/help/2019/dec/13/payment-faqs"
-      },
-      {
-        title: "Where can I view my payment plan?",
-        link: "https://www.theguardian.com/help/2019/dec/13/payment-faqs"
-      },
-      {
-        title: "What payment methods do you accept?",
-        link: "https://www.theguardian.com/help/2019/dec/13/payment-faqs"
-      },
-      {
-        title: "How do I cancel my subscription?",
-        link: "https://www.theguardian.com/help/2019/dec/13/payment-faqs"
-      }
-    ],
-    seeAll: {
-      title: "See all billing FAQs",
-      link: "https://www.theguardian.com/help/2019/dec/13/payment-faqs"
-    }
+  {
+    id: "q2",
+    title: "How do I change my delivery address?",
+    link:
+      "https://www.theguardian.com/help/2020/nov/17/i-need-to-change-my-delivery-address"
   },
-  "Print subscriptions": {
-    id: "subscriptions",
-    links: [
-      {
-        title: "My newspaper is missing a section",
-        link: "https://www.theguardian.com/help/2017/dec/11/help-with-delivery"
-      },
-      {
-        title: "Where can I use my vouchers?",
-        link: "https://www.theguardian.com/help/2017/dec/11/help-with-vouchers"
-      },
-      {
-        title: "I've haven't received my vouchers",
-        link: "https://www.theguardian.com/help/2017/dec/11/help-with-vouchers"
-      },
-      {
-        title: "I've lost my vouchers",
-        link: "https://www.theguardian.com/help/2017/dec/11/help-with-vouchers"
-      }
-    ],
-    seeAll: {
-      title: "See all print FAQs",
-      link:
-        "https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions"
-    }
+  {
+    id: "q3",
+    title: "My delivery is late or missing",
+    link:
+      "https://www.theguardian.com/help/2020/nov/17/my-delivery-is-late-or-missing"
   },
-  Account: {
-    id: "signing-in-and-accounts",
-    links: [
-      {
-        title: "How do I reset my password?",
-        link: "https://profile.theguardian.com/reset"
-      },
-      {
-        title: "How can I change my email address?",
-        link: "https://manage.theguardian.com/account-settings"
-      },
-      {
-        title: "Why am I still seeing banners/ads?",
-        link: "https://www.theguardian.com/help/identity-faq"
-      },
-      {
-        title: "How do I change my username?",
-        link: "https://www.theguardian.com/help/identity-faq"
-      }
-    ],
-    seeAll: {
-      title: "See all account FAQs",
-      link: "https://www.theguardian.com/help/identity-faq"
-    }
+  {
+    id: "q4",
+    title: "Where can I use my Subscription Card or vouchers?",
+    link:
+      "https://www.theguardian.com/help/2020/nov/20/im-a-print-subscriber-where-can-i-pick-up-my-papers"
+  },
+  {
+    id: "q5",
+    title: "How do I update my payment details?",
+    link:
+      "https://www.theguardian.com/help/2020/nov/17/how-do-i-update-my-payment-details"
+  },
+  {
+    id: "q6",
+    title: "How do I reset my password?",
+    link:
+      "https://www.theguardian.com/help/2020/nov/19/ive-forgotten-my-password"
   }
-};
+];
 
-export const Help = (_: RouteComponentProps) => (
-  <PageContainer selectedNavItem={NAV_LINKS.help} pageTitle="Help centre">
-    <div
-      css={css`
-        display: flex;
-        flex-wrap: wrap;
-        margin: 50px -10px -10px -10px;
-      `}
-    >
-      {Object.keys(faqs).map((faqSectionTitle, sectionIndex) => {
-        const faqSectionLinks = faqs[faqSectionTitle as FaqSectionNames].links;
-        const faqSectionId = faqs[faqSectionTitle as FaqSectionNames].id;
-        const seeAllNavItem: NavItem =
-          faqs[faqSectionTitle as FaqSectionNames].seeAll;
-        return (
-          <div
-            key={`section-${sectionIndex}`}
+const listStyle = css`
+  list-style: none;
+  margin: 0 0 20px;
+  padding: 0;
+`;
+
+const listItemStyle = css`
+  display: block;
+  & + li {
+    margin-top: ${space[5]}px;
+  }
+`;
+
+const listItemAnchorStyle = css`
+  ${textSans.medium()};
+  color: ${palette.neutral[20]};
+  text-decoration: underline;
+`;
+
+const h2Style = css`
+  border-top: 1px solid ${palette.neutral["86"]};
+  margin-top: 30px;
+  ${minWidth.tablet} {
+    margin-top: 40px;
+  }
+  ${headline.small({ fontWeight: "bold" })};
+`;
+
+const h3Style = css`
+  margin-top: 30px;
+  ${minWidth.tablet} {
+    margin-top: 40px;
+  }
+  ${headline.xxsmall({ fontWeight: "bold" })};
+`;
+
+const callCentreToggleSpanStyle = (isOpen: boolean) => css`
+  cursor: pointer;
+  text-decoration: underline;
+  color: ${palette.brand[500]};
+  position: relative;
+  :after {
+    content: "";
+    display: block;
+    width: 7px;
+    height: 7px;
+    border-top: 2px solid ${palette.brand["500"]};
+    border-right: 2px solid ${palette.brand["500"]};
+    position: absolute;
+    top: 50%;
+    transform: ${isOpen
+      ? "translateY(-5%) rotate(315deg)"
+      : "translateY(-50%) rotate(135deg)"};
+    transition: transform 0.3s ease;
+    right: -12px;
+  }
+`;
+
+export const Help = (_: RouteComponentProps) => {
+  const [callCentreOpen, setCallCentreOpen] = useState<boolean>(false);
+  return (
+    <PageContainer selectedNavItem={NAV_LINKS.help} pageTitle="Help centre">
+      <h2 css={h2Style}>How can we help?</h2>
+      <ul css={listStyle}>
+        {highlightedQuestions.map(question => (
+          <li key={question.id} css={listItemStyle}>
+            <a href={question.link} css={listItemAnchorStyle}>
+              {question.title}
+            </a>
+          </li>
+        ))}
+      </ul>
+      <h3 css={h3Style}>Can’t find what you’re looking for?</h3>
+      <p
+        css={css`
+          ${textSans.medium()};
+        `}
+      >
+        Visit our Help Centre to find more useful information
+      </p>
+      <LinkButton
+        to={"/help-centre/"}
+        text={"Visit Help Centre"}
+        colour={palette.brand[800]}
+        textColour={palette.brand[400]}
+        fontWeight={"bold"}
+        onClick={() =>
+          trackEvent({
+            eventCategory: "help-page",
+            eventAction: "help-centre-cta-click"
+          })
+        }
+      />
+      <p
+        css={css`
+          ${textSans.medium()};
+          margin-top: 30px;
+          ${minWidth.tablet} {
+            margin-top: 40px;
+          }
+        `}
+      >
+        If you still can’t find what you need and want to contact us, check{" "}
+        <span
+          css={callCentreToggleSpanStyle(callCentreOpen)}
+          onClick={() => setCallCentreOpen(!callCentreOpen)}
+        >
+          here
+        </span>
+      </p>
+      {callCentreOpen && (
+        <>
+          <CallCentreEmailAndNumbers />
+          <p
             css={css`
-              border: 1px solid ${palette.neutral["86"]};
-              flex: 1 1 370px;
-              margin: 10px;
-              display: flex;
-              flex-direction: column;
+              ${textSans.medium()};
+              margin-top: 30px;
+              ${minWidth.tablet} {
+                margin-top: 40px;
+              }
             `}
           >
-            <h2
-              css={css`
-                ${textSans.medium({ fontWeight: "bold" })};
-                color: #333333;
-                position: relative;
-                margin: 0;
-                padding: 18px 0 18px 60px;
-                border-bottom: 1px solid ${palette.neutral["86"]};
-                width: 100%;
-              `}
-            >
-              <i
-                css={css`
-                  position: absolute;
-                  top: 11px;
-                  left: 11px;
-                `}
-              >
-                {getHelpSectionIcon(faqSectionId)}
-              </i>
-              {faqSectionTitle}
-            </h2>
-            <ul
-              css={css`
-                list-style: none;
-                margin: 0 0 20px;
-                padding: 0 12px;
-              `}
-            >
-              {faqSectionLinks.map((faqLink, questionIndex) => (
-                <li
-                  key={`${faqSectionId}Question-${questionIndex}`}
-                  css={css`
-                    padding: 12px 20px 12px 0;
-                    border-bottom: 1px solid ${palette.neutral["86"]};
-                    position: relative;
-                  `}
-                >
-                  <a
-                    href={faqLink.link}
-                    target="_blank"
-                    css={css`
-                      display: inline-block;
-                      width: 100%;
-                      ${textSans.medium()};
-                      color: ${palette.neutral["7"]};
-                      :visited {
-                        color: ${palette.neutral["7"]};
-                      }
-                    `}
-                    onClick={() => {
-                      trackEvent({
-                        eventCategory: "href",
-                        eventAction: "click",
-                        eventLabel: faqLink.link
-                      });
-                    }}
-                  >
-                    {faqLink.title}
-                  </a>
-                  <span
-                    css={css`
-                      display: block;
-                      width: 7px;
-                      height: 7px;
-                      border-top: 2px solid ${palette.neutral["7"]};
-                      border-right: 2px solid ${palette.neutral["7"]};
-                      position: absolute;
-                      top: 50%;
-                      transform: translateY(-50%) rotate(45deg);
-                      right: 7px;
-                    `}
-                  />
-                </li>
-              ))}
-            </ul>
-            <div
-              css={css`
-                margin: auto 11px 20px 11px;
-              `}
-            >
-              <a
-                href={seeAllNavItem.link}
-                target={"_blank"}
-                css={css`
-                  display: inline-block;
-                  ${textSans.small({ fontWeight: "bold" })};
-                  line-height: 36px;
-                  min-height: 36px;
-                  height: 36px;
-                  border-radius: 18px;
-                  padding: 0 16px;
-                  color: ${palette.brand[400]};
-                  background-color: ${palette.brand[800]};
-                  :hover {
-                    background-color: ${Color(palette.brand[800], "hex")
-                      .darken(0.1)
-                      .string()};
-                  }
-                  :visited {
-                    color: ${palette.brand[400]};
-                  }
-                `}
-                onClick={() => {
-                  trackEvent({
-                    eventCategory: "href",
-                    eventAction: "click",
-                    eventLabel: seeAllNavItem.link
-                  });
-                }}
-              >
-                {seeAllNavItem.title}
-              </a>
-            </div>
-          </div>
-        );
-      })}
-    </div>
-    <h2
-      css={css`
-        border-top: 1px solid ${palette.neutral["86"]};
-        margin-top: 30px;
-        ${minWidth.tablet} {
-          margin-top: 40px;
-        }
-        ${headline.small({ fontWeight: "bold" })};
-      `}
-    >
-      Can’t find what you’re looking for?
-    </h2>
-    <CallCentreEmailAndNumbers />
-    <h2
-      css={css`
-        border-top: 1px solid ${palette.neutral["86"]};
-        margin-top: 30px;
-        ${minWidth.tablet} {
-          margin-top: 40px;
-        }
-        ${headline.small({ fontWeight: "bold" })};
-      `}
-    >
-      Having a technical issue?
-    </h2>
-    <a
-      href={reportTechnicalIssue.link}
-      onClick={() => {
-        trackEvent({
-          eventCategory: "href",
-          eventAction: "click",
-          eventLabel: "report_technical_issue"
-        });
-      }}
-    >
-      <Button
-        text={reportTechnicalIssue.title}
-        fontWeight="bold"
-        colour={palette.brand[400]}
-        textColour={palette.neutral[100]}
-        height="36px"
-        right
-      />
-    </a>
-  </PageContainer>
-);
+            Or use our contact form to get in touch and we’ll get back to you as
+            soon as possible.
+          </p>
+          <LinkButton
+            to={"/contact-us/"}
+            text={"Take me to the form"}
+            colour={palette.brand[800]}
+            textColour={palette.brand[400]}
+            fontWeight={"bold"}
+            onClick={() =>
+              trackEvent({
+                eventCategory: "help-page",
+                eventAction: "contact-us-cta-click"
+              })
+            }
+          />
+        </>
+      )}
+    </PageContainer>
+  );
+};

--- a/app/client/components/help.tsx
+++ b/app/client/components/help.tsx
@@ -10,12 +10,6 @@ import { CallCentreEmailAndNumbers } from "./callCenterEmailAndNumbers";
 import { NAV_LINKS } from "./nav/navConfig";
 import { PageContainer } from "./page";
 
-export type FaqSectionNames =
-  | "Delivery"
-  | "Billing and payments"
-  | "Print subscriptions"
-  | "Account";
-
 interface Question {
   id: string;
   title: string;

--- a/app/client/components/help.tsx
+++ b/app/client/components/help.tsx
@@ -113,6 +113,14 @@ const callCentreToggleSpanStyle = (isOpen: boolean) => css`
   }
 `;
 
+const pStyle = css`
+  ${textSans.medium()};
+  margin-top: 30px;
+  ${minWidth.tablet} {
+    margin-top: 40px;
+  }
+`;
+
 export const Help = (_: RouteComponentProps) => {
   const [callCentreOpen, setCallCentreOpen] = useState<boolean>(false);
   return (
@@ -148,15 +156,7 @@ export const Help = (_: RouteComponentProps) => {
           })
         }
       />
-      <p
-        css={css`
-          ${textSans.medium()};
-          margin-top: 30px;
-          ${minWidth.tablet} {
-            margin-top: 40px;
-          }
-        `}
-      >
+      <p css={pStyle}>
         If you still can’t find what you need and want to contact us, check{" "}
         <span
           css={callCentreToggleSpanStyle(callCentreOpen)}
@@ -168,15 +168,7 @@ export const Help = (_: RouteComponentProps) => {
       {callCentreOpen && (
         <>
           <CallCentreEmailAndNumbers />
-          <p
-            css={css`
-              ${textSans.medium()};
-              margin-top: 30px;
-              ${minWidth.tablet} {
-                margin-top: 40px;
-              }
-            `}
-          >
+          <p css={pStyle}>
             Or use our contact form to get in touch and we’ll get back to you as
             soon as possible.
           </p>


### PR DESCRIPTION
## What does this change?
Now that the help centre is live there is no need to duplicate it's content in the help page in MMA. 

This pr replaces the old content with links to popular questions, a link to the help centre and links to the call centre contact details and contact us form

## Images
Before            |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/2510683/101182809-83b1a480-3646-11eb-8737-f2059d1a8b8a.png)  |  ![](https://user-images.githubusercontent.com/2510683/101182884-9d52ec00-3646-11eb-9068-81fb91f21288.png)