### PR TITLE
Add functionality for links in Known Issues banner

### DIFF
--- a/app/client/components/helpCentre/knownIssues.tsx
+++ b/app/client/components/helpCentre/knownIssues.tsx
@@ -72,10 +72,8 @@ export const KnownIssues = () => {
           <div
             css={{
               border: `4px solid ${palette.news[400]}`,
-              padding: `${space[3]}px ${space[3]}px ${space[3]}px ${space[3]}px`,
+              padding: `${space[3]}px ${space[3]}px ${space[3]}px 42px`,
               position: "relative",
-              display: "flex",
-              alignItems: "center",
               ...gridItemPlacement(1, 4),
 
               [minWidth.tablet]: {
@@ -93,31 +91,26 @@ export const KnownIssues = () => {
           >
             <i
               css={css`
-                margin-right: ${space[3]}px;
+                position: absolute;
+                top: 50%;
+                transform: translateY(-50%);
+                left: ${space[3]}px;
               `}
             >
               <ErrorIcon />
             </i>
-            <div
+            <h4
               css={css`
-                display: flex;
-                flex-direction: column;
+                ${textSans.medium({ fontWeight: "bold" })};
+                color: ${palette.news[400]};
+                margin: 0;
               `}
             >
-              <h4
-                css={css`
-                  ${textSans.medium({ fontWeight: "bold" })};
-                  color: ${palette.news[400]};
-                  margin: 0;
-                  display: inline;
-                `}
-              >
-                {issue.message}
-              </h4>
+              {issue.message}&nbsp;
               {issue.link && (
                 <a
                   css={css`
-                    ${textSans.small({ fontWeight: "regular" })}
+                    text-decoration: underline;
                   `}
                   href={issue.link}
                   target="_blank"
@@ -125,7 +118,7 @@ export const KnownIssues = () => {
                   Click here for more information
                 </a>
               )}
-            </div>
+            </h4>
           </div>
         </div>
       ))}

--- a/app/client/components/helpCentre/knownIssues.tsx
+++ b/app/client/components/helpCentre/knownIssues.tsx
@@ -11,6 +11,7 @@ import { ErrorIcon } from "../svgs/errorIcon";
 interface Issue {
   date: string;
   message: string;
+  link?: string;
   affectedProducts?: string[];
 }
 
@@ -71,8 +72,10 @@ export const KnownIssues = () => {
           <div
             css={{
               border: `4px solid ${palette.news[400]}`,
-              padding: `${space[3]}px ${space[3]}px ${space[3]}px 42px`,
+              padding: `${space[3]}px ${space[3]}px ${space[3]}px ${space[3]}px`,
               position: "relative",
+              display: "flex",
+              alignItems: "center",
               ...gridItemPlacement(1, 4),
 
               [minWidth.tablet]: {
@@ -90,23 +93,39 @@ export const KnownIssues = () => {
           >
             <i
               css={css`
-                position: absolute;
-                top: 50%;
-                transform: translateY(-50%);
-                left: ${space[3]}px;
+                margin-right: ${space[3]}px;
               `}
             >
               <ErrorIcon />
             </i>
-            <h4
+            <div
               css={css`
-                ${textSans.medium({ fontWeight: "bold" })};
-                color: ${palette.news[400]};
-                margin: 0;
+                display: flex;
+                flex-direction: column;
               `}
             >
-              {issue.message}
-            </h4>
+              <h4
+                css={css`
+                  ${textSans.medium({ fontWeight: "bold" })};
+                  color: ${palette.news[400]};
+                  margin: 0;
+                  display: inline;
+                `}
+              >
+                {issue.message}
+              </h4>
+              {issue.link && (
+                <a
+                  css={css`
+                    ${textSans.small({ fontWeight: "regular" })}
+                  `}
+                  href={issue.link}
+                  target="_blank"
+                >
+                  Click here for more information
+                </a>
+              )}
+            </div>
           </div>
         </div>
       ))}


### PR DESCRIPTION
## What does this change?
This PR adds an optional link to the an issue alert. This means we can now provide further information to the user about the issue should we choose to.

## Images
Before
![](https://user-images.githubusercontent.com/44685872/106272128-753bcf80-6228-11eb-971e-80123bfa65fe.png)

After
![](https://user-images.githubusercontent.com/44685872/106759902-2aa4c380-662b-11eb-88c2-8bc061921423.png)
