### PR TITLE
Send ophan event on reminder view

### DIFF
--- a/app/client/components/cancel/cancellationContributionReminder.tsx
+++ b/app/client/components/cancel/cancellationContributionReminder.tsx
@@ -3,7 +3,7 @@ import { Button } from "@guardian/src-button";
 import { space } from "@guardian/src-foundations";
 import { SvgArrowRightStraight } from "@guardian/src-icons";
 import { Radio, RadioGroup } from "@guardian/src-radio";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { getGeoLocation } from "../../geolocation";
 import { trackEventInOphanOnly } from "../analytics";
 
@@ -115,6 +115,14 @@ export const CancellationContributionReminder: React.FC = () => {
     setReminder();
     setHasSetReminder(true);
   };
+
+  useEffect(() => {
+    trackEventInOphanOnly({
+      eventCategory: "cancellation_flow",
+      eventAction: "view",
+      eventLabel: `set_reminder`
+    });
+  }, []);
 
   return (
     <div css={containerStyles}>


### PR DESCRIPTION
## What does this change?
Send an ophan event when the set reminder component is viewed. This is to allow us to more easily calculate a 'conversion rate' for one of our data studio dashboards.

## Images
<img width="491" alt="Screenshot 2021-02-26 at 08 44 43" src="https://user-images.githubusercontent.com/17720442/109277664-88ce5c00-780f-11eb-8a96-12286ea7671c.png">
