### PR TITLE
Realign contact us form icons

### DIFF
--- a/app/client/components/contactUs/techIcon.tsx
+++ b/app/client/components/contactUs/techIcon.tsx
@@ -6,7 +6,7 @@ interface TechIconProps {
 }
 
 export const TechIcon = (props: TechIconProps) => (
-  <svg width="19" height="19" viewBox="0 0 23 23" fill="none">
+  <svg width="20" height="20" viewBox="0 0 22 22" fill="none">
     <path
       fillRule="evenodd"
       clipRule="evenodd"

--- a/app/client/components/svgs/commentsIcon.tsx
+++ b/app/client/components/svgs/commentsIcon.tsx
@@ -6,7 +6,13 @@ interface CommentsIconProps {
 }
 
 export const CommentsIcon = (props: CommentsIconProps) => (
-  <svg width="18" height="17" viewBox="0 0 18 17" fill="none">
+  <svg
+    width="18"
+    height="17"
+    viewBox="0 0 18 17"
+    fill="none"
+    css={{ marginTop: "4px" }}
+  >
     <path
       fillRule="evenodd"
       clipRule="evenodd"

--- a/app/client/components/svgs/newspaperIcon.tsx
+++ b/app/client/components/svgs/newspaperIcon.tsx
@@ -6,7 +6,13 @@ interface NewspaperIconProps {
 }
 
 export const NewspaperIcon = (props: NewspaperIconProps) => (
-  <svg width="20" height="16" viewBox="0 0 20 16" fill="none">
+  <svg
+    width="20"
+    height="16"
+    viewBox="0 0 20 16"
+    fill="none"
+    css={{ marginTop: "2px" }}
+  >
     <path
       fillRule="evenodd"
       clipRule="evenodd"

--- a/app/client/components/svgs/newspaperVoucherIcon.tsx
+++ b/app/client/components/svgs/newspaperVoucherIcon.tsx
@@ -6,7 +6,7 @@ interface NewspaperVoucherIconProps {
 }
 
 export const NewspaperVoucherIcon = (props: NewspaperVoucherIconProps) => (
-  <svg width="16" height="18" viewBox="0 0 16 18" fill="none">
+  <svg width="16" height="18" viewBox="0 0 15 18" fill="none">
     <path
       fillRule="evenodd"
       clipRule="evenodd"


### PR DESCRIPTION
## What does this change?
This PR centers the contact us form svg icons in their respective containers

## Images
| Before  | After |
| ------------- | ------------- |
|  ![image](https://user-images.githubusercontent.com/44685872/110955753-d2579480-8341-11eb-9314-ac197de28245.png) | ![image](https://user-images.githubusercontent.com/44685872/110955686-c23fb500-8341-11eb-9cd0-001a13c6db1e.png) |
