### PR TITLE
Remove react server rendering

### DIFF
--- a/app/client/components/main.tsx
+++ b/app/client/components/main.tsx
@@ -4,11 +4,7 @@ import { serif } from "../styles/fonts";
 import { Footer } from "./footer/footer";
 import Header from "./header";
 
-export interface WithOptionalServerPathWithQueryParams {
-  serverPathWithQueryParams?: string;
-}
-
-interface MainProps extends WithOptionalServerPathWithQueryParams {
+interface MainProps {
   children: any;
 }
 

--- a/app/client/components/user.tsx
+++ b/app/client/components/user.tsx
@@ -1,5 +1,5 @@
 import { css, Global } from "@emotion/core";
-import { Redirect, Router, ServerLocation } from "@reach/router";
+import { Redirect, Router } from "@reach/router";
 import React from "react";
 import {
   GROUPED_PRODUCT_TYPES,
@@ -41,14 +41,14 @@ import { HolidaysOverview } from "./holiday/holidaysOverview";
 import { EmailAndMarketing } from "./identity/EmailAndMarketing";
 import { PublicProfile } from "./identity/PublicProfile";
 import { Settings } from "./identity/Settings";
-import { Main, WithOptionalServerPathWithQueryParams } from "./main";
+import { Main } from "./main";
 import { ConfirmPaymentUpdate } from "./payment/update/confirmPaymentUpdate";
 import { PaymentUpdated } from "./payment/update/paymentUpdated";
 import { PaymentUpdateFlow } from "./payment/update/updatePaymentFlow";
 import { ScrollToTop } from "./scrollToTop";
 
-const User = (props: WithOptionalServerPathWithQueryParams) => (
-  <Main {...props}>
+const User = () => (
+  <Main>
     <Global styles={css(`${global}`)} />
     <Global styles={css(`${fonts}`)} />
 
@@ -191,12 +191,6 @@ const User = (props: WithOptionalServerPathWithQueryParams) => (
       <Redirect default from="/*" to="/" noThrow />
     </Router>
   </Main>
-);
-
-export const ServerUser = (serverPathWithQueryParams: string) => (
-  <ServerLocation url={serverPathWithQueryParams}>
-    <User serverPathWithQueryParams={serverPathWithQueryParams} />
-  </ServerLocation>
 );
 
 export const BrowserUser = (

--- a/app/client/user.ts
+++ b/app/client/user.ts
@@ -15,4 +15,4 @@ if (typeof window !== "undefined" && window.guardian && window.guardian.dsn) {
 }
 
 const element = document.getElementById("app");
-ReactDOM.hydrate(BrowserUser, element);
+ReactDOM.render(BrowserUser, element);

--- a/app/server/html.ts
+++ b/app/server/html.ts
@@ -16,14 +16,11 @@ const insertGlobals = (globals: Globals) => {
   </script>`;
 };
 
-const html: (
-  _: {
-    readonly body: string;
-    readonly title: string;
-    readonly src: string;
-    readonly globals: Globals;
-  }
-) => string = ({ body, title, src, globals }) => `
+const html: (_: {
+  readonly title: string;
+  readonly src: string;
+  readonly globals: Globals;
+}) => string = ({ title, src, globals }) => `
   <!DOCTYPE html>
   <html>
     <head>
@@ -34,7 +31,7 @@ const html: (
       <link rel="shortcut icon" type="image/png" href="https://assets.guim.co.uk/images/favicons/46bd2faa1ab438684a6d4528a655a8bd/32x32.ico" />
     </head>
     <body style="margin:0">
-      <div id="app">${body}</div>
+      <div id="app"></div>
       </body>
       <script>
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/app/server/routes/frontend.ts
+++ b/app/server/routes/frontend.ts
@@ -1,7 +1,5 @@
 import * as Sentry from "@sentry/node";
 import { Request, Response, Router } from "express";
-import { renderToString } from "react-dom/server";
-import { ServerUser } from "../../client/components/user";
 import { conf, Environments } from "../config";
 import html from "../html";
 import { log } from "../log";
@@ -37,18 +35,12 @@ const getRecaptchaPublicKey = async () => {
   }
 };
 
-router.use(withIdentity(), async (req: Request, res: Response) => {
-  /**
-   * renderToString() will take our React app and turn it into a string
-   * to be inserted into our Html template function.
-   */
-  const body = renderToString(ServerUser(req.url));
+router.use(withIdentity(), async (_: Request, res: Response) => {
   const title = "My Account | The Guardian";
   const src = "/static/user.js";
 
   res.send(
     html({
-      body,
       title,
       src,
       globals: {


### PR DESCRIPTION
## What does this change?
This PR removes the React server-side rendering. It still server-side renders the HTML that React renders now so it's easier to introduce the extra information we want on it (such as global variables, scripts, etc.)

## Why are we doing this?
We are working on code splitting the codebase as a way to alleviate the large bundle size it currently has. Code splitting becomes quite complex if you couple it with server-side rendering. However manage-frontend does not get have much need of server-side rendering at this point, so we are trialing removing it to more easily introduce code splitting.

## Have we considered potential risks?
Removing the server-side rendering from the project aggravates the problem of having a large bundle size, as it takes longer for users to see content. For that reason **this PR is not to be merged until the code splitting PR is ready** and we are confident that our approach adequately addresses all the performance concerns. In the meantime this PR will remain open to gather feedback.