### PR TITLE
Put GA behind consent

### DIFF
--- a/app/client/components/analytics.tsx
+++ b/app/client/components/analytics.tsx
@@ -1,5 +1,5 @@
 import { Location } from "@reach/router";
-import React, { ReactNode } from "react";
+import React, { useEffect, useState } from "react";
 import parse from "url-parse";
 import { OphanProduct } from "../../shared/ophanTypes";
 import { ProductDetail } from "../../shared/productResponse";
@@ -77,85 +77,102 @@ export const applyAnyOptimiseExperiments = () => {
   }
 };
 
-export class AnalyticsTracker extends React.PureComponent<{}> {
-  public readonly INTCMP?: string;
+export const AnalyticsTracker = () => {
+  const [cmpInitialised, setCmpInitialised] = useState<boolean>(false);
 
-  constructor(props: {}) {
-    super(props);
-    if (typeof window !== "undefined" && window.ga) {
-      const queryParams = parse(window.location.href, true).query;
+  if (typeof window !== "undefined" && window.ga) {
+    const queryParams = parse(window.location.href, true).query;
 
-      this.INTCMP = queryParams.INTCMP;
+    const INTCMP = queryParams.INTCMP;
 
-      if (window.guardian) {
+    if (window.guardian) {
+      // tslint:disable-next-line:no-object-mutation
+      window.guardian.INTCMP = INTCMP;
+
+      const abName = queryParams.abName;
+      const abVariant = queryParams.abVariant;
+
+      if (abName && abVariant) {
         // tslint:disable-next-line:no-object-mutation
-        window.guardian.INTCMP = this.INTCMP;
-
-        const abName = queryParams.abName;
-        const abVariant = queryParams.abVariant;
-
-        if (abName && abVariant) {
-          window.guardian.abTest = {
-            name: abName,
-            variant: abVariant
-          };
-        }
+        window.guardian.abTest = {
+          name: abName,
+          variant: abVariant
+        };
       }
-
-      if (window.dataLayer === undefined) {
-        window.dataLayer = [];
-      }
-
-      window.ga("create", "UA-51507017-5", "auto");
-      window.ga("require", "GTM-M985W29");
-      window.ga("set", "transport", "beacon");
-      if (this.INTCMP) {
-        window.ga("set", "dimension12", this.INTCMP);
-      }
-      window.ga("set", "dimension29", MMA_AB_TEST_DIMENSION_VALUE);
-
-      new MutationObserver(applyAnyOptimiseExperiments).observe(document.body, {
-        attributes: false,
-        characterData: false,
-        childList: true,
-        subtree: true,
-        attributeOldValue: false,
-        characterDataOldValue: false
-      });
     }
+
+    if (window.dataLayer === undefined) {
+      // tslint:disable-next-line:no-object-mutation
+      window.dataLayer = [];
+    }
+
+    window.ga("create", "UA-51507017-5", "auto");
+    window.ga("require", "GTM-M985W29");
+    window.ga("set", "transport", "beacon");
+    if (INTCMP) {
+      window.ga("set", "dimension12", INTCMP);
+    }
+    window.ga("set", "dimension29", MMA_AB_TEST_DIMENSION_VALUE);
+
+    new MutationObserver(applyAnyOptimiseExperiments).observe(document.body, {
+      attributes: false,
+      characterData: false,
+      childList: true,
+      subtree: true,
+      attributeOldValue: false,
+      characterDataOldValue: false
+    });
   }
 
-  public render(): ReactNode {
-    return (
-      <Location>
-        {({ location }) => {
-          if (location && typeof window !== "undefined") {
-            if (
-              window.guardian &&
-              window.guardian.ophan &&
-              window.guardian.ophan.sendInitialEvent
-            ) {
-              if (window.guardian.spaTransition) {
-                window.guardian.ophan.sendInitialEvent(location.href);
-              } else {
-                // tslint:disable-next-line:no-object-mutation
-                window.guardian.spaTransition = true;
-              }
-            }
-            if (window.ga) {
-              window.ga("send", "pageview", {
-                location: location.href,
-                page: location.pathname + location.search,
-                dimension12: this.INTCMP,
-                dimension29: MMA_AB_TEST_DIMENSION_VALUE
-              });
-              // TODO add ophan pageViewId as a GA dimension
-              applyAnyOptimiseExperiments();
+  useEffect(() => {
+    import("@guardian/consent-management-platform").then(
+      ({ onConsentChange, getConsentFor }) => {
+        onConsentChange(consentState => {
+          // Suppressing "Element implicitly has an 'any' type because index expression is not of type 'number'."
+          // @ts-ignore-start
+          // tslint:disable-next-line:no-object-mutation
+          window["ga-disable-UA-51507017-5"] = !getConsentFor(
+            "google-analytics",
+            consentState
+          );
+          // @ts-ignore-end
+
+          setCmpInitialised(true);
+        });
+      }
+    );
+  }, []);
+
+  return cmpInitialised ? (
+    <Location>
+      {({ location }) => {
+        if (location && typeof window !== "undefined") {
+          if (
+            window.guardian &&
+            window.guardian.ophan &&
+            window.guardian.ophan.sendInitialEvent
+          ) {
+            if (window.guardian.spaTransition) {
+              window.guardian.ophan.sendInitialEvent(location.href);
+            } else {
+              // tslint:disable-next-line:no-object-mutation
+              window.guardian.spaTransition = true;
             }
           }
-          return null; // null is a valid React node type, but void is not.
-        }}
-      </Location>
-    );
-  }
-}
+
+          if (window.ga) {
+            window.ga("send", "pageview", {
+              location: location.href,
+              page: location.pathname + location.search,
+              dimension12: window.guardian.INTCMP,
+              dimension29: MMA_AB_TEST_DIMENSION_VALUE
+            });
+            // TODO add ophan pageViewId as a GA dimension
+            applyAnyOptimiseExperiments();
+          }
+        }
+        return null; // null is a valid React node type, but void is not.
+      }}
+    </Location>
+  ) : null;
+};

--- a/app/client/components/analytics.tsx
+++ b/app/client/components/analytics.tsx
@@ -24,6 +24,7 @@ interface Event {
   eventValue?: number;
 }
 
+const GA_UA = "UA-51507017-5";
 const MMA_AB_TEST_DIMENSION_VALUE = ""; // this can be used for a/b testing
 
 export const trackEvent = (
@@ -106,7 +107,7 @@ export const AnalyticsTracker = () => {
       window.dataLayer = [];
     }
 
-    window.ga("create", "UA-51507017-5", "auto");
+    window.ga("create", GA_UA, "auto");
     window.ga("require", "GTM-M985W29");
     window.ga("set", "transport", "beacon");
     if (INTCMP) {
@@ -131,7 +132,7 @@ export const AnalyticsTracker = () => {
           // Suppressing "Element implicitly has an 'any' type because index expression is not of type 'number'."
           // @ts-ignore-start
           // tslint:disable-next-line:no-object-mutation
-          window["ga-disable-UA-51507017-5"] = !getConsentFor(
+          window[`ga-disable-${GA_UA}`] = !getConsentFor(
             "google-analytics",
             consentState
           );

--- a/app/client/components/analytics.tsx
+++ b/app/client/components/analytics.tsx
@@ -79,7 +79,7 @@ export const applyAnyOptimiseExperiments = () => {
 };
 
 export const AnalyticsTracker = () => {
-  const [cmpInitialised, setCmpInitialised] = useState<boolean>(false);
+  const [cmpIsInitialised, setCmpIsInitialised] = useState<boolean>(false);
 
   if (typeof window !== "undefined" && window.ga) {
     const queryParams = parse(window.location.href, true).query;
@@ -138,13 +138,13 @@ export const AnalyticsTracker = () => {
           );
           // @ts-ignore-end
 
-          setCmpInitialised(true);
+          setCmpIsInitialised(true);
         });
       }
     );
   }, []);
 
-  return cmpInitialised ? (
+  return cmpIsInitialised ? (
     <Location>
       {({ location }) => {
         if (location && typeof window !== "undefined") {


### PR DESCRIPTION
## What does this change?
Puts Google Analytics behind consent. It also converts the `AnalyticsTracker` components to use hooks.

Most of the changes in the PR are related to the conversion to hooks. The parts that are specifically about putting GA behind consent are the parts inside the `useEffect` and the `cmpIsInitialised`. The behaviour now will be to wait until the first consent signal is obtained (meaning the CMP is initialised) before starting to track the page views (bit inside the component's return) and that's what the `cmpIsInitialised` state variable is used for. The way we suppress tracking events when consent is not present is by using the opt out mechanism described in [GA's documentation](https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out) on line 135.

Tested locally and on CODE from IPs in GB, US and AUS.

## How to test
Give or deny consent with the appropriate privacy manager ('privacy settings link at the bottom of the page'). Check the browser's network tab. When consent is denied there should no longer be any calls to the `https://www.google-analytics.com/j/collect` endpoint.

## Notes
As part of this task a bug with `@guardian/consent-management-platform` was discovered where, if a user is shown the TCFv2 banner on page load,  the `onConsentChange` callbacks are only called after a user interacts with the banner. This bug was reported in detail to comm-dev in guardian/consent-management-platform#382 who have very quickly addressed it with guardian/consent-management-platform#383. However the fix was yet live at the time for this PR. This means that until a fix is released and our version updated, GA and Ophan to be initialised only after the user has interacted with the banner, on pages where a TCFv2 banner is shown on page load. This is considerable an acceptable impact given that the fix is on its way and no tracking events happen before the user interacts with this banner, as it prevents interaction with the page until dismissed.