### PR TITLE
Patch in necessary permissions for wazuh

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -95,6 +95,7 @@ Resources:
       ImageId: !Ref AMI
       SecurityGroups:
         - !Ref InstanceSecurityGroup
+        - !Ref WazuhSecurityGroup 
       InstanceType: !FindInMap [StageVariables, !Ref Stage, InstanceType]
       IamInstanceProfile: !Ref InstanceProfile
       AssociatePublicIpAddress: false
@@ -222,6 +223,22 @@ Resources:
                   - !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:*/CODE/*
                   - !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:*/${Stage}/* # avoids PROD resources being available to lower environments
 
+  DescribeEC2Policy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: describe-ec2-policy
+      PolicyDocument:
+        Statement:
+        - Effect: Allow
+          Resource: "*"
+          Action:
+          - ec2:DescribeTags
+          - ec2:DescribeInstances
+          - autoscaling:DescribeAutoScalingGroups
+          - autoscaling:DescribeAutoScalingInstances
+      Roles:
+      - !Ref AppRole
+
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
@@ -315,6 +332,18 @@ Resources:
           FromPort: 443
           ToPort: 443
           CidrIp: 0.0.0.0/0
+
+  WazuhSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow outbound traffic from wazuh agent to manager
+      VpcId:
+        Ref: VpcId
+      SecurityGroupEgress:
+      - IpProtocol: tcp
+        FromPort: 1514
+        ToPort: 1515
+        CidrIp: 0.0.0.0/0
 
   ManageFrontendLogGroup:
     Type: "AWS::Logs::LogGroup"


### PR DESCRIPTION
## What does this change?

There's currently a major review of the guardian's security practices under the cyber security programme. One of the projects in this programme is to install a vulnerability scanner called Wazuh in guardian ec2 instances.

This patch enables Wazuh to work by

* Opening ports 1514 and 1515 for outbound traffic
* Giving permission to the instance to call describe-tags,
   so the agent can identify itself in a human readable way with 
   the wazuh server.


## How to test
Deploy to CODE and see if the wazuh agent successfully connects with the central server 

Works in code ✅


## How can we measure success?
Wazuh will start reporting vulnerabilities to infosec!

## Have we considered potential risks?
CFN could be wrong and cause downtime.
