### PR TITLE
Move Contact Us into Help Centre

### DIFF
--- a/app/client/components/HelpCentrePage.tsx
+++ b/app/client/components/HelpCentrePage.tsx
@@ -29,11 +29,11 @@ const HelpCentreRouter = () => {
         <Router primary={true} css={{ height: "100%" }}>
           <HelpCentre path="/help-centre" />
 
-          <ContactUs path="/contact-us" />
-          <ContactUs path="/contact-us/:urlTopicId" />
-          <ContactUs path="/contact-us/:urlTopicId/:urlSubTopicId" />
-          <ContactUs path="/contact-us/:urlTopicId/:urlSubTopicId/:urlSubSubTopicId" />
-          <ContactUs path="/contact-us/:urlTopicId/:urlSubTopicId/:urlSubSubTopicId/:urlSuccess" />
+          <ContactUs path="/help-centre/contact-us" />
+          <ContactUs path="/help-centre/contact-us/:urlTopicId" />
+          <ContactUs path="/help-centre/contact-us/:urlTopicId/:urlSubTopicId" />
+          <ContactUs path="/help-centre/contact-us/:urlTopicId/:urlSubTopicId/:urlSubSubTopicId" />
+          <ContactUs path="/help-centre/contact-us/:urlTopicId/:urlSubTopicId/:urlSubSubTopicId/:urlSuccess" />
 
           {/* otherwise redirect to root instead of having a "not found page" */}
           <Redirect default from="/*" to="/help-centre" noThrow />

--- a/app/client/components/HelpCentrePageSkeleton.tsx
+++ b/app/client/components/HelpCentrePageSkeleton.tsx
@@ -19,7 +19,7 @@ const nonMMALocationObjectArr: LocationObject[] = [
   },
   {
     title: "Need to contact us about something?",
-    path: "/contact-us"
+    path: "/help-centre/contact-us"
   }
 ];
 

--- a/app/client/components/contactUs/contactUs.tsx
+++ b/app/client/components/contactUs/contactUs.tsx
@@ -80,7 +80,7 @@ const ContactUs = (props: ContactUsProps) => {
       eventLabel: selectedTopic
     });
 
-    navigate(`/contact-us/${selectedTopic}`, { replace: true });
+    navigate(`/help-centre/contact-us/${selectedTopic}`, { replace: true });
   };
 
   const setSubTopic = (selectedSubTopic: string) => {
@@ -90,9 +90,12 @@ const ContactUs = (props: ContactUsProps) => {
       eventLabel: selectedSubTopic
     });
 
-    navigate(`/contact-us/${currentTopic?.id}/${selectedSubTopic}`, {
-      replace: true
-    });
+    navigate(
+      `/help-centre/contact-us/${currentTopic?.id}/${selectedSubTopic}`,
+      {
+        replace: true
+      }
+    );
   };
 
   const setSubSubTopic = (selectedSubSubTopic: string) => {
@@ -103,7 +106,7 @@ const ContactUs = (props: ContactUsProps) => {
     });
 
     navigate(
-      `/contact-us/${currentTopic?.id}/${currentSubTopic?.id}/${selectedSubSubTopic}`,
+      `/help-centre/contact-us/${currentTopic?.id}/${currentSubTopic?.id}/${selectedSubSubTopic}`,
       {
         replace: true
       }
@@ -138,7 +141,7 @@ const ContactUs = (props: ContactUsProps) => {
       });
 
       const urlSections = [
-        "/contact-us",
+        "/help-centre/contact-us",
         currentTopic?.id,
         currentSubTopic?.id || "0",
         currentSubSubTopic?.id || "0",

--- a/app/client/components/help.tsx
+++ b/app/client/components/help.tsx
@@ -173,7 +173,7 @@ const Help = (_: RouteComponentProps) => {
             soon as possible.
           </p>
           <LinkButton
-            href="/contact-us/"
+            href="/help-centre/contact-us/"
             priority="secondary"
             onClick={() =>
               trackEvent({

--- a/app/client/components/helpCentre/helpCentre.tsx
+++ b/app/client/components/helpCentre/helpCentre.tsx
@@ -89,7 +89,7 @@ const HelpCentre = (_: HelpCentreProps) => (
           textColour={brand[400]}
           fontWeight={"bold"}
           text="Take me to the form"
-          to="/contact-us/"
+          to="/help-centre/contact-us/"
           onClick={() =>
             trackEvent({
               eventCategory: "help-centre",

--- a/app/server/server.ts
+++ b/app/server/server.ts
@@ -74,8 +74,7 @@ server.use("/api/", routes.api);
 server.use("/idapi", routes.idapi);
 server.use(routes.productsProvider("/api/"));
 
-// Help Centre and Contact Us
-server.use("/contact-us", routes.helpcentre);
+// Help Centre
 server.use("/help-centre", routes.helpcentre);
 
 // ALL OTHER ENDPOINTS CAN BE HANDLED BY MMA CLIENT SIDE REACT ROUTING

--- a/app/shared/__tests__/requiresSignin.ts
+++ b/app/shared/__tests__/requiresSignin.ts
@@ -2,11 +2,11 @@ import { requiresSignin } from "../requiresSignin";
 
 describe("requiresSignin", () => {
   test("returns false for a public path", () => {
-    expect(requiresSignin("/contact-us")).toEqual(false);
+    expect(requiresSignin("/help-centre")).toEqual(false);
   });
 
   test("returns false for a folder inside a public path", () => {
-    expect(requiresSignin("/contact-us/1/")).toEqual(false);
+    expect(requiresSignin("/help-centre/1/")).toEqual(false);
   });
 
   test("returns true for a private path (base path)", () => {
@@ -18,6 +18,6 @@ describe("requiresSignin", () => {
   });
 
   test("returns true for a private path hidden within a public path (path traversal attack)", () => {
-    expect(requiresSignin("/contact-us/../billing")).toEqual(true);
+    expect(requiresSignin("/help-centre/../billing")).toEqual(true);
   });
 });

--- a/app/shared/requiresSignin.ts
+++ b/app/shared/requiresSignin.ts
@@ -1,12 +1,7 @@
 import * as pathLib from "path";
 
 // To avoid security vulnerabilities do not add public paths that do not end in a slash
-const publicPaths = [
-  "/contact-us/",
-  "/api/contact-us/",
-  "/help-centre/",
-  "/api/known-issues/"
-];
+const publicPaths = ["/api/contact-us/", "/help-centre/", "/api/known-issues/"];
 
 export const requiresSignin = (path: string) => {
   const normalizedPath = pathLib.normalize(path + "/");


### PR DESCRIPTION
## What does this change?
The Contact Us form is part of the Help Centre. However, because it was created first it got its own separate URL. This PR moves it from `https//manage.theguardian.com/contact-us` to `https://manage.theguardian.com/help-centre/contact-us`.