### PR TITLE
add instance name to ASG

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -82,6 +82,13 @@ Resources:
         - Key: Stage
           Value: !Ref Stage
           PropagateAtLaunch: true
+        - Key: Name
+          Value: !Join
+            - '-'
+            - - !Ref Stack
+              - !Ref Stage
+              - !Ref App
+          PropagateAtLaunch: 'true'
   LaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:


### PR DESCRIPTION
this makes it easier to understand the AWS console, also for reserved instances/trusted advisor
![image](https://user-images.githubusercontent.com/7304387/108708294-29b7d100-7509-11eb-94b5-3b4c55783a6a.png)
