### PR TITLE
[RB] - remove the xmas and new years opening hours

### DIFF
--- a/app/client/__tests__/__snapshots__/main.tsx.snap
+++ b/app/client/__tests__/__snapshots__/main.tsx.snap
@@ -1414,7 +1414,7 @@ exports[`Main renders something 1`] = `
               }
             >
               © 
-              2020
+              2021
                Guardian News and Media Limited or its affiliated companies. All rights reserved.
             </div>
           </div>

--- a/app/client/components/callCenterEmailAndNumbers.tsx
+++ b/app/client/components/callCenterEmailAndNumbers.tsx
@@ -34,8 +34,6 @@ const PHONE_DATA: PhoneRegion[] = [
     key: "UK & ROW",
     title: "United Kingdom, Europe and rest of world",
     openingHours: "9am - 6pm Monday - Sunday (GMT/BST)",
-    additionalOpeningHoursInfo:
-      "Closed Christmas Day, Boxing Day and New Years Day",
     phoneNumbers: [
       {
         phoneNumber: "+44 (0) 330 333 6790"
@@ -46,7 +44,6 @@ const PHONE_DATA: PhoneRegion[] = [
     key: "AUS",
     title: "Australia, New Zealand, and Asia Pacific",
     openingHours: "9am - 5pm Monday - Friday (AEDT)",
-    additionalOpeningHoursInfo: "Closed Christmas Day",
     phoneNumbers: [
       {
         phoneNumber: "1800 773 766",
@@ -62,7 +59,6 @@ const PHONE_DATA: PhoneRegion[] = [
     key: "US",
     title: "Canada and USA",
     openingHours: "9am - 5pm on weekdays (EST/EDT)",
-    additionalOpeningHoursInfo: "Closed Christmas Eve and Christmas Day",
     phoneNumbers: [
       {
         phoneNumber: "1-844-632-2010",


### PR DESCRIPTION
## What does this change?
Remove the xmas and new years opening hours from the contact phone numbers and email component

## Images
![xmascancelled](https://user-images.githubusercontent.com/2510683/103532605-78d77300-4e83-11eb-9835-20a53f696916.png)

