### PR TITLE
Refactor + update contributions amount update form

### DIFF
--- a/app/client/__tests__/components/accountoverview/contributionUpdateAmount.tsx
+++ b/app/client/__tests__/components/accountoverview/contributionUpdateAmount.tsx
@@ -3,7 +3,7 @@ import { debug, fireEvent, render, screen } from "@testing-library/react";
 import each from "jest-each";
 import { before } from "lodash";
 import * as React from "react";
-import { ContributionUpdateAmountProps } from "../../../components/accountoverview/contributionUpdateAmount";
+import { ContributionUpdateAmount } from "../../../components/accountoverview/contributionUpdateAmount";
 
 const mainPlan = interval => ({
   start: "2019-10-30",

--- a/app/client/__tests__/components/accountoverview/contributionUpdateAmount.tsx
+++ b/app/client/__tests__/components/accountoverview/contributionUpdateAmount.tsx
@@ -3,7 +3,7 @@ import { debug, fireEvent, render, screen } from "@testing-library/react";
 import each from "jest-each";
 import { before } from "lodash";
 import * as React from "react";
-import { ContributionUpdateAmountForm } from "../../../components/accountoverview/contributionUpdateAmountForm";
+import { ContributionUpdateAmountProps } from "../../../components/accountoverview/contributionUpdateAmount";
 
 const mainPlan = interval => ({
   start: "2019-10-30",
@@ -30,7 +30,7 @@ each`
   "renders validation error if $interval.interval amount below $expectedMinAmount",
   (params, done) => {
     const { container } = render(
-      <ContributionUpdateAmountForm
+      <ContributionUpdateAmount
         subscriptionId="A-123"
         mainPlan={mainPlan(params.interval)}
         amountUpdateStateChange={jest.fn()}
@@ -72,7 +72,7 @@ each`
   "renders validation error if $interval.interval amount above $expectedMaxAmount",
   (params, done) => {
     const { container } = render(
-      <ContributionUpdateAmountForm
+      <ContributionUpdateAmount
         subscriptionId="A-123"
         mainPlan={mainPlan(params.interval)}
         amountUpdateStateChange={jest.fn()}
@@ -108,7 +108,7 @@ each`
 
 test("renders validation error if blank input is provided", done => {
   const { container } = render(
-    <ContributionUpdateAmountForm
+    <ContributionUpdateAmount
       subscriptionId="A-123"
       mainPlan={mainPlan("month")}
       amountUpdateStateChange={jest.fn()}
@@ -141,7 +141,7 @@ test("renders validation error if blank input is provided", done => {
 
 test("renders validation error if a string is attempted to be input", done => {
   const { container } = render(
-    <ContributionUpdateAmountForm
+    <ContributionUpdateAmount
       subscriptionId="A-123"
       mainPlan={mainPlan("month")}
       amountUpdateStateChange={jest.fn()}
@@ -179,7 +179,7 @@ test("input correct value", done => {
   console.error = mockedError; // tslint:disable-line:no-console
 
   const { container } = render(
-    <ContributionUpdateAmountForm
+    <ContributionUpdateAmount
       subscriptionId="A-123"
       mainPlan={mainPlan("month")}
       amountUpdateStateChange={jest.fn()}

--- a/app/client/components/accountoverview/contributionUpdateAmount.tsx
+++ b/app/client/components/accountoverview/contributionUpdateAmount.tsx
@@ -32,12 +32,15 @@ export const ContributionUpdateAmount = (
   }
 
   const [status, setStatus] = useState<Status>(Status.OVERVIEW);
-  const [, setConfirmedAmount] = useState<number | null>(null);
+  const [confirmedAmount, setConfirmedAmount] = useState<number | null>(null);
+
+  const currentAmount = confirmedAmount || props.mainPlan.amount / 100;
 
   if (status === Status.EDITING) {
     return (
       <ContributionUpdateAmountForm
         {...props}
+        currentAmount={currentAmount}
         onUpdateConfirmed={updatedAmount => {
           setConfirmedAmount(updatedAmount);
           setStatus(Status.CONFIRMED);
@@ -66,9 +69,9 @@ export const ContributionUpdateAmount = (
             title: `${capitalize(
               augmentInterval(props.mainPlan.interval)
             )} amount`,
-            value: `${props.mainPlan.currency}${(
-              props.mainPlan.amount / 100
-            ).toFixed(2)} ${props.mainPlan.currencyISO}`
+            value: `${props.mainPlan.currency}${currentAmount.toFixed(2)} ${
+              props.mainPlan.currencyISO
+            }`
           }
         ]}
       />

--- a/app/client/components/accountoverview/contributionUpdateAmount.tsx
+++ b/app/client/components/accountoverview/contributionUpdateAmount.tsx
@@ -25,24 +25,30 @@ interface ContributionUpdateAmountProps {
 export const ContributionUpdateAmount = (
   props: ContributionUpdateAmountProps
 ) => {
-  const [showForm, setFormDisplayStatus] = useState<boolean>(false);
-  const [showConfirmation, setConfirmationStatus] = useState<boolean>(false);
-  const [confirmedAmount, setConfirmedAmount] = useState<number | null>(null);
+  enum Status {
+    OVERVIEW,
+    EDITING,
+    CONFIRMED
+  }
 
-  if (showForm) {
+  const [status, setStatus] = useState<Status>(Status.OVERVIEW);
+  const [, setConfirmedAmount] = useState<number | null>(null);
+
+  if (status === Status.EDITING) {
     return (
       <ContributionUpdateAmountForm
         {...props}
         onUpdateConfirmed={updatedAmount => {
           setConfirmedAmount(updatedAmount);
-          setFormDisplayStatus(false);
-          setConfirmationStatus(true);
+          setStatus(Status.CONFIRMED);
         }}
       />
     );
-  } else if (showConfirmation && confirmedAmount) {
-    return (
-      <>
+  }
+
+  return (
+    <>
+      {status === Status.CONFIRMED && (
         <SuccessMessage
           message={`We have successfully updated the amount of your contribution. ${props.nextPaymentDate &&
             `This amount will be taken on ${formatDateStr(
@@ -52,34 +58,7 @@ export const ContributionUpdateAmount = (
             margin-bottom: ${space[5]}px;
           `}
         />
-        <ProductDescriptionListTable
-          borderColour={palette.neutral[86]}
-          content={[
-            {
-              title: `${capitalize(
-                augmentInterval(props.mainPlan.interval)
-              )} amount`,
-              value: `${props.mainPlan.currency}${confirmedAmount.toFixed(2)} ${
-                props.mainPlan.currencyISO
-              }`
-            }
-          ]}
-        />
-        <Button
-          colour={palette.brand[800]}
-          textColour={palette.brand[400]}
-          fontWeight="bold"
-          text="Change amount"
-          onClick={() => {
-            setConfirmationStatus(false);
-          }}
-        />
-      </>
-    );
-  }
-
-  return (
-    <>
+      )}
       <ProductDescriptionListTable
         borderColour={palette.neutral[86]}
         content={[
@@ -99,7 +78,7 @@ export const ContributionUpdateAmount = (
         fontWeight="bold"
         text="Change amount"
         onClick={() => {
-          setFormDisplayStatus(true);
+          setStatus(Status.EDITING);
         }}
       />
     </>

--- a/app/client/components/accountoverview/contributionUpdateAmount.tsx
+++ b/app/client/components/accountoverview/contributionUpdateAmount.tsx
@@ -1,21 +1,18 @@
-import { css, SerializedStyles } from "@emotion/core";
+import { css } from "@emotion/core";
 import { palette, space } from "@guardian/src-foundations";
-import { textSans } from "@guardian/src-foundations/typography";
-import { InlineError } from "@guardian/src-inline-error";
 import { capitalize } from "lodash";
-import React, { Dispatch, SetStateAction, useEffect, useState } from "react";
+import React, { Dispatch, SetStateAction, useState } from "react";
 import { formatDateStr } from "../../../shared/dates";
 import {
   augmentInterval,
   PaidSubscriptionPlan
 } from "../../../shared/productResponse";
 import { ProductType } from "../../../shared/productTypes";
-import { trackEvent } from "../analytics";
-import AsyncLoader from "../asyncLoader";
 import { Button } from "../buttons";
 import { SuccessMessage } from "../delivery/address/deliveryAddressEditConfirmation";
-import { Input } from "../input";
 import { ProductDescriptionListTable } from "../productDescriptionListTable";
+
+import { ContributionUpdateAmountForm } from "./contributionUpdateAmountForm";
 
 interface ContributionUpdateAmountProps {
   subscriptionId: string;
@@ -25,323 +22,25 @@ interface ContributionUpdateAmountProps {
   amountUpdateStateChange: Dispatch<SetStateAction<number | null>>;
 }
 
-type ContributionInterval = "month" | "year";
-
-interface ContributionAmountOptions {
-  amounts: number[];
-  otherDefaultAmount: number;
-  minAmount: number;
-  maxAmount: number;
-}
-
-interface ContributionAmountsLookup {
-  [currencyISO: string]: {
-    month: ContributionAmountOptions;
-    year: ContributionAmountOptions;
-  };
-}
-
-class UpdateAmountLoader extends AsyncLoader<string> {}
-
-// TODO: make this dynamic (i.e. looks up api/config file agreed/shared by contributions team)
-const contributionAmountsLookup: ContributionAmountsLookup = {
-  GBP: {
-    month: {
-      amounts: [3, 7, 12],
-      otherDefaultAmount: 2,
-      minAmount: 2,
-      maxAmount: 166
-    },
-    year: {
-      amounts: [60, 120, 240, 480],
-      otherDefaultAmount: 10,
-      minAmount: 10,
-      maxAmount: 2000
-    }
-  },
-  USD: {
-    month: {
-      amounts: [5, 10, 20],
-      otherDefaultAmount: 2,
-      minAmount: 2,
-      maxAmount: 800
-    },
-    year: {
-      amounts: [50, 100, 250, 500],
-      otherDefaultAmount: 20,
-      minAmount: 10,
-      maxAmount: 10000
-    }
-  },
-  EUR: {
-    month: {
-      amounts: [6, 10, 20],
-      otherDefaultAmount: 2,
-      minAmount: 2,
-      maxAmount: 166
-    },
-    year: {
-      amounts: [50, 100, 250, 500],
-      otherDefaultAmount: 10,
-      minAmount: 10,
-      maxAmount: 2000
-    }
-  },
-  AUD: {
-    month: {
-      amounts: [10, 20, 40],
-      otherDefaultAmount: 10,
-      minAmount: 10,
-      maxAmount: 200
-    },
-    year: {
-      amounts: [80, 250, 500, 750],
-      otherDefaultAmount: 10,
-      minAmount: 10,
-      maxAmount: 2000
-    }
-  },
-  NZD: {
-    month: {
-      amounts: [10, 20, 50],
-      otherDefaultAmount: 10,
-      minAmount: 10,
-      maxAmount: 200
-    },
-    year: {
-      amounts: [50, 100, 250, 500],
-      otherDefaultAmount: 10,
-      minAmount: 10,
-      maxAmount: 2000
-    }
-  },
-  CAD: {
-    month: {
-      amounts: [5, 10, 20],
-      otherDefaultAmount: 5,
-      minAmount: 5,
-      maxAmount: 166
-    },
-    year: {
-      amounts: [60, 100, 250, 500],
-      otherDefaultAmount: 10,
-      minAmount: 10,
-      maxAmount: 2000
-    }
-  },
-  international: {
-    month: {
-      amounts: [5, 10, 20],
-      otherDefaultAmount: 5,
-      minAmount: 5,
-      maxAmount: 166
-    },
-    year: {
-      amounts: [60, 100, 250, 500],
-      otherDefaultAmount: 10,
-      minAmount: 10,
-      maxAmount: 2000
-    }
-  }
-};
-
 export const ContributionUpdateAmount = (
   props: ContributionUpdateAmountProps
 ) => {
-  const currentContributionOptions = (contributionAmountsLookup[
-    props.mainPlan.currencyISO
-  ] || contributionAmountsLookup.international)[
-    props.mainPlan.interval as ContributionInterval
-  ];
-
-  const [otherAmount, setOtherAmount] = useState<string | number>(
-    currentContributionOptions.otherDefaultAmount
-  );
-  const [isOtherAmountSelected, setIsOtherAmountSelected] = useState<boolean>(
-    false
-  );
-  const [selectedValue, setSelectedValue] = useState<string | number>();
-  const [inValidationErrorState, setValidationErrorState] = useState(false);
-  const [validationErrorMessage, setValidationErrorMessage] = useState<string>(
-    ""
-  );
-
   const [showForm, setFormDisplayStatus] = useState<boolean>(false);
-
-  const [showUpdateLoader, setDisplayOfUpdateLoader] = useState<boolean>(false);
-
   const [showConfirmation, setConfirmationStatus] = useState<boolean>(false);
-
-  const [updateFailed, setUpdateFailedStatus] = useState<boolean>(false);
-
   const [confirmedAmount, setConfirmedAmount] = useState<number | null>(null);
 
-  useEffect(() => {
-    if (inValidationErrorState) {
-      const validationResult = validateChoice();
-      setValidationErrorState(!validationResult.passed);
-    }
-    if (confirmedAmount) {
-      props.amountUpdateStateChange(confirmedAmount);
-    }
-  }, [otherAmount, selectedValue, confirmedAmount]);
-
-  const getAmountUpdater = (
-    newAmount: number,
-    productType: ProductType,
-    subscriptionName: string
-  ) => async () =>
-    await fetch(
-      `/api/update/amount/${productType.urlPart}/${subscriptionName}`,
-      {
-        credentials: "include",
-        method: "POST",
-        mode: "same-origin",
-        body: JSON.stringify({ newPaymentAmount: newAmount })
-      }
-    );
-
-  const radioOptionCss: SerializedStyles = css`
-    input {
-      display: none;
-    }
-    input + label {
-      display: block;
-      text-align: center;
-      box-sizing: border-box;
-      border-radius: 4px;
-      border: 1px solid ${palette.neutral[60]};
-      color: ${palette.neutral[46]};
-      font-weight: bold;
-      margin: 0 auto;
-      padding: 0;
-      line-height: 48px;
-      width: 120px;
-      cursor: pointer;
-    }
-    input:checked + label {
-      background-color: ${palette.brand[800]};
-      color: ${palette.brand[400]};
-      border: 0;
-      box-shadow: 0 0 0 4px ${palette.brand[500]};
-    }
-    display: inline-block;
-    margin: 0 ${space[3]}px ${space[3]}px 0;
-  `;
-
-  const otherAmountOnFocus = () => {
-    setIsOtherAmountSelected(true);
-    setSelectedValue("other");
-  };
-
-  interface ValidationChoice {
-    passed: boolean;
-    message?: string;
-    noSelection?: boolean;
-  }
-
-  const validateChoice = (): ValidationChoice => {
-    const chosenOption =
-      selectedValue &&
-      (selectedValue === "other"
-        ? otherAmount
-        : `${selectedValue}`.replace(props.mainPlan.currency, ""));
-    const chosenOptionNum = Number(chosenOption);
-    if (!chosenOption) {
-      return {
-        passed: false,
-        message: "Please make a selection",
-        noSelection: true
-      };
-    } else if (chosenOptionNum === props.mainPlan.amount / 100) {
-      return {
-        passed: false,
-        message: "You have selected the same amount as you currently contribute"
-      };
-    } else if (isNaN(chosenOptionNum)) {
-      return {
-        passed: false,
-        message:
-          "There is a problem with the amount you have selected, please make sure it is a valid amount"
-      };
-    } else if (
-      !isNaN(chosenOptionNum) &&
-      chosenOptionNum < currentContributionOptions.minAmount
-    ) {
-      return {
-        passed: false,
-        message: `There is a minimum ${
-          props.mainPlan.interval
-        }ly contribution amount of ${
-          props.mainPlan.currency
-        }${currentContributionOptions.minAmount.toFixed(2)} ${
-          props.mainPlan.currencyISO
-        }`
-      };
-    } else if (
-      !isNaN(chosenOptionNum) &&
-      chosenOptionNum > currentContributionOptions.maxAmount
-    ) {
-      return {
-        passed: false,
-        message: `There is a maximum ${
-          props.mainPlan.interval
-        }ly contribution amount of ${
-          props.mainPlan.currency
-        }${currentContributionOptions.maxAmount.toFixed(2)} ${
-          props.mainPlan.currencyISO
-        }`
-      };
-    }
-    return {
-      passed: true
-    };
-  };
-
-  const pendingAmount =
-    selectedValue === "other"
-      ? Number(`${otherAmount}`.replace(props.mainPlan.currency, ""))
-      : Number(`${selectedValue}`.replace(props.mainPlan.currency, ""));
-
-  if (showUpdateLoader && !showConfirmation) {
+  if (showForm) {
     return (
-      <UpdateAmountLoader
-        fetch={getAmountUpdater(
-          pendingAmount,
-          props.productType,
-          props.subscriptionId
-        )}
-        readerOnOK={(resp: Response) => resp.text()}
-        render={() => {
-          trackEvent({
-            eventCategory: "amount_change",
-            eventAction: "contributions_amount_change_success",
-            eventLabel: `by ${props.mainPlan.currency}${(
-              pendingAmount -
-              props.mainPlan.amount / 100
-            ).toFixed(2)}${props.mainPlan.currencyISO}`
-          });
-          setConfirmedAmount(pendingAmount);
-          setUpdateFailedStatus(false);
+      <ContributionUpdateAmountForm
+        {...props}
+        onUpdateConfirmed={updatedAmount => {
+          setConfirmedAmount(updatedAmount);
+          setFormDisplayStatus(false);
           setConfirmationStatus(true);
-          setDisplayOfUpdateLoader(false);
-          return null;
         }}
-        loadingMessage={"Updating..."}
-        errorRender={() => {
-          trackEvent({
-            eventCategory: "amount_change",
-            eventAction: "contributions_amount_change_failed"
-          });
-          setUpdateFailedStatus(true);
-          setDisplayOfUpdateLoader(false);
-          return null;
-        }}
-        spinnerScale={0.7}
-        inline
       />
     );
-  } else if (showConfirmation) {
+  } else if (showConfirmation && confirmedAmount) {
     return (
       <>
         <SuccessMessage
@@ -360,7 +59,7 @@ export const ContributionUpdateAmount = (
               title: `${capitalize(
                 augmentInterval(props.mainPlan.interval)
               )} amount`,
-              value: `${props.mainPlan.currency}${pendingAmount.toFixed(2)} ${
+              value: `${props.mainPlan.currency}${confirmedAmount.toFixed(2)} ${
                 props.mainPlan.currencyISO
               }`
             }
@@ -373,137 +72,6 @@ export const ContributionUpdateAmount = (
           text="Change amount"
           onClick={() => {
             setConfirmationStatus(false);
-            setUpdateFailedStatus(false);
-            setDisplayOfUpdateLoader(false);
-          }}
-        />
-      </>
-    );
-  } else if (showForm) {
-    return (
-      <>
-        {updateFailed && (
-          <InlineError>
-            Updating failed this time. Please try again later...
-          </InlineError>
-        )}
-        <div
-          css={css`
-            border: 1px solid ${palette.neutral[20]};
-            margin-bottom: ${space[5]}px;
-          `}
-        >
-          <dl
-            css={css`
-              padding: ${space[5]}px;
-              margin: 0;
-              border-bottom: 1px solid ${palette.neutral[20]};
-              ${textSans.medium()};
-            `}
-          >
-            <dt
-              css={css`
-                font-weight: bold;
-                display: inline-block;
-              `}
-            >
-              {capitalize(augmentInterval(props.mainPlan.interval))} amount
-            </dt>
-            <dd
-              css={css`
-                display: inline-block;
-              `}
-            >{`${props.mainPlan.currency}${(
-              confirmedAmount || props.mainPlan.amount / 100
-            ).toFixed(2)} ${props.mainPlan.currencyISO}`}</dd>
-          </dl>
-          <div
-            css={css`
-              ${textSans.medium()};
-              padding: ${space[5]}px;
-            `}
-          >
-            <h4
-              css={css`
-                ${textSans.medium({ fontWeight: "bold" })};
-                margin: 0 0 ${inValidationErrorState ? space[3] : 0}px 0;
-              `}
-            >
-              Choose the amount to contribute
-            </h4>
-            {inValidationErrorState && !selectedValue && (
-              <InlineError>{validationErrorMessage}</InlineError>
-            )}
-            {currentContributionOptions.amounts.map(possibleAmount => (
-              <div css={radioOptionCss} key={`amount-${possibleAmount}`}>
-                <input
-                  type="radio"
-                  id={`amount-${possibleAmount}`}
-                  name="amount"
-                  value={`${props.mainPlan.currency}${possibleAmount}`}
-                  onChange={e => {
-                    setSelectedValue(e.target.value);
-                    setIsOtherAmountSelected(false);
-                  }}
-                />
-                <label
-                  htmlFor={`amount-${possibleAmount}`}
-                >{`${props.mainPlan.currency}${possibleAmount}`}</label>
-              </div>
-            ))}
-            <div css={radioOptionCss}>
-              <input
-                type="radio"
-                id="amount-other"
-                name="amount"
-                value="other"
-                checked={isOtherAmountSelected}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                  setIsOtherAmountSelected(e.target.checked);
-                }}
-              />
-              <label htmlFor="amount-other">Other</label>
-            </div>
-            {isOtherAmountSelected && (
-              <div
-                css={css`
-                  margin-top: ${space[3]}px;
-                `}
-              >
-                <Input
-                  type="number"
-                  min={`${currentContributionOptions.minAmount}`}
-                  step="1.00"
-                  label="Other amount"
-                  prefixValue={props.mainPlan.currency}
-                  width={30}
-                  value={otherAmount}
-                  changeSetState={setOtherAmount}
-                  onFocus={otherAmountOnFocus}
-                  setFocus={isOtherAmountSelected}
-                  inErrorState={
-                    inValidationErrorState &&
-                    (!!selectedValue || (isOtherAmountSelected && !otherAmount))
-                  }
-                  errorMessage={validationErrorMessage}
-                />
-              </div>
-            )}
-          </div>
-        </div>
-        <Button
-          colour={palette.brand[800]}
-          textColour={palette.brand[400]}
-          fontWeight="bold"
-          text="Change amount"
-          onClick={() => {
-            const validationResult = validateChoice();
-            setValidationErrorState(!validationResult.passed);
-            if (!validationResult.passed) {
-              setValidationErrorMessage(validationResult.message as string);
-              return;
-            }
-            setDisplayOfUpdateLoader(true);
           }}
         />
       </>

--- a/app/client/components/accountoverview/contributionUpdateAmount.tsx
+++ b/app/client/components/accountoverview/contributionUpdateAmount.tsx
@@ -17,7 +17,7 @@ import { SuccessMessage } from "../delivery/address/deliveryAddressEditConfirmat
 import { Input } from "../input";
 import { ProductDescriptionListTable } from "../productDescriptionListTable";
 
-interface ContributionUpdateAmountForm {
+interface ContributionUpdateAmountProps {
   subscriptionId: string;
   mainPlan: PaidSubscriptionPlan;
   productType: ProductType;
@@ -145,8 +145,8 @@ const contributionAmountsLookup: ContributionAmountsLookup = {
   }
 };
 
-export const ContributionUpdateAmountForm = (
-  props: ContributionUpdateAmountForm
+export const ContributionUpdateAmount = (
+  props: ContributionUpdateAmountProps
 ) => {
   const currentContributionOptions = (contributionAmountsLookup[
     props.mainPlan.currencyISO

--- a/app/client/components/accountoverview/contributionUpdateAmountForm.tsx
+++ b/app/client/components/accountoverview/contributionUpdateAmountForm.tsx
@@ -154,13 +154,13 @@ export const ContributionUpdateAmountForm = (
     props.mainPlan.interval as ContributionInterval
   ];
 
-  const [otherAmount, setOtherAmount] = useState<string | number>(
+  const [otherAmount, setOtherAmount] = useState<number | null>(
     currentContributionOptions.otherDefaultAmount
   );
   const [isOtherAmountSelected, setIsOtherAmountSelected] = useState<boolean>(
     false
   );
-  const [selectedValue, setSelectedValue] = useState<string | number>();
+  const [selectedValue, setSelectedValue] = useState<number | null>(null);
   const [inValidationErrorState, setValidationErrorState] = useState(false);
   const [validationErrorMessage, setValidationErrorMessage] = useState<string>(
     ""
@@ -204,11 +204,7 @@ export const ContributionUpdateAmountForm = (
   }
 
   const validateChoice = (): ValidationChoice => {
-    const chosenOption =
-      selectedValue &&
-      (selectedValue === "other"
-        ? otherAmount
-        : `${selectedValue}`.replace(props.mainPlan.currency, ""));
+    const chosenOption = isOtherAmountSelected ? otherAmount : selectedValue;
 
     const chosenOptionNum = Number(chosenOption);
     if (!chosenOption) {
@@ -262,10 +258,9 @@ export const ContributionUpdateAmountForm = (
     };
   };
 
-  const pendingAmount =
-    selectedValue === "other"
-      ? Number(`${otherAmount}`.replace(props.mainPlan.currency, ""))
-      : Number(`${selectedValue}`.replace(props.mainPlan.currency, ""));
+  const pendingAmount = Number(
+    isOtherAmountSelected ? otherAmount : selectedValue
+  );
 
   const amountLabel = (amount: number) => {
     return `${props.mainPlan.currency} ${amount} per ${props.mainPlan.interval}`;
@@ -386,7 +381,7 @@ export const ContributionUpdateAmountForm = (
                   checked={isOtherAmountSelected}
                   onChange={() => {
                     setIsOtherAmountSelected(true);
-                    setSelectedValue("other");
+                    setSelectedValue(null);
                   }}
                 />
               </>
@@ -404,9 +399,12 @@ export const ContributionUpdateAmountForm = (
                   step={1}
                   min={currentContributionOptions.minAmount}
                   max={currentContributionOptions.maxAmount}
-                  value={otherAmount}
-                  onChange={event => setOtherAmount(event.target.value)}
-                  error={validationErrorMessage}
+                  value={otherAmount || ""}
+                  onChange={event =>
+                    setOtherAmount(
+                      event.target.value ? Number(event.target.value) : null
+                    )
+                  }
                 />
               </div>
             )}

--- a/app/client/components/accountoverview/contributionUpdateAmountForm.tsx
+++ b/app/client/components/accountoverview/contributionUpdateAmountForm.tsx
@@ -317,7 +317,7 @@ export const ContributionUpdateAmountForm = (
       >
         <dl
           css={css`
-            padding: ${space[5]}px;
+            padding: ${space[3]}px ${space[5]}px;
             margin: 0;
             border-bottom: 1px solid ${palette.neutral[20]};
             ${textSans.medium()};
@@ -342,7 +342,7 @@ export const ContributionUpdateAmountForm = (
         <div
           css={css`
             ${textSans.medium()};
-            padding: ${space[5]}px;
+            padding: ${space[3]}px ${space[5]}px;
           `}
         >
           {inValidationErrorState && !selectedValue && (

--- a/app/client/components/accountoverview/contributionUpdateAmountForm.tsx
+++ b/app/client/components/accountoverview/contributionUpdateAmountForm.tsx
@@ -19,6 +19,8 @@ interface ContributionUpdateAmountFormProps {
   subscriptionId: string;
   mainPlan: PaidSubscriptionPlan;
   productType: ProductType;
+  // we use this over the value in mainPlan as that value isn't updated after the user submits this form
+  currentAmount: number;
   nextPaymentDate: string | null;
   onUpdateConfirmed: (updatedAmount: number) => void;
 }
@@ -207,6 +209,7 @@ export const ContributionUpdateAmountForm = (
       (selectedValue === "other"
         ? otherAmount
         : `${selectedValue}`.replace(props.mainPlan.currency, ""));
+
     const chosenOptionNum = Number(chosenOption);
     if (!chosenOption) {
       return {
@@ -214,7 +217,7 @@ export const ContributionUpdateAmountForm = (
         message: "Please make a selection",
         noSelection: true
       };
-    } else if (chosenOptionNum === props.mainPlan.amount / 100) {
+    } else if (chosenOptionNum === props.currentAmount) {
       return {
         passed: false,
         message: "You have selected the same amount as you currently contribute"
@@ -282,8 +285,7 @@ export const ContributionUpdateAmountForm = (
             eventCategory: "amount_change",
             eventAction: "contributions_amount_change_success",
             eventLabel: `by ${props.mainPlan.currency}${(
-              pendingAmount -
-              props.mainPlan.amount / 100
+              pendingAmount - props.currentAmount
             ).toFixed(2)}${props.mainPlan.currencyISO}`
           });
           setConfirmedAmount(pendingAmount);
@@ -338,9 +340,9 @@ export const ContributionUpdateAmountForm = (
             css={css`
               display: inline-block;
             `}
-          >{`${props.mainPlan.currency}${(props.mainPlan.amount / 100).toFixed(
-            2
-          )} ${props.mainPlan.currencyISO}`}</dd>
+          >{`${props.mainPlan.currency}${props.currentAmount.toFixed(2)} ${
+            props.mainPlan.currencyISO
+          }`}</dd>
         </dl>
         <div
           css={css`

--- a/app/client/components/accountoverview/contributionUpdateAmountForm.tsx
+++ b/app/client/components/accountoverview/contributionUpdateAmountForm.tsx
@@ -207,7 +207,7 @@ export const ContributionUpdateAmountForm = (
     const chosenOption = isOtherAmountSelected ? otherAmount : selectedValue;
 
     const chosenOptionNum = Number(chosenOption);
-    if (!chosenOption) {
+    if (!chosenOption && !isOtherAmountSelected) {
       return {
         passed: false,
         message: "Please make a selection",
@@ -218,7 +218,7 @@ export const ContributionUpdateAmountForm = (
         passed: false,
         message: "You have selected the same amount as you currently contribute"
       };
-    } else if (isNaN(chosenOptionNum)) {
+    } else if (!chosenOption || isNaN(chosenOptionNum)) {
       return {
         passed: false,
         message:

--- a/app/client/components/accountoverview/contributionUpdateAmountForm.tsx
+++ b/app/client/components/accountoverview/contributionUpdateAmountForm.tsx
@@ -1,0 +1,468 @@
+import { css, SerializedStyles } from "@emotion/core";
+import { palette, space } from "@guardian/src-foundations";
+import { textSans } from "@guardian/src-foundations/typography";
+import { InlineError } from "@guardian/src-inline-error";
+import { capitalize } from "lodash";
+import React, { useEffect, useState } from "react";
+import {
+  augmentInterval,
+  PaidSubscriptionPlan
+} from "../../../shared/productResponse";
+import { ProductType } from "../../../shared/productTypes";
+import { trackEvent } from "../analytics";
+import AsyncLoader from "../asyncLoader";
+import { Button } from "../buttons";
+import { Input } from "../input";
+
+interface ContributionUpdateAmountFormProps {
+  subscriptionId: string;
+  mainPlan: PaidSubscriptionPlan;
+  productType: ProductType;
+  nextPaymentDate: string | null;
+  onUpdateConfirmed: (updatedAmount: number) => void;
+}
+
+type ContributionInterval = "month" | "year";
+
+interface ContributionAmountOptions {
+  amounts: number[];
+  otherDefaultAmount: number;
+  minAmount: number;
+  maxAmount: number;
+}
+
+interface ContributionAmountsLookup {
+  [currencyISO: string]: {
+    month: ContributionAmountOptions;
+    year: ContributionAmountOptions;
+  };
+}
+
+class UpdateAmountLoader extends AsyncLoader<string> {}
+
+// TODO: make this dynamic (i.e. looks up api/config file agreed/shared by contributions team)
+const contributionAmountsLookup: ContributionAmountsLookup = {
+  GBP: {
+    month: {
+      amounts: [3, 7, 12],
+      otherDefaultAmount: 2,
+      minAmount: 2,
+      maxAmount: 166
+    },
+    year: {
+      amounts: [60, 120, 240, 480],
+      otherDefaultAmount: 10,
+      minAmount: 10,
+      maxAmount: 2000
+    }
+  },
+  USD: {
+    month: {
+      amounts: [5, 10, 20],
+      otherDefaultAmount: 2,
+      minAmount: 2,
+      maxAmount: 800
+    },
+    year: {
+      amounts: [50, 100, 250, 500],
+      otherDefaultAmount: 20,
+      minAmount: 10,
+      maxAmount: 10000
+    }
+  },
+  EUR: {
+    month: {
+      amounts: [6, 10, 20],
+      otherDefaultAmount: 2,
+      minAmount: 2,
+      maxAmount: 166
+    },
+    year: {
+      amounts: [50, 100, 250, 500],
+      otherDefaultAmount: 10,
+      minAmount: 10,
+      maxAmount: 2000
+    }
+  },
+  AUD: {
+    month: {
+      amounts: [10, 20, 40],
+      otherDefaultAmount: 10,
+      minAmount: 10,
+      maxAmount: 200
+    },
+    year: {
+      amounts: [80, 250, 500, 750],
+      otherDefaultAmount: 10,
+      minAmount: 10,
+      maxAmount: 2000
+    }
+  },
+  NZD: {
+    month: {
+      amounts: [10, 20, 50],
+      otherDefaultAmount: 10,
+      minAmount: 10,
+      maxAmount: 200
+    },
+    year: {
+      amounts: [50, 100, 250, 500],
+      otherDefaultAmount: 10,
+      minAmount: 10,
+      maxAmount: 2000
+    }
+  },
+  CAD: {
+    month: {
+      amounts: [5, 10, 20],
+      otherDefaultAmount: 5,
+      minAmount: 5,
+      maxAmount: 166
+    },
+    year: {
+      amounts: [60, 100, 250, 500],
+      otherDefaultAmount: 10,
+      minAmount: 10,
+      maxAmount: 2000
+    }
+  },
+  international: {
+    month: {
+      amounts: [5, 10, 20],
+      otherDefaultAmount: 5,
+      minAmount: 5,
+      maxAmount: 166
+    },
+    year: {
+      amounts: [60, 100, 250, 500],
+      otherDefaultAmount: 10,
+      minAmount: 10,
+      maxAmount: 2000
+    }
+  }
+};
+
+export const ContributionUpdateAmountForm = (
+  props: ContributionUpdateAmountFormProps
+) => {
+  const currentContributionOptions = (contributionAmountsLookup[
+    props.mainPlan.currencyISO
+  ] || contributionAmountsLookup.international)[
+    props.mainPlan.interval as ContributionInterval
+  ];
+
+  const [otherAmount, setOtherAmount] = useState<string | number>(
+    currentContributionOptions.otherDefaultAmount
+  );
+  const [isOtherAmountSelected, setIsOtherAmountSelected] = useState<boolean>(
+    false
+  );
+  const [selectedValue, setSelectedValue] = useState<string | number>();
+  const [inValidationErrorState, setValidationErrorState] = useState(false);
+  const [validationErrorMessage, setValidationErrorMessage] = useState<string>(
+    ""
+  );
+  const [showUpdateLoader, setDisplayOfUpdateLoader] = useState<boolean>(false);
+  const [updateFailed, setUpdateFailedStatus] = useState<boolean>(false);
+  const [confirmedAmount, setConfirmedAmount] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (inValidationErrorState) {
+      const validationResult = validateChoice();
+      setValidationErrorState(!validationResult.passed);
+    }
+  }, [otherAmount, selectedValue]);
+
+  useEffect(() => {
+    if (confirmedAmount) {
+      props.onUpdateConfirmed(confirmedAmount);
+    }
+  }, [confirmedAmount]);
+
+  const getAmountUpdater = (
+    newAmount: number,
+    productType: ProductType,
+    subscriptionName: string
+  ) => async () =>
+    await fetch(
+      `/api/update/amount/${productType.urlPart}/${subscriptionName}`,
+      {
+        credentials: "include",
+        method: "POST",
+        mode: "same-origin",
+        body: JSON.stringify({ newPaymentAmount: newAmount })
+      }
+    );
+
+  const radioOptionCss: SerializedStyles = css`
+    input {
+      display: none;
+    }
+    input + label {
+      display: block;
+      text-align: center;
+      box-sizing: border-box;
+      border-radius: 4px;
+      border: 1px solid ${palette.neutral[60]};
+      color: ${palette.neutral[46]};
+      font-weight: bold;
+      margin: 0 auto;
+      padding: 0;
+      line-height: 48px;
+      width: 120px;
+      cursor: pointer;
+    }
+    input:checked + label {
+      background-color: ${palette.brand[800]};
+      color: ${palette.brand[400]};
+      border: 0;
+      box-shadow: 0 0 0 4px ${palette.brand[500]};
+    }
+    display: inline-block;
+    margin: 0 ${space[3]}px ${space[3]}px 0;
+  `;
+
+  const otherAmountOnFocus = () => {
+    setIsOtherAmountSelected(true);
+    setSelectedValue("other");
+  };
+
+  interface ValidationChoice {
+    passed: boolean;
+    message?: string;
+    noSelection?: boolean;
+  }
+
+  const validateChoice = (): ValidationChoice => {
+    const chosenOption =
+      selectedValue &&
+      (selectedValue === "other"
+        ? otherAmount
+        : `${selectedValue}`.replace(props.mainPlan.currency, ""));
+    const chosenOptionNum = Number(chosenOption);
+    if (!chosenOption) {
+      return {
+        passed: false,
+        message: "Please make a selection",
+        noSelection: true
+      };
+    } else if (chosenOptionNum === props.mainPlan.amount / 100) {
+      return {
+        passed: false,
+        message: "You have selected the same amount as you currently contribute"
+      };
+    } else if (isNaN(chosenOptionNum)) {
+      return {
+        passed: false,
+        message:
+          "There is a problem with the amount you have selected, please make sure it is a valid amount"
+      };
+    } else if (
+      !isNaN(chosenOptionNum) &&
+      chosenOptionNum < currentContributionOptions.minAmount
+    ) {
+      return {
+        passed: false,
+        message: `There is a minimum ${
+          props.mainPlan.interval
+        }ly contribution amount of ${
+          props.mainPlan.currency
+        }${currentContributionOptions.minAmount.toFixed(2)} ${
+          props.mainPlan.currencyISO
+        }`
+      };
+    } else if (
+      !isNaN(chosenOptionNum) &&
+      chosenOptionNum > currentContributionOptions.maxAmount
+    ) {
+      return {
+        passed: false,
+        message: `There is a maximum ${
+          props.mainPlan.interval
+        }ly contribution amount of ${
+          props.mainPlan.currency
+        }${currentContributionOptions.maxAmount.toFixed(2)} ${
+          props.mainPlan.currencyISO
+        }`
+      };
+    }
+    return {
+      passed: true
+    };
+  };
+
+  const pendingAmount =
+    selectedValue === "other"
+      ? Number(`${otherAmount}`.replace(props.mainPlan.currency, ""))
+      : Number(`${selectedValue}`.replace(props.mainPlan.currency, ""));
+
+  if (showUpdateLoader) {
+    return (
+      <UpdateAmountLoader
+        fetch={getAmountUpdater(
+          pendingAmount,
+          props.productType,
+          props.subscriptionId
+        )}
+        readerOnOK={(resp: Response) => resp.text()}
+        render={() => {
+          trackEvent({
+            eventCategory: "amount_change",
+            eventAction: "contributions_amount_change_success",
+            eventLabel: `by ${props.mainPlan.currency}${(
+              pendingAmount -
+              props.mainPlan.amount / 100
+            ).toFixed(2)}${props.mainPlan.currencyISO}`
+          });
+          // props.onUpdateConfirmed(pendingAmount);
+          setConfirmedAmount(pendingAmount);
+          // setUpdateFailedStatus(false);
+          // setConfirmationStatus(true);
+          // setDisplayOfUpdateLoader(false);
+          return null;
+        }}
+        loadingMessage={"Updating..."}
+        errorRender={() => {
+          trackEvent({
+            eventCategory: "amount_change",
+            eventAction: "contributions_amount_change_failed"
+          });
+          setUpdateFailedStatus(true);
+          setDisplayOfUpdateLoader(false);
+          return null;
+        }}
+        spinnerScale={0.7}
+        inline
+      />
+    );
+  }
+
+  return (
+    <>
+      {updateFailed && (
+        <InlineError>
+          Updating failed this time. Please try again later...
+        </InlineError>
+      )}
+      <div
+        css={css`
+          border: 1px solid ${palette.neutral[20]};
+          margin-bottom: ${space[5]}px;
+        `}
+      >
+        <dl
+          css={css`
+            padding: ${space[5]}px;
+            margin: 0;
+            border-bottom: 1px solid ${palette.neutral[20]};
+            ${textSans.medium()};
+          `}
+        >
+          <dt
+            css={css`
+              font-weight: bold;
+              display: inline-block;
+            `}
+          >
+            {capitalize(augmentInterval(props.mainPlan.interval))} amount
+          </dt>
+          <dd
+            css={css`
+              display: inline-block;
+            `}
+          >{`${props.mainPlan.currency}${(props.mainPlan.amount / 100).toFixed(
+            2
+          )} ${props.mainPlan.currencyISO}`}</dd>
+        </dl>
+        <div
+          css={css`
+            ${textSans.medium()};
+            padding: ${space[5]}px;
+          `}
+        >
+          <h4
+            css={css`
+              ${textSans.medium({ fontWeight: "bold" })};
+              margin: 0 0 ${inValidationErrorState ? space[3] : 0}px 0;
+            `}
+          >
+            Choose the amount to contribute
+          </h4>
+          {inValidationErrorState && !selectedValue && (
+            <InlineError>{validationErrorMessage}</InlineError>
+          )}
+          {currentContributionOptions.amounts.map(possibleAmount => (
+            <div css={radioOptionCss} key={`amount-${possibleAmount}`}>
+              <input
+                type="radio"
+                id={`amount-${possibleAmount}`}
+                name="amount"
+                value={`${props.mainPlan.currency}${possibleAmount}`}
+                onChange={e => {
+                  setSelectedValue(e.target.value);
+                  setIsOtherAmountSelected(false);
+                }}
+              />
+              <label
+                htmlFor={`amount-${possibleAmount}`}
+              >{`${props.mainPlan.currency}${possibleAmount}`}</label>
+            </div>
+          ))}
+          <div css={radioOptionCss}>
+            <input
+              type="radio"
+              id="amount-other"
+              name="amount"
+              value="other"
+              checked={isOtherAmountSelected}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                setIsOtherAmountSelected(e.target.checked);
+              }}
+            />
+            <label htmlFor="amount-other">Other</label>
+          </div>
+          {isOtherAmountSelected && (
+            <div
+              css={css`
+                margin-top: ${space[3]}px;
+              `}
+            >
+              <Input
+                type="number"
+                min={`${currentContributionOptions.minAmount}`}
+                step="1.00"
+                label="Other amount"
+                prefixValue={props.mainPlan.currency}
+                width={30}
+                value={otherAmount}
+                changeSetState={setOtherAmount}
+                onFocus={otherAmountOnFocus}
+                setFocus={isOtherAmountSelected}
+                inErrorState={
+                  inValidationErrorState &&
+                  (!!selectedValue || (isOtherAmountSelected && !otherAmount))
+                }
+                errorMessage={validationErrorMessage}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+      <Button
+        colour={palette.brand[800]}
+        textColour={palette.brand[400]}
+        fontWeight="bold"
+        text="Change amount"
+        onClick={() => {
+          const validationResult = validateChoice();
+          setValidationErrorState(!validationResult.passed);
+          if (!validationResult.passed) {
+            setValidationErrorMessage(validationResult.message as string);
+            return;
+          }
+          setDisplayOfUpdateLoader(true);
+        }}
+      />
+    </>
+  );
+};

--- a/app/client/components/accountoverview/contributionUpdateAmountForm.tsx
+++ b/app/client/components/accountoverview/contributionUpdateAmountForm.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/core";
 import { ChoiceCard, ChoiceCardGroup } from "@guardian/src-choice-card";
-import { palette, space } from "@guardian/src-foundations";
+import { neutral, palette, space } from "@guardian/src-foundations";
 import { textSans } from "@guardian/src-foundations/typography";
 import { InlineError } from "@guardian/src-inline-error";
 import { TextInput } from "@guardian/src-text-input";
@@ -266,6 +266,26 @@ export const ContributionUpdateAmountForm = (
     return `${props.mainPlan.currency} ${amount} per ${props.mainPlan.interval}`;
   };
 
+  const weeklyBreakDown = (): string | null => {
+    const chosenAmount = isOtherAmountSelected ? otherAmount : selectedValue;
+    if (!chosenAmount) {
+      return null;
+    }
+
+    let weeklyAmount: number;
+    if (props.mainPlan.interval === "month") {
+      weeklyAmount = (chosenAmount * 12) / 52;
+    } else {
+      weeklyAmount = chosenAmount / 52;
+    }
+
+    return `Contributing ${
+      props.mainPlan.currency
+    }${chosenAmount} works out as ${
+      props.mainPlan.currency
+    }${weeklyAmount.toFixed(2)} each week`;
+  };
+
   if (showUpdateLoader) {
     return (
       <UpdateAmountLoader
@@ -408,6 +428,16 @@ export const ContributionUpdateAmountForm = (
                 />
               </div>
             )}
+          </div>
+
+          <div
+            css={css`
+              margin-top: ${space[2]}px;
+              color: ${neutral[46]};
+              font-size: 15px;
+            `}
+          >
+            <em>{weeklyBreakDown()}</em>
           </div>
         </div>
       </div>

--- a/app/client/components/accountoverview/manageProduct.tsx
+++ b/app/client/components/accountoverview/manageProduct.tsx
@@ -31,7 +31,7 @@ import { SupportTheGuardianButton } from "../supportTheGuardianButton";
 import { ErrorIcon } from "../svgs/errorIcon";
 import { GiftIcon } from "../svgs/giftIcon";
 import { RouteableStepPropsForGrouped } from "../wizardRouterAdapter";
-import { ContributionUpdateAmountForm } from "./contributionUpdateAmountForm";
+import { ContributionUpdateAmount } from "./contributionUpdateAmount";
 import { NewsletterOptinSection } from "./newsletterOptinSection";
 import { SixForSixExplainerIfApplicable } from "./sixForSixExplainer";
 
@@ -134,7 +134,7 @@ const InnerContent = ({ props, productDetail }: InnerContentProps) => {
       )}
 
       {isAmountOveridable && isPaidSubscriptionPlan(mainPlan) ? (
-        <ContributionUpdateAmountForm
+        <ContributionUpdateAmount
           subscriptionId={productDetail.subscription.subscriptionId}
           mainPlan={mainPlan}
           productType={specificProductType}

--- a/app/package.json
+++ b/app/package.json
@@ -132,6 +132,7 @@
     "@guardian/consent-management-platform": "^3.4.8",
     "@guardian/src-button": "^2.5.0",
     "@guardian/src-checkbox": "^1.8.0",
+    "@guardian/src-choice-card": "^2.5.0",
     "@guardian/src-foundations": "^1.9.1",
     "@guardian/src-icons": "^1.8.0",
     "@guardian/src-inline-error": "^1.9.1",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1463,6 +1463,14 @@
     "@guardian/src-helpers" "^1.8.0"
     "@guardian/src-user-feedback" "^1.8.0"
 
+"@guardian/src-choice-card@^2.5.0":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-choice-card/-/src-choice-card-2.7.1.tgz#680cbf5f28365235bdbffb350901c16545e47786"
+  integrity sha512-suiE51/8LQOSvPSiLA9GrCyqJ/z0sUOToe6Do1Du0LIJt52G5LVwtsGRshdtAieVCSuDvGgrtvDngbz7JXuchw==
+  dependencies:
+    "@guardian/src-helpers" "^2.7.1"
+    "@guardian/src-user-feedback" "^2.7.1"
+
 "@guardian/src-foundations@^1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-1.8.0.tgz#4b2276d849917471c3cc46e25fd952eb35c3e40a"
@@ -1477,6 +1485,11 @@
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-2.5.0.tgz#5c96d17b7a6d5a8b317356cc7866dd3061ce9d88"
   integrity sha512-B8LyzqXcidyAgkBnMWNa1CdC6GHyC/5HP4ueB8mRzw8SffrRPJmRayR9eJRdt3c6LpqVv0oPOfeEfKPH+jDN2Q==
+
+"@guardian/src-foundations@^2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-2.7.1.tgz#d245a5ebedd520bf3be1b10ff7c5a0b5962a0a03"
+  integrity sha512-U0XVJWugB6vXoORZPcfvnISAhwaIM5/Pz5uGj628+OcqF3vwm0dBUt1UTesVqOsG7tVUQvGG/n96wXWjGwmVmQ==
 
 "@guardian/src-helpers@^1.8.0":
   version "1.8.0"
@@ -1499,6 +1512,13 @@
   dependencies:
     "@guardian/src-foundations" "^2.5.0"
 
+"@guardian/src-helpers@^2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-helpers/-/src-helpers-2.7.1.tgz#b16834473f7f89716f7d98c60f3394e4bb6a3305"
+  integrity sha512-HGc+hkBq+ltlCeRrgsJ5a+tpGnvVg8iZgzOxkzeiMTCxbR8c5vtogFx51trgvb5sH5780UoDFh0ACGY1xyMamw==
+  dependencies:
+    "@guardian/src-foundations" "^2.7.1"
+
 "@guardian/src-icons@^1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@guardian/src-icons/-/src-icons-1.8.0.tgz#fdfc1d8164c74f0586198a11c8b64ad1f545c602"
@@ -1508,6 +1528,11 @@
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/@guardian/src-icons/-/src-icons-1.9.1.tgz#86d9dba8085042014e5851db8b2388ff2a25c201"
   integrity sha512-wdLFDoE8qvKxRyb3EjTBvErMxsYpsckrb/2eRtEjqm4dP2nycK51qTyhLS9aJXvILQnlZLKg5yVbxKdYQokEgQ==
+
+"@guardian/src-icons@^2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-icons/-/src-icons-2.7.1.tgz#600ba5a16fd3857657360632caac1b2f38740829"
+  integrity sha512-gQ7XrH3R++kZOXSK4e5ajRrUxNMgzQH7LiQ4HSYH51mJceh3YWtsc4934O5sCpJjJjhFiWGYubbg4BG14smUPg==
 
 "@guardian/src-inline-error@^1.9.1":
   version "1.9.1"
@@ -1545,6 +1570,14 @@
   dependencies:
     "@guardian/src-helpers" "^1.8.0"
     "@guardian/src-icons" "^1.8.0"
+
+"@guardian/src-user-feedback@^2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-user-feedback/-/src-user-feedback-2.7.1.tgz#aa27c9179509267870d60e323c5cb6d04f53adb4"
+  integrity sha512-FLMuAJDEYNwdlypn35aKpzU7BK5NuatdLDGGrO/D+YrJ/o0N8mlGNAYWBMPFoLgcFvh+v1borTUjOhIaNgtkyA==
+  dependencies:
+    "@guardian/src-helpers" "^2.7.1"
+    "@guardian/src-icons" "^2.7.1"
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"


### PR DESCRIPTION
## What does this change?
The main point of this PR was to pull out the contributions amount update form into a separate component so we can use it during the cancellation flow. To do that `ContributionUpdateAmountForm` was renamed to `ContributionUpdateAmount` and the form part of that was pulled out into a new (albeit with an old name!) `ContributionUpdateAmountForm`. 

I also took the oportunity to update the form itself. We've now got 'frequency buttons' (e.g $3 per month) and we're using source for choice cards + text input. We've also got the weekly breakdown (e.g. Contributing £3 works out as £0.69 each week). There were also some small tweaks to padding.

## Images
<img width="431" alt="Screenshot 2020-12-11 at 09 58 46" src="https://user-images.githubusercontent.com/17720442/101889669-96246480-3b97-11eb-81e6-d38818ee86a8.png">
<img width="610" alt="Screenshot 2020-12-11 at 09 59 03" src="https://user-images.githubusercontent.com/17720442/101889676-97559180-3b97-11eb-94cb-7336fecc37fc.png">
<img width="830" alt="Screenshot 2020-12-11 at 09 59 23" src="https://user-images.githubusercontent.com/17720442/101889680-9886be80-3b97-11eb-8eb7-bc09fe065562.png">


