### PR TITLE
Soft opt ins

### DIFF
--- a/app/client/components/accountoverview/manageProduct.tsx
+++ b/app/client/components/accountoverview/manageProduct.tsx
@@ -326,9 +326,9 @@ const InnerContent = ({ props, productDetail }: InnerContentProps) => {
           </>
         )}
 
-      {specificProductType.restrictedNewsletterIDs && (
+      {specificProductType.productPageNewsletterIDs && (
         <NewsletterOptinSection
-          activeNewletterIDs={specificProductType.restrictedNewsletterIDs}
+          activeNewletterIDs={specificProductType.productPageNewsletterIDs}
         />
       )}
 

--- a/app/client/components/identity/EmailAndMarketing/ConsentSection.tsx
+++ b/app/client/components/identity/EmailAndMarketing/ConsentSection.tsx
@@ -11,6 +11,10 @@ interface ConsentSectionProps {
   consents: ConsentOption[];
 }
 
+const releaseSoftOptIns = false;
+const softOptInEmailConsents = (consents: ConsentOption[]): ConsentOption[] =>
+  consents.filter(consent => !!consent.isProduct && releaseSoftOptIns);
+
 const otherEmailConsents = (consents: ConsentOption[]): ConsentOption[] => {
   const ids = ["supporter", "jobs", "holidays", "events", "offers"];
   return ConsentOptions.findByIds(consents, ids);
@@ -51,6 +55,7 @@ export const ConsentSection: FC<ConsentSectionProps> = props => {
         our products, services and events.
       `}
     >
+      {consentPreferences(softOptInEmailConsents(consents), clickHandler)}
       {consentPreferences(otherEmailConsents(consents), clickHandler)}
       <h2
         css={{

--- a/app/client/components/identity/idapi/consents.ts
+++ b/app/client/components/identity/idapi/consents.ts
@@ -6,23 +6,27 @@ interface ConsentAPIResponse {
   description: string;
   name: string;
   isOptOut: boolean;
+  isChannel: boolean;
+  isProduct: boolean;
 }
 
 const consentToConsentOption = (
   response: ConsentAPIResponse
 ): ConsentOption => {
-  const { id, description, name, isOptOut } = response;
+  const { id, description, name, isProduct, isChannel, isOptOut } = response;
   return {
     id,
     description,
     name,
+    isProduct,
+    isChannel,
     type: isOptOut ? ConsentOptionType.OPT_OUT : ConsentOptionType.EMAIL,
     subscribed: false
   };
 };
 
 export const read = async (): Promise<ConsentOption[]> => {
-  const url = "/consents";
+  const url = "/consents?filter=all";
   return (await identityFetch(url)).map(consentToConsentOption);
 };
 

--- a/app/client/components/identity/models.ts
+++ b/app/client/components/identity/models.ts
@@ -63,6 +63,8 @@ export interface ConsentOption {
   type: ConsentOptionType;
   subscribed: boolean;
   identityName?: string;
+  isProduct?: boolean;
+  isChannel?: boolean;
 }
 
 export interface ConsentOptionCollection {

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -453,8 +453,7 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
     softOptInIDs: [
       SOFT_OPT_IN_IDS.support_onboarding,
       SOFT_OPT_IN_IDS.guardian_weekly_newsletter,
-      SOFT_OPT_IN_IDS.similar_products,
-      SOFT_OPT_IN_IDS.supporter_newsletter
+      SOFT_OPT_IN_IDS.similar_products
     ],
     getOphanProductType: () => "PRINT_SUBSCRIPTION", // TODO create a GUARDIAN_WEEKLY Product in Ophan data model
     renewalMetadata: {

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -428,6 +428,8 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
     getOphanProductType: () => "PRINT_SUBSCRIPTION",
     productPageNewsletterIDs: [FRONT_PAGE_NEWSLETTER_ID],
     softOptInIDs: [
+      SOFT_OPT_IN_IDS.support_onboarding,
+      SOFT_OPT_IN_IDS.subscriber_preview,
       SOFT_OPT_IN_IDS.similar_products,
       SOFT_OPT_IN_IDS.supporter_newsletter
     ],

--- a/app/shared/productTypes.tsx
+++ b/app/shared/productTypes.tsx
@@ -141,6 +141,7 @@ export interface ProductType {
   shortFriendlyName?: string;
   allProductsProductTypeFilterString: AllProductsProductTypeFilterString;
   urlPart: ProductUrlPart;
+  softOptInIDs: string[];
   legacyUrlPart?: string; // could easily adapt to be string[] if multiple were required in future
   getOphanProductType?: (
     productDetail: ProductDetail
@@ -160,7 +161,7 @@ export interface ProductType {
     explicitSingleDayOfWeek?: string;
   };
   shouldShowJoinDateNotStartDate?: true;
-  restrictedNewsletterIDs?: string[];
+  productPageNewsletterIDs?: string[];
 }
 
 export interface GroupedProductType extends ProductType {
@@ -203,6 +204,14 @@ const calculateProductTitle = (baseProductTitle: string) => (
 ) => baseProductTitle + (mainPlan?.name ? ` - ${mainPlan.name}` : "");
 
 const FRONT_PAGE_NEWSLETTER_ID = "6009";
+enum SOFT_OPT_IN_IDS {
+  support_onboarding = "your_support_onboarding",
+  similar_products = "similar_guardian_products",
+  supporter_newsletter = "supporter_newsletter",
+  subscriber_preview = "subscriber_preview",
+  digi_subscriber_preview = "digital_subscriber_preview",
+  guardian_weekly_newsletter = "guardian_weekly_newsletter"
+}
 
 type ProductTypeKeys =
   | "membership"
@@ -248,7 +257,12 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
     cancelledCopy:
       "Your membership has been cancelled. You will continue to receive the benefits of your membership until",
     tierLabel: "Membership tier",
-    shouldShowJoinDateNotStartDate: true
+    shouldShowJoinDateNotStartDate: true,
+    softOptInIDs: [
+      SOFT_OPT_IN_IDS.support_onboarding,
+      SOFT_OPT_IN_IDS.similar_products,
+      SOFT_OPT_IN_IDS.supporter_newsletter
+    ]
   },
   contributions: {
     productTitle: () => "Recurring contribution",
@@ -258,6 +272,11 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
     getOphanProductType: () => "RECURRING_CONTRIBUTION",
     noProductSupportUrlSuffix: "/contribute",
     updateAmountMdaEndpoint: "contribution-update-amount",
+    softOptInIDs: [
+      SOFT_OPT_IN_IDS.support_onboarding,
+      SOFT_OPT_IN_IDS.similar_products,
+      SOFT_OPT_IN_IDS.supporter_newsletter
+    ],
     cancellation: {
       linkOnProductPage: true,
       reasons: contributionsCancellationReasons,
@@ -304,11 +323,17 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
     allProductsProductTypeFilterString: "Paper",
     urlPart: "paper",
     getOphanProductType: () => "PRINT_SUBSCRIPTION",
-    restrictedNewsletterIDs: [FRONT_PAGE_NEWSLETTER_ID],
+    productPageNewsletterIDs: [FRONT_PAGE_NEWSLETTER_ID],
     delivery: {
       showAddress: showDeliveryAddressCheck,
       enableDeliveryInstructionsUpdate: true
-    }
+    },
+    softOptInIDs: [
+      SOFT_OPT_IN_IDS.support_onboarding,
+      SOFT_OPT_IN_IDS.subscriber_preview,
+      SOFT_OPT_IN_IDS.similar_products,
+      SOFT_OPT_IN_IDS.supporter_newsletter
+    ]
   },
   homedelivery: {
     productTitle: calculateProductTitle("Newspaper Delivery"),
@@ -317,7 +342,13 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
     allProductsProductTypeFilterString: "HomeDelivery",
     urlPart: "homedelivery",
     getOphanProductType: () => "PRINT_SUBSCRIPTION",
-    restrictedNewsletterIDs: [FRONT_PAGE_NEWSLETTER_ID],
+    productPageNewsletterIDs: [FRONT_PAGE_NEWSLETTER_ID],
+    softOptInIDs: [
+      SOFT_OPT_IN_IDS.support_onboarding,
+      SOFT_OPT_IN_IDS.subscriber_preview,
+      SOFT_OPT_IN_IDS.similar_products,
+      SOFT_OPT_IN_IDS.supporter_newsletter
+    ],
     holidayStops: {
       issueKeyword: "paper"
     },
@@ -346,7 +377,13 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
     allProductsProductTypeFilterString: "Voucher",
     urlPart: "voucher",
     getOphanProductType: () => "PRINT_SUBSCRIPTION",
-    restrictedNewsletterIDs: [FRONT_PAGE_NEWSLETTER_ID],
+    productPageNewsletterIDs: [FRONT_PAGE_NEWSLETTER_ID],
+    softOptInIDs: [
+      SOFT_OPT_IN_IDS.support_onboarding,
+      SOFT_OPT_IN_IDS.subscriber_preview,
+      SOFT_OPT_IN_IDS.similar_products,
+      SOFT_OPT_IN_IDS.supporter_newsletter
+    ],
     holidayStops: {
       issueKeyword: "voucher",
       alternateNoticeString: "one day's notice",
@@ -389,7 +426,11 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
     urlPart: "subscriptioncard",
     legacyUrlPart: "digitalvoucher",
     getOphanProductType: () => "PRINT_SUBSCRIPTION",
-    restrictedNewsletterIDs: [FRONT_PAGE_NEWSLETTER_ID],
+    productPageNewsletterIDs: [FRONT_PAGE_NEWSLETTER_ID],
+    softOptInIDs: [
+      SOFT_OPT_IN_IDS.similar_products,
+      SOFT_OPT_IN_IDS.supporter_newsletter
+    ],
     holidayStops: {
       issueKeyword: "issue",
       alternateNoticeString: "one day's notice",
@@ -407,6 +448,12 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
     shortFriendlyName: "Guardian Weekly",
     allProductsProductTypeFilterString: "Weekly",
     urlPart: "guardianweekly",
+    softOptInIDs: [
+      SOFT_OPT_IN_IDS.support_onboarding,
+      SOFT_OPT_IN_IDS.guardian_weekly_newsletter,
+      SOFT_OPT_IN_IDS.similar_products,
+      SOFT_OPT_IN_IDS.supporter_newsletter
+    ],
     getOphanProductType: () => "PRINT_SUBSCRIPTION", // TODO create a GUARDIAN_WEEKLY Product in Ophan data model
     renewalMetadata: {
       alternateButtonText: "Subscribe here",
@@ -456,6 +503,12 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
     legacyUrlPart: "digitalpack",
     getOphanProductType: () => "DIGITAL_SUBSCRIPTION",
     showTrialRemainingIfApplicable: true,
+    softOptInIDs: [
+      SOFT_OPT_IN_IDS.support_onboarding,
+      SOFT_OPT_IN_IDS.digi_subscriber_preview,
+      SOFT_OPT_IN_IDS.similar_products,
+      SOFT_OPT_IN_IDS.supporter_newsletter
+    ],
     cancellation: {
       linkOnProductPage: true,
       reasons: digipackCancellationReasons,
@@ -505,6 +558,10 @@ export const GROUPED_PRODUCT_TYPES: {
     groupFriendlyName: "subscriptions",
     allProductsProductTypeFilterString: "ContentSubscription",
     urlPart: "subscriptions",
+    softOptInIDs: [
+      SOFT_OPT_IN_IDS.similar_products,
+      SOFT_OPT_IN_IDS.supporter_newsletter
+    ],
     mapGroupedToSpecific: (
       productDetail: ProductDetail | CancelledProductDetail
     ) => {


### PR DESCRIPTION
## What does this change?
This pr is the manage-frontend part of the wider soft-opt in work. The scope of this pr is the loading of the new consents endpoint from identity api and displaying of relevant soft opt in's dependent on what products the user has. 

Users should be able to see which emails they are opted into and out of and be able to opt in and out of them.

**Until the other parts of the soft-opt in work in support-frontend (work to opt users in, on product acquisition) and support-service-lambdas (work to opt users out when they reach their cancellation effective date) are done, then the new opt ins should not be visible to the user. This is handled crudely in the code using the following boolean in** `client/components/identity/EmailAndMarketing/ConsentSection.tsx`

![Screenshot 2021-02-09 at 16 04 39](https://user-images.githubusercontent.com/2510683/107393224-74415280-6af2-11eb-97b4-9d7a3d96eae8.png)

## Images
example of the new opt ins (they will be hidden as part of this pr though)
![Screenshot 2021-02-09 at 09 47 34](https://user-images.githubusercontent.com/2510683/107394486-db133b80-6af3-11eb-9e43-a263c19800ba.png)

