### PR TITLE
Update snyk policy

### DIFF
--- a/app/.snyk
+++ b/app/.snyk
@@ -5,105 +5,105 @@ ignore:
   SNYK-JS-LODASH-590103:
     - '@emotion/core > @emotion/css > babel-plugin-emotion > @babel/helper-module-imports > @babel/types > lodash':
         reason: no upgrade or patch available
-        expires: '2021-02-07T15:34:06.024Z'
+        expires: '2021-03-10T11:42:04.829Z'
     - '@emotion/styled > babel-plugin-emotion > @babel/helper-module-imports > @babel/types > lodash':
         reason: no upgrade or patch available
-        expires: '2021-02-07T15:34:06.024Z'
+        expires: '2021-03-10T11:42:04.829Z'
     - formik > lodash:
         reason: no upgrade or patch available
-        expires: '2021-02-07T15:34:06.024Z'
+        expires: '2021-03-10T11:42:04.829Z'
     - winston > async > lodash:
         reason: no upgrade or patch available
-        expires: '2021-02-07T15:34:06.025Z'
+        expires: '2021-03-10T11:42:04.829Z'
     - yup > lodash:
         reason: no upgrade or patch available
-        expires: '2021-02-07T15:34:06.025Z'
+        expires: '2021-03-10T11:42:04.829Z'
     - winston > async > lodash:
         reason: no upgrade or patch available
-        expires: '2020-12-16T11:03:52.660Z'
+        expires: '2021-03-10T11:42:04.829Z'
     - yup > lodash:
         reason: no upgrade or patch available
-        expires: '2020-12-16T11:03:52.660Z'
+        expires: '2021-03-10T11:42:04.829Z'
     - formik > lodash:
         reason: No remediation available
-        expires: '2020-12-20T10:37:44.000Z'
+        expires: '2021-03-10T11:42:04.829Z'
     - '@emotion/styled > babel-plugin-emotion > @babel/helper-module-imports > @babel/types > lodash':
         reason: no upgrade or patch available
-        expires: '2021-01-16T16:29:26.231Z'
+        expires: '2021-03-10T11:42:04.829Z'
     - winston > async > lodash:
         reason: no upgrade or patch available
-        expires: '2021-01-16T16:29:26.231Z'
+        expires: '2021-03-10T11:42:04.829Z'
     - yup > lodash:
         reason: no upgrade or patch available
-        expires: '2021-01-16T16:29:26.232Z'
+        expires: '2021-03-10T11:42:04.829Z'
   SNYK-JS-MINIMIST-559764:
     - node-pre-gyp > mkdirp > minimist:
         reason: no upgrade or patch available
-        expires: '2021-02-07T15:34:06.025Z'
+        expires: '2021-03-10T11:42:04.829Z'
     - node-pre-gyp > tar > mkdirp > minimist:
         reason: no upgrade or patch available
-        expires: '2021-02-07T15:34:06.025Z'
+        expires: '2021-03-10T11:42:04.829Z'
     - node-pre-gyp > rc > minimist:
         reason: no upgrade or patch available
-        expires: '2021-02-07T15:34:06.025Z'
+        expires: '2021-03-10T11:42:04.829Z'
   SNYK-JS-UAPARSERJS-610226:
     - formik > create-react-context > fbjs > ua-parser-js:
         reason: no upgrade or patch available
-        expires: '2021-02-07T15:34:06.025Z'
+        expires: '2021-03-10T11:42:04.829Z'
     - react-daterange-picker > create-react-class > fbjs > ua-parser-js:
         reason: no upgrade or patch available
-        expires: '2021-02-07T15:34:06.025Z'
+        expires: '2021-03-10T11:42:04.829Z'
     - react-daterange-picker > react-addons-pure-render-mixin > fbjs > ua-parser-js:
         reason: no upgrade or patch available
-        expires: '2021-02-07T15:34:06.025Z'
+        expires: '2021-03-10T11:42:04.829Z'
     - react-daterange-picker > create-react-class > fbjs > ua-parser-js:
         reason: no upgrade or patch available
-        expires: '2020-12-16T11:03:52.660Z'
+        expires: '2021-03-10T11:42:04.829Z'
     - react-daterange-picker > react-addons-pure-render-mixin > fbjs > ua-parser-js:
         reason: no upgrade or patch available
-        expires: '2020-12-16T11:03:52.660Z'
+        expires: '2021-03-10T11:42:04.829Z'
     - react-daterange-picker > create-react-class > fbjs > ua-parser-js:
         reason: no upgrade or patch available
-        expires: '2021-01-16T16:29:26.231Z'
+        expires: '2021-03-10T11:42:04.829Z'
     - react-daterange-picker > react-addons-pure-render-mixin > fbjs > ua-parser-js:
         reason: no upgrade or patch available
-        expires: '2021-01-16T16:29:26.231Z'
+        expires: '2021-03-10T11:42:04.829Z'
   SNYK-JS-NODEFETCH-674311:
     - formik > create-react-context > fbjs > isomorphic-fetch > node-fetch:
         reason: no upgrade or patch available
-        expires: '2021-02-07T15:34:06.024Z'
+        expires: '2021-03-10T11:42:04.829Z'
     - react-daterange-picker > create-react-class > fbjs > isomorphic-fetch > node-fetch:
         reason: no upgrade or patch available
-        expires: '2021-02-07T15:34:06.025Z'
+        expires: '2021-03-10T11:42:04.829Z'
     - react-daterange-picker > react-addons-pure-render-mixin > fbjs > isomorphic-fetch > node-fetch:
         reason: no upgrade or patch available
-        expires: '2021-02-07T15:34:06.025Z'
+        expires: '2021-03-10T11:42:04.829Z'
     - react-daterange-picker > create-react-class > fbjs > isomorphic-fetch > node-fetch:
         reason: no upgrade or patch available
-        expires: '2020-12-16T11:03:52.660Z'
+        expires: '2021-03-10T11:42:04.829Z'
     - react-daterange-picker > react-addons-pure-render-mixin > fbjs > isomorphic-fetch > node-fetch:
         reason: no upgrade or patch available
-        expires: '2020-12-16T11:03:52.661Z'
+        expires: '2021-03-10T11:42:04.829Z'
     - react-daterange-picker > create-react-class > fbjs > isomorphic-fetch > node-fetch:
         reason: no upgrade or patch available
-        expires: '2021-01-16T16:29:26.231Z'
+        expires: '2021-03-10T11:42:04.829Z'
     - react-daterange-picker > react-addons-pure-render-mixin > fbjs > isomorphic-fetch > node-fetch:
         reason: no upgrade or patch available
-        expires: '2021-01-16T16:29:26.231Z'
+        expires: '2021-03-10T11:42:04.829Z'
   SNYK-JS-UAPARSERJS-1023599:
     - formik > create-react-context > fbjs > ua-parser-js:
         reason: None given
-        expires: '2021-02-12T17:53:35.352Z'
+        expires: '2021-03-10T11:42:04.829Z'
     - react-daterange-picker > create-react-class > fbjs > ua-parser-js:
         reason: None given
-        expires: '2021-02-12T17:53:35.352Z'
+        expires: '2021-03-10T11:42:04.829Z'
     - react-daterange-picker > react-addons-pure-render-mixin > fbjs > ua-parser-js:
         reason: None given
-        expires: '2021-02-12T17:53:35.352Z'
+        expires: '2021-03-10T11:42:04.829Z'
   SNYK-JS-INI-1048974:
     - node-pre-gyp > rc > ini:
         reason: None given
-        expires: '2021-02-12T17:53:35.352Z'
+        expires: '2021-03-10T11:42:04.829Z'
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   SNYK-JS-LODASH-450202:


### PR DESCRIPTION
## What does this change?
Updates the snyk policy. Ignores vulnerable libraries that no available patch. Updates the expiry date on all ignores libraries to the same day to minimise disturbance to developers.

NOTE: It is urgent that we reconsider our current use of the `formik` and `react-daterange-picker` as these now have a number of accumulated security vulnerabilities.