### PR TITLE
Help centre header styling updates

### DIFF
--- a/app/client/components/helpCentre/helpCentreHeader.tsx
+++ b/app/client/components/helpCentre/helpCentreHeader.tsx
@@ -32,7 +32,10 @@ const HelpCentreHeader = (props: HelpCentreHeaderProps) => {
     height: 100%;
     max-width: calc(${breakpoints.wide}px + 2.5rem);
     margin: auto;
-    padding: 0px ${space[5]}px;
+    padding: 0px ${space[3]}px;
+    ${minWidth.tablet} {
+      padding: 0px ${space[5]}px;
+    }
   `;
 
   const h1Css = css`
@@ -54,7 +57,7 @@ const HelpCentreHeader = (props: HelpCentreHeaderProps) => {
   `;
 
   const divCss = css`
-    margin: ${space[3]}px;
+    margin: ${space[3]}px ${space[3]}px 0 0;
     align-self: flex-start;
   `;
 

--- a/app/client/components/svgs/theGuardianLogo.tsx
+++ b/app/client/components/svgs/theGuardianLogo.tsx
@@ -1,4 +1,3 @@
-import { space } from "@guardian/src-foundations";
 import React from "react";
 import { minWidth } from "../../styles/breakpoints";
 
@@ -12,7 +11,6 @@ export const TheGuardianLogo = (props: TheGuardianLogoProps) => (
   <a
     css={{
       display: "block",
-      margin: `${space[3]}px`,
       width: `${props.width || 121}px`,
       height: `${props.height || 39}px`,
       textAlign: "right",


### PR DESCRIPTION
## What does this change?
This PR fixes the alignment of the help centre header on mobile

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/44685872/110959354-83136300-8345-11eb-94ed-0deeaad81479.png) | ![image](https://user-images.githubusercontent.com/44685872/110959185-5a8b6900-8345-11eb-94e1-605131e86663.png)|