### PR TITLE
Send country code in create reminder request

### DIFF
--- a/app/client/components/cancel/cancellationContributionReminder.tsx
+++ b/app/client/components/cancel/cancellationContributionReminder.tsx
@@ -4,6 +4,7 @@ import { space } from "@guardian/src-foundations";
 import { SvgArrowRightStraight } from "@guardian/src-icons";
 import { Radio, RadioGroup } from "@guardian/src-radio";
 import React, { useState } from "react";
+import { getGeoLocation } from "../../geolocation";
 import { trackEventInOphanOnly } from "../analytics";
 
 const containerStyles = css`
@@ -96,6 +97,7 @@ export const CancellationContributionReminder: React.FC = () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         email,
+        country: getGeoLocation(),
         reminderPlatform: REMINDER_PLATFORM,
         reminderComponent: REMINDER_COMPONENT,
         reminderStage: REMINDER_STAGE,


### PR DESCRIPTION
## What does this change?
Send country code in create reminder request. The endpoint was initially getting this data from a header set by fastly. However, becaue this request is proxied via the manage backend, the location is the location of the AWS instance that serves that request, not the user. Now we send the country too which the reminder endpoint will use over the fastly header