### PR TITLE
Remove snyk from the build steps

### DIFF
--- a/.github/workflows/snyk.monitor.yml
+++ b/.github/workflows/snyk.monitor.yml
@@ -8,9 +8,9 @@ jobs:
   monitor:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/node@master
+        uses: snyk/actions/node@0.3.0
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:

--- a/.github/workflows/snyk.monitor.yml
+++ b/.github/workflows/snyk.monitor.yml
@@ -14,4 +14,5 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
+          args: --org=the-guardian-cuu --project-name=guardian/manage-frontend
           command: monitor

--- a/.github/workflows/snyk.monitor.yml
+++ b/.github/workflows/snyk.monitor.yml
@@ -1,0 +1,17 @@
+# Snyk Vulnerability Check on main branches will report results to snyk.io
+name: Snyk Vulnerability Check
+on:
+  push:
+    branches:
+      - main
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/node@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          command: monitor

--- a/.github/workflows/snyk.monitor.yml
+++ b/.github/workflows/snyk.monitor.yml
@@ -1,11 +1,11 @@
-# Snyk Vulnerability Check on main branches will report results to snyk.io
-name: Snyk Vulnerability Check
+# Run snyk monitor, which will report results to snyk.io
+name: Snyk
 on:
   push:
     branches:
       - main
 jobs:
-  security:
+  monitor:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -14,5 +14,5 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --org=the-guardian-cuu --project-name=guardian/manage-frontend
+          args: --org=the-guardian-cuu --project-name=guardian/manage-frontend --debug --file=./app/yarn.lock
           command: monitor

--- a/.github/workflows/snyk.test.yml
+++ b/.github/workflows/snyk.test.yml
@@ -8,9 +8,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/node@master
+        uses: snyk/actions/node@0.3.0
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:

--- a/.github/workflows/snyk.test.yml
+++ b/.github/workflows/snyk.test.yml
@@ -1,11 +1,11 @@
-# Snyk Vulnerability Check on branches other than main will not report results to snyk.io
-name: Snyk Vulnerability Check
+# Run snyk test, which will not report results to snyk.io
+name: Snyk
 on:
   push:
-    branches:
-      - "!main"
+    branches-ignore:
+      - main
 jobs:
-  security:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -13,3 +13,5 @@ jobs:
         uses: snyk/actions/node@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --debug --file=./app/yarn.lock

--- a/.github/workflows/snyk.test.yml
+++ b/.github/workflows/snyk.test.yml
@@ -1,0 +1,15 @@
+# Snyk Vulnerability Check on branches other than main will not report results to snyk.io
+name: Snyk Vulnerability Check
+on:
+  push:
+    branches:
+      - "!main"
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/node@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/app/package.json
+++ b/app/package.json
@@ -14,7 +14,7 @@
     "bundle-check-client-if-changed": "((git diff --name-only --cached | grep 'yarn.lock') && yarn bundle-check-client) || true",
     "serve-dev": "webpack-dev-server --config ./webpack.dev.client.js --public manage.thegulocal.com",
     "watch": "yarn bundle-dev-server && (yarn bundle-dev-server -w & yarn start & yarn serve-dev)",
-    "test": "snyk test && jest --coverage && yarn type-check && yarn lint ",
+    "test": "jest --coverage && yarn type-check && yarn lint ",
     "jest": "jest",
     "updateSnapshot": "jest -u",
     "sonar-scanner": "cd .. && app/node_modules/sonar-scanner/bin/sonar-scanner -Dsonar.projectVersion=$(git rev-parse --short HEAD)",


### PR DESCRIPTION
## What does this change?
This PR removes snyk from the build step and moves it into a GitHub action

`snyk monitor` will run on any push to main. `snyk test` will run on all other branches. This will make it so our builds aren't blocked in case a vulnerability is found, which means we won't have to ignore them in the snyk policy. The snyk action is not required to pass for a PR to be merged. It's merely informative.

In a separate PR I will reset snyk's policy settings to remove the ignores we've been adding, now that it won't block the builds.

Note: Running `snyk wizard` will prompt to add a `snyk test` step to our `yarn test` script. This will no longer be necessary.