### PR TITLE
Update help centre landing page and contact us layout

### DIFF
--- a/app/client/components/HelpCentrePageSkeleton.tsx
+++ b/app/client/components/HelpCentrePageSkeleton.tsx
@@ -12,29 +12,31 @@ interface LocationObject {
   path: string;
 }
 
-const nonMMALocationObjectArr: LocationObject[] = [
+const helpCentreLocationObjectArr: LocationObject[] = [
   {
-    title: "Help Centre",
+    title: "How can we help you?",
     path: "/help-centre"
   },
   {
-    title: "Need to contact us about something?",
+    title: "Need to contact us?",
     path: "/help-centre/contact-us"
   }
 ];
 
-const MMAPageSkeleton = () => (
+const HelpCentrePageSkeleton = () => (
   <Location>
     {({ location }) => {
-      const selectedNonMMALocationObject = nonMMALocationObjectArr.filter(
-        currentObject => location.pathname.startsWith(currentObject.path)
+      const selectedhelpCentreLocationObject = helpCentreLocationObjectArr.filter(
+        currentObject =>
+          location.pathname === currentObject.path ||
+          location.pathname === currentObject.path + "/"
       )[0];
 
-      if (selectedNonMMALocationObject) {
+      if (selectedhelpCentreLocationObject) {
         return (
           <>
-            <SectionHeader title={selectedNonMMALocationObject.title} />
-            <SectionPageContainer sectionTitle="&nbsp;">
+            <SectionHeader title={selectedhelpCentreLocationObject.title} />
+            <SectionPageContainer>
               <div
                 css={css`
                   margin-bottom: ${space[24]}px;
@@ -53,4 +55,4 @@ const MMAPageSkeleton = () => (
   </Location>
 );
 
-export default MMAPageSkeleton;
+export default HelpCentrePageSkeleton;

--- a/app/client/components/MMAPageSkeleton.tsx
+++ b/app/client/components/MMAPageSkeleton.tsx
@@ -114,7 +114,9 @@ const MMAPageSkeleton = () => (
   <Location>
     {({ location }) => {
       const selectedMMALocationObject = MMALocationObjectArr.filter(
-        currentObject => location.pathname === currentObject.path
+        currentObject =>
+          location.pathname === currentObject.path ||
+          location.pathname === currentObject.path + "/"
       )[0];
 
       if (selectedMMALocationObject) {

--- a/app/client/components/contactUs/contactUs.tsx
+++ b/app/client/components/contactUs/contactUs.tsx
@@ -163,38 +163,12 @@ const ContactUs = (props: ContactUsProps) => {
     }
   };
 
-  const HeaderTitle = (
-    <span>
-      Need to contact us{" "}
-      <span
-        css={{
-          display: "none",
-          [minWidth.desktop]: {
-            display: "inline"
-          }
-        }}
-      >
-        about something?
-      </span>
-    </span>
-  );
+  const HeaderTitle = <span>Need to contact us?</span>;
 
   return (
     <>
-      <SectionHeader
-        breadcrumbs={[
-          {
-            title: "Help centre",
-            link: "https://www.theguardian.com/help"
-          },
-          {
-            title: "Contact us",
-            currentPage: true
-          }
-        ]}
-        title={HeaderTitle}
-      />
-      <SectionPageContainer sectionTitle="Contact us">
+      <SectionHeader title={HeaderTitle} />
+      <SectionPageContainer>
         <div
           css={css`
             margin-bottom: ${space[24]}px;

--- a/app/client/components/helpCentre/helpCentre.tsx
+++ b/app/client/components/helpCentre/helpCentre.tsx
@@ -19,26 +19,6 @@ interface HelpCentreProps extends RouteComponentProps {
   urlSuccess?: string;
 }
 
-const titleStyle = css`
-  ${headline.xsmall({ fontWeight: "bold" })};
-  margin: 0;
-  border-top: 1px solid ${neutral[86]};
-  ${minWidth.desktop} {
-    font-size: 1.75rem;
-    border-top: 0;
-  }
-`;
-
-const popularTopicsTitleStyle = css`
-  ${headline.xxsmall({ fontWeight: "bold" })};
-  border-top: 1px solid ${neutral[86]};
-  margin-top: ${space[6]}px;
-  padding: ${space[1]}px 0;
-  ${minWidth.desktop} {
-    margin-top: ${space[9]}px;
-  }
-`;
-
 const subtitleStyles = css`
   border-top: 1px solid ${neutral["86"]};
   margin-top: 30px;
@@ -50,16 +30,15 @@ const subtitleStyles = css`
 
 const HelpCentre = (_: HelpCentreProps) => (
   <>
-    <SectionHeader title="Help Centre" />
+    <SectionHeader title="How can we help you?" />
     <KnownIssues />
-    <SectionPageContainer sectionTitle="Help Centre">
+    <SectionPageContainer>
       <div
         css={css`
           margin-bottom: ${space[24]}px;
         `}
       >
-        <h1 css={titleStyle}>How can we help you?</h1>
-        <h2 css={popularTopicsTitleStyle}>Most popular topics</h2>
+        <h2 css={subtitleStyles}>Most popular topics</h2>
         <div
           css={css`
             display: flex;

--- a/app/client/components/helpCentre/knownIssues.tsx
+++ b/app/client/components/helpCentre/knownIssues.tsx
@@ -81,11 +81,11 @@ export const KnownIssues = () => {
               },
 
               [minWidth.desktop]: {
-                ...gridItemPlacement(4, 9)
+                ...gridItemPlacement(3, 9)
               },
 
               [minWidth.wide]: {
-                ...gridItemPlacement(4, 12)
+                ...gridItemPlacement(3, 12)
               }
             }}
           >

--- a/app/client/components/sectionHeader.tsx
+++ b/app/client/components/sectionHeader.tsx
@@ -16,7 +16,6 @@ interface SectionHeaderProps {
 }
 
 const chevronCss = css`
-  display: block;
   width: 7px;
   height: 7px;
   border-top: 2px solid ${neutral["7"]};
@@ -57,7 +56,6 @@ export const SectionHeader = (props: SectionHeaderProps) => (
     >
       <div
         css={{
-          display: "block",
           marginTop: `${space[3]}px`,
           ...gridItemPlacement(1, 12)
         }}
@@ -80,10 +78,10 @@ export const SectionHeader = (props: SectionHeaderProps) => (
               Help Centre
             </span>
           ) : (
-            <>
+            <span css={{ marginLeft: "1rem" }}>
               <span css={chevronCss} />
-              &nbsp; &nbsp; Back to Help centre
-            </>
+              Back to Help centre
+            </span>
           )}
         </a>
       </div>

--- a/app/client/components/sectionHeader.tsx
+++ b/app/client/components/sectionHeader.tsx
@@ -1,16 +1,35 @@
 import { css } from "@emotion/core";
-import { breakpoints, palette, space } from "@guardian/src-foundations";
+import {
+  breakpoints,
+  neutral,
+  palette,
+  space
+} from "@guardian/src-foundations";
 import { textSans, titlepiece } from "@guardian/src-foundations/typography";
 import Color from "color";
 import React from "react";
 import { minWidth } from "../styles/breakpoints";
 import { gridBase, gridItemPlacement } from "../styles/grid";
-import { Breadcrumbs } from "./page";
 
 interface SectionHeaderProps {
   title: string | JSX.Element;
-  breadcrumbs?: Breadcrumbs[];
 }
+
+const chevronCss = css`
+  display: block;
+  width: 7px;
+  height: 7px;
+  border-top: 2px solid ${neutral["7"]};
+  border-right: 2px solid ${neutral["7"]};
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%) rotate(-135deg);
+  left: ${space[1]}px;
+`;
+
+const isLandingPage =
+  window.location.pathname === "/help-centre" ||
+  window.location.pathname === "/help-centre/";
 
 export const SectionHeader = (props: SectionHeaderProps) => (
   <header
@@ -38,47 +57,40 @@ export const SectionHeader = (props: SectionHeaderProps) => (
     >
       <div
         css={{
-          display: "none",
+          display: "block",
           marginTop: `${space[3]}px`,
-          [minWidth.desktop]: {
-            ...gridItemPlacement(1, 3),
-            display: "block"
-          }
+          ...gridItemPlacement(1, 12)
         }}
       >
-        {props.breadcrumbs?.map((breadcrumbItem, index) => (
-          <React.Fragment key={`breadcrumb-${index}`}>
-            {breadcrumbItem.link ? (
-              <a
-                href={breadcrumbItem.link}
-                css={css`
-                  ${textSans.medium()};
-                  color: ${palette.neutral[0]};
-                `}
-              >
-                {breadcrumbItem.title}
-              </a>
-            ) : (
-              <span
-                css={css`
-                  ${textSans.medium({
-                    fontWeight: breadcrumbItem.currentPage ? "bold" : "regular"
-                  })};
-                  color: ${palette.neutral[0]};
-                `}
-              >
-                {breadcrumbItem.title}
-              </span>
-            )}
-            {props.breadcrumbs?.length &&
-              index < props.breadcrumbs?.length - 1 && <span>{" / "}</span>}
-          </React.Fragment>
-        ))}
+        <a
+          href="/help-centre"
+          css={css`
+            ${textSans.medium()};
+            color: ${palette.neutral[0]};
+            position: relative;
+          `}
+        >
+          {isLandingPage ? (
+            <span
+              css={css`
+                ${textSans.medium({ fontWeight: "bold" })};
+                color: ${palette.neutral[0]};
+              `}
+            >
+              Help Centre
+            </span>
+          ) : (
+            <>
+              <span css={chevronCss} />
+              &nbsp; &nbsp; Back to Help centre
+            </>
+          )}
+        </a>
       </div>
       <h1
         css={{
           font: titlepiece.small(),
-          fontSize: "24px",
+          fontSize: "2rem",
           ...gridItemPlacement(1, 4),
           margin: `${space[9]}px 0 0 0`,
           padding: `${space[3]}px 0`,
@@ -88,8 +100,8 @@ export const SectionHeader = (props: SectionHeaderProps) => (
           },
 
           [minWidth.desktop]: {
-            ...gridItemPlacement(4, 9),
-            fontSize: "42px",
+            ...gridItemPlacement(3, 10),
+            fontSize: "2.625rem",
             paddingLeft: `${space[5]}px`,
             marginTop: `${space[24]}px`,
             marginLeft: `-${space[5]}px`,
@@ -97,7 +109,7 @@ export const SectionHeader = (props: SectionHeaderProps) => (
             borderTop: `1px solid ${palette.neutral[86]}`
           },
           [minWidth.wide]: {
-            ...gridItemPlacement(4, 13)
+            ...gridItemPlacement(3, 14)
           }
         }}
       >

--- a/app/client/components/sectionPageContainer.tsx
+++ b/app/client/components/sectionPageContainer.tsx
@@ -1,12 +1,9 @@
-import { css } from "@emotion/core";
 import { breakpoints, palette, space } from "@guardian/src-foundations";
-import { headline } from "@guardian/src-foundations/typography";
 import React, { ReactNode } from "react";
 import { minWidth } from "../styles/breakpoints";
 import { gridBase, gridItemPlacement } from "../styles/grid";
 
 interface SectionPageContainerProps {
-  sectionTitle: string;
   children: ReactNode;
 }
 
@@ -35,32 +32,6 @@ export const SectionPageContainer = (props: SectionPageContainerProps) => (
         }
       }}
     >
-      <div
-        css={{
-          display: "none",
-
-          [minWidth.desktop]: {
-            ...gridItemPlacement(1, 3),
-            display: "block",
-            paddingRight: 0
-          },
-
-          [minWidth.wide]: {
-            ...gridItemPlacement(1, 3)
-          }
-        }}
-      >
-        <h3
-          css={css`
-            ${headline.xxxsmall({ fontWeight: "bold" })};
-            margin: 0;
-            padding: ${space[2]}px 0;
-            border-right: 1px solid ${palette.neutral[86]};
-          `}
-        >
-          {props.sectionTitle}
-        </h3>
-      </div>
       <section
         css={{
           ...gridItemPlacement(1, 4),
@@ -70,11 +41,11 @@ export const SectionPageContainer = (props: SectionPageContainerProps) => (
           },
 
           [minWidth.desktop]: {
-            ...gridItemPlacement(4, 9)
+            ...gridItemPlacement(3, 9)
           },
 
           [minWidth.wide]: {
-            ...gridItemPlacement(4, 12)
+            ...gridItemPlacement(3, 12)
           }
         }}
       >


### PR DESCRIPTION
## What does this change?
This updates the grid placement and text content for the landing and contact us pages. 
MMA and help centre page skeletons have also been updated to handle a trailing slash for each endpoint.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
![image](https://user-images.githubusercontent.com/44685872/108378042-9034aa80-71fc-11eb-87f4-9164a3b533ec.png)
![image](https://user-images.githubusercontent.com/44685872/108378107-9f1b5d00-71fc-11eb-99d2-cc64ae248022.png)
