### PR TITLE
[RB] - re-escalate existing newspaper delivery problems

### DIFF
--- a/app/client/components/delivery/records/deliveryRecords.tsx
+++ b/app/client/components/delivery/records/deliveryRecords.tsx
@@ -247,11 +247,9 @@ export const DeliveryRecordsFC = (props: DeliveryRecordsFCProps) => {
     currentPageEndIndex: number
   ) => index >= currentPageStartIndex && index <= currentPageEndIndex;
 
-  // const hasExistingDeliveryProblem = checkForExistingDeliveryProblem(
-  //   props.data.results
-  // );
-
-  const hasExistingDeliveryProblem = false; // TODO re-instate commented code when call-centre has capacity to investigate
+  const hasExistingDeliveryProblem = checkForExistingDeliveryProblem(
+    props.data.results
+  );
 
   const filteredData = filterData();
 


### PR DESCRIPTION
## What does this change?
Over the Christmas period we allowed users to go through the delivery reporting journey without escalation to csr's.

This pr revert that change so that existing delivery problems get escalated as before.
