### PR TITLE
Avoid loading GA unless consent has been obtained

### DIFF
--- a/app/client/components/gaStub.tsx
+++ b/app/client/components/gaStub.tsx
@@ -1,0 +1,26 @@
+// @ts-nocheck
+// Ignoring next few lines to maintain GA's code snippet
+
+export const runGaStub = () => {
+  /* tslint:disable */
+  (function(i, s, o, g, r, a, m) {
+    i["GoogleAnalyticsObject"] = r;
+    (i[r] =
+      i[r] ||
+      function() {
+        (i[r].q = i[r].q || []).push(arguments);
+      }),
+      (i[r].l = 1 * new Date());
+    (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
+    a.async = 1;
+    a.src = g;
+    m.parentNode.insertBefore(a, m);
+  })(
+    window,
+    document,
+    "script",
+    "https://www.google-analytics.com/analytics.js",
+    "ga"
+  );
+  /* tslint:enable */
+};

--- a/app/server/html.ts
+++ b/app/server/html.ts
@@ -33,12 +33,6 @@ const html: (_: {
     <body style="margin:0">
       <div id="app"></div>
       </body>
-      <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-      </script>
       <script src="${src}?release=${WEBPACK_BUILD}"></script>
   </html>
 `;


### PR DESCRIPTION
## What does this change?
This PR changes our analytics so they do not load any script until after consent has been obtained. This avoids race conditions as well as tracking through http requests.