### PR TITLE
Introduce code splitting

### DIFF
--- a/app/client/__tests__/components/delivery/records/deliveryRecords/deliveryRecords.tsx
+++ b/app/client/__tests__/components/delivery/records/deliveryRecords/deliveryRecords.tsx
@@ -1,4 +1,4 @@
-import moment = require("moment");
+import moment from "moment";
 import { checkForExistingDeliveryProblem } from "../../../../../components/delivery/records/deliveryRecords";
 import { DeliveryRecordDetail } from "../../../../../components/delivery/records/deliveryRecordsApi";
 

--- a/app/client/__tests__/components/delivery/records/deliveryRecords/step1.tsx
+++ b/app/client/__tests__/components/delivery/records/deliveryRecords/step1.tsx
@@ -7,8 +7,7 @@ import {
   PRODUCT_TYPES
 } from "../../../../../../shared/productTypes";
 import { DeliveryRecordCard } from "../../../../../components/delivery/records/deliveryRecordCard";
-import {
-  DeliveryRecords,
+import DeliveryRecords, {
   DeliveryRecordsFC
 } from "../../../../../components/delivery/records/deliveryRecords";
 import { DeliveryRecordProblemForm } from "../../../../../components/delivery/records/deliveryRecordsProblemForm";

--- a/app/client/components/accountoverview/accountOverview.tsx
+++ b/app/client/components/accountoverview/accountOverview.tsx
@@ -115,7 +115,7 @@ const AccountOverviewRenderer = ([mdaResponse, cancelledProductsResponse]: [
   );
 };
 
-export const AccountOverview = (_: RouteComponentProps) => {
+const AccountOverview = (_: RouteComponentProps) => {
   return (
     <PageContainer
       selectedNavItem={NAV_LINKS.accountOverview}
@@ -142,3 +142,5 @@ const AccountOverviewFetcher = () =>
       mode: "same-origin"
     })
   ]);
+
+export default AccountOverview;

--- a/app/client/components/accountoverview/manageProduct.tsx
+++ b/app/client/components/accountoverview/manageProduct.tsx
@@ -387,7 +387,7 @@ const CancellationCTA = (props: CancellationCTAProps) => {
   );
 };
 
-export const ManageProduct = (props: RouteableStepPropsForGrouped) => (
+const ManageProduct = (props: RouteableStepPropsForGrouped) => (
   <FlowWrapper
     {...props}
     productType={props.groupedProductType}
@@ -413,3 +413,5 @@ export const ManageProduct = (props: RouteableStepPropsForGrouped) => (
     )}
   </FlowWrapper>
 );
+
+export default ManageProduct;

--- a/app/client/components/billing/billing.tsx
+++ b/app/client/components/billing/billing.tsx
@@ -254,7 +254,7 @@ const BillingRenderer = ([mdaResponse, invoiceResponse]: [
   );
 };
 
-export const Billing = (_: RouteComponentProps) => {
+const Billing = (_: RouteComponentProps) => {
   return (
     <PageContainer selectedNavItem={NAV_LINKS.billing} pageTitle="Billing">
       <BillingDataAsyncLoader
@@ -274,3 +274,5 @@ const billingFetcher = () =>
       mode: "same-origin"
     })
   ]);
+
+export default Billing;

--- a/app/client/components/cancel/cancellationFlow.tsx
+++ b/app/client/components/cancel/cancellationFlow.tsx
@@ -216,7 +216,7 @@ const ReasonPickerRenderer = (
   );
 };
 
-export const CancellationFlow = (props: RouteableStepProps) => (
+const CancellationFlow = (props: RouteableStepProps) => (
   <FlowWrapper
     {...props}
     loadingMessagePrefix="Checking the status of your"
@@ -255,3 +255,5 @@ export const CancellationFlow = (props: RouteableStepProps) => (
     }
   </FlowWrapper>
 );
+
+export default CancellationFlow;

--- a/app/client/components/contactUs/contactUs.tsx
+++ b/app/client/components/contactUs/contactUs.tsx
@@ -22,7 +22,7 @@ interface ContactUsProps extends RouteComponentProps {
   urlSuccess?: string;
 }
 
-export const ContactUs = (props: ContactUsProps) => {
+const ContactUs = (props: ContactUsProps) => {
   const currentTopic = contactUsConfig.find(
     topic => topic.id === props.urlTopicId
   );
@@ -283,3 +283,5 @@ export const ContactUs = (props: ContactUsProps) => {
     </>
   );
 };
+
+export default ContactUs;

--- a/app/client/components/delivery/address/deliveryAddressForm.tsx
+++ b/app/client/components/delivery/address/deliveryAddressForm.tsx
@@ -699,7 +699,7 @@ const Form = (props: FormProps) => {
   );
 };
 
-export const DeliveryAddressForm = (props: RouteableStepProps) => {
+const DeliveryAddressForm = (props: RouteableStepProps) => {
   // const ProductDetailContext = React.createContext(props.location?.state);
   return (
     <PageContainer
@@ -744,3 +744,5 @@ export const DeliveryAddressForm = (props: RouteableStepProps) => {
     </PageContainer>
   );
 };
+
+export default DeliveryAddressForm;

--- a/app/client/components/delivery/records/deliveryRecords.tsx
+++ b/app/client/components/delivery/records/deliveryRecords.tsx
@@ -757,7 +757,7 @@ export const DeliveryRecordsFC = (props: DeliveryRecordsFCProps) => {
   );
 };
 
-export const DeliveryRecords = (props: DeliveryRecordsRouteableStepProps) => {
+const DeliveryRecords = (props: DeliveryRecordsRouteableStepProps) => {
   return (
     <FlowWrapper
       {...props}
@@ -789,3 +789,5 @@ export const DeliveryRecords = (props: DeliveryRecordsRouteableStepProps) => {
     </FlowWrapper>
   );
 };
+
+export default DeliveryRecords;

--- a/app/client/components/help.tsx
+++ b/app/client/components/help.tsx
@@ -121,7 +121,7 @@ const pStyle = css`
   }
 `;
 
-export const Help = (_: RouteComponentProps) => {
+const Help = (_: RouteComponentProps) => {
   const [callCentreOpen, setCallCentreOpen] = useState<boolean>(false);
   return (
     <PageContainer selectedNavItem={NAV_LINKS.help} pageTitle="Help">
@@ -190,3 +190,5 @@ export const Help = (_: RouteComponentProps) => {
     </PageContainer>
   );
 };
+
+export default Help;

--- a/app/client/components/helpCentre/helpCentre.tsx
+++ b/app/client/components/helpCentre/helpCentre.tsx
@@ -46,7 +46,7 @@ const contactUsTitleStyle = css`
   ${headline.small({ fontWeight: "bold" })};
 `;
 
-export const HelpCentre = (_: HelpCentreProps) => (
+const HelpCentre = (_: HelpCentreProps) => (
   <>
     <SectionHeader title="Help Centre" />
     <KnownIssues />
@@ -100,3 +100,5 @@ export const HelpCentre = (_: HelpCentreProps) => (
     </SectionPageContainer>
   </>
 );
+
+export default HelpCentre;

--- a/app/client/components/holiday/holidaysOverview.tsx
+++ b/app/client/components/holiday/holidaysOverview.tsx
@@ -313,7 +313,7 @@ interface HolidaysOverviewState {
   existingHolidayStopToAmend: HolidayStopRequest | null;
 }
 
-export class HolidaysOverview extends React.Component<
+class HolidaysOverview extends React.Component<
   HolidayStopsRouteableStepProps,
   HolidaysOverviewState
 > {
@@ -370,3 +370,5 @@ export class HolidaysOverview extends React.Component<
     newValue: HolidayStopRequest | null
   ) => this.setState({ existingHolidayStopToAmend: newValue });
 }
+
+export default HolidaysOverview;

--- a/app/client/components/identity/EmailAndMarketing/index.tsx
+++ b/app/client/components/identity/EmailAndMarketing/index.tsx
@@ -15,7 +15,7 @@ import { EmailSettingsSection } from "./EmailSettingsSection";
 import { NewsletterSection } from "./NewsletterSection";
 import { OptOutSection } from "./OptOutSection";
 
-export const EmailAndMarketing = (_: { path?: string }) => {
+const EmailAndMarketing = (_: { path?: string }) => {
   const { options, error, subscribe, unsubscribe, unsubscribeAll } = Actions;
   const [email, setEmail] = useState<string>("");
   const [removed, setRemoved] = useState(false);
@@ -134,3 +134,5 @@ export const EmailAndMarketing = (_: { path?: string }) => {
     </PageContainer>
   );
 };
+
+export default EmailAndMarketing;

--- a/app/client/components/identity/PublicProfile/index.tsx
+++ b/app/client/components/identity/PublicProfile/index.tsx
@@ -19,7 +19,7 @@ import { ProfileFormSection } from "./ProfileFormSection";
 
 const hasUsername = (user: User) => !!user.username;
 
-export const PublicProfile = (_: { path?: string }) => {
+const PublicProfile = (_: { path?: string }) => {
   const [user, setUser] = useState<User>();
   const [error, setError] = useState(false);
 
@@ -120,3 +120,5 @@ export const PublicProfile = (_: { path?: string }) => {
     </PageContainer>
   );
 };
+
+export default PublicProfile;

--- a/app/client/components/identity/Settings/index.tsx
+++ b/app/client/components/identity/Settings/index.tsx
@@ -22,7 +22,7 @@ const loader = (
   </WithStandardTopMargin>
 );
 
-export const Settings = (_: { path?: string }) => {
+const Settings = (_: { path?: string }) => {
   const [user, setUser] = useState<User>();
   const [error, setError] = useState(false);
   const [emailMessage, setEmailMessage] = useState<string | null>(null);
@@ -102,3 +102,5 @@ export const Settings = (_: { path?: string }) => {
     </PageContainer>
   );
 };
+
+export default Settings;

--- a/app/client/components/page.tsx
+++ b/app/client/components/page.tsx
@@ -220,7 +220,7 @@ const PageHeaderContainer: React.SFC<PageHeaderContainerProps> = (
               `}
           `}
         >
-          {props.title}
+          {props.title || <>&nbsp;</>}
         </h1>
       </div>
     </div>

--- a/app/client/components/pageSkeleton.tsx
+++ b/app/client/components/pageSkeleton.tsx
@@ -1,0 +1,177 @@
+import { css } from "@emotion/core";
+import { space } from "@guardian/src-foundations";
+import { Location } from "@reach/router";
+import React from "react";
+import {
+  GROUPED_PRODUCT_TYPES,
+  PRODUCT_TYPES,
+  shouldHaveHolidayStopsFlow
+} from "../../shared/productTypes";
+import { MenuSpecificNavItem, NAV_LINKS } from "./nav/navConfig";
+import { PageContainer, WithStandardTopMargin } from "./page";
+import { SectionHeader } from "./sectionHeader";
+import { SectionPageContainer } from "./sectionPageContainer";
+import { Spinner } from "./spinner";
+
+interface LocationObject {
+  title: string;
+  path: string;
+  selectedNavItem: MenuSpecificNavItem;
+}
+
+const manageProductLocationObjects: LocationObject[] = Object.values(
+  GROUPED_PRODUCT_TYPES
+).map(groupedProductType => ({
+  title: `Manage ${groupedProductType.shortFriendlyName ||
+    groupedProductType.friendlyName}`,
+  path: `/${groupedProductType.urlPart}`,
+  selectedNavItem: NAV_LINKS.accountOverview
+}));
+
+const cancellationFlowLocationObjects: LocationObject[] = Object.values(
+  PRODUCT_TYPES
+).map(productType => ({
+  title: `Cancel ${productType.shortFriendlyName || productType.friendlyName}`,
+  path: `/cancel/${productType.urlPart}`,
+  selectedNavItem: NAV_LINKS.accountOverview
+}));
+
+const paymentUpdateFlowLocationObjects: LocationObject[] = Object.values(
+  PRODUCT_TYPES
+).map(productType => ({
+  title: "Manage payment method",
+  path: `/payment/${productType.urlPart}`,
+  selectedNavItem: NAV_LINKS.accountOverview
+}));
+
+const holidaysOverviewLocationObjects: LocationObject[] = Object.values(
+  PRODUCT_TYPES
+)
+  .filter(shouldHaveHolidayStopsFlow)
+  .map(productType => ({
+    title: "Manage suspensions",
+    path: `/suspend/${productType.urlPart}`,
+    selectedNavItem: NAV_LINKS.accountOverview
+  }));
+
+const deliveryAddressFormLocationObjects: LocationObject[] = Object.values(
+  PRODUCT_TYPES
+)
+  .filter(shouldHaveHolidayStopsFlow)
+  .map(productType => ({
+    title: "Update delivery details",
+    path: `/delivery/${productType.urlPart}/address`,
+    selectedNavItem: NAV_LINKS.accountOverview
+  }));
+
+const deliveryRecordsLocationObjects: LocationObject[] = Object.values(
+  PRODUCT_TYPES
+)
+  .filter(shouldHaveHolidayStopsFlow)
+  .map(productType => ({
+    title: "Delivery history",
+    path: `/delivery/${productType.urlPart}/records`,
+    selectedNavItem: NAV_LINKS.accountOverview
+  }));
+
+const MMALocationObjectArr: LocationObject[] = [
+  {
+    title: "Account overview",
+    path: "/",
+    selectedNavItem: NAV_LINKS.accountOverview
+  },
+  {
+    title: "Billing",
+    path: "/billing",
+    selectedNavItem: NAV_LINKS.billing
+  },
+  ...manageProductLocationObjects,
+  ...cancellationFlowLocationObjects,
+  ...paymentUpdateFlowLocationObjects,
+  ...holidaysOverviewLocationObjects,
+  ...deliveryAddressFormLocationObjects,
+  ...deliveryRecordsLocationObjects,
+  {
+    title: "Emails & marketing",
+    path: "/email-prefs",
+    selectedNavItem: NAV_LINKS.emailPrefs
+  },
+  {
+    title: "Edit your profile",
+    path: "/public-settings",
+    selectedNavItem: NAV_LINKS.profile
+  },
+  {
+    title: "Settings",
+    path: "/account-settings",
+    selectedNavItem: NAV_LINKS.settings
+  },
+  {
+    title: "Help",
+    path: "/help",
+    selectedNavItem: NAV_LINKS.help
+  }
+];
+
+const nonMMALocationObjectArr: LocationObject[] = [
+  {
+    title: "Help Centre",
+    path: "/help-centre",
+    selectedNavItem: NAV_LINKS.help
+  },
+  {
+    title: "Need to contact us about something?",
+    path: "/contact-us",
+    selectedNavItem: NAV_LINKS.help
+  }
+];
+
+const PageSkeleton = () => {
+  return (
+    <Location>
+      {({ location }) => {
+        const selectedMMALocationObject = MMALocationObjectArr.filter(
+          currentObject => location.pathname === currentObject.path
+        )[0];
+        const selectedNonMMALocationObject = nonMMALocationObjectArr.filter(
+          currentObject => location.pathname.startsWith(currentObject.path)
+        )[0];
+
+        if (selectedNonMMALocationObject) {
+          return (
+            <>
+              <SectionHeader title={selectedNonMMALocationObject.title} />
+              <SectionPageContainer sectionTitle="&nbsp;">
+                <div
+                  css={css`
+                    margin-bottom: ${space[24]}px;
+                  `}
+                >
+                  <WithStandardTopMargin>
+                    <Spinner />
+                  </WithStandardTopMargin>
+                  <div style={{ height: "50vh" }} />
+                </div>
+              </SectionPageContainer>
+            </>
+          );
+        }
+
+        if (selectedMMALocationObject) {
+          return (
+            <PageContainer
+              selectedNavItem={selectedMMALocationObject.selectedNavItem}
+              pageTitle={selectedMMALocationObject.title}
+            >
+              <WithStandardTopMargin>
+                <Spinner />
+              </WithStandardTopMargin>
+            </PageContainer>
+          );
+        }
+      }}
+    </Location>
+  );
+};
+
+export default PageSkeleton;

--- a/app/client/components/payment/update/updatePaymentFlow.tsx
+++ b/app/client/components/payment/update/updatePaymentFlow.tsx
@@ -326,7 +326,7 @@ class PaymentUpdaterStep extends React.Component<
   };
 }
 
-export const PaymentUpdateFlow = (props: RouteableStepProps) => {
+const PaymentUpdateFlow = (props: RouteableStepProps) => {
   const navItemReferrer = getNavItemFromFlowReferrer(
     props.location?.state?.flowReferrer?.title
   );
@@ -360,3 +360,5 @@ export const PaymentUpdateFlow = (props: RouteableStepProps) => {
     </FlowReferrerContext.Provider>
   );
 };
+
+export default PaymentUpdateFlow;

--- a/app/client/components/user.tsx
+++ b/app/client/components/user.tsx
@@ -1,6 +1,6 @@
 import { css, Global } from "@emotion/core";
 import { Redirect, Router } from "@reach/router";
-import React from "react";
+import React, { lazy, Suspense } from "react";
 import {
   GROUPED_PRODUCT_TYPES,
   GroupedProductType,
@@ -15,181 +15,197 @@ import {
 } from "../../shared/productTypes";
 import { fonts } from "../styles/fonts";
 import global from "../styles/global";
-import { AccountOverview } from "./accountoverview/accountOverview";
-import { ManageProduct } from "./accountoverview/manageProduct";
 import { AnalyticsTracker } from "./analytics";
-import { Billing } from "./billing/billing";
-import { CancellationFlow } from "./cancel/cancellationFlow";
 import { CancellationReason } from "./cancel/cancellationReason";
 import { ExecuteCancellation } from "./cancel/stages/executeCancellation";
 import { GenericSaveAttempt } from "./cancel/stages/genericSaveAttempt";
 import { SavedCancellation } from "./cancel/stages/savedCancellation";
 import { CMPBanner } from "./consent/CMPBanner";
-import { ContactUs } from "./contactUs/contactUs";
 import { DeliveryAddressEditConfirmation } from "./delivery/address/deliveryAddressEditConfirmation";
-import { DeliveryAddressForm } from "./delivery/address/deliveryAddressForm";
 import { DeliveryAddressReview } from "./delivery/address/deliveryAddressReview";
-import { DeliveryRecords } from "./delivery/records/deliveryRecords";
 import { DeliveryRecordsProblemConfirmation } from "./delivery/records/deliveryRecordsProblemConfirmation";
 import { DeliveryRecordsProblemReview } from "./delivery/records/deliveryRecordsProblemReview";
-import { Help } from "./help";
-import { HelpCentre } from "./helpCentre/helpCentre";
 import { HolidayConfirmed } from "./holiday/holidayConfirmed";
 import { HolidayDateChooser } from "./holiday/holidayDateChooser";
 import { HolidayReview } from "./holiday/holidayReview";
-import { HolidaysOverview } from "./holiday/holidaysOverview";
-import { EmailAndMarketing } from "./identity/EmailAndMarketing";
-import { PublicProfile } from "./identity/PublicProfile";
-import { Settings } from "./identity/Settings";
 import { Main } from "./main";
+import PageSkeleton from "./pageSkeleton";
 import { ConfirmPaymentUpdate } from "./payment/update/confirmPaymentUpdate";
 import { PaymentUpdated } from "./payment/update/paymentUpdated";
-import { PaymentUpdateFlow } from "./payment/update/updatePaymentFlow";
 import { ScrollToTop } from "./scrollToTop";
+
+const AccountOverview = lazy(() => import("./accountoverview/accountOverview"));
+const Billing = lazy(() => import("./billing/billing"));
+const ManageProduct = lazy(() => import("./accountoverview/manageProduct"));
+const CancellationFlow = lazy(() => import("./cancel/cancellationFlow"));
+const PaymentUpdateFlow = lazy(() =>
+  import("./payment/update/updatePaymentFlow")
+);
+const HolidaysOverview = lazy(() => import("./holiday/holidaysOverview"));
+const DeliveryAddressForm = lazy(() =>
+  import("./delivery/address/deliveryAddressForm")
+);
+const DeliveryRecords = lazy(() =>
+  import("./delivery/records/deliveryRecords")
+);
+const EmailAndMarketing = lazy(() => import("./identity/EmailAndMarketing"));
+const PublicProfile = lazy(() => import("./identity/PublicProfile"));
+const Settings = lazy(() => import("./identity/Settings"));
+const Help = lazy(() => import("./help"));
+const HelpCentre = lazy(() => import("./helpCentre/helpCentre"));
+const ContactUs = lazy(() => import("./contactUs/contactUs"));
 
 const User = () => (
   <Main>
     <Global styles={css(`${global}`)} />
     <Global styles={css(`${fonts}`)} />
+    {/* replace with a real fallback component */}
+    <Suspense fallback={<PageSkeleton />}>
+      <Router primary={true} css={{ height: "100%" }}>
+        <AccountOverview path="/" />
+        <Billing path="/billing" />
 
-    <Router primary={true} css={{ height: "100%" }}>
-      <AccountOverview path="/" />
-      <Billing path="/billing" />
+        {Object.values(GROUPED_PRODUCT_TYPES).map(
+          (groupedProductType: GroupedProductType) => (
+            <ManageProduct
+              key={groupedProductType.urlPart}
+              path={"/" + groupedProductType.urlPart}
+              groupedProductType={groupedProductType}
+            />
+          )
+        )}
+        {Object.values(PRODUCT_TYPES).map((productType: ProductType) => (
+          <CancellationFlow
+            key={productType.urlPart}
+            path={"/cancel/" + productType.urlPart}
+            productType={productType}
+          >
+            {hasCancellationFlow(productType) &&
+              productType.cancellation.reasons.map(
+                (reason: CancellationReason) => (
+                  <GenericSaveAttempt
+                    path={reason.reasonId}
+                    productType={productType}
+                    reason={reason}
+                    key={reason.reasonId}
+                    linkLabel={reason.linkLabel}
+                  >
+                    <ExecuteCancellation
+                      path="confirmed"
+                      productType={productType}
+                    />
+                    {!!reason.savedBody && (
+                      <SavedCancellation
+                        path="saved"
+                        reason={reason}
+                        productType={productType}
+                      />
+                    )}
+                  </GenericSaveAttempt>
+                )
+              )}
+          </CancellationFlow>
+        ))}
 
-      {Object.values(GROUPED_PRODUCT_TYPES).map(
-        (groupedProductType: GroupedProductType) => (
-          <ManageProduct
-            key={groupedProductType.urlPart}
-            path={"/" + groupedProductType.urlPart}
-            groupedProductType={groupedProductType}
-          />
-        )
-      )}
-      {Object.values(PRODUCT_TYPES).map((productType: ProductType) => (
-        <CancellationFlow
-          key={productType.urlPart}
-          path={"/cancel/" + productType.urlPart}
-          productType={productType}
-        >
-          {hasCancellationFlow(productType) &&
-            productType.cancellation.reasons.map(
-              (reason: CancellationReason) => (
-                <GenericSaveAttempt
-                  path={reason.reasonId}
-                  productType={productType}
-                  reason={reason}
-                  key={reason.reasonId}
-                  linkLabel={reason.linkLabel}
-                >
-                  <ExecuteCancellation
+        {Object.values(PRODUCT_TYPES).map((productType: ProductType) => (
+          <PaymentUpdateFlow
+            key={productType.urlPart}
+            path={"/payment/" + productType.urlPart}
+            productType={productType}
+          >
+            <ConfirmPaymentUpdate path="confirm" productType={productType}>
+              <PaymentUpdated path="updated" productType={productType} />
+            </ConfirmPaymentUpdate>
+          </PaymentUpdateFlow>
+        ))}
+
+        {Object.values(PRODUCT_TYPES)
+          .filter(shouldHaveHolidayStopsFlow)
+          .map((productType: ProductTypeWithHolidayStopsFlow) => (
+            <HolidaysOverview
+              key={productType.urlPart}
+              path={"/suspend/" + productType.urlPart}
+              productType={productType}
+            >
+              <HolidayDateChooser path="create" productType={productType}>
+                <HolidayReview path="review" productType={productType}>
+                  <HolidayConfirmed
                     path="confirmed"
                     productType={productType}
                   />
-                  {!!reason.savedBody && (
-                    <SavedCancellation
-                      path="saved"
-                      reason={reason}
-                      productType={productType}
-                    />
-                  )}
-                </GenericSaveAttempt>
-              )
-            )}
-        </CancellationFlow>
-      ))}
-
-      {Object.values(PRODUCT_TYPES).map((productType: ProductType) => (
-        <PaymentUpdateFlow
-          key={productType.urlPart}
-          path={"/payment/" + productType.urlPart}
-          productType={productType}
-        >
-          <ConfirmPaymentUpdate path="confirm" productType={productType}>
-            <PaymentUpdated path="updated" productType={productType} />
-          </ConfirmPaymentUpdate>
-        </PaymentUpdateFlow>
-      ))}
-
-      {Object.values(PRODUCT_TYPES)
-        .filter(shouldHaveHolidayStopsFlow)
-        .map((productType: ProductTypeWithHolidayStopsFlow) => (
-          <HolidaysOverview
-            key={productType.urlPart}
-            path={"/suspend/" + productType.urlPart}
-            productType={productType}
-          >
-            <HolidayDateChooser path="create" productType={productType}>
-              <HolidayReview path="review" productType={productType}>
-                <HolidayConfirmed path="confirmed" productType={productType} />
-              </HolidayReview>
-            </HolidayDateChooser>
-            <HolidayDateChooser
-              path="amend"
-              productType={productType}
-              requiresExistingHolidayStopToAmendInContext
-            >
-              <HolidayReview path="review" productType={productType}>
-                <HolidayConfirmed path="confirmed" productType={productType} />
-              </HolidayReview>
-            </HolidayDateChooser>
-          </HolidaysOverview>
-        ))}
-
-      {Object.values(PRODUCT_TYPES)
-        .filter(hasDeliveryFlow)
-        .map((productType: ProductType) => (
-          <DeliveryAddressForm
-            key={productType.urlPart}
-            path={`/delivery/${productType.urlPart}/address`}
-            productType={productType}
-          >
-            <DeliveryAddressReview path="review" productType={productType}>
-              <DeliveryAddressEditConfirmation
-                path="confirmed"
+                </HolidayReview>
+              </HolidayDateChooser>
+              <HolidayDateChooser
+                path="amend"
                 productType={productType}
-              />
-            </DeliveryAddressReview>
-          </DeliveryAddressForm>
-        ))}
+                requiresExistingHolidayStopToAmendInContext
+              >
+                <HolidayReview path="review" productType={productType}>
+                  <HolidayConfirmed
+                    path="confirmed"
+                    productType={productType}
+                  />
+                </HolidayReview>
+              </HolidayDateChooser>
+            </HolidaysOverview>
+          ))}
 
-      {Object.values(PRODUCT_TYPES)
-        .filter(hasDeliveryRecordsFlow)
-        .map((productType: ProductTypeWithDeliveryRecordsProperties) => (
-          <DeliveryRecords
-            key={productType.urlPart}
-            path={`/delivery/${productType.urlPart}/records`}
-            productType={productType}
-          >
-            <DeliveryRecordsProblemReview
-              path="review"
+        {Object.values(PRODUCT_TYPES)
+          .filter(hasDeliveryFlow)
+          .map((productType: ProductType) => (
+            <DeliveryAddressForm
+              key={productType.urlPart}
+              path={`/delivery/${productType.urlPart}/address`}
               productType={productType}
             >
-              <DeliveryRecordsProblemConfirmation
-                path="confirmed"
+              <DeliveryAddressReview path="review" productType={productType}>
+                <DeliveryAddressEditConfirmation
+                  path="confirmed"
+                  productType={productType}
+                />
+              </DeliveryAddressReview>
+            </DeliveryAddressForm>
+          ))}
+
+        {Object.values(PRODUCT_TYPES)
+          .filter(hasDeliveryRecordsFlow)
+          .map((productType: ProductTypeWithDeliveryRecordsProperties) => (
+            <DeliveryRecords
+              key={productType.urlPart}
+              path={`/delivery/${productType.urlPart}/records`}
+              productType={productType}
+            >
+              <DeliveryRecordsProblemReview
+                path="review"
                 productType={productType}
-              />
-            </DeliveryRecordsProblemReview>
-          </DeliveryRecords>
-        ))}
+              >
+                <DeliveryRecordsProblemConfirmation
+                  path="confirmed"
+                  productType={productType}
+                />
+              </DeliveryRecordsProblemReview>
+            </DeliveryRecords>
+          ))}
 
-      <EmailAndMarketing path="/email-prefs" />
+        <EmailAndMarketing path="/email-prefs" />
 
-      <PublicProfile path="/public-settings" />
+        <PublicProfile path="/public-settings" />
 
-      <Settings path="/account-settings" />
+        <Settings path="/account-settings" />
 
-      <Help path="/help" />
-      <HelpCentre path="/help-centre" />
+        <Help path="/help" />
+        <HelpCentre path="/help-centre" />
 
-      <ContactUs path="/contact-us" />
-      <ContactUs path="/contact-us/:urlTopicId" />
-      <ContactUs path="/contact-us/:urlTopicId/:urlSubTopicId" />
-      <ContactUs path="/contact-us/:urlTopicId/:urlSubTopicId/:urlSubSubTopicId" />
-      <ContactUs path="/contact-us/:urlTopicId/:urlSubTopicId/:urlSubSubTopicId/:urlSuccess" />
+        <ContactUs path="/contact-us" />
+        <ContactUs path="/contact-us/:urlTopicId" />
+        <ContactUs path="/contact-us/:urlTopicId/:urlSubTopicId" />
+        <ContactUs path="/contact-us/:urlTopicId/:urlSubTopicId/:urlSubSubTopicId" />
+        <ContactUs path="/contact-us/:urlTopicId/:urlSubTopicId/:urlSubSubTopicId/:urlSuccess" />
 
-      {/* otherwise redirect to root instead of having a "not found page" */}
-      <Redirect default from="/*" to="/" noThrow />
-    </Router>
+        {/* otherwise redirect to root instead of having a "not found page" */}
+        <Redirect default from="/*" to="/" noThrow />
+      </Router>
+    </Suspense>
   </Main>
 );
 

--- a/app/client/components/user.tsx
+++ b/app/client/components/user.tsx
@@ -59,7 +59,6 @@ const User = () => (
   <Main>
     <Global styles={css(`${global}`)} />
     <Global styles={css(`${fonts}`)} />
-    {/* replace with a real fallback component */}
     <Suspense fallback={<PageSkeleton />}>
       <Router primary={true} css={{ height: "100%" }}>
         <AccountOverview path="/" />

--- a/app/jest.config.js
+++ b/app/jest.config.js
@@ -8,6 +8,10 @@ module.exports = {
   snapshotSerializers: ["jest-emotion"],
   globals: {
     "ts-jest": {
+      tsConfig: {
+        jsx: "react",
+        module: "commonjs"
+      },
       babelConfig: require("./webpack.common").babelCommon
     }
   },

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     /* Basic Options */
     "target": "esnext" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
-    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
+    "module": "esnext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
@@ -34,7 +34,7 @@
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */
-    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */


### PR DESCRIPTION
## What does this change?
This PR introduces route based code splitting using React Lazy and Suspense. A Suspense fallback component has also been added which acts as an intermediary view whilst each separate code chunk is loading. React Lazy works with files that have a default export so the relevant pages have been updated.

The tsconfig `module` value has been changed from `commonjs` to `ESnext` in order to get the code splitting to work as expected, with the previous setting webpack had trouble separating chunks. As a result of changing the tsconfig the jest configuration has also been updated to ensure it uses commonjs.

## How can we measure success?
- the parsed bundle size was 1.32mb and is now 1.06mb
- the gzipped bundle size was 362kb and is now 303.19kb

## Have we considered potential risks?
There was a risk of users seeing a blank whilst the page was loading. We have addressed this by including an intermediary view (pageSkeleton) whilst chunks are loading.

## Images
This is what it looks like on a fast 3G connection
![](https://user-images.githubusercontent.com/44685872/105369749-c03b5e80-5bfa-11eb-9272-581c21014d5b.gif)

Successfully tested on CODE

Co-authored by @ripecosta @rBangay 
