### PR TITLE
[RB] - increase title font size on mobile breakpoints

### DIFF
--- a/app/client/components/helpCentre/helpCentre.tsx
+++ b/app/client/components/helpCentre/helpCentre.tsx
@@ -17,7 +17,7 @@ interface HelpCentreProps extends RouteComponentProps {
 }
 
 const titleStyle = css`
-  ${headline.xxsmall({ fontWeight: "bold" })};
+  ${headline.xsmall({ fontWeight: "bold" })};
   margin: 0;
   border-top: 1px solid ${palette.neutral[86]};
   ${minWidth.desktop} {


### PR DESCRIPTION
## What does this change?
Increase the font size of the `How can we help you?` title in the help centre on mobile breakpoints

## Images
Before             |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/2510683/101890849-2d3dec00-3b99-11eb-8835-5f530494c610.png)  |  ![](https://user-images.githubusercontent.com/2510683/101890893-3dee6200-3b99-11eb-9fca-26a26d04211e.png)

