### PR TITLE
Don't show e.g "I would rather make an annual contribution" cancellation reason to annual contributors 

### DIFF
--- a/app/client/components/cancel/cancellationFlow.tsx
+++ b/app/client/components/cancel/cancellationFlow.tsx
@@ -21,7 +21,6 @@ import { WithStandardTopMargin } from "../page";
 import { ProgressIndicator } from "../progressIndicator";
 import { RadioButton } from "../radioButton";
 import {
-  MultiRouteableProps,
   ReturnToAccountOverviewButton,
   RouteableStepProps,
   WizardStep
@@ -36,7 +35,9 @@ import {
   cancellationDateFetcher,
   CancellationDateResponse
 } from "./cancellationDateResponse";
+import { CancellationReason } from "./cancellationReason";
 import { ContactUsToCancel } from "./contactUsToCancel";
+import { GenericSaveAttemptProps } from "./stages/genericSaveAttempt";
 
 export interface RouteableStepPropsWithCancellationFlow
   extends RouteableStepProps {
@@ -52,6 +53,9 @@ interface ReasonPickerState {
   reasonPath: string;
   cancellationPolicy?: string;
 }
+
+const shouldShow = (reason: CancellationReason, productDetail: ProductDetail) =>
+  reason.shouldShow ? reason.shouldShow(productDetail) : true;
 
 class ReasonPicker extends React.Component<
   ReasonPickerProps,
@@ -75,7 +79,7 @@ class ReasonPicker extends React.Component<
 
     // we extract the options from the children rather than direct from the ProductType to guarantee the routes are setup correctly
     const options = this.props.children.props.children.map(
-      (child: { props: MultiRouteableProps }) => child.props
+      (child: { props: GenericSaveAttemptProps }) => child.props
     );
 
     const innerContent = (
@@ -96,16 +100,19 @@ class ReasonPicker extends React.Component<
         <WithStandardTopMargin>
           <h4>Please select a reason</h4>
           <form css={css({ marginBottom: "30px" })}>
-            {options.map((reason: MultiRouteableProps) => (
-              <RadioButton
-                key={reason.path}
-                value={reason.path}
-                label={reason.linkLabel}
-                checked={reason.path === this.state.reasonPath}
-                groupName="reasons"
-                onChange={() => this.setState({ reasonPath: reason.path })}
-              />
-            ))}
+            {options.map(
+              (reason: GenericSaveAttemptProps) =>
+                shouldShow(reason.reason, this.props.productDetail) && (
+                  <RadioButton
+                    key={reason.path}
+                    value={reason.path}
+                    label={reason.linkLabel}
+                    checked={reason.path === this.state.reasonPath}
+                    groupName="reasons"
+                    onChange={() => this.setState({ reasonPath: reason.path })}
+                  />
+                )
+            )}
           </form>
 
           {shouldOfferEffectiveDateOptions && (

--- a/app/client/components/cancel/cancellationReason.ts
+++ b/app/client/components/cancel/cancellationReason.ts
@@ -1,3 +1,4 @@
+import { ProductDetail } from "../../../shared/productResponse";
 import { SavedBodyProps } from "./stages/savedCancellation";
 
 export interface CancellationReason {
@@ -14,6 +15,7 @@ export interface CancellationReason {
   hideContactUs?: boolean;
   skipFeedback?: boolean;
   savedBody?: React.FC<SavedBodyProps>;
+  shouldShow?: (productDetail: ProductDetail) => boolean;
 }
 
 export type CancellationReasonId =

--- a/app/client/components/cancel/contributions/contributionsCancellationReasons.tsx
+++ b/app/client/components/cancel/contributions/contributionsCancellationReasons.tsx
@@ -1,7 +1,11 @@
 import React from "react";
+import {
+  getMainPlan,
+  isPaidSubscriptionPlan,
+  ProductDetail
+} from "../../../../shared/productResponse";
 import { CancellationReason } from "../cancellationReason";
 import ContributionsCancellationAmountUpdatedSaved from "./contributionsCancellationAmountUpdatedSaved";
-
 import ContributionsCancellationFlowFinancialSaveAttempt from "./contributionsCancellationFlowFinancialSaveAttempt";
 import ContributionsCancellationPaymentIssueSaveAttempt from "./contributionsCancellationFlowPaymentIssueSaveAttempt";
 
@@ -100,7 +104,14 @@ export const contributionsCancellationReasons: CancellationReason[] = [
         </p>
       </>
     ),
-    alternateFeedbackIntro
+    alternateFeedbackIntro,
+    shouldShow: (productDetail: ProductDetail) => {
+      const mainPlan = getMainPlan(productDetail.subscription);
+      if (!isPaidSubscriptionPlan(mainPlan)) {
+        return false;
+      }
+      return mainPlan.interval === "month";
+    }
   },
   {
     reasonId: "mma_wants_monthly_contribution",
@@ -114,7 +125,14 @@ export const contributionsCancellationReasons: CancellationReason[] = [
         </p>
       </>
     ),
-    alternateFeedbackIntro
+    alternateFeedbackIntro,
+    shouldShow: (productDetail: ProductDetail) => {
+      const mainPlan = getMainPlan(productDetail.subscription);
+      if (!isPaidSubscriptionPlan(mainPlan)) {
+        return false;
+      }
+      return mainPlan.interval === "year";
+    }
   },
   {
     reasonId: "mma_health",

--- a/app/client/components/cancel/stages/genericSaveAttempt.tsx
+++ b/app/client/components/cancel/stages/genericSaveAttempt.tsx
@@ -38,7 +38,7 @@ import { CaseCreationWrapper } from "../caseCreationWrapper";
 import { CaseUpdateAsyncLoader, getUpdateCasePromise } from "../caseUpdate";
 import { RestOfCancellationFlow } from "../physicalSubsCancellationFlowWrapper";
 
-interface GenericSaveAttemptProps extends MultiRouteableProps {
+export interface GenericSaveAttemptProps extends MultiRouteableProps {
   reason: CancellationReason;
   productType: ProductTypeWithCancellationFlow;
 }


### PR DESCRIPTION
## What does this change?
The two user facing changes are:
- Don't show "I would rather make an annual contribution" to annual contributors
- Don't show "I would rather make an monthly contribution" to monthly contributors 

To do this, I've added an optional (seemed less painfull to make it optional) `shouldShow` function to the `cancellationReason` model. I'm not super familiar with all the data types, but `ProductDetail` seemed like a reasonable choice for the argument here. It worked for this particular use case and I think it would work for potential future ones? (Very much open to suggestions here though!)
 
## Images
### annual contributor - "I would rather make an annual contribution" is hidden
<img width="967" alt="Screenshot 2021-01-19 at 09 16 32" src="https://user-images.githubusercontent.com/17720442/105014343-3ba0e280-5a38-11eb-9325-be0008c31baf.png">

