### PR TITLE
Add support reminder consent to the email prefs page

### DIFF
--- a/app/client/components/cancel/cancellationContributionReminder.tsx
+++ b/app/client/components/cancel/cancellationContributionReminder.tsx
@@ -34,7 +34,7 @@ interface ReminderChoice {
   thankYouMessage: string;
 }
 
-const REMINDER_ENDPOINT = "/api/reminder";
+const REMINDER_ENDPOINT = "/api/reminders";
 const REMINDER_PLATFORM = "MMA";
 const REMINDER_STAGE = "WINBACK";
 const REMINDER_COMPONENT = "CANCELLATION";

--- a/app/client/components/identity/EmailAndMarketing/ConsentSection.tsx
+++ b/app/client/components/identity/EmailAndMarketing/ConsentSection.tsx
@@ -15,6 +15,9 @@ const releaseSoftOptIns = false;
 const softOptInEmailConsents = (consents: ConsentOption[]): ConsentOption[] =>
   consents.filter(consent => !!consent.isProduct && releaseSoftOptIns);
 
+const supportReminderConsent = (consents: ConsentOption[]): ConsentOption[] =>
+  ConsentOptions.findByIds(consents, ["support_reminder"]);
+
 const otherEmailConsents = (consents: ConsentOption[]): ConsentOption[] => {
   const ids = ["supporter", "jobs", "holidays", "events", "offers"];
   return ConsentOptions.findByIds(consents, ids);
@@ -55,6 +58,7 @@ export const ConsentSection: FC<ConsentSectionProps> = props => {
         our products, services and events.
       `}
     >
+      {consentPreferences(supportReminderConsent(consents), clickHandler)}
       {consentPreferences(softOptInEmailConsents(consents), clickHandler)}
       {consentPreferences(otherEmailConsents(consents), clickHandler)}
       <h2

--- a/app/client/components/identity/idapi/supportReminders.ts
+++ b/app/client/components/identity/idapi/supportReminders.ts
@@ -1,18 +1,61 @@
+import * as Sentry from "@sentry/browser";
 import { ConsentOption, ConsentOptionType } from "../models";
 
-const supportReminder: ConsentOption = {
+interface ReminderStatusApiResponse {
+  recurringStatus: "NotSet" | "Active" | "Cancelled";
+}
+
+const REMINDERS_STATUS_ENDPOINT = "/api/reminders/status";
+const CANCEL_REMINDERS_ENDPOINT = "/api/reminders/cancel";
+const REACTIVATE_REMINDERS_ENDPOINT = "/api/reminders/reactivate";
+
+const getConsent = (isActive: boolean): ConsentOption => ({
   id: "support_reminder",
   description:
     "We will invite you to make a contribution in support of Guardian journalism, using the cadence you picked when you last signed up.",
   name: "Contribution reminder emails",
   type: ConsentOptionType.SUPPORT_REMINDER,
-  subscribed: true
-};
+  subscribed: isActive
+});
 
 export const read = async (): Promise<ConsentOption[]> => {
-  return [supportReminder];
+  const response = await fetch(REMINDERS_STATUS_ENDPOINT);
+  const reminderStatus = (await response.json()) as ReminderStatusApiResponse;
+  if (reminderStatus.recurringStatus === "NotSet") {
+    return [];
+  }
+
+  return [getConsent(reminderStatus.recurringStatus === "Active")];
 };
 
 export const update = async (id: string, subscribed: boolean = true) => {
-  console.log(id, subscribed);
+  const email = window.guardian.identityDetails.email;
+  if (!email) {
+    Sentry.captureMessage(`No email address to update consent: ${id}`);
+    return;
+  }
+
+  if (!subscribed) {
+    await cancelReminder(email);
+  } else {
+    await reactivateReminder(email);
+  }
 };
+
+const cancelReminder = (email: string) =>
+  fetch(CANCEL_REMINDERS_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({ email })
+  });
+
+const reactivateReminder = (email: string) =>
+  fetch(REACTIVATE_REMINDERS_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({ email })
+  });

--- a/app/client/components/identity/idapi/supportReminders.ts
+++ b/app/client/components/identity/idapi/supportReminders.ts
@@ -1,0 +1,18 @@
+import { ConsentOption, ConsentOptionType } from "../models";
+
+const supportReminder: ConsentOption = {
+  id: "support_reminder",
+  description:
+    "We will invite you to make a contribution in support of Guardian journalism, using the cadence you picked when you last signed up.",
+  name: "Contribution reminder emails",
+  type: ConsentOptionType.SUPPORT_REMINDER,
+  subscribed: true
+};
+
+export const read = async (): Promise<ConsentOption[]> => {
+  return [supportReminder];
+};
+
+export const update = async (id: string, subscribed: boolean = true) => {
+  console.log(id, subscribed);
+};

--- a/app/client/components/identity/idapi/supportReminders.ts
+++ b/app/client/components/identity/idapi/supportReminders.ts
@@ -3,7 +3,7 @@ import { ConsentOption, ConsentOptionType } from "../models";
 
 interface ReminderStatusApiResponse {
   recurringStatus: "NotSet" | "Active" | "Cancelled";
-  recurringReminderCode: string;
+  recurringReminderCode?: string;
 }
 
 let recurringReminderCode = "";
@@ -28,7 +28,7 @@ export const read = async (): Promise<ConsentOption[]> => {
     return [];
   }
 
-  recurringReminderCode = reminderStatus.recurringReminderCode;
+  recurringReminderCode = reminderStatus.recurringReminderCode ?? "";
 
   return [getConsent(reminderStatus.recurringStatus === "Active")];
 };

--- a/app/client/components/identity/identity.ts
+++ b/app/client/components/identity/identity.ts
@@ -2,6 +2,7 @@ import * as ConsentsAPI from "./idapi/consents";
 import * as NewslettersAPI from "./idapi/newsletters";
 import * as NewslettersSubscriptionsAPI from "./idapi/newsletterSubscriptions";
 import * as RemoveSubscriptionsAPI from "./idapi/removeSubscriptions";
+import * as SupportRemindersApi from "./idapi/supportReminders";
 import * as UserAPI from "./idapi/user";
 
 import {
@@ -16,6 +17,8 @@ const isNewsletter = (option: ConsentOption): boolean =>
   option.type === ConsentOptionType.NEWSLETTER;
 const isConsent = (option: ConsentOption): boolean =>
   option.type !== ConsentOptionType.NEWSLETTER;
+const isSupportReminderConsent = (option: ConsentOption): boolean =>
+  option.type === ConsentOptionType.SUPPORT_REMINDER;
 
 const mapSubscriptions = (
   subscriptions: string[],
@@ -77,14 +80,18 @@ export const ConsentOptions: ConsentOptionCollection = {
       ConsentsAPI.read(),
       UserAPI.read()
     ]);
+    const supportReminders = await SupportRemindersApi.read();
+
     return mapSubscriptions(
       [...subscriptions, ...user.consents],
-      [...newsletters, ...consents]
+      [...newsletters, ...consents, ...supportReminders]
     );
   },
   async subscribe(option: ConsentOption): Promise<void> {
     if (isNewsletter(option)) {
       return NewslettersAPI.update(option.id, true);
+    } else if (isSupportReminderConsent(option)) {
+      return SupportRemindersApi.update(option.id, true);
     } else {
       return ConsentsAPI.update(option.id, true);
     }
@@ -92,6 +99,8 @@ export const ConsentOptions: ConsentOptionCollection = {
   async unsubscribe(option: ConsentOption): Promise<void> {
     if (isNewsletter(option)) {
       return NewslettersAPI.update(option.id, false);
+    } else if (isSupportReminderConsent(option)) {
+      return SupportRemindersApi.update(option.id, false);
     } else {
       return ConsentsAPI.update(option.id, false);
     }

--- a/app/client/components/identity/models.ts
+++ b/app/client/components/identity/models.ts
@@ -18,7 +18,8 @@ export enum ErrorTypes {
 export enum ConsentOptionType {
   EMAIL = "EMAIL",
   NEWSLETTER = "NEWSLETTER",
-  OPT_OUT = "OPT_OUT"
+  OPT_OUT = "OPT_OUT",
+  SUPPORT_REMINDER = "SUPPORT_REMINDER"
 }
 
 export interface User {

--- a/app/server/reminderApi.ts
+++ b/app/server/reminderApi.ts
@@ -3,22 +3,60 @@ import { Request, Response } from "express";
 import fetch from "node-fetch";
 import { conf } from "./config";
 
-export const reminderHandler = (req: Request, res: Response) =>
-  setReminder(req.body).then(response => {
+export const createReminderHandler = (req: Request, res: Response) =>
+  createReminder(req.body).then(response => {
     if (!response.ok) {
       captureMessage("Reminder sign up failed at the point of request");
     }
     res.sendStatus(response.status);
   });
 
+export const cancelReminderHandler = (req: Request, res: Response) =>
+  cancelReminder(req.body).then(response => {
+    if (!response.ok) {
+      captureMessage("Cancel failed at the point of request");
+    }
+    res.sendStatus(response.status);
+  });
+
+export const reactivateReminderHandler = (req: Request, res: Response) =>
+  reactivateReminder(req.body).then(response => {
+    if (!response.ok) {
+      captureMessage("Reactivate failed at the point of request");
+    }
+    res.sendStatus(response.status);
+  });
+
 const isProd = conf.STAGE === "PROD";
 
-const reminderEndpoint = isProd
-  ? "https://support.theguardian.com/reminders/create/one-off"
-  : "https://support.code.dev-theguardian.com/reminders/create/one-off";
+const baseReminderEndpoint = isProd
+  ? "https://support.theguardian.com/reminders/"
+  : "https://support.code.dev-theguardian.com/reminders/";
 
-const setReminder = (body: any) =>
-  fetch(reminderEndpoint, {
+const createOneOffReminderEndpoint = baseReminderEndpoint + "create/one-off";
+const cancelRemindersEndpoint = baseReminderEndpoint + "cancel";
+const reactivateRemindersEndpoint = baseReminderEndpoint + "reactivate";
+
+const createReminder = (body: any) =>
+  fetch(createOneOffReminderEndpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body
+  });
+
+const cancelReminder = (body: any) =>
+  fetch(cancelRemindersEndpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body
+  });
+
+const reactivateReminder = (body: any) =>
+  fetch(reactivateRemindersEndpoint, {
     method: "POST",
     headers: {
       "Content-Type": "application/json"

--- a/app/server/routes/api.ts
+++ b/app/server/routes/api.ts
@@ -23,7 +23,11 @@ import { contactUsFormHandler } from "../contactUsApi";
 import { augmentProductDetailWithDeliveryAddressChangeEffectiveDateForToday } from "../fulfilmentDateCalculatorReader";
 import { log } from "../log";
 import { withIdentity } from "../middleware/identityMiddleware";
-import { reminderHandler } from "../reminderApi";
+import {
+  cancelReminderHandler,
+  createReminderHandler,
+  reactivateReminderHandler
+} from "../reminderApi";
 import { stripeSetupIntentHandler } from "../stripeSetupIntentsHandler";
 
 const router = Router();
@@ -227,6 +231,12 @@ router.get("/known-issues", async (_, response) => {
 
 router.post("/contact-us", contactUsFormHandler);
 
-router.post("/reminder", reminderHandler);
+router.post("/reminders", createReminderHandler);
+router.get(
+  "/reminders/status",
+  membersDataApiHandler("user-attributes/me/reminders", "MDA_REMINDERS_STATUS")
+);
+router.post("/reminders/cancel", cancelReminderHandler);
+router.post("/reminders/reactivate", reactivateReminderHandler);
 
 export default router;


### PR DESCRIPTION
## What does this change?
Add a support reminder consent to the email reminders page. Removing this consent will cancel *all* pending reminders (both recurring and one-offs). Re-consenting will reactivate *only* their recurring reminder. A user that has never set a recurring reminder will not see this consent. 

**DO NOT MERGE** until after: https://github.com/guardian/members-data-api/pull/508 (this updates endpoint in mdapi)

## Images
<img width="824" alt="Screenshot 2021-02-26 at 13 40 25" src="https://user-images.githubusercontent.com/17720442/109312193-aa930780-783e-11eb-9518-d23f8a3d876a.png">
