### PR TITLE
Update "A payment issue" cancellation flow

### DIFF
--- a/app/client/components/cancel/contributions/contributionsCancellationFeedbackForm.tsx
+++ b/app/client/components/cancel/contributions/contributionsCancellationFeedbackForm.tsx
@@ -1,0 +1,82 @@
+import { css } from "@emotion/core";
+import { Button } from "@guardian/src-button";
+import React, { useState } from "react";
+import { CaseUpdateAsyncLoader, getUpdateCasePromise } from "../caseUpdate";
+import ContributionsCancellationFeedbackFormThankYou from "./contributionsCancellationFeedbackFormThankYou";
+
+const textAreaStyles = css`
+  width: 100%;
+  font-size: inherit;
+  font-family: inherit;
+  border: 1px solid black;
+`;
+
+const buttonContainerStyles = css`
+  margin-top: 18px;
+`;
+
+interface ContributionsFeedbackFormProps {
+  isTestUser: boolean;
+  caseId: string;
+}
+
+type Status = "EDITING" | "SUBMITTED";
+
+const CHARACTER_LIMIT = 2_500;
+const NUM_ROWS = 8;
+
+const getPatchUpdateCaseFunc = (
+  isTestUser: boolean,
+  caseId: string,
+  feedback: string
+) => async () =>
+  await getUpdateCasePromise(isTestUser, "_FEEDBACK", caseId, {
+    Description: feedback,
+    Subject: "Online Cancellation Query"
+  });
+
+const ContributionsFeedbackForm: React.FC<ContributionsFeedbackFormProps> = ({
+  isTestUser,
+  caseId
+}: ContributionsFeedbackFormProps) => {
+  const [feedback, setFeedback] = useState("");
+  const [status, setStatus] = useState<Status>("EDITING");
+
+  const updateFeedback = (event: React.ChangeEvent<HTMLTextAreaElement>) =>
+    setFeedback(event.target.value);
+
+  const submit = () => {
+    setStatus("SUBMITTED");
+  };
+
+  return status === "SUBMITTED" ? (
+    <div>
+      <CaseUpdateAsyncLoader
+        loadingMessage="Storing your feedback..."
+        fetch={getPatchUpdateCaseFunc(isTestUser, caseId, feedback)}
+        render={() => <ContributionsCancellationFeedbackFormThankYou />}
+      />
+    </div>
+  ) : (
+    <div>
+      <p>
+        Please share any further thoughts you have about cancelling – you can
+        help us improve. Thank you.
+      </p>
+      <textarea
+        css={textAreaStyles}
+        maxLength={CHARACTER_LIMIT}
+        rows={NUM_ROWS}
+        value={feedback}
+        onChange={updateFeedback}
+      />
+      <div css={buttonContainerStyles}>
+        <Button priority="secondary" onClick={submit}>
+          Submit the form
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default ContributionsFeedbackForm;

--- a/app/client/components/cancel/contributions/contributionsCancellationFeedbackFormThankYou.tsx
+++ b/app/client/components/cancel/contributions/contributionsCancellationFeedbackFormThankYou.tsx
@@ -1,0 +1,33 @@
+import { css } from "@emotion/core";
+import { space } from "@guardian/src-foundations";
+import { neutral } from "@guardian/src-foundations/palette";
+import React from "react";
+
+const containerStyles = css`
+  margin-left: ${space[4]}px;
+  padding-left: ${space[4]}px;
+  border-left: 1px solid ${neutral[7]};
+`;
+
+const ContributionsFeedbackFormThankYou: React.FC = () => {
+  return (
+    <div css={containerStyles}>
+      <p
+        css={{
+          fontSize: "1rem",
+          fontWeight: 500
+        }}
+      >
+        Thank you for your feedback.
+      </p>
+      <span>
+        The Guardian is dedicated to keeping our independent, investigative
+        journalism open to all. We report on the facts, challenging the powerful
+        and holding them to account. Support from our readers makes what we do
+        possible and we appreciate hearing from you to help improve our service.
+      </span>
+    </div>
+  );
+};
+
+export default ContributionsFeedbackFormThankYou;

--- a/app/client/components/cancel/contributions/contributionsCancellationFlowFinancialSaveAttempt.tsx
+++ b/app/client/components/cancel/contributions/contributionsCancellationFlowFinancialSaveAttempt.tsx
@@ -11,13 +11,10 @@ import {
 } from "../../../../shared/productResponse";
 import { getMainPlan, isProduct } from "../../../../shared/productResponse";
 import { PRODUCT_TYPES } from "../../../../shared/productTypes";
-import {
-  contributionAmountsLookup,
-  ContributionInterval,
-  ContributionUpdateAmountForm
-} from "../../accountoverview/contributionUpdateAmountForm";
+import { ContributionUpdateAmountForm } from "../../accountoverview/contributionUpdateAmountForm";
 import { trackEventInOphanOnly } from "../../analytics";
 import { GenericErrorMessage } from "../../identity/GenericErrorMessage";
+import { getIsPayingMinAmount } from "./utils";
 
 const container = css`
   & > * + * {
@@ -83,18 +80,11 @@ const ContributionsCancellationFlowFinancialSaveAttempt: React.FC = () => {
           return <GenericErrorMessage />;
         }
 
-        const currentContributionOptions = (contributionAmountsLookup[
-          mainPlan.currencyISO
-        ] || contributionAmountsLookup.international)[
-          mainPlan.interval as ContributionInterval
-        ];
-
-        const isAlreadyPayingMinAmount =
-          mainPlan.amount / 100 <= currentContributionOptions.minAmount;
+        const isPayingMinAmount = getIsPayingMinAmount(mainPlan);
 
         return (
           <div css={container}>
-            {isAlreadyPayingMinAmount ? (
+            {isPayingMinAmount ? (
               <>
                 <div>
                   We understand that financial circumstances change, and your

--- a/app/client/components/cancel/contributions/contributionsCancellationFlowPaymentIssueSaveAttempt.tsx
+++ b/app/client/components/cancel/contributions/contributionsCancellationFlowPaymentIssueSaveAttempt.tsx
@@ -1,0 +1,200 @@
+import { css } from "@emotion/core";
+import { Button, LinkButton } from "@guardian/src-button";
+import { space } from "@guardian/src-foundations";
+import { SvgArrowLeftStraight } from "@guardian/src-icons";
+import { navigate } from "@reach/router";
+import * as Sentry from "@sentry/browser";
+import React, { useState } from "react";
+import {
+  isPaidSubscriptionPlan,
+  MembersDataApiItemContext
+} from "../../../../shared/productResponse";
+import { getMainPlan, isProduct } from "../../../../shared/productResponse";
+import { PRODUCT_TYPES } from "../../../../shared/productTypes";
+import {
+  contributionAmountsLookup,
+  ContributionInterval,
+  ContributionUpdateAmountForm
+} from "../../accountoverview/contributionUpdateAmountForm";
+import { trackEventInOphanOnly } from "../../analytics";
+import { GenericErrorMessage } from "../../identity/GenericErrorMessage";
+
+const container = css`
+  & > * + * {
+    margin-top: ${space[6]}px;
+`;
+
+const ContributionsCancellationFlowPaymentIssueSaveAttempt: React.FC = () => {
+  const [showAmountUpdateForm, setShowUpdateForm] = useState(false);
+
+  const onManageClicked = (
+    event: React.MouseEvent<HTMLAnchorElement, MouseEvent>
+  ) => {
+    event.preventDefault();
+    trackEventInOphanOnly({
+      eventCategory: "cancellation_flow_payment_issue",
+      eventAction: "click",
+      eventLabel: "manage"
+    });
+
+    navigate("/contributions");
+  };
+
+  const onUpdateConfirmed = (updatedAmount: number) => {
+    trackEventInOphanOnly({
+      eventCategory: "cancellation_flow_payment_issue",
+      eventAction: "click",
+      eventLabel: "change"
+    });
+
+    navigate(`mma_payment_issue/saved`, { state: { updatedAmount } });
+  };
+
+  const onReduceClicked = () => {
+    trackEventInOphanOnly({
+      eventCategory: "cancellation_flow_payment_issue",
+      eventAction: "click",
+      eventLabel: "reduce"
+    });
+
+    setShowUpdateForm(true);
+  };
+
+  const onCancelClicked = () => {
+    trackEventInOphanOnly({
+      eventCategory: "cancellation_flow_payment_issue",
+      eventAction: "click",
+      eventLabel: "cancel"
+    });
+
+    navigate(`mma_payment_issue/confirmed`);
+  };
+
+  const onReturnClicked = (
+    event: React.MouseEvent<HTMLAnchorElement, MouseEvent>
+  ) => {
+    event.preventDefault();
+    navigate("/");
+  };
+
+  return (
+    <MembersDataApiItemContext.Consumer>
+      {productDetail => {
+        if (!isProduct(productDetail)) {
+          Sentry.captureMessage(
+            "MembersDataApiItem is not a productDetail in ContributionsCancellationFlowPaymentIssueSaveAttempt"
+          );
+          return <GenericErrorMessage />;
+        }
+
+        const mainPlan = getMainPlan(productDetail.subscription);
+
+        if (!isPaidSubscriptionPlan(mainPlan)) {
+          Sentry.captureMessage(
+            "mainPlan is not a PaidSubscriptionPlan in ContributionsCancellationFlowPaymentIssueSaveAttempt"
+          );
+          return <GenericErrorMessage />;
+        }
+
+        const currentContributionOptions = (contributionAmountsLookup[
+          mainPlan.currencyISO
+        ] || contributionAmountsLookup.international)[
+          mainPlan.interval as ContributionInterval
+        ];
+
+        const isAlreadyPayingMinAmount =
+          mainPlan.amount / 100 <= currentContributionOptions.minAmount;
+
+        return (
+          <div css={container}>
+            <div
+              css={css`
+                & > * + * {
+                  margin-top: ${space[6]}px;
+                }
+              `}
+            >
+              <p>
+                Before cancelling your contribution, please double-check your
+                payment details. You can update these quickly and easily.
+              </p>
+
+              <div
+                css={css`
+                  & > * + * {
+                    margin-left: ${space[4]}px;
+                  }
+                `}
+              >
+                <LinkButton href="/contributions" onClick={onManageClicked}>
+                  Manage payment method
+                </LinkButton>
+
+                {isAlreadyPayingMinAmount && (
+                  <Button onClick={onCancelClicked} priority="subdued">
+                    I still want to cancel
+                  </Button>
+                )}
+              </div>
+            </div>
+            {!isAlreadyPayingMinAmount && (
+              <div>
+                <p>
+                  If your contribution is no longer affordable, please consider
+                  reducing its size rather than cancelling it. Simply pick a new
+                  amount and we’ll do the rest.
+                </p>
+
+                {showAmountUpdateForm ? (
+                  <ContributionUpdateAmountForm
+                    currentAmount={mainPlan.amount / 100}
+                    subscriptionId={productDetail.subscription.subscriptionId}
+                    mainPlan={mainPlan}
+                    productType={PRODUCT_TYPES.contributions}
+                    nextPaymentDate={productDetail.subscription.nextPaymentDate}
+                    mode="CANCELLATION_SAVE"
+                    onUpdateConfirmed={onUpdateConfirmed}
+                  />
+                ) : (
+                  <div
+                    css={css`
+                      & > * + * {
+                        margin-left: ${space[4]}px;
+                      }
+                    `}
+                  >
+                    <Button onClick={onReduceClicked} priority="secondary">
+                      Reduce amount
+                    </Button>
+
+                    <Button onClick={onCancelClicked} priority="subdued">
+                      I still want to cancel
+                    </Button>
+                  </div>
+                )}
+              </div>
+            )}
+
+            <div
+              css={css`
+                margin-top: ${space[24]}px;
+              `}
+            >
+              <LinkButton
+                href="/"
+                onClick={onReturnClicked}
+                priority="tertiary"
+                icon={<SvgArrowLeftStraight />}
+                iconSide="left"
+              >
+                Return to your account
+              </LinkButton>
+            </div>
+          </div>
+        );
+      }}
+    </MembersDataApiItemContext.Consumer>
+  );
+};
+
+export default ContributionsCancellationFlowPaymentIssueSaveAttempt;

--- a/app/client/components/cancel/contributions/contributionsCancellationFlowPaymentIssueSaveAttempt.tsx
+++ b/app/client/components/cancel/contributions/contributionsCancellationFlowPaymentIssueSaveAttempt.tsx
@@ -18,6 +18,8 @@ import {
 } from "../../accountoverview/contributionUpdateAmountForm";
 import { trackEventInOphanOnly } from "../../analytics";
 import { GenericErrorMessage } from "../../identity/GenericErrorMessage";
+import { CancellationCaseIdContext } from "../cancellationContexts";
+import ContributionsFeedbackForm from "./contributionsCancellationFeedbackForm";
 
 const container = css`
   & > * + * {
@@ -175,9 +177,26 @@ const ContributionsCancellationFlowPaymentIssueSaveAttempt: React.FC = () => {
               </div>
             )}
 
+            <CancellationCaseIdContext.Consumer>
+              {caseId =>
+                caseId && (
+                  <div
+                    css={css`
+                      margin-top: ${space[9]}px;
+                    `}
+                  >
+                    <ContributionsFeedbackForm
+                      isTestUser={productDetail.isTestUser}
+                      caseId={caseId}
+                    />
+                  </div>
+                )
+              }
+            </CancellationCaseIdContext.Consumer>
+
             <div
               css={css`
-                margin-top: ${space[24]}px;
+                margin-top: ${space[12]}px;
               `}
             >
               <LinkButton

--- a/app/client/components/cancel/contributions/contributionsCancellationFlowPaymentIssueSaveAttempt.tsx
+++ b/app/client/components/cancel/contributions/contributionsCancellationFlowPaymentIssueSaveAttempt.tsx
@@ -11,15 +11,12 @@ import {
 } from "../../../../shared/productResponse";
 import { getMainPlan, isProduct } from "../../../../shared/productResponse";
 import { PRODUCT_TYPES } from "../../../../shared/productTypes";
-import {
-  contributionAmountsLookup,
-  ContributionInterval,
-  ContributionUpdateAmountForm
-} from "../../accountoverview/contributionUpdateAmountForm";
+import { ContributionUpdateAmountForm } from "../../accountoverview/contributionUpdateAmountForm";
 import { trackEventInOphanOnly } from "../../analytics";
 import { GenericErrorMessage } from "../../identity/GenericErrorMessage";
 import { CancellationCaseIdContext } from "../cancellationContexts";
 import ContributionsFeedbackForm from "./contributionsCancellationFeedbackForm";
+import { getIsPayingMinAmount } from "./utils";
 
 const container = css`
   & > * + * {
@@ -98,14 +95,7 @@ const ContributionsCancellationFlowPaymentIssueSaveAttempt: React.FC = () => {
           return <GenericErrorMessage />;
         }
 
-        const currentContributionOptions = (contributionAmountsLookup[
-          mainPlan.currencyISO
-        ] || contributionAmountsLookup.international)[
-          mainPlan.interval as ContributionInterval
-        ];
-
-        const isAlreadyPayingMinAmount =
-          mainPlan.amount / 100 <= currentContributionOptions.minAmount;
+        const isPayingMinAmount = getIsPayingMinAmount(mainPlan);
 
         return (
           <div css={container}>
@@ -132,14 +122,14 @@ const ContributionsCancellationFlowPaymentIssueSaveAttempt: React.FC = () => {
                   Manage payment method
                 </LinkButton>
 
-                {isAlreadyPayingMinAmount && (
+                {isPayingMinAmount && (
                   <Button onClick={onCancelClicked} priority="subdued">
                     I still want to cancel
                   </Button>
                 )}
               </div>
             </div>
-            {!isAlreadyPayingMinAmount && (
+            {!isPayingMinAmount && (
               <div>
                 <p>
                   If your contribution is no longer affordable, please consider

--- a/app/client/components/cancel/contributions/contributionsCancellationReasons.tsx
+++ b/app/client/components/cancel/contributions/contributionsCancellationReasons.tsx
@@ -1,10 +1,9 @@
-import { Link } from "@reach/router";
 import React from "react";
-import { hrefStyle } from "../cancellationConstants";
 import { CancellationReason } from "../cancellationReason";
 import ContributionsCancellationAmountUpdatedSaved from "./contributionsCancellationAmountUpdatedSaved";
 
 import ContributionsCancellationFlowFinancialSaveAttempt from "./contributionsCancellationFlowFinancialSaveAttempt";
+import ContributionsCancellationPaymentIssueSaveAttempt from "./contributionsCancellationFlowPaymentIssueSaveAttempt";
 
 const saveBody = <> </>;
 const alternateFeedbackIntro =
@@ -61,18 +60,11 @@ export const contributionsCancellationReasons: CancellationReason[] = [
     reasonId: "mma_payment_issue",
     linkLabel: "A payment issue",
     saveTitle: "You have experienced an issue with your payment",
-    saveBody: (
-      <>
-        <p>
-          You can review your payment method and update your details in the{" "}
-          <Link css={hrefStyle} to={"/contributions"}>
-            manage your account
-          </Link>{" "}
-          section, without the need to cancel your contribution.
-        </p>
-      </>
-    ),
-    alternateFeedbackIntro
+    saveBody: <ContributionsCancellationPaymentIssueSaveAttempt />,
+    savedBody: ContributionsCancellationAmountUpdatedSaved,
+    hideSaveActions: true,
+    skipFeedback: true,
+    hideContactUs: true
   },
   {
     reasonId: "mma_direct_debit",

--- a/app/client/components/cancel/contributions/utils.ts
+++ b/app/client/components/cancel/contributions/utils.ts
@@ -1,0 +1,15 @@
+import { PaidSubscriptionPlan } from "../../../../shared/productResponse";
+import {
+  contributionAmountsLookup,
+  ContributionInterval
+} from "../../accountoverview/contributionUpdateAmountForm";
+
+export const getIsPayingMinAmount = (mainPlan: PaidSubscriptionPlan) => {
+  const currentContributionOptions = (contributionAmountsLookup[
+    mainPlan.currencyISO
+  ] || contributionAmountsLookup.international)[
+    mainPlan.interval as ContributionInterval
+  ];
+
+  return mainPlan.amount / 100 <= currentContributionOptions.minAmount;
+};


### PR DESCRIPTION
## What does this change?
Update "A payment issue" cancellation flow, as per [this card](https://trello.com/c/BbWsdbz6/2491-mma-cancellation-a-payment-issue-flow). There's some duplication here, but it didn't seem worth the effort to fight to get the current feedback form working for me so I created a new one (which will also use on the "I would rather do a [single/monthly/annual] contribution]" flow.

## Images

### review + <= min amount

<img width="967" alt="Screenshot 2021-01-15 at 10 52 47" src="https://user-images.githubusercontent.com/17720442/104717261-ec4d7000-5720-11eb-82a2-b8d60d38f094.png">

### review + > min amount
<img width="967" alt="Screenshot 2021-01-15 at 10 54 12" src="https://user-images.githubusercontent.com/17720442/104717265-efe0f700-5720-11eb-9051-5d25d38c2ca0.png">

### confirmed (saved)
<img width="967" alt="Screenshot 2021-01-15 at 10 54 28" src="https://user-images.githubusercontent.com/17720442/104717271-f2435100-5720-11eb-8554-2b54723b0860.png">

