### PR TITLE
Add API Gateway key resolution to healthcheck

### DIFF
--- a/app/server/apiGatewayDiscovery.ts
+++ b/app/server/apiGatewayDiscovery.ts
@@ -231,7 +231,7 @@ export const memoisedApiGatewayAuthForHealthcheck = () => {
   ) => {
     const { host, apiKey } = await memoisedHostKeyPair;
     const errMsg = `Failed to fetch authentication credentials for API Gateway service layer. Healthcheck failed!`;
-    if (!apiKey && host) {
+    if (apiKey && host) {
       next();
     } else {
       log.error(errMsg);

--- a/app/server/routes/core.ts
+++ b/app/server/routes/core.ts
@@ -1,4 +1,5 @@
-import { Response, Router } from "express";
+import { Request, Response, Router } from "express";
+import { memoisedApiGatewayAuthForHealthcheck } from "../apiGatewayDiscovery";
 import { withIdentity } from "../middleware/identityMiddleware";
 
 const router = Router();
@@ -6,7 +7,8 @@ const router = Router();
 router.get(
   "/_healthcheck",
   withIdentity(200), // healthcheck needs identity redirect service to be accessible (returns 200 if redirect required)
-  (_, res: Response) => {
+  memoisedApiGatewayAuthForHealthcheck(),
+  (_: Request, res: Response) => {
     res.send("OK - signed in");
   }
 );


### PR DESCRIPTION
## What does this change?

* https://trello.com/c/lNk6s2s8/1766-hook-up-authentication-to-healthcheck-in-manage-frontend
* Occasionally, although with seemingly increasing frequency, upon deployment we fail to fetch API Gateway credentials due to AWS rate limiting which results in inability to talk to any of the APIs in the "service layer"

    ```
    {"message":"ERROR loading host and api key for ...Rate exceeded","code":"Throttling", ...}
    ```
* This PR tries to hook up credentials resolution to the healthcheck such that instances do not spin up in the first place. Previously despite failure to load api keys it would still deploy the boxes which would result in users likely facing errors in MMA.

## How to test

My flow is usually

1. Fresh janus
1. sudo nginx
2. start-api.sh members-data-api
2. cd app
3. yarn watch
4. failure injection by direct code mutation

## How can we measure success?

If the rate limit problem is hit, hopefully deployment fails, which should prompt the developer to redeploy, which should likely work, as hitting this haphazardous transient issue twice in relatively quick succession should be rather unlikely.

## Have we considered potential risks?

Without memoisation the AWS periodic healthcheck mechanism would fetch the key each time so the call is memoised such that it happens only once on deployment.

