### PR TITLE
Remove the changeTier field from ProductType

### DIFF
--- a/app/client/components/accountoverview/manageProduct.tsx
+++ b/app/client/components/accountoverview/manageProduct.tsx
@@ -1,5 +1,4 @@
 import { css } from "@emotion/core";
-import { Button } from "@guardian/src-button";
 import { space } from "@guardian/src-foundations";
 import { brand, brandAlt, neutral } from "@guardian/src-foundations/palette";
 import { headline, textSans } from "@guardian/src-foundations/typography";
@@ -149,11 +148,6 @@ const InnerContent = ({ props, productDetail }: InnerContentProps) => {
         />
       )}
 
-      {specificProductType.changeTierUrl && (
-        <a href={specificProductType.changeTierUrl(window?.guardian?.domain)}>
-          <Button priority="secondary">Change tier</Button>
-        </a>
-      )}
       <h2
         css={css`
           ${subHeadingCss}

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -151,7 +151,6 @@ export interface ProductType {
   ) => OphanProduct | undefined;
   shouldRevealSubscriptionId?: boolean;
   tierLabel?: string;
-  changeTierUrl?: (domain?: string) => string;
   renewalMetadata?: SupportTheGuardianButtonProps;
   noProductSupportUrlSuffix?: string;
   cancellation?: CancellationFlowProperties; // undefined 'cancellation' means no cancellation flow
@@ -299,8 +298,6 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
     cancelledCopy:
       "Your membership has been cancelled. You will continue to receive the benefits of your membership until",
     tierLabel: "Membership tier",
-    changeTierUrl: (domain?: string) =>
-      `https://membership.${domain || "theguardian.com"}/tier/change`,
     shouldShowJoinDateNotStartDate: true
   },
   contributions: {


### PR DESCRIPTION
## What does this change?
We are no longer allowing members to change their tier via membership.theguardian.com so this PR removes the 'change tier' button from the manage product page. 

As membership was the product which had a change tier option I have also removed it from the ProductType type.

## How to test
Log into manage with an account that has a membership and click the 'manage membership' button, you should no longer see the 'change tier' button on the manage product page.


## How can we measure success?
This is just a tidy up exercise

