### PR TITLE
Remove --skipLibCheck

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "start": "nodemon --inspect ./dist/server",
-    "type-check": "tsc --noEmit --skipLibCheck",
+    "type-check": "tsc --noEmit",
     "pretty-quick": "pretty-quick",
     "lint": "tslint -p .",
     "bundle": "copy-node-modules . ./dist && yarn webpack --config webpack.production.js",


### PR DESCRIPTION
## What does this change?

Removes this `--skipLibCheck` flag from the `type-check` script.

Follows on from #389 which removed hundreds of type errors relating to `@typoes/react`, and subsequent PRs that remove `react-stripe-elements` and upgrade `jest`.

## How to test

```sh
$ yarn type-check
```

## How can we measure success?

Difficult, but I expect it would be useful at dev time to catch type issues with third party libs.

## Have we considered potential risks?

This could conceivably increase build time as all `*.d.ts` files from `node_modules` are now included in the compilation process. From testing, this adds about 3-5 seconds onto the build time.

However I think the increased integrity from integration testing third party libs is likely to be worth it.

## Images

No visual changes
