### PR TITLE
Check if auth keys are fetchable before identity healthcheck

### DIFF
--- a/app/server/apiGatewayDiscovery.ts
+++ b/app/server/apiGatewayDiscovery.ts
@@ -218,22 +218,18 @@ export const getContactUsAPIHostAndKey = async () => {
  * Used to fail riff raff deployment. Uses an arbitrarily selected service layer api as a check.
  * Memoised in the sense of credentials fetching happens only once on deployment.
  */
-function tmp(): HostAndApiKey {
-  return {};
-}
-export const memoisedApiGatewayAuthForHealthcheck = () => {
-  // const memoisedHostKeyPair = getHostAndApiKeyForStack(
-  //   "membership",
-  //   "holiday-stop-api",
-  //   "PROD"
-  // );
+export const authKeysAreFetchableMemoisedHealthcheck = () => {
+  const memoisedHostKeyPair = getHostAndApiKeyForStack(
+    "membership",
+    "holiday-stop-api",
+    "PROD"
+  );
   return async (
     _: express.Request,
     res: express.Response,
     next: express.NextFunction
   ) => {
-    // const { host, apiKey } = await memoisedHostKeyPair;
-    const { host, apiKey } = tmp();
+    const { host, apiKey } = await memoisedHostKeyPair;
     const errMsg = `Failed to fetch authentication credentials for API Gateway service layer. Healthcheck failed!`;
     if (apiKey && host) {
       next();

--- a/app/server/apiGatewayDiscovery.ts
+++ b/app/server/apiGatewayDiscovery.ts
@@ -218,21 +218,26 @@ export const getContactUsAPIHostAndKey = async () => {
  * Used to fail riff raff deployment. Uses an arbitrarily selected service layer api as a check.
  * Memoised in the sense of credentials fetching happens only once on deployment.
  */
+function tmp(): HostAndApiKey {
+  return {};
+}
 export const memoisedApiGatewayAuthForHealthcheck = () => {
-  const memoisedHostKeyPair = getHostAndApiKeyForStack(
-    "membership",
-    "holiday-stop-api",
-    "PROD"
-  );
+  // const memoisedHostKeyPair = getHostAndApiKeyForStack(
+  //   "membership",
+  //   "holiday-stop-api",
+  //   "PROD"
+  // );
   return async (
     _: express.Request,
     res: express.Response,
     next: express.NextFunction
   ) => {
-    const { host, apiKey } = await memoisedHostKeyPair;
+    // const { host, apiKey } = await memoisedHostKeyPair;
+    const { host, apiKey } = tmp();
     const errMsg = `Failed to fetch authentication credentials for API Gateway service layer. Healthcheck failed!`;
     if (apiKey && host) {
       next();
+      // res.status(500).send(errMsg);
     } else {
       log.error(errMsg);
       res.status(500).send(errMsg);

--- a/app/server/apiGatewayDiscovery.ts
+++ b/app/server/apiGatewayDiscovery.ts
@@ -237,7 +237,6 @@ export const memoisedApiGatewayAuthForHealthcheck = () => {
     const errMsg = `Failed to fetch authentication credentials for API Gateway service layer. Healthcheck failed!`;
     if (apiKey && host) {
       next();
-      // res.status(500).send(errMsg);
     } else {
       log.error(errMsg);
       res.status(500).send(errMsg);

--- a/app/server/middleware/identityMiddleware.ts
+++ b/app/server/middleware/identityMiddleware.ts
@@ -9,7 +9,6 @@ import { requiresSignin } from "../../shared/requiresSignin";
 import { handleAwsRelatedError } from "../awsIntegration";
 import { conf } from "../config";
 import { idapiConfigPromise } from "../idapiConfig";
-import { log } from "../log";
 
 interface RedirectResponseBody extends IdentityDetails {
   signInStatus: string;
@@ -148,7 +147,6 @@ export const withIdentity: (
   res: express.Response,
   next: express.NextFunction
 ) => {
-  log.info("Running identity healthcheck...");
   const errorHandler = (message: string, detail?: any) => {
     handleAwsRelatedError(message, detail);
     res.sendStatus(500); // TODO maybe server side render a pretty response
@@ -159,7 +157,6 @@ export const withIdentity: (
   idapiConfigPromise
     .then(idapiConfig => {
       if (idapiConfig) {
-        log.info("Running identity healthcheck idapiConfig==true...");
         fetch(
           url.format({
             protocol: "https",
@@ -182,15 +179,12 @@ export const withIdentity: (
               redirectResponse.json() as Promise<RedirectResponseBody>
           )
           .then(redirectResponseBody => {
-            log.info("Running identity healthcheck redirectResponseBody...");
             // tslint:disable-next-line:no-object-mutation
             Object.assign(res.locals, { identity: redirectResponseBody });
 
             if (!requiresSignin(req.originalUrl)) {
-              log.info("Running identity healthcheck !requiresSignin...");
               next();
             } else if (redirectResponseBody.redirect) {
-              log.info("Running identity healthcheck requiresSignin...");
               redirectOrCustomStatusCode(
                 res,
                 augmentRedirectURL(

--- a/app/server/middleware/identityMiddleware.ts
+++ b/app/server/middleware/identityMiddleware.ts
@@ -9,6 +9,7 @@ import { requiresSignin } from "../../shared/requiresSignin";
 import { handleAwsRelatedError } from "../awsIntegration";
 import { conf } from "../config";
 import { idapiConfigPromise } from "../idapiConfig";
+import { log } from "../log";
 
 interface RedirectResponseBody extends IdentityDetails {
   signInStatus: string;
@@ -147,6 +148,7 @@ export const withIdentity: (
   res: express.Response,
   next: express.NextFunction
 ) => {
+  log.info("Running identity healthcheck...");
   const errorHandler = (message: string, detail?: any) => {
     handleAwsRelatedError(message, detail);
     res.sendStatus(500); // TODO maybe server side render a pretty response
@@ -157,6 +159,7 @@ export const withIdentity: (
   idapiConfigPromise
     .then(idapiConfig => {
       if (idapiConfig) {
+        log.info("Running identity healthcheck idapiConfig==true...");
         fetch(
           url.format({
             protocol: "https",
@@ -179,12 +182,15 @@ export const withIdentity: (
               redirectResponse.json() as Promise<RedirectResponseBody>
           )
           .then(redirectResponseBody => {
+            log.info("Running identity healthcheck redirectResponseBody...");
             // tslint:disable-next-line:no-object-mutation
             Object.assign(res.locals, { identity: redirectResponseBody });
 
             if (!requiresSignin(req.originalUrl)) {
+              log.info("Running identity healthcheck !requiresSignin...");
               next();
             } else if (redirectResponseBody.redirect) {
+              log.info("Running identity healthcheck requiresSignin...");
               redirectOrCustomStatusCode(
                 res,
                 augmentRedirectURL(

--- a/app/server/routes/core.ts
+++ b/app/server/routes/core.ts
@@ -1,17 +1,12 @@
 import { Request, Response, Router } from "express";
 import { log } from "../log";
-import { withIdentity } from "../middleware/identityMiddleware";
 
 const router = Router();
 
-router.get(
-  "/_healthcheck",
-  withIdentity(200), // healthcheck needs identity redirect service to be accessible (returns 200 if redirect required)
-  (_: Request, res: Response) => {
-    log.info("healthcheck ok");
-    res.send("OK - signed in");
-  }
-);
+router.get("/_healthcheck", (_: Request, res: Response) => {
+  log.info("processing healthcheck...");
+  res.status(500).send("Boom boom boom");
+});
 
 router.get("/_prout", (_, res: Response) => {
   res.send(`<pre>${GIT_COMMIT_HASH}</pre>`);

--- a/app/server/routes/core.ts
+++ b/app/server/routes/core.ts
@@ -1,5 +1,6 @@
 import { Request, Response, Router } from "express";
 import { memoisedApiGatewayAuthForHealthcheck } from "../apiGatewayDiscovery";
+import { log } from "../log";
 import { withIdentity } from "../middleware/identityMiddleware";
 
 const router = Router();
@@ -9,6 +10,7 @@ router.get(
   withIdentity(200), // healthcheck needs identity redirect service to be accessible (returns 200 if redirect required)
   memoisedApiGatewayAuthForHealthcheck(),
   (_: Request, res: Response) => {
+    log.info("healthcheck ok");
     res.send("OK - signed in");
   }
 );

--- a/app/server/routes/core.ts
+++ b/app/server/routes/core.ts
@@ -1,12 +1,17 @@
 import { Request, Response, Router } from "express";
-import { log } from "../log";
+import { memoisedApiGatewayAuthForHealthcheck } from "../apiGatewayDiscovery";
+import { withIdentity } from "../middleware/identityMiddleware";
 
 const router = Router();
 
-router.get("/_healthcheck", (_: Request, res: Response) => {
-  log.info("processing healthcheck...");
-  res.status(500).send("Boom boom boom");
-});
+router.get(
+  "/_healthcheck",
+  memoisedApiGatewayAuthForHealthcheck(),
+  withIdentity(200), // healthcheck needs identity redirect service to be accessible (returns 200 if redirect required)
+  (_: Request, res: Response) => {
+    res.send("OK - signed in");
+  }
+);
 
 router.get("/_prout", (_, res: Response) => {
   res.send(`<pre>${GIT_COMMIT_HASH}</pre>`);

--- a/app/server/routes/core.ts
+++ b/app/server/routes/core.ts
@@ -1,12 +1,16 @@
 import { Request, Response, Router } from "express";
-import { memoisedApiGatewayAuthForHealthcheck } from "../apiGatewayDiscovery";
+import { authKeysAreFetchableMemoisedHealthcheck } from "../apiGatewayDiscovery";
 import { withIdentity } from "../middleware/identityMiddleware";
 
 const router = Router();
 
+/**
+ * In some cases withIdentity might not call its next middleware so if you add a new healthcheck to the sequence
+ * you might have to add it above withIdentity.
+ */
 router.get(
   "/_healthcheck",
-  memoisedApiGatewayAuthForHealthcheck(),
+  authKeysAreFetchableMemoisedHealthcheck(),
   withIdentity(200), // healthcheck needs identity redirect service to be accessible (returns 200 if redirect required)
   (_: Request, res: Response) => {
     res.send("OK - signed in");

--- a/app/server/routes/core.ts
+++ b/app/server/routes/core.ts
@@ -1,5 +1,4 @@
 import { Request, Response, Router } from "express";
-import { memoisedApiGatewayAuthForHealthcheck } from "../apiGatewayDiscovery";
 import { log } from "../log";
 import { withIdentity } from "../middleware/identityMiddleware";
 
@@ -8,7 +7,6 @@ const router = Router();
 router.get(
   "/_healthcheck",
   withIdentity(200), // healthcheck needs identity redirect service to be accessible (returns 200 if redirect required)
-  memoisedApiGatewayAuthForHealthcheck(),
   (_: Request, res: Response) => {
     log.info("healthcheck ok");
     res.send("OK - signed in");


### PR DESCRIPTION
## What does this change?

Fix for [Add API Gateway key resolution to healthcheck #559](https://github.com/guardian/manage-frontend/pull/559)

## How to test

Tested in CODE by forcing 500 result from `authKeysAreFetchableMemoisedHealthcheck` and observing deployment fail.

## Have we considered potential risks?

Arguably healthcheck logic could be made clearer however since `withIdentity` is used beyond just the healtcheck any refactoring is perhaps best left for a dedicated PR.