### PR TITLE
Rename Help section page title

### DIFF
--- a/app/client/components/help.tsx
+++ b/app/client/components/help.tsx
@@ -124,7 +124,7 @@ const pStyle = css`
 export const Help = (_: RouteComponentProps) => {
   const [callCentreOpen, setCallCentreOpen] = useState<boolean>(false);
   return (
-    <PageContainer selectedNavItem={NAV_LINKS.help} pageTitle="Help centre">
+    <PageContainer selectedNavItem={NAV_LINKS.help} pageTitle="Help">
       <h2 css={h2Style}>How can we help?</h2>
       <ul css={listStyle}>
         {highlightedQuestions.map(question => (


### PR DESCRIPTION
## What does this change?
Renames the Help section page title to differentiate between the Help section on the MMA (old Help Centre) and the new Help Centre.