### PR TITLE
Parameterise keys healthcheck by stage

### DIFF
--- a/app/server/apiGatewayDiscovery.ts
+++ b/app/server/apiGatewayDiscovery.ts
@@ -222,7 +222,7 @@ export const authKeysAreFetchableMemoisedHealthcheck = () => {
   const memoisedHostKeyPair = getHostAndApiKeyForStack(
     "membership",
     "holiday-stop-api",
-    "PROD"
+    conf.STAGE.toUpperCase()
   );
   return async (
     _: express.Request,


### PR DESCRIPTION
## What does this change?

- CODE has no permissions to fetch PROD keys.
- Fix https://github.com/guardian/manage-frontend/pull/577

## How to test

Try deploying to CODE.

