### PR TITLE
Split MMA and HelpCentre bundles

### DIFF
--- a/app/client/HelpCentrePage.ts
+++ b/app/client/HelpCentrePage.ts
@@ -2,7 +2,7 @@ import "@babel/polyfill";
 import * as Sentry from "@sentry/browser";
 import "ophan-tracker-js/build/ophan.manage-my-account";
 import ReactDOM from "react-dom";
-import { BrowserUser } from "./components/user";
+import { HelpCentrePage } from "./components/HelpCentrePage";
 
 declare var WEBPACK_BUILD: string;
 
@@ -15,4 +15,4 @@ if (typeof window !== "undefined" && window.guardian && window.guardian.dsn) {
 }
 
 const element = document.getElementById("app");
-ReactDOM.render(BrowserUser, element);
+ReactDOM.render(HelpCentrePage, element);

--- a/app/client/MMAPage.ts
+++ b/app/client/MMAPage.ts
@@ -1,0 +1,18 @@
+import "@babel/polyfill";
+import * as Sentry from "@sentry/browser";
+import "ophan-tracker-js/build/ophan.manage-my-account";
+import ReactDOM from "react-dom";
+import { MMAPage } from "./components/MMAPage";
+
+declare var WEBPACK_BUILD: string;
+
+if (typeof window !== "undefined" && window.guardian && window.guardian.dsn) {
+  Sentry.init({
+    dsn: window.guardian.dsn,
+    release: WEBPACK_BUILD || "local",
+    environment: window.guardian.domain
+  });
+}
+
+const element = document.getElementById("app");
+ReactDOM.render(MMAPage, element);

--- a/app/client/__tests__/components/header.tsx
+++ b/app/client/__tests__/components/header.tsx
@@ -8,7 +8,12 @@ Enzyme.configure({ adapter: new Adapter() });
 describe.only("Header", () => {
   it("renders the header in a signed out state", () => {
     const wrapper = mount(<Header />);
-    expect(wrapper.find("Link").text()).toEqual("Sign in");
+    expect(
+      wrapper
+        .find("a")
+        .at(0)
+        .text()
+    ).toEqual("Sign in");
   });
 
   it("renders the header in a signed in state", () => {

--- a/app/client/components/HelpCentrePage.tsx
+++ b/app/client/components/HelpCentrePage.tsx
@@ -9,6 +9,10 @@ import HelpCentrePageSkeleton from "./HelpCentrePageSkeleton";
 import { Main } from "./main";
 import { ScrollToTop } from "./scrollToTop";
 
+// The code below uses magic comments to instruct Webpack on
+// how to name the chunks these dynamic imports produce
+// More information: https://webpack.js.org/api/module-methods/#magic-comments
+
 const HelpCentre = lazy(() =>
   import(/* webpackChunkName: "HelpCentre" */ "./helpCentre/helpCentre")
 );

--- a/app/client/components/HelpCentrePage.tsx
+++ b/app/client/components/HelpCentrePage.tsx
@@ -1,0 +1,49 @@
+import { css, Global } from "@emotion/core";
+import { Redirect, Router } from "@reach/router";
+import React, { lazy, Suspense } from "react";
+import { fonts } from "../styles/fonts";
+import global from "../styles/global";
+import { AnalyticsTracker } from "./analytics";
+import { CMPBanner } from "./consent/CMPBanner";
+import { Main } from "./main";
+import PageSkeleton from "./pageSkeleton";
+import { ScrollToTop } from "./scrollToTop";
+
+const HelpCentre = lazy(() =>
+  import(/* webpackChunkName: "HelpCentre" */ "./helpCentre/helpCentre")
+);
+const ContactUs = lazy(() =>
+  import(/* webpackChunkName: "ContactUs" */ "./contactUs/contactUs")
+);
+
+const HelpCentreRouter = () => {
+  return (
+    <Main>
+      <Global styles={css(`${global}`)} />
+      <Global styles={css(`${fonts}`)} />
+      <Suspense fallback={<PageSkeleton />}>
+        <Router primary={true} css={{ height: "100%" }}>
+          <HelpCentre path="/help-centre" />
+
+          <ContactUs path="/contact-us" />
+          <ContactUs path="/contact-us/:urlTopicId" />
+          <ContactUs path="/contact-us/:urlTopicId/:urlSubTopicId" />
+          <ContactUs path="/contact-us/:urlTopicId/:urlSubTopicId/:urlSubSubTopicId" />
+          <ContactUs path="/contact-us/:urlTopicId/:urlSubTopicId/:urlSubSubTopicId/:urlSuccess" />
+
+          {/* otherwise redirect to root instead of having a "not found page" */}
+          <Redirect default from="/*" to="/" noThrow />
+        </Router>
+      </Suspense>
+    </Main>
+  );
+};
+
+export const HelpCentrePage = (
+  <>
+    <AnalyticsTracker />
+    <HelpCentreRouter />
+    <CMPBanner />
+    <ScrollToTop />
+  </>
+);

--- a/app/client/components/HelpCentrePage.tsx
+++ b/app/client/components/HelpCentrePage.tsx
@@ -5,8 +5,8 @@ import { fonts } from "../styles/fonts";
 import global from "../styles/global";
 import { AnalyticsTracker } from "./analytics";
 import { CMPBanner } from "./consent/CMPBanner";
+import HelpCentrePageSkeleton from "./HelpCentrePageSkeleton";
 import { Main } from "./main";
-import PageSkeleton from "./pageSkeleton";
 import { ScrollToTop } from "./scrollToTop";
 
 const HelpCentre = lazy(() =>
@@ -21,7 +21,7 @@ const HelpCentreRouter = () => {
     <Main>
       <Global styles={css(`${global}`)} />
       <Global styles={css(`${fonts}`)} />
-      <Suspense fallback={<PageSkeleton />}>
+      <Suspense fallback={<HelpCentrePageSkeleton />}>
         <Router primary={true} css={{ height: "100%" }}>
           <HelpCentre path="/help-centre" />
 

--- a/app/client/components/HelpCentrePage.tsx
+++ b/app/client/components/HelpCentrePage.tsx
@@ -32,7 +32,7 @@ const HelpCentreRouter = () => {
           <ContactUs path="/contact-us/:urlTopicId/:urlSubTopicId/:urlSubSubTopicId/:urlSuccess" />
 
           {/* otherwise redirect to root instead of having a "not found page" */}
-          <Redirect default from="/*" to="/" noThrow />
+          <Redirect default from="/*" to="/help-centre" noThrow />
         </Router>
       </Suspense>
     </Main>

--- a/app/client/components/HelpCentrePageSkeleton.tsx
+++ b/app/client/components/HelpCentrePageSkeleton.tsx
@@ -23,36 +23,34 @@ const nonMMALocationObjectArr: LocationObject[] = [
   }
 ];
 
-const MMAPageSkeleton = () => {
-  return (
-    <Location>
-      {({ location }) => {
-        const selectedNonMMALocationObject = nonMMALocationObjectArr.filter(
-          currentObject => location.pathname.startsWith(currentObject.path)
-        )[0];
+const MMAPageSkeleton = () => (
+  <Location>
+    {({ location }) => {
+      const selectedNonMMALocationObject = nonMMALocationObjectArr.filter(
+        currentObject => location.pathname.startsWith(currentObject.path)
+      )[0];
 
-        if (selectedNonMMALocationObject) {
-          return (
-            <>
-              <SectionHeader title={selectedNonMMALocationObject.title} />
-              <SectionPageContainer sectionTitle="&nbsp;">
-                <div
-                  css={css`
-                    margin-bottom: ${space[24]}px;
-                  `}
-                >
-                  <WithStandardTopMargin>
-                    <Spinner />
-                  </WithStandardTopMargin>
-                  <div style={{ height: "50vh" }} />
-                </div>
-              </SectionPageContainer>
-            </>
-          );
-        }
-      }}
-    </Location>
-  );
-};
+      if (selectedNonMMALocationObject) {
+        return (
+          <>
+            <SectionHeader title={selectedNonMMALocationObject.title} />
+            <SectionPageContainer sectionTitle="&nbsp;">
+              <div
+                css={css`
+                  margin-bottom: ${space[24]}px;
+                `}
+              >
+                <WithStandardTopMargin>
+                  <Spinner />
+                </WithStandardTopMargin>
+                <div style={{ height: "50vh" }} />
+              </div>
+            </SectionPageContainer>
+          </>
+        );
+      }
+    }}
+  </Location>
+);
 
 export default MMAPageSkeleton;

--- a/app/client/components/HelpCentrePageSkeleton.tsx
+++ b/app/client/components/HelpCentrePageSkeleton.tsx
@@ -1,0 +1,58 @@
+import { css } from "@emotion/core";
+import { space } from "@guardian/src-foundations";
+import { Location } from "@reach/router";
+import React from "react";
+import { WithStandardTopMargin } from "./page";
+import { SectionHeader } from "./sectionHeader";
+import { SectionPageContainer } from "./sectionPageContainer";
+import { Spinner } from "./spinner";
+
+interface LocationObject {
+  title: string;
+  path: string;
+}
+
+const nonMMALocationObjectArr: LocationObject[] = [
+  {
+    title: "Help Centre",
+    path: "/help-centre"
+  },
+  {
+    title: "Need to contact us about something?",
+    path: "/contact-us"
+  }
+];
+
+const MMAPageSkeleton = () => {
+  return (
+    <Location>
+      {({ location }) => {
+        const selectedNonMMALocationObject = nonMMALocationObjectArr.filter(
+          currentObject => location.pathname.startsWith(currentObject.path)
+        )[0];
+
+        if (selectedNonMMALocationObject) {
+          return (
+            <>
+              <SectionHeader title={selectedNonMMALocationObject.title} />
+              <SectionPageContainer sectionTitle="&nbsp;">
+                <div
+                  css={css`
+                    margin-bottom: ${space[24]}px;
+                  `}
+                >
+                  <WithStandardTopMargin>
+                    <Spinner />
+                  </WithStandardTopMargin>
+                  <div style={{ height: "50vh" }} />
+                </div>
+              </SectionPageContainer>
+            </>
+          );
+        }
+      }}
+    </Location>
+  );
+};
+
+export default MMAPageSkeleton;

--- a/app/client/components/MMAPage.tsx
+++ b/app/client/components/MMAPage.tsx
@@ -29,7 +29,7 @@ import { HolidayConfirmed } from "./holiday/holidayConfirmed";
 import { HolidayDateChooser } from "./holiday/holidayDateChooser";
 import { HolidayReview } from "./holiday/holidayReview";
 import { Main } from "./main";
-import PageSkeleton from "./pageSkeleton";
+import MMAPageSkeleton from "./MMAPageSkeleton";
 import { ConfirmPaymentUpdate } from "./payment/update/confirmPaymentUpdate";
 import { PaymentUpdated } from "./payment/update/paymentUpdated";
 import { ScrollToTop } from "./scrollToTop";
@@ -87,7 +87,7 @@ const MMARouter = () => (
   <Main>
     <Global styles={css(`${global}`)} />
     <Global styles={css(`${fonts}`)} />
-    <Suspense fallback={<PageSkeleton />}>
+    <Suspense fallback={<MMAPageSkeleton />}>
       <Router primary={true} css={{ height: "100%" }}>
         <AccountOverview path="/" />
         <Billing path="/billing" />

--- a/app/client/components/MMAPage.tsx
+++ b/app/client/components/MMAPage.tsx
@@ -34,6 +34,10 @@ import { ConfirmPaymentUpdate } from "./payment/update/confirmPaymentUpdate";
 import { PaymentUpdated } from "./payment/update/paymentUpdated";
 import { ScrollToTop } from "./scrollToTop";
 
+// The code below uses magic comments to instruct Webpack on
+// how to name the chunks these dynamic imports produce
+// More information: https://webpack.js.org/api/module-methods/#magic-comments
+
 const AccountOverview = lazy(() =>
   import(
     /* webpackChunkName: "AccountOverview" */ "./accountoverview/accountOverview"

--- a/app/client/components/MMAPage.tsx
+++ b/app/client/components/MMAPage.tsx
@@ -34,28 +34,56 @@ import { ConfirmPaymentUpdate } from "./payment/update/confirmPaymentUpdate";
 import { PaymentUpdated } from "./payment/update/paymentUpdated";
 import { ScrollToTop } from "./scrollToTop";
 
-const AccountOverview = lazy(() => import("./accountoverview/accountOverview"));
-const Billing = lazy(() => import("./billing/billing"));
-const ManageProduct = lazy(() => import("./accountoverview/manageProduct"));
-const CancellationFlow = lazy(() => import("./cancel/cancellationFlow"));
-const PaymentUpdateFlow = lazy(() =>
-  import("./payment/update/updatePaymentFlow")
+const AccountOverview = lazy(() =>
+  import(
+    /* webpackChunkName: "AccountOverview" */ "./accountoverview/accountOverview"
+  )
 );
-const HolidaysOverview = lazy(() => import("./holiday/holidaysOverview"));
+const Billing = lazy(() =>
+  import(/* webpackChunkName: "Billing" */ "./billing/billing")
+);
+const ManageProduct = lazy(() =>
+  import(
+    /* webpackChunkName: "ManageProduct" */ "./accountoverview/manageProduct"
+  )
+);
+const CancellationFlow = lazy(() =>
+  import(/* webpackChunkName: "CancellationFlow" */ "./cancel/cancellationFlow")
+);
+const PaymentUpdateFlow = lazy(() =>
+  import(
+    /* webpackChunkName: "PaymentUpdateFlow" */ "./payment/update/updatePaymentFlow"
+  )
+);
+const HolidaysOverview = lazy(() =>
+  import(
+    /* HolidaysOverview: "holidaysoverview" */ "./holiday/holidaysOverview"
+  )
+);
 const DeliveryAddressForm = lazy(() =>
-  import("./delivery/address/deliveryAddressForm")
+  import(
+    /* webpackChunkName: "DeliveryAddressForm" */ "./delivery/address/deliveryAddressForm"
+  )
 );
 const DeliveryRecords = lazy(() =>
-  import("./delivery/records/deliveryRecords")
+  import(
+    /* webpackChunkName: "DeliveryRecords" */ "./delivery/records/deliveryRecords"
+  )
 );
-const EmailAndMarketing = lazy(() => import("./identity/EmailAndMarketing"));
-const PublicProfile = lazy(() => import("./identity/PublicProfile"));
-const Settings = lazy(() => import("./identity/Settings"));
-const Help = lazy(() => import("./help"));
-const HelpCentre = lazy(() => import("./helpCentre/helpCentre"));
-const ContactUs = lazy(() => import("./contactUs/contactUs"));
+const EmailAndMarketing = lazy(() =>
+  import(
+    /* webpackChunkName: "EmailAndMarketing" */ "./identity/EmailAndMarketing"
+  )
+);
+const PublicProfile = lazy(() =>
+  import(/* webpackChunkName: "PublicProfile" */ "./identity/PublicProfile")
+);
+const Settings = lazy(() =>
+  import(/* webpackChunkName: "Settings" */ "./identity/Settings")
+);
+const Help = lazy(() => import(/* webpackChunkName: "Help" */ "./help"));
 
-const User = () => (
+const MMARouter = () => (
   <Main>
     <Global styles={css(`${global}`)} />
     <Global styles={css(`${fonts}`)} />
@@ -193,25 +221,17 @@ const User = () => (
         <Settings path="/account-settings" />
 
         <Help path="/help" />
-        <HelpCentre path="/help-centre" />
 
-        <ContactUs path="/contact-us" />
-        <ContactUs path="/contact-us/:urlTopicId" />
-        <ContactUs path="/contact-us/:urlTopicId/:urlSubTopicId" />
-        <ContactUs path="/contact-us/:urlTopicId/:urlSubTopicId/:urlSubSubTopicId" />
-        <ContactUs path="/contact-us/:urlTopicId/:urlSubTopicId/:urlSubSubTopicId/:urlSuccess" />
-
-        {/* otherwise redirect to root instead of having a "not found page" */}
         <Redirect default from="/*" to="/" noThrow />
       </Router>
     </Suspense>
   </Main>
 );
 
-export const BrowserUser = (
+export const MMAPage = (
   <>
     <AnalyticsTracker />
-    <User />
+    <MMARouter />
     <CMPBanner />
     <ScrollToTop />
   </>

--- a/app/client/components/MMAPageSkeleton.tsx
+++ b/app/client/components/MMAPageSkeleton.tsx
@@ -1,5 +1,3 @@
-import { css } from "@emotion/core";
-import { space } from "@guardian/src-foundations";
 import { Location } from "@reach/router";
 import React from "react";
 import {
@@ -9,8 +7,6 @@ import {
 } from "../../shared/productTypes";
 import { MenuSpecificNavItem, NAV_LINKS } from "./nav/navConfig";
 import { PageContainer, WithStandardTopMargin } from "./page";
-import { SectionHeader } from "./sectionHeader";
-import { SectionPageContainer } from "./sectionPageContainer";
 import { Spinner } from "./spinner";
 
 interface LocationObject {
@@ -113,49 +109,13 @@ const MMALocationObjectArr: LocationObject[] = [
   }
 ];
 
-const nonMMALocationObjectArr: LocationObject[] = [
-  {
-    title: "Help Centre",
-    path: "/help-centre",
-    selectedNavItem: NAV_LINKS.help
-  },
-  {
-    title: "Need to contact us about something?",
-    path: "/contact-us",
-    selectedNavItem: NAV_LINKS.help
-  }
-];
-
-const PageSkeleton = () => {
+const MMAPageSkeleton = () => {
   return (
     <Location>
       {({ location }) => {
         const selectedMMALocationObject = MMALocationObjectArr.filter(
           currentObject => location.pathname === currentObject.path
         )[0];
-        const selectedNonMMALocationObject = nonMMALocationObjectArr.filter(
-          currentObject => location.pathname.startsWith(currentObject.path)
-        )[0];
-
-        if (selectedNonMMALocationObject) {
-          return (
-            <>
-              <SectionHeader title={selectedNonMMALocationObject.title} />
-              <SectionPageContainer sectionTitle="&nbsp;">
-                <div
-                  css={css`
-                    margin-bottom: ${space[24]}px;
-                  `}
-                >
-                  <WithStandardTopMargin>
-                    <Spinner />
-                  </WithStandardTopMargin>
-                  <div style={{ height: "50vh" }} />
-                </div>
-              </SectionPageContainer>
-            </>
-          );
-        }
 
         if (selectedMMALocationObject) {
           return (
@@ -174,4 +134,4 @@ const PageSkeleton = () => {
   );
 };
 
-export default PageSkeleton;
+export default MMAPageSkeleton;

--- a/app/client/components/MMAPageSkeleton.tsx
+++ b/app/client/components/MMAPageSkeleton.tsx
@@ -109,29 +109,27 @@ const MMALocationObjectArr: LocationObject[] = [
   }
 ];
 
-const MMAPageSkeleton = () => {
-  return (
-    <Location>
-      {({ location }) => {
-        const selectedMMALocationObject = MMALocationObjectArr.filter(
-          currentObject => location.pathname === currentObject.path
-        )[0];
+const MMAPageSkeleton = () => (
+  <Location>
+    {({ location }) => {
+      const selectedMMALocationObject = MMALocationObjectArr.filter(
+        currentObject => location.pathname === currentObject.path
+      )[0];
 
-        if (selectedMMALocationObject) {
-          return (
-            <PageContainer
-              selectedNavItem={selectedMMALocationObject.selectedNavItem}
-              pageTitle={selectedMMALocationObject.title}
-            >
-              <WithStandardTopMargin>
-                <Spinner />
-              </WithStandardTopMargin>
-            </PageContainer>
-          );
-        }
-      }}
-    </Location>
-  );
-};
+      if (selectedMMALocationObject) {
+        return (
+          <PageContainer
+            selectedNavItem={selectedMMALocationObject.selectedNavItem}
+            pageTitle={selectedMMALocationObject.title}
+          >
+            <WithStandardTopMargin>
+              <Spinner />
+            </WithStandardTopMargin>
+          </PageContainer>
+        );
+      }
+    }}
+  </Location>
+);
 
 export default MMAPageSkeleton;

--- a/app/client/components/header.tsx
+++ b/app/client/components/header.tsx
@@ -77,8 +77,8 @@ const Header = () => {
           </>
         )}
         {headerStatus === "signedOut" && (
-          <Link
-            to={"/"}
+          <a
+            href={"/"}
             css={{
               textDecoration: "none",
               color: palette.neutral["100"],
@@ -97,7 +97,7 @@ const Header = () => {
             }}
           >
             Sign in
-          </Link>
+          </a>
         )}
         <GridRoundel
           fillMain={palette.neutral["100"]}

--- a/app/client/components/help.tsx
+++ b/app/client/components/help.tsx
@@ -1,4 +1,5 @@
 import { css } from "@emotion/core";
+import { LinkButton } from "@guardian/src-button";
 import { space } from "@guardian/src-foundations";
 import { brand, neutral } from "@guardian/src-foundations/palette";
 import { headline, textSans } from "@guardian/src-foundations/typography";
@@ -6,7 +7,6 @@ import { RouteComponentProps } from "@reach/router";
 import React, { useState } from "react";
 import { minWidth } from "../styles/breakpoints";
 import { trackEvent } from "./analytics";
-import { LinkButton } from "./buttons";
 import { CallCentreEmailAndNumbers } from "./callCenterEmailAndNumbers";
 import { NAV_LINKS } from "./nav/navConfig";
 import { PageContainer } from "./page";
@@ -145,18 +145,17 @@ const Help = (_: RouteComponentProps) => {
         Visit our Help Centre to find more useful information
       </p>
       <LinkButton
-        to={"/help-centre/"}
-        text={"Visit Help Centre"}
-        colour={brand[800]}
-        textColour={brand[400]}
-        fontWeight={"bold"}
+        href="/help-centre/"
+        priority="secondary"
         onClick={() =>
           trackEvent({
             eventCategory: "help-page",
             eventAction: "help-centre-cta-click"
           })
         }
-      />
+      >
+        Visit Help Centre
+      </LinkButton>
       <p css={pStyle}>
         If you still can’t find what you need and want to contact us, check{" "}
         <span
@@ -174,18 +173,17 @@ const Help = (_: RouteComponentProps) => {
             soon as possible.
           </p>
           <LinkButton
-            to={"/contact-us/"}
-            text={"Take me to the form"}
-            colour={brand[800]}
-            textColour={brand[400]}
-            fontWeight={"bold"}
+            href="/contact-us/"
+            priority="secondary"
             onClick={() =>
               trackEvent({
                 eventCategory: "help-page",
                 eventAction: "contact-us-cta-click"
               })
             }
-          />
+          >
+            Take me to the form
+          </LinkButton>
         </>
       )}
     </PageContainer>

--- a/app/server/routes/frontendCommon.ts
+++ b/app/server/routes/frontendCommon.ts
@@ -1,14 +1,9 @@
 import * as Sentry from "@sentry/node";
-import { Request, Response, Router } from "express";
 import { conf, Environments } from "../config";
-import html from "../html";
 import { log } from "../log";
-import { withIdentity } from "../middleware/identityMiddleware";
 import { recaptchaConfigPromise } from "../recaptchaConfig";
 
-const router = Router();
-
-const clientDSN =
+export const clientDSN =
   conf.ENVIRONMENT === Environments.PRODUCTION && conf.CLIENT_DSN
     ? conf.CLIENT_DSN
     : null;
@@ -16,7 +11,7 @@ if (conf.ENVIRONMENT === Environments.PRODUCTION && !conf.CLIENT_DSN) {
   log.error("NO SENTRY IN CLIENT PROD!");
 }
 
-const getRecaptchaPublicKey = async () => {
+export const getRecaptchaPublicKey = async () => {
   try {
     const recaptchaConfig = await recaptchaConfigPromise;
     const recaptchaPublicKey = recaptchaConfig?.publicKey;
@@ -34,23 +29,3 @@ const getRecaptchaPublicKey = async () => {
     Sentry.captureException(err);
   }
 };
-
-router.use(withIdentity(), async (_: Request, res: Response) => {
-  const title = "My Account | The Guardian";
-  const src = "/static/user.js";
-
-  res.send(
-    html({
-      title,
-      src,
-      globals: {
-        domain: conf.DOMAIN,
-        dsn: clientDSN,
-        identityDetails: res.locals.identity,
-        recaptchaPublicKey: await getRecaptchaPublicKey()
-      }
-    })
-  );
-});
-
-export default router;

--- a/app/server/routes/helpCentreFrontend.ts
+++ b/app/server/routes/helpCentreFrontend.ts
@@ -1,0 +1,27 @@
+import { Request, Response, Router } from "express";
+import { conf } from "../config";
+import html from "../html";
+import { withIdentity } from "../middleware/identityMiddleware";
+import { clientDSN, getRecaptchaPublicKey } from "./frontendCommon";
+
+const router = Router();
+
+router.use(withIdentity(), async (_: Request, res: Response) => {
+  const title = "Help Centre | The Guardian";
+  const src = "/static/helpcentre.js";
+
+  res.send(
+    html({
+      title,
+      src,
+      globals: {
+        domain: conf.DOMAIN,
+        dsn: clientDSN,
+        identityDetails: res.locals.identity,
+        recaptchaPublicKey: await getRecaptchaPublicKey()
+      }
+    })
+  );
+});
+
+export default router;

--- a/app/server/routes/index.ts
+++ b/app/server/routes/index.ts
@@ -1,6 +1,7 @@
 export { default as core } from "./core";
 export { default as api } from "./api";
 export { default as profile } from "./profile";
-export { default as frontend } from "./frontend";
+export { default as frontend } from "./mmaFrontend";
+export { default as helpcentre } from "./helpCentreFrontend";
 export { default as productsProvider } from "./products";
 export { default as idapi } from "./idapi";

--- a/app/server/routes/mmaFrontend.ts
+++ b/app/server/routes/mmaFrontend.ts
@@ -1,0 +1,27 @@
+import { Request, Response, Router } from "express";
+import { conf } from "../config";
+import html from "../html";
+import { withIdentity } from "../middleware/identityMiddleware";
+import { clientDSN, getRecaptchaPublicKey } from "./frontendCommon";
+
+const router = Router();
+
+router.use(withIdentity(), async (_: Request, res: Response) => {
+  const title = "My Account | The Guardian";
+  const src = "/static/mma.js";
+
+  res.send(
+    html({
+      title,
+      src,
+      globals: {
+        domain: conf.DOMAIN,
+        dsn: clientDSN,
+        identityDetails: res.locals.identity,
+        recaptchaPublicKey: await getRecaptchaPublicKey()
+      }
+    })
+  );
+});
+
+export default router;

--- a/app/server/server.ts
+++ b/app/server/server.ts
@@ -72,9 +72,14 @@ server.use(routes.core);
 server.use("/profile/", routes.profile);
 server.use("/api/", routes.api);
 server.use("/idapi", routes.idapi);
+
 server.use(routes.productsProvider("/api/"));
 
-// ALL OTHER ENDPOINTS CAN BE HANDLED BY CLIENT SIDE REACT ROUTING
+// Help Centre and Contact Us
+server.use("/contact-us", routes.helpcentre);
+server.use("/help-centre", routes.helpcentre);
+
+// ALL OTHER ENDPOINTS CAN BE HANDLED BY MMA CLIENT SIDE REACT ROUTING
 server.use(routes.frontend);
 
 if (conf.SERVER_DSN) {

--- a/app/server/server.ts
+++ b/app/server/server.ts
@@ -72,7 +72,6 @@ server.use(routes.core);
 server.use("/profile/", routes.profile);
 server.use("/api/", routes.api);
 server.use("/idapi", routes.idapi);
-
 server.use(routes.productsProvider("/api/"));
 
 // Help Centre and Contact Us

--- a/app/webpack.common.js
+++ b/app/webpack.common.js
@@ -99,7 +99,8 @@ const server = merge(common, {
 
 const client = merge(common, {
   entry: {
-    user: ["whatwg-fetch", "./client/user"]
+    mma: ["whatwg-fetch", "./client/MMAPage"],
+    helpcentre: ["whatwg-fetch", "./client/HelpCentrePage"]
   },
   output: {
     path: path.resolve(__dirname, "dist", "static"),


### PR DESCRIPTION
## What does this change?
This PR splits our single bundle (user.js) into an MMA bundle and Help Centre bundle to improve bundle size. MMA's bundle size has a minimal reduction but the Help Centre bundle shrinks significantly. This will provide a better experience for users accessing the Help Centre and the Contact Us form.

It also adds [magic comments](https://webpack.js.org/api/module-methods/#magic-comments) to the dynamic imports that instruct Webpack on how to name the chunk produced byt that import. This will make it easier for us to debug any issues that involve the chunks.

Note: More can be done to further decrease the bundle sizes, especially for the Help Centre. As it stands there is still unnecessary code being imported into each bundle because of how our code e organised.I will raise a separate PR with these changes and both can be merged to master at the same time.

### Bundle analysis

Before | After
------------ | -------------
![Screenshot 2021-02-01 at 18 14 35](https://user-images.githubusercontent.com/48949546/106500632-f65dc580-64b9-11eb-8679-7a7c36b8549b.png) | ![Screenshot 2021-02-01 at 18 17 47](https://user-images.githubusercontent.com/48949546/106500653-fd84d380-64b9-11eb-8d30-332225308fda.png)

#### Summary

&nbsp; | parsed | gziped
------------ | ------------- | -------------
Single bundle | 1.06 MB | 302.85 KB
MMA bundle | 1.06 MB | 302.04 KB
HelpCentre bundle | 460.13 KB | **139.89 KB**

### Browser analysis
How much code do we actually need to load before the user can interact with the page?
<sub>This includes the main bundle plus any chunks needed to render each of the landing page</sub>

&nbsp; | Before | After | % Change
------------ | ------------- | ------------- | -------------
MMA | 331.2 KB | 331.3 KB | +0.03%
Help Centre | 323.4 KB | **207.3 KB** | **-35.9%**
Contact Us | 328.1 KB | **171.2 KB** | **-47.82%**