### PR TITLE
Add reminder sign up at end of contribution cancellation flow

### DIFF
--- a/app/client/components/cancel/cancellationContributionReminder.tsx
+++ b/app/client/components/cancel/cancellationContributionReminder.tsx
@@ -1,0 +1,157 @@
+import { css } from "@emotion/core";
+import { Button } from "@guardian/src-button";
+import { space } from "@guardian/src-foundations";
+import { SvgArrowRightStraight } from "@guardian/src-icons";
+import { Radio, RadioGroup } from "@guardian/src-radio";
+import React, { useState } from "react";
+import { trackEventInOphanOnly } from "../analytics";
+
+const containerStyles = css`
+  padding-bottom: ${space[24]}px;
+`;
+
+const setReminderContainerStyles = css`
+  & > * + * {
+    margin-top: ${space[9]}px;
+  }
+`;
+
+const formContainerStyles = css`
+  & > * + * {
+    margin-top: ${space[6]}px;
+  }
+`;
+
+interface ReminderSignup {
+  reminderPeriod: string;
+  reminderOption: string;
+}
+
+interface ReminderChoice {
+  signup: ReminderSignup;
+  label: string;
+  thankYouMessage: string;
+}
+
+const REMINDER_ENDPOINT = "/api/reminder";
+const REMINDER_PLATFORM = "MMA";
+const REMINDER_STAGE = "WINBACK";
+const REMINDER_COMPONENT = "CANCELLATION";
+
+const getReminderPeriod = (date: Date) => {
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1; // javascript dates run from 0-11, we want 1-12
+  const paddedMonth = month.toString().padStart(2, "0");
+
+  return `${year}-${paddedMonth}-01`;
+};
+
+const getReminderOption = (monthsUntilDate: number) =>
+  `${monthsUntilDate}-months`;
+
+const getDefaultLabel = (date: Date, monthsUntilDate: number, now: Date) => {
+  const month = date.toLocaleDateString("default", { month: "long" });
+  const year =
+    now.getFullYear() === date.getFullYear() ? "" : ` ${date.getFullYear()}`;
+
+  return `in ${monthsUntilDate} months (${month}${year})`;
+};
+
+const getDefaultThankYouMessage = (date: Date) =>
+  date.toLocaleDateString("default", {
+    month: "long"
+  });
+
+const getDefaultReminderChoice = (monthsUntilDate: number): ReminderChoice => {
+  const now = new Date();
+  const date = new Date(now.getFullYear(), now.getMonth() + monthsUntilDate);
+
+  return {
+    label: getDefaultLabel(date, monthsUntilDate, now),
+    thankYouMessage: getDefaultThankYouMessage(date),
+    signup: {
+      reminderPeriod: getReminderPeriod(date),
+      reminderOption: getReminderOption(monthsUntilDate)
+    }
+  };
+};
+
+const getDefaultReminderChoices = (): ReminderChoice[] => [
+  getDefaultReminderChoice(3),
+  getDefaultReminderChoice(6),
+  getDefaultReminderChoice(9)
+];
+
+export const CancellationContributionReminder: React.FC = () => {
+  const [selectedChoiceIndex, setSelectedChoiceIndex] = useState(0);
+  const [hasSetReminder, setHasSetReminder] = useState(false);
+
+  const email = window.guardian.identityDetails.email;
+  const reminderChoices = getDefaultReminderChoices();
+  const selectedChoice = reminderChoices[selectedChoiceIndex];
+
+  const setReminder = () =>
+    fetch(REMINDER_ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email,
+        reminderPlatform: REMINDER_PLATFORM,
+        reminderComponent: REMINDER_COMPONENT,
+        reminderStage: REMINDER_STAGE,
+        ...selectedChoice.signup
+      })
+    });
+
+  const onSubmit = () => {
+    trackEventInOphanOnly({
+      eventCategory: "cancellation_flow",
+      eventAction: "click",
+      eventLabel: `set_reminder__${selectedChoice.signup.reminderOption}`
+    });
+
+    setReminder();
+    setHasSetReminder(true);
+  };
+
+  return (
+    <div css={containerStyles}>
+      {hasSetReminder ? (
+        <p>
+          Thank you for setting up support reminder. We will be in touch in{" "}
+          {selectedChoice.thankYouMessage}, so look out for a message from the
+          Guardian in your inbox.
+        </p>
+      ) : (
+        <div css={setReminderContainerStyles}>
+          <p>
+            We can invite you to support our journalism again at a later date,
+            when it might suit you better. This will be no more than two emails,
+            with no obligation to give.
+          </p>
+
+          <div css={formContainerStyles}>
+            <RadioGroup name="reminder" label="I'd like to be reminded in:">
+              {reminderChoices.map((choice, index) => (
+                <Radio
+                  value={`${index}`}
+                  label={choice.label}
+                  checked={selectedChoiceIndex === index}
+                  onChange={() => setSelectedChoiceIndex(index)}
+                />
+              ))}
+            </RadioGroup>
+
+            <Button
+              onClick={onSubmit}
+              icon={<SvgArrowRightStraight />}
+              iconSide="right"
+            >
+              Set my reminder
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/app/client/components/cancel/cancellationSummary.tsx
+++ b/app/client/components/cancel/cancellationSummary.tsx
@@ -12,6 +12,7 @@ import { SupportTheGuardianButton } from "../supportTheGuardianButton";
 import { WithStandardTopMargin } from "../WithStandardTopMargin";
 import { hrefStyle } from "./cancellationConstants";
 import { CancellationReasonContext } from "./cancellationContexts";
+import { CancellationContributionReminder } from "./cancellationContributionReminder";
 
 const actuallyCancelled = (
   productType: ProductType,
@@ -19,120 +20,130 @@ const actuallyCancelled = (
 ) => {
   const deliveryRecordsLink: string = `/delivery/${productType.urlPart}/records`;
   const subscription = productDetail.subscription;
+
   return (
     <>
       <WithStandardTopMargin>
         <h3>Your {productType.friendlyName} is cancelled.</h3>
-        {productType.cancellation && (
-          <p>
-            {productType.cancellation?.alternateSummaryMainPara ||
-              (subscription.end ? (
-                <>
-                  You will continue to receive the benefits of your{" "}
-                  {productType.friendlyName} until{" "}
-                  <b>
-                    {cancellationFormatDate(
-                      subscription.cancellationEffectiveDate
-                    )}
-                  </b>
-                  . You will not be charged again. If you think you’re owed a
-                  refund, please contact us at{" "}
-                  <a
-                    css={hrefStyle}
-                    href="mailto:customer.help@theguardian.com"
-                  >
-                    customer.help@theguardian.com
-                  </a>
-                  .
-                </>
-              ) : (
-                "Your cancellation is effective immediately."
-              ))}
-          </p>
-        )}
-      </WithStandardTopMargin>
-      <ResubscribeThrasher
-        usageContext={`${productType.urlPart}_cancellation_summary`}
-      >
-        <WithStandardTopMargin>
-          {hasDeliveryRecordsFlow(productType) && (
+        {productType.cancellation &&
+          !productType.cancellation.shouldHideSummaryMainPara && (
             <p>
-              You can still{" "}
-              <Link
-                css={css`
-                  color: ${brand[500]};
-                  text-decoration: underline;
-                  :visited {
-                    color: ${brand[500]};
-                  }
-                `}
-                to={deliveryRecordsLink}
-                state={productDetail}
-              >
-                view your previous deliveries
-              </Link>{" "}
-              and{" "}
-              <Link
-                css={css`
-                  color: ${brand[500]};
-                  text-decoration: underline;
-                  :visited {
-                    color: ${brand[500]};
-                  }
-                `}
-                to={deliveryRecordsLink}
-                state={productDetail}
-              >
-                report a delivery problem
-              </Link>
-              .
+              {productType.cancellation?.alternateSummaryMainPara ||
+                (subscription.end ? (
+                  <>
+                    You will continue to receive the benefits of your{" "}
+                    {productType.friendlyName} until{" "}
+                    <b>
+                      {cancellationFormatDate(
+                        subscription.cancellationEffectiveDate
+                      )}
+                    </b>
+                    . You will not be charged again. If you think you’re owed a
+                    refund, please contact us at{" "}
+                    <a
+                      css={hrefStyle}
+                      href="mailto:customer.help@theguardian.com"
+                    >
+                      customer.help@theguardian.com
+                    </a>
+                    .
+                  </>
+                ) : (
+                  "Your cancellation is effective immediately."
+                ))}
             </p>
           )}
-          <CancellationReasonContext.Consumer>
-            {reason =>
-              (!productType.cancellation ||
-                !productType.cancellation
-                  .onlyShowSupportSectionIfAlternateText ||
-                productType.cancellation.summaryReasonSpecificPara(reason)) && (
-                <>
-                  <p>
-                    {productType.cancellation &&
-                    productType.cancellation.summaryReasonSpecificPara &&
-                    productType.cancellation.summaryReasonSpecificPara(reason)
-                      ? productType.cancellation.summaryReasonSpecificPara(
-                          reason
-                        )
-                      : "If you are interested in supporting our journalism in other ways, " +
-                        "please consider either a contribution or a subscription."}
-                  </p>
-                  <div css={{ marginBottom: "30px" }}>
-                    <SupportTheGuardianButton
-                      urlSuffix={
-                        productType.cancellation &&
-                        productType.cancellation
-                          .alternateSupportButtonUrlSuffix &&
-                        productType.cancellation.alternateSupportButtonUrlSuffix(
-                          reason
-                        )
-                      }
-                      alternateButtonText={
-                        productType.cancellation &&
-                        productType.cancellation.alternateSupportButtonText &&
-                        productType.cancellation.alternateSupportButtonText(
-                          reason
-                        )
-                      }
-                      supportReferer={
-                        productType.urlPart + "_cancellation_summary"
-                      }
-                    />
-                  </div>
-                </>
-              )
-            }
-          </CancellationReasonContext.Consumer>
-        </WithStandardTopMargin>
-      </ResubscribeThrasher>
+      </WithStandardTopMargin>
+      {productType.cancellation?.shouldShowReminder && (
+        <CancellationContributionReminder />
+      )}
+
+      {!productType.cancellation?.shouldHideThrasher && (
+        <ResubscribeThrasher
+          usageContext={`${productType.urlPart}_cancellation_summary`}
+        >
+          <WithStandardTopMargin>
+            {hasDeliveryRecordsFlow(productType) && (
+              <p>
+                You can still{" "}
+                <Link
+                  css={css`
+                    color: ${brand[500]};
+                    text-decoration: underline;
+                    :visited {
+                      color: ${brand[500]};
+                    }
+                  `}
+                  to={deliveryRecordsLink}
+                  state={productDetail}
+                >
+                  view your previous deliveries
+                </Link>{" "}
+                and{" "}
+                <Link
+                  css={css`
+                    color: ${brand[500]};
+                    text-decoration: underline;
+                    :visited {
+                      color: ${brand[500]};
+                    }
+                  `}
+                  to={deliveryRecordsLink}
+                  state={productDetail}
+                >
+                  report a delivery problem
+                </Link>
+                .
+              </p>
+            )}
+            <CancellationReasonContext.Consumer>
+              {reason =>
+                (!productType.cancellation ||
+                  !productType.cancellation
+                    .onlyShowSupportSectionIfAlternateText ||
+                  productType.cancellation.summaryReasonSpecificPara(
+                    reason
+                  )) && (
+                  <>
+                    <p>
+                      {productType.cancellation &&
+                      productType.cancellation.summaryReasonSpecificPara &&
+                      productType.cancellation.summaryReasonSpecificPara(reason)
+                        ? productType.cancellation.summaryReasonSpecificPara(
+                            reason
+                          )
+                        : "If you are interested in supporting our journalism in other ways, " +
+                          "please consider either a contribution or a subscription."}
+                    </p>
+                    <div css={{ marginBottom: "30px" }}>
+                      <SupportTheGuardianButton
+                        urlSuffix={
+                          productType.cancellation &&
+                          productType.cancellation
+                            .alternateSupportButtonUrlSuffix &&
+                          productType.cancellation.alternateSupportButtonUrlSuffix(
+                            reason
+                          )
+                        }
+                        alternateButtonText={
+                          productType.cancellation &&
+                          productType.cancellation.alternateSupportButtonText &&
+                          productType.cancellation.alternateSupportButtonText(
+                            reason
+                          )
+                        }
+                        supportReferer={
+                          productType.urlPart + "_cancellation_summary"
+                        }
+                      />
+                    </div>
+                  </>
+                )
+              }
+            </CancellationReasonContext.Consumer>
+          </WithStandardTopMargin>
+        </ResubscribeThrasher>
+      )}
     </>
   );
 };

--- a/app/package.json
+++ b/app/package.json
@@ -137,7 +137,7 @@
     "@guardian/src-foundations": "^1.9.1",
     "@guardian/src-icons": "^1.8.0",
     "@guardian/src-inline-error": "^1.9.1",
-    "@guardian/src-radio": "^1.8.0",
+    "@guardian/src-radio": "^2.5.0",
     "@guardian/src-svgs": "^1.8.0",
     "@guardian/src-text-input": "^1.8.0",
     "@reach/router": "^1.3.4",

--- a/app/server/reminderApi.ts
+++ b/app/server/reminderApi.ts
@@ -1,0 +1,27 @@
+import { captureMessage } from "@sentry/node";
+import { Request, Response } from "express";
+import fetch from "node-fetch";
+import { conf } from "./config";
+
+export const reminderHandler = (req: Request, res: Response) =>
+  setReminder(req.body).then(response => {
+    if (!response.ok) {
+      captureMessage("Reminder sign up failed at the point of request");
+    }
+    res.sendStatus(response.status);
+  });
+
+const isProd = conf.STAGE === "PROD";
+
+const reminderEndpoint = isProd
+  ? "https://support.theguardian.com/reminders/create/one-off"
+  : "https://support.code.dev-theguardian.com/reminders/create/one-off";
+
+const setReminder = (body: any) =>
+  fetch(reminderEndpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body
+  });

--- a/app/server/routes/api.ts
+++ b/app/server/routes/api.ts
@@ -23,6 +23,7 @@ import { contactUsFormHandler } from "../contactUsApi";
 import { augmentProductDetailWithDeliveryAddressChangeEffectiveDateForToday } from "../fulfilmentDateCalculatorReader";
 import { log } from "../log";
 import { withIdentity } from "../middleware/identityMiddleware";
+import { reminderHandler } from "../reminderApi";
 import { stripeSetupIntentHandler } from "../stripeSetupIntentsHandler";
 
 const router = Router();
@@ -225,5 +226,7 @@ router.get("/known-issues", async (_, response) => {
 });
 
 router.post("/contact-us", contactUsFormHandler);
+
+router.post("/reminder", reminderHandler);
 
 export default router;

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -78,6 +78,7 @@ interface CancellationFlowProperties {
   startPageOfferEffectiveDateOptions?: true;
   hideReasonTitlePrefix?: true;
   alternateSummaryMainPara?: string;
+  shouldHideSummaryMainPara?: true;
   summaryReasonSpecificPara: (
     reasonId: OptionalCancellationReasonId
   ) => string | undefined;
@@ -89,6 +90,8 @@ interface CancellationFlowProperties {
     reasonId: OptionalCancellationReasonId
   ) => string | undefined;
   swapFeedbackAndContactUs?: true;
+  shouldShowReminder?: true;
+  shouldHideThrasher?: true;
 }
 
 export interface HolidayStopFlowProperties {
@@ -282,7 +285,7 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
       reasons: contributionsCancellationReasons,
       sfCaseProduct: "Recurring - Contributions",
       startPageBody: contributionsCancellationFlowStart,
-      alternateSummaryMainPara: "Thank you for your valuable support.",
+      shouldHideSummaryMainPara: true,
       summaryReasonSpecificPara: (reasonId: OptionalCancellationReasonId) => {
         switch (reasonId) {
           case "mma_financial_circumstances":
@@ -313,7 +316,9 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
         }
       },
       alternateSupportButtonUrlSuffix: () => "/contribute", // TODO tweak the support url to preselect single/monthly/annual once functionality is available
-      swapFeedbackAndContactUs: true
+      swapFeedbackAndContactUs: true,
+      shouldHideThrasher: true,
+      shouldShowReminder: true
     }
   },
   // FIXME: DEPRECATED: once Braze templates have been updated to use voucher/homedelivery, then replace with redirect to /subscriptions for anything with 'paper' in the URL

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1492,6 +1492,11 @@
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-2.7.1.tgz#d245a5ebedd520bf3be1b10ff7c5a0b5962a0a03"
   integrity sha512-U0XVJWugB6vXoORZPcfvnISAhwaIM5/Pz5uGj628+OcqF3vwm0dBUt1UTesVqOsG7tVUQvGG/n96wXWjGwmVmQ==
 
+"@guardian/src-foundations@^2.8.1":
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-2.8.1.tgz#f684927187006e80988cc617fa110cf2b2d2a962"
+  integrity sha512-CFpmL8ZGYfBp0YdFR9MaZRL+PfbbZFTwV2k4r/0+9KXh4U/mhmQWjJ/75GvtuLc5K2HQK42kf0SMnqRnHL/s1A==
+
 "@guardian/src-helpers@^1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@guardian/src-helpers/-/src-helpers-1.8.0.tgz#8c4ad4689cf1725e758aec66da1fc2252f3127a3"
@@ -1520,6 +1525,13 @@
   dependencies:
     "@guardian/src-foundations" "^2.7.1"
 
+"@guardian/src-helpers@^2.8.1":
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-helpers/-/src-helpers-2.8.1.tgz#5ec0708c9ca027917b39cdef74da4e9f97f5313a"
+  integrity sha512-OHUbYfXu3NQBlxHMjPFQyKATDz9ZX1VDJDL5sJTjUqtoE7xeBmKevU3RG19lqv+Y4xtiN5HDw4h5dWf35fy3SA==
+  dependencies:
+    "@guardian/src-foundations" "^2.8.1"
+
 "@guardian/src-icons@^1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@guardian/src-icons/-/src-icons-1.8.0.tgz#fdfc1d8164c74f0586198a11c8b64ad1f545c602"
@@ -1535,6 +1547,11 @@
   resolved "https://registry.yarnpkg.com/@guardian/src-icons/-/src-icons-2.7.1.tgz#600ba5a16fd3857657360632caac1b2f38740829"
   integrity sha512-gQ7XrH3R++kZOXSK4e5ajRrUxNMgzQH7LiQ4HSYH51mJceh3YWtsc4934O5sCpJjJjhFiWGYubbg4BG14smUPg==
 
+"@guardian/src-icons@^2.8.1":
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-icons/-/src-icons-2.8.1.tgz#e9e0e5a44f6f2b01f54fc80a76f3afd6d68a1a49"
+  integrity sha512-vpVoU6YFF2jnYG6+95spyNGVK+gzTwr9SBU9/7jrBBNuzRaDMVGDBV8QgqNojcfTSiMVXYtfChYahyDGWFtAAQ==
+
 "@guardian/src-inline-error@^1.9.1":
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/@guardian/src-inline-error/-/src-inline-error-1.9.1.tgz#2be05aec7371f97122689f44cfb47df501330056"
@@ -1543,13 +1560,21 @@
     "@guardian/src-helpers" "^1.9.1"
     "@guardian/src-icons" "^1.9.1"
 
-"@guardian/src-radio@^1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-radio/-/src-radio-1.8.0.tgz#20255a824949cf516106b73638ae48a4e0b30f60"
-  integrity sha512-dnMOSEcOpXsTv1zB7OddBeLxh+RbgCKt07liM2b6528q2m8mCdT9HwtlHV6gxgQ3i/2jzvNagDrLfg2yQMwczg==
+"@guardian/src-label@^2.8.1":
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-label/-/src-label-2.8.1.tgz#afd689ab6abfb48c9072b83054f61683b710ef38"
+  integrity sha512-9vNAuWNq4rl1Im32TS5bW7tbAcOxWv7P5lJoPKXVtQWTosp+DyIhlBmn9Fkx/2EkUF0FlUOkIn3N2DlpwU10Kg==
   dependencies:
-    "@guardian/src-helpers" "^1.8.0"
-    "@guardian/src-user-feedback" "^1.8.0"
+    "@guardian/src-helpers" "^2.8.1"
+
+"@guardian/src-radio@^2.5.0":
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-radio/-/src-radio-2.8.1.tgz#a57a5baa2e0efbfe2c9b9215a7a72fa79092a9d9"
+  integrity sha512-61yqGw80jyQ+Ei614kWmCzZOwU+KY5sDsAtAxCS584EBCvYA6rY+xf9a1aC4rYlT3bwBmrFECqNh5n8u0P/BYQ==
+  dependencies:
+    "@guardian/src-helpers" "^2.8.1"
+    "@guardian/src-label" "^2.8.1"
+    "@guardian/src-user-feedback" "^2.8.1"
 
 "@guardian/src-svgs@^1.8.0":
   version "1.8.0"
@@ -1579,6 +1604,14 @@
   dependencies:
     "@guardian/src-helpers" "^2.7.1"
     "@guardian/src-icons" "^2.7.1"
+
+"@guardian/src-user-feedback@^2.8.1":
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-user-feedback/-/src-user-feedback-2.8.1.tgz#80f7413f64d93c3767cf4417696f2c6c22889001"
+  integrity sha512-uXJa6z1fqN82Xgo1yyIk2Lrel5Hy/QilEHnGyPHnS4ZTy3wnM22ZhmFtntbM91hiyhdbfTBa3HVYVb44RdDDRw==
+  dependencies:
+    "@guardian/src-helpers" "^2.8.1"
+    "@guardian/src-icons" "^2.8.1"
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"


### PR DESCRIPTION
## What does this change?
Update the cancellation confirmed screen for recurring contributions to give users the option to sign up for a reminder in the future. 

## Images
<img width="870" alt="Screenshot 2021-02-15 at 14 06 54" src="https://user-images.githubusercontent.com/17720442/107956719-79414e80-6f97-11eb-925f-1d2e058f8b5b.png">

<img width="870" alt="Screenshot 2021-02-15 at 14 06 59" src="https://user-images.githubusercontent.com/17720442/107956727-7c3c3f00-6f97-11eb-8614-a0b73f44b2a9.png">

