### PR TITLE
Help Centre Topic & Article pages

### DIFF
--- a/app/client/components/HelpCentrePage.tsx
+++ b/app/client/components/HelpCentrePage.tsx
@@ -17,17 +17,17 @@ const HelpCentre = lazy(() =>
   import(/* webpackChunkName: "HelpCentre" */ "./helpCentre/helpCentre")
 );
 
-const HelpCentreArticle = lazy(() =>
-  import(
-    /* webpackChunkName: "HelpCentreArticle" */ "./helpCentre/helpCentreArticle"
-  )
-);
+// const HelpCentreArticle = lazy(() =>
+//   import(
+//     /* webpackChunkName: "HelpCentreArticle" */ "./helpCentre/helpCentreArticle"
+//   )
+// );
 
-const HelpCentreTopic = lazy(() =>
-  import(
-    /* webpackChunkName: "HelpCentreTopic" */ "./helpCentre/helpCentreTopic"
-  )
-);
+// const HelpCentreTopic = lazy(() =>
+//   import(
+//     /* webpackChunkName: "HelpCentreTopic" */ "./helpCentre/helpCentreTopic"
+//   )
+// );
 
 const ContactUs = lazy(() =>
   import(/* webpackChunkName: "ContactUs" */ "./contactUs/contactUs")
@@ -42,8 +42,8 @@ const HelpCentreRouter = () => {
         <Router primary={true} css={{ height: "100%" }}>
           <HelpCentre path="/help-centre" />
 
-          <HelpCentreArticle path="/help-centre/article/:articleCode" />
-          <HelpCentreTopic path="/help-centre/topic/:topicCode" />
+          {/* <HelpCentreArticle path="/help-centre/article/:articleCode" />
+          <HelpCentreTopic path="/help-centre/topic/:topicCode" /> */}
 
           <ContactUs path="/help-centre/contact-us" />
           <ContactUs path="/help-centre/contact-us/:urlTopicId" />

--- a/app/client/components/HelpCentrePage.tsx
+++ b/app/client/components/HelpCentrePage.tsx
@@ -17,7 +17,12 @@ const HelpCentre = lazy(() =>
   import(/* webpackChunkName: "HelpCentre" */ "./helpCentre/helpCentre")
 );
 
-// placeholder import for the help centre see all topics page
+const HelpCentreArticle = lazy(() =>
+  import(
+    /* webpackChunkName: "HelpCentreArticle" */ "./helpCentre/helpCentreArticle"
+  )
+);
+
 const HelpCentreTopic = lazy(() =>
   import(
     /* webpackChunkName: "HelpCentreTopic" */ "./helpCentre/helpCentreTopic"
@@ -37,6 +42,7 @@ const HelpCentreRouter = () => {
         <Router primary={true} css={{ height: "100%" }}>
           <HelpCentre path="/help-centre" />
 
+          <HelpCentreArticle path="/help-centre/article/:articleCode" />
           <HelpCentreTopic path="/help-centre/topic/:topicCode" />
 
           <ContactUs path="/help-centre/contact-us" />

--- a/app/client/components/HelpCentrePage.tsx
+++ b/app/client/components/HelpCentrePage.tsx
@@ -18,11 +18,11 @@ const HelpCentre = lazy(() =>
 );
 
 // placeholder import for the help centre see all topics page
-// const HelpCentreTopic = lazy(() =>
-//   import(
-//     /* webpackChunkName: "HelpCentreTopic" */ "./helpCentre/helpCentreTopic"
-//   )
-// );
+const HelpCentreTopic = lazy(() =>
+  import(
+    /* webpackChunkName: "HelpCentreTopic" */ "./helpCentre/helpCentreTopic"
+  )
+);
 
 const ContactUs = lazy(() =>
   import(/* webpackChunkName: "ContactUs" */ "./contactUs/contactUs")
@@ -37,7 +37,7 @@ const HelpCentreRouter = () => {
         <Router primary={true} css={{ height: "100%" }}>
           <HelpCentre path="/help-centre" />
 
-          {/* <HelpCentreTopic path="/help-centre/topic/:topicCode" /> */}
+          <HelpCentreTopic path="/help-centre/topic/:topicCode" />
 
           <ContactUs path="/help-centre/contact-us" />
           <ContactUs path="/help-centre/contact-us/:urlTopicId" />

--- a/app/client/components/helpCentre/BackToHelpCentreButton.tsx
+++ b/app/client/components/helpCentre/BackToHelpCentreButton.tsx
@@ -1,0 +1,30 @@
+import { css } from "@emotion/core";
+import { space } from "@guardian/src-foundations";
+import { brand, neutral } from "@guardian/src-foundations/palette";
+import React from "react";
+import { LinkButton } from "../buttons";
+
+const divCss = css`
+  margin: 67px ${space[3]}px 0 ${space[3]}px;
+`;
+
+const buttonDivCss = css`
+  margin-top: ${space[4]}px;
+  padding-top: ${space[4]}px;
+  border-top: 1px solid ${neutral["86"]};
+`;
+
+export const BackToHelpCentreButton = () => (
+  <div css={divCss}>
+    <div css={buttonDivCss}>
+      <LinkButton
+        to="/help-centre"
+        text={"Back to Help Centre"}
+        fontWeight={"bold"}
+        textColour={`${brand["400"]}`}
+        colour={`${brand["800"]}`}
+        left={true}
+      />
+    </div>
+  </div>
+);

--- a/app/client/components/helpCentre/BackToHelpCentreButton.tsx
+++ b/app/client/components/helpCentre/BackToHelpCentreButton.tsx
@@ -4,27 +4,21 @@ import { brand, neutral } from "@guardian/src-foundations/palette";
 import React from "react";
 import { LinkButton } from "../buttons";
 
-const divCss = css`
-  margin: 67px ${space[3]}px 0 ${space[3]}px;
-`;
-
 const buttonDivCss = css`
-  margin-top: ${space[4]}px;
+  margin-top: ${space[12]}px;
   padding-top: ${space[4]}px;
   border-top: 1px solid ${neutral["86"]};
 `;
 
 export const BackToHelpCentreButton = () => (
-  <div css={divCss}>
-    <div css={buttonDivCss}>
-      <LinkButton
-        to="/help-centre"
-        text={"Back to Help Centre"}
-        fontWeight={"bold"}
-        textColour={`${brand["400"]}`}
-        colour={`${brand["800"]}`}
-        left={true}
-      />
-    </div>
+  <div css={buttonDivCss}>
+    <LinkButton
+      to="/help-centre"
+      text={"Back to Help Centre"}
+      fontWeight={"bold"}
+      textColour={`${brand["400"]}`}
+      colour={`${brand["800"]}`}
+      left={true}
+    />
   </div>
 );

--- a/app/client/components/helpCentre/HelpCentreTypes.ts
+++ b/app/client/components/helpCentre/HelpCentreTypes.ts
@@ -1,0 +1,18 @@
+export interface Article {
+  path: string;
+  title: string;
+}
+
+export interface SingleTopic {
+  title: string;
+  articles: Article[];
+}
+
+export interface SingleTopicWithPath extends SingleTopic {
+  path: string;
+}
+
+export interface MoreTopics {
+  title: string;
+  topics: SingleTopicWithPath[];
+}

--- a/app/client/components/helpCentre/HelpCentreTypes.ts
+++ b/app/client/components/helpCentre/HelpCentreTypes.ts
@@ -1,18 +1,47 @@
-export interface Article {
-  path: string;
+interface BaseArticle {
   title: string;
 }
 
-export interface SingleTopic {
+interface ArticleWithPath extends BaseArticle {
+  path: string;
+}
+
+interface BaseTopic {
   title: string;
-  articles: Article[];
+}
+
+interface TopicWithPath extends BaseTopic {
+  path: string;
+}
+
+export interface SingleTopic extends BaseTopic {
+  articles: ArticleWithPath[];
 }
 
 export interface SingleTopicWithPath extends SingleTopic {
   path: string;
 }
 
-export interface MoreTopics {
-  title: string;
+export interface MoreTopics extends BaseTopic {
   topics: SingleTopicWithPath[];
+}
+
+export interface Article extends BaseArticle {
+  body: BaseNode[];
+  topics: TopicWithPath[];
+}
+
+export interface BaseNode {
+  element: string;
+}
+export interface TextNode extends BaseNode {
+  content: string;
+}
+
+export interface ElementNode extends BaseNode {
+  content: BaseNode[];
+}
+
+export interface LinkNode extends ElementNode {
+  href: string;
 }

--- a/app/client/components/helpCentre/HelpTopicBox.tsx
+++ b/app/client/components/helpCentre/HelpTopicBox.tsx
@@ -71,13 +71,18 @@ const seeAllAnchorStyle = css`
   }
 `;
 
+const linksLisWithMargintStyle = css`
+  ${linksListStyle};
+  padding: 0 ${space[3]}px;
+`;
+
 export const HelpTopicBox = (props: HelpTopicBoxProps) => (
   <div css={boxHolderStyle}>
     <h2 css={boxTitleStyle}>
       <i css={iconStyle}>{getHelpSectionIcon(props.topic.id)}</i>
       {props.topic.title}
     </h2>
-    <ul css={linksListStyle}>
+    <ul css={linksLisWithMargintStyle}>
       {props.topic.links.map((question, questionIndex) => (
         <li
           key={`${props.topic.id}Question-${questionIndex}`}

--- a/app/client/components/helpCentre/helpCentre.tsx
+++ b/app/client/components/helpCentre/helpCentre.tsx
@@ -11,13 +11,9 @@ import { CallCentreEmailAndNumbers } from "../callCenterEmailAndNumbers";
 import { SectionContent } from "../sectionContent";
 import { SectionHeader } from "../sectionHeader";
 import { helpCentreConfig } from "./helpCentreConfig";
-import { HelpCentreMoreTopics } from "./helpCentreMoreTopics";
+import { HelpCentreLandingMoreTopics } from "./helpCentreLandingMoreTopics";
 import { HelpTopicBox } from "./HelpTopicBox";
 import { KnownIssues } from "./knownIssues";
-
-interface HelpCentreProps extends RouteComponentProps {
-  urlSuccess?: string;
-}
 
 const subtitleStyles = css`
   border-top: 1px solid ${neutral["86"]};
@@ -28,7 +24,7 @@ const subtitleStyles = css`
   ${headline.small({ fontWeight: "bold" })};
 `;
 
-const HelpCentre = (_: HelpCentreProps) => (
+const HelpCentre = (_: RouteComponentProps) => (
   <>
     <SectionHeader title="How can we help you?" />
     <KnownIssues />
@@ -52,7 +48,9 @@ const HelpCentre = (_: HelpCentreProps) => (
           ))}
         </div>
         <h2 css={subtitleStyles}>More Topics</h2>
-        <HelpCentreMoreTopics />
+        {/* HelpCentreMoreTopics will replace HelpCentreLandingMoreTopics
+        once we convert the landing page to loading dynamic content */}
+        <HelpCentreLandingMoreTopics />
         <h2 css={subtitleStyles}>Still can’t find what you’re looking for?</h2>
         <CallCentreEmailAndNumbers />
         <p

--- a/app/client/components/helpCentre/helpCentreArticle.tsx
+++ b/app/client/components/helpCentre/helpCentreArticle.tsx
@@ -1,0 +1,139 @@
+import { css } from "@emotion/core";
+import { space } from "@guardian/src-foundations";
+import { navigate, RouteComponentProps } from "@reach/router";
+import * as Sentry from "@sentry/browser";
+import React, { useEffect, useState } from "react";
+import { SectionContent } from "../sectionContent";
+import { SectionHeader } from "../sectionHeader";
+import { Spinner } from "../spinner";
+import { WithStandardTopMargin } from "../WithStandardTopMargin";
+import { BackToHelpCentreButton } from "./BackToHelpCentreButton";
+import { helpCentreNavConfig } from "./helpCentreConfig";
+import { h2Css } from "./helpCentreStyles";
+import {
+  Article,
+  BaseNode,
+  ElementNode,
+  LinkNode,
+  TextNode
+} from "./HelpCentreTypes";
+
+interface HelpCentreArticleProps extends RouteComponentProps {
+  articleCode?: string;
+}
+
+const HelpCentreTopic = (props: HelpCentreArticleProps) => {
+  const [article, setArticle] = useState<Article | undefined>(undefined);
+
+  useEffect(() => {
+    setArticle(undefined);
+    fetch(`/api/help-centre/article/${props.articleCode}`)
+      .then(response => {
+        if (response.ok) {
+          return response.json();
+        } else {
+          Sentry.captureMessage(
+            `Fetching article ${props.articleCode} returned ${response.status}.`
+          );
+          navigate("/help-centre");
+        }
+      })
+      .then(articleData => setArticle(articleData as Article))
+      .catch(error =>
+        Sentry.captureException(
+          `Failed to fetch article ${props.articleCode}. Error: ${error}`
+        )
+      );
+  }, [props.articleCode]);
+
+  const selectedNavTopic = helpCentreNavConfig.find(
+    topic => topic.id === article?.topics[0].path
+  );
+
+  return (
+    <>
+      <SectionHeader title="How can we help you?" pageHasNav={true} />
+      <SectionContent hasNav={true} selectedTopicObject={selectedNavTopic}>
+        <div
+          css={css`
+            margin: 0 ${space[3]}px ${space[24]}px ${space[3]}px;
+          `}
+        >
+          <h2 css={h2Css}>{article?.title}</h2>
+          {article ? <ArticleBody article={article} /> : <Loading />}
+          <BackToHelpCentreButton />
+        </div>
+      </SectionContent>
+    </>
+  );
+};
+
+const Loading = () => (
+  <WithStandardTopMargin>
+    <Spinner loadingMessage={"Fetching article..."} />
+  </WithStandardTopMargin>
+);
+
+// This is to appease React's "Lists need a unique key" error
+// A 5 character random string should be safe enough (no collisions)
+const getRandomKey = () =>
+  Math.random()
+    .toString(36)
+    .replace(/[^a-z]+/g, "")
+    .substr(0, 5);
+
+interface ArticleBodyProps {
+  article: Article;
+}
+
+const ArticleBody = (props: ArticleBodyProps) => {
+  const parseBody = (body: BaseNode[] | BaseNode): React.ReactNode => {
+    if (Array.isArray(body)) {
+      return body.map(parseBody);
+    } else {
+      const key = getRandomKey();
+      switch (body.element) {
+        case "text": {
+          return (body as TextNode).content;
+        }
+        case "h2": {
+          return <h2 key={key}>{parseBody((body as ElementNode).content)}</h2>;
+        }
+        case "p": {
+          return <p key={key}>{parseBody((body as ElementNode).content)}</p>;
+        }
+        case "ol": {
+          return <ol key={key}>{parseBody((body as ElementNode).content)}</ol>;
+        }
+        case "ul": {
+          return <ul key={key}>{parseBody((body as ElementNode).content)}</ul>;
+        }
+        case "li": {
+          return <li key={key}>{parseBody((body as ElementNode).content)}</li>;
+        }
+        case "b": {
+          return <b key={key}>{parseBody((body as ElementNode).content)}</b>;
+        }
+        case "i": {
+          return <i key={key}>{parseBody((body as ElementNode).content)}</i>;
+        }
+        case "a": {
+          const node = body as LinkNode;
+          return (
+            <a key={key} href={node.href}>
+              {parseBody(node.content)}
+            </a>
+          );
+        }
+        default: {
+          Sentry.captureMessage(`Found unexpected element (${body.element}).`);
+          return null;
+        }
+      }
+    }
+  };
+
+  return <div>{parseBody(props.article.body)}</div>;
+};
+
+export default HelpCentreTopic;

--- a/app/client/components/helpCentre/helpCentreArticle.tsx
+++ b/app/client/components/helpCentre/helpCentreArticle.tsx
@@ -1,5 +1,3 @@
-import { css } from "@emotion/core";
-import { space } from "@guardian/src-foundations";
 import { navigate, RouteComponentProps } from "@reach/router";
 import * as Sentry from "@sentry/browser";
 import React, { useEffect, useState } from "react";
@@ -54,15 +52,9 @@ const HelpCentreTopic = (props: HelpCentreArticleProps) => {
     <>
       <SectionHeader title="How can we help you?" pageHasNav={true} />
       <SectionContent hasNav={true} selectedTopicObject={selectedNavTopic}>
-        <div
-          css={css`
-            margin: 0 ${space[3]}px ${space[24]}px ${space[3]}px;
-          `}
-        >
-          <h2 css={h2Css}>{article?.title}</h2>
-          {article ? <ArticleBody article={article} /> : <Loading />}
-          <BackToHelpCentreButton />
-        </div>
+        <h2 css={h2Css}>{article?.title}</h2>
+        {article ? <ArticleBody article={article} /> : <Loading />}
+        <BackToHelpCentreButton />
       </SectionContent>
     </>
   );

--- a/app/client/components/helpCentre/helpCentreArticle.tsx
+++ b/app/client/components/helpCentre/helpCentreArticle.tsx
@@ -1,5 +1,5 @@
 import { navigate, RouteComponentProps } from "@reach/router";
-import * as Sentry from "@sentry/browser";
+import { captureException, captureMessage } from "@sentry/browser";
 import React, { useEffect, useState } from "react";
 import { SectionContent } from "../sectionContent";
 import { SectionHeader } from "../sectionHeader";
@@ -30,7 +30,7 @@ const HelpCentreTopic = (props: HelpCentreArticleProps) => {
         if (response.ok) {
           return response.json();
         } else {
-          Sentry.captureMessage(
+          captureMessage(
             `Fetching article ${props.articleCode} returned ${response.status}.`
           );
           navigate("/help-centre");
@@ -38,7 +38,7 @@ const HelpCentreTopic = (props: HelpCentreArticleProps) => {
       })
       .then(articleData => setArticle(articleData as Article))
       .catch(error =>
-        Sentry.captureException(
+        captureException(
           `Failed to fetch article ${props.articleCode}. Error: ${error}`
         )
       );
@@ -122,7 +122,7 @@ const ArticleBody = (props: ArticleBodyProps) => {
           );
         }
         default: {
-          Sentry.captureMessage(`Found unexpected element (${body.element}).`);
+          captureMessage(`Found unexpected element (${body.element}).`);
           return null;
         }
       }

--- a/app/client/components/helpCentre/helpCentreArticle.tsx
+++ b/app/client/components/helpCentre/helpCentreArticle.tsx
@@ -53,7 +53,14 @@ const HelpCentreTopic = (props: HelpCentreArticleProps) => {
       <SectionHeader title="How can we help you?" pageHasNav={true} />
       <SectionContent hasNav={true} selectedTopicObject={selectedNavTopic}>
         <h2 css={h2Css}>{article?.title}</h2>
-        {article ? <ArticleBody article={article} /> : <Loading />}
+        {article ? (
+          <ArticleBody
+            article={article}
+            articleCode={props.articleCode ?? ""}
+          />
+        ) : (
+          <Loading />
+        )}
         <BackToHelpCentreButton />
       </SectionContent>
     </>
@@ -66,24 +73,21 @@ const Loading = () => (
   </WithStandardTopMargin>
 );
 
-// This is to appease React's "Lists need a unique key" error
-// A 5 character random string should be safe enough (no collisions)
-const getRandomKey = () =>
-  Math.random()
-    .toString(36)
-    .replace(/[^a-z]+/g, "")
-    .substr(0, 5);
-
 interface ArticleBodyProps {
   article: Article;
+  articleCode: string;
 }
 
 const ArticleBody = (props: ArticleBodyProps) => {
+  // This is to appease React's "Lists need a unique key" error
+  let keyCounter = 0;
+  const getKey = () => props.articleCode + keyCounter++;
+
   const parseBody = (body: BaseNode[] | BaseNode): React.ReactNode => {
     if (Array.isArray(body)) {
       return body.map(parseBody);
     } else {
-      const key = getRandomKey();
+      const key = getKey();
       switch (body.element) {
         case "text": {
           return (body as TextNode).content;

--- a/app/client/components/helpCentre/helpCentreConfig.ts
+++ b/app/client/components/helpCentre/helpCentreConfig.ts
@@ -406,7 +406,7 @@ export interface HelpCentreNavConfig {
   title: string;
 }
 
-export const helpCentreNavConfig = [
+export const helpCentreNavConfig: HelpCentreNavConfig[] = [
   { id: "delivery", title: "Delivery" },
   { id: "billing", title: "Billing" },
   { id: "accounts", title: "Accounts & Sign in" },

--- a/app/client/components/helpCentre/helpCentreConfig.ts
+++ b/app/client/components/helpCentre/helpCentreConfig.ts
@@ -409,7 +409,7 @@ export interface HelpCentreNavConfig {
 export const helpCentreNavConfig = [
   { id: "delivery", title: "Delivery" },
   { id: "billing", title: "Billing" },
-  { id: "accounts-and-sign-in", title: "Accounts & Sign in" },
+  { id: "accounts", title: "Accounts & Sign in" },
   { id: "the-guardian-website", title: "The Guardian Website" },
   { id: "journalism", title: "Journalism" },
   { id: "print-subscriptions", title: "Print Subscriptions" },

--- a/app/client/components/helpCentre/helpCentreLandingMoreTopics.tsx
+++ b/app/client/components/helpCentre/helpCentreLandingMoreTopics.tsx
@@ -3,6 +3,7 @@ import { space } from "@guardian/src-foundations";
 import { neutral } from "@guardian/src-foundations/palette";
 import { textSans } from "@guardian/src-foundations/typography";
 import React, { useState } from "react";
+import { maxWidth } from "../../styles/breakpoints";
 import { trackEvent } from "../analytics";
 import { helpCentreMoreQuestionsConfig } from "./helpCentreConfig";
 import {
@@ -28,8 +29,9 @@ export const HelpCentreLandingMoreTopics = () => {
   const showHideCss = `
     ${textSans.xsmall()};
     margin-left: ${space[3]}px;
-    @media only screen and (max-width: 375px) {
-    display: none;
+    ${maxWidth.mobileMedium} {
+      display: none;
+    }
   }
   `;
 

--- a/app/client/components/helpCentre/helpCentreLandingMoreTopics.tsx
+++ b/app/client/components/helpCentre/helpCentreLandingMoreTopics.tsx
@@ -37,11 +37,7 @@ export const HelpCentreLandingMoreTopics = () => {
   };
   return (
     <div css={moreTopicsStyles}>
-      <div
-        css={css`
-          ${containterCss}
-        `}
-      >
+      <div css={containterCss}>
         {helpCentreMoreQuestionsConfig.map((topic, topicIndex) => {
           const isOpen = topicIndex === indexOfOpenSection;
           const isNotFirstOption = topicIndex > 0;
@@ -62,11 +58,7 @@ export const HelpCentreLandingMoreTopics = () => {
                   {isOpen ? "Hide" : "Show"}
                 </span>
               </h2>
-              <ul
-                css={css`
-                  ${innerSectionCss(isOpen)};
-                `}
-              >
+              <ul css={innerSectionCss(isOpen)}>
                 {topic.links.map((question, questionIndex) => (
                   <li
                     key={`${topic.id}Question-${questionIndex}`}

--- a/app/client/components/helpCentre/helpCentreLandingMoreTopics.tsx
+++ b/app/client/components/helpCentre/helpCentreLandingMoreTopics.tsx
@@ -1,0 +1,103 @@
+import { css } from "@emotion/core";
+import { space } from "@guardian/src-foundations";
+import { textSans } from "@guardian/src-foundations/typography";
+import React, { useState } from "react";
+import { trackEvent } from "../analytics";
+import { helpCentreMoreQuestionsConfig } from "./helpCentreConfig";
+import {
+  containterCss,
+  innerSectionCss,
+  innerSectionDivCss,
+  linkAnchorStyle,
+  linkArrowStyle,
+  sectionTitleCss
+} from "./helpCentreStyles";
+
+const moreTopicsStyles = css({
+  marginBottom: "10px",
+  display: "flex",
+  flexWrap: "wrap",
+  textAlign: "left",
+  fontWeight: "normal"
+});
+
+export const HelpCentreLandingMoreTopics = () => {
+  const [indexOfOpenSection, setIndexOfOpenSection] = useState<number>();
+
+  const showHideCss = `
+    ${textSans.xsmall()};
+    margin-left: ${space[3]}px;
+    @media only screen and (max-width: 375px) {
+    display: none;
+  }
+  `;
+
+  const handleSectionClick = (sectionNum: number) => () => {
+    setIndexOfOpenSection(indexOfOpenSection === sectionNum ? -1 : sectionNum);
+  };
+  return (
+    <div css={moreTopicsStyles}>
+      <div
+        css={css`
+          ${containterCss}
+        `}
+      >
+        {helpCentreMoreQuestionsConfig.map((topic, topicIndex) => {
+          const isOpen = topicIndex === indexOfOpenSection;
+          const isNotFirstOption = topicIndex > 0;
+          return (
+            <div key={topic.id}>
+              <h2
+                css={css`
+                  ${sectionTitleCss(isOpen, isNotFirstOption)};
+                `}
+                onClick={handleSectionClick(topicIndex)}
+              >
+                {topic.title}
+                <span
+                  css={css`
+                    ${showHideCss};
+                  `}
+                >
+                  {isOpen ? "Hide" : "Show"}
+                </span>
+              </h2>
+              <ul
+                css={css`
+                  ${innerSectionCss(isOpen)};
+                `}
+              >
+                {topic.links.map((question, questionIndex) => (
+                  <li
+                    key={`${topic.id}Question-${questionIndex}`}
+                    css={css`
+                      ${innerSectionDivCss};
+                      ${questionIndex < topic.links.length - 1 &&
+                        "border-bottom: 1px solid #DCDCDC"};
+                    `}
+                  >
+                    <a
+                      href={question.link}
+                      target="_blank"
+                      css={linkAnchorStyle}
+                      onClick={() => {
+                        trackEvent({
+                          eventCategory: "help-centre",
+                          eventAction: "more-topics-q-click",
+                          eventLabel: `${topic.id}-${question.id}`
+                        });
+                      }}
+                    >
+                      {question.title}
+                    </a>
+                    <span css={linkArrowStyle} />
+                  </li>
+                ))}
+              </ul>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/app/client/components/helpCentre/helpCentreLandingMoreTopics.tsx
+++ b/app/client/components/helpCentre/helpCentreLandingMoreTopics.tsx
@@ -23,17 +23,21 @@ const moreTopicsStyles = css({
   fontWeight: "normal"
 });
 
+const showHideCss = css`
+  ${textSans.xsmall()};
+  margin-left: ${space[3]}px;
+  ${maxWidth.mobileMedium} {
+    display: none;
+  }
+`;
+
+const liStyles = (index: number, length: number) => css`
+  ${innerSectionDivCss};
+  ${index < length - 1 && `border-bottom: 1px solid ${neutral[86]}`};
+`;
+
 export const HelpCentreLandingMoreTopics = () => {
   const [indexOfOpenSection, setIndexOfOpenSection] = useState<number>();
-
-  const showHideCss = `
-    ${textSans.xsmall()};
-    margin-left: ${space[3]}px;
-    ${maxWidth.mobileMedium} {
-      display: none;
-    }
-  }
-  `;
 
   const handleSectionClick = (sectionNum: number) => () => {
     setIndexOfOpenSection(indexOfOpenSection === sectionNum ? -1 : sectionNum);
@@ -47,29 +51,17 @@ export const HelpCentreLandingMoreTopics = () => {
           return (
             <div key={topic.id}>
               <h2
-                css={css`
-                  ${sectionTitleCss(isOpen, isNotFirstOption)};
-                `}
+                css={sectionTitleCss(isOpen, isNotFirstOption)}
                 onClick={handleSectionClick(topicIndex)}
               >
                 {topic.title}
-                <span
-                  css={css`
-                    ${showHideCss};
-                  `}
-                >
-                  {isOpen ? "Hide" : "Show"}
-                </span>
+                <span css={showHideCss}>{isOpen ? "Hide" : "Show"}</span>
               </h2>
               <ul css={innerSectionCss(isOpen)}>
                 {topic.links.map((question, questionIndex) => (
                   <li
                     key={`${topic.id}Question-${questionIndex}`}
-                    css={css`
-                      ${innerSectionDivCss};
-                      ${questionIndex < topic.links.length - 1 &&
-                        `border-bottom: 1px solid ${neutral[86]}`};
-                    `}
+                    css={liStyles(questionIndex, topic.links.length)}
                   >
                     <a
                       href={question.link}

--- a/app/client/components/helpCentre/helpCentreLandingMoreTopics.tsx
+++ b/app/client/components/helpCentre/helpCentreLandingMoreTopics.tsx
@@ -1,5 +1,6 @@
 import { css } from "@emotion/core";
 import { space } from "@guardian/src-foundations";
+import { neutral } from "@guardian/src-foundations/palette";
 import { textSans } from "@guardian/src-foundations/typography";
 import React, { useState } from "react";
 import { trackEvent } from "../analytics";
@@ -65,7 +66,7 @@ export const HelpCentreLandingMoreTopics = () => {
                     css={css`
                       ${innerSectionDivCss};
                       ${questionIndex < topic.links.length - 1 &&
-                        "border-bottom: 1px solid #DCDCDC"};
+                        `border-bottom: 1px solid ${neutral[86]}`};
                     `}
                   >
                     <a

--- a/app/client/components/helpCentre/helpCentreMoreTopics.tsx
+++ b/app/client/components/helpCentre/helpCentreMoreTopics.tsx
@@ -33,6 +33,11 @@ const showHideCss = css`
   }
 `;
 
+const liStyles = (index: number, length: number) => css`
+  ${innerSectionDivCss};
+  ${index < length - 1 && `border-bottom: 1px solid ${neutral[86]}`};
+`;
+
 interface HelpCentreMoreTopicsProps {
   id: string;
   moreTopics: MoreTopics;
@@ -53,9 +58,7 @@ export const HelpCentreMoreTopics = (props: HelpCentreMoreTopicsProps) => {
             return (
               <div key={topic.path}>
                 <h2
-                  css={css`
-                    ${sectionTitleCss(isOpen, isNotFirstOption)};
-                  `}
+                  css={sectionTitleCss(isOpen, isNotFirstOption)}
                   onClick={() =>
                     setOpenSection(openSection === topicIndex ? -1 : topicIndex)
                   }
@@ -67,11 +70,7 @@ export const HelpCentreMoreTopics = (props: HelpCentreMoreTopicsProps) => {
                   {topic.articles.map((article, articleIndex) => (
                     <li
                       key={article.path}
-                      css={css`
-                        ${innerSectionDivCss};
-                        ${articleIndex < topic.articles.length - 1 &&
-                          `border-bottom: 1px solid ${neutral[86]}`};
-                      `}
+                      css={liStyles(articleIndex, topic.articles.length)}
                     >
                       <Link
                         css={linkAnchorStyle}

--- a/app/client/components/helpCentre/helpCentreMoreTopics.tsx
+++ b/app/client/components/helpCentre/helpCentreMoreTopics.tsx
@@ -1,5 +1,6 @@
 import { css } from "@emotion/core";
 import { space } from "@guardian/src-foundations";
+import { neutral } from "@guardian/src-foundations/palette";
 import { textSans } from "@guardian/src-foundations/typography";
 import { Link } from "@reach/router";
 import React, { useState } from "react";
@@ -68,7 +69,7 @@ export const HelpCentreMoreTopics = (props: HelpCentreMoreTopicsProps) => {
                       css={css`
                         ${innerSectionDivCss};
                         ${articleIndex < topic.articles.length - 1 &&
-                          "border-bottom: 1px solid #DCDCDC"};
+                          `border-bottom: 1px solid ${neutral[86]}`};
                       `}
                     >
                       <Link

--- a/app/client/components/helpCentre/helpCentreMoreTopics.tsx
+++ b/app/client/components/helpCentre/helpCentreMoreTopics.tsx
@@ -43,11 +43,7 @@ export const HelpCentreMoreTopics = (props: HelpCentreMoreTopicsProps) => {
     <>
       <h2 css={h2Css}>{props.moreTopics.title}</h2>
       <div css={moreTopicsStyles}>
-        <div
-          css={css`
-            ${containterCss}
-          `}
-        >
+        <div css={containterCss}>
           {props.moreTopics.topics.map((topic, topicIndex) => {
             const isOpen = topicIndex === openSection;
             const isNotFirstOption = topicIndex > 0;
@@ -65,11 +61,7 @@ export const HelpCentreMoreTopics = (props: HelpCentreMoreTopicsProps) => {
                   {topic.title}
                   <span css={showHideCss}>{isOpen ? "Hide" : "Show"}</span>
                 </h2>
-                <ul
-                  css={css`
-                    ${innerSectionCss(isOpen)};
-                  `}
-                >
+                <ul css={innerSectionCss(isOpen)}>
                   {topic.articles.map((article, articleIndex) => (
                     <li
                       key={article.path}

--- a/app/client/components/helpCentre/helpCentreMoreTopics.tsx
+++ b/app/client/components/helpCentre/helpCentreMoreTopics.tsx
@@ -1,103 +1,107 @@
 import { css } from "@emotion/core";
 import { space } from "@guardian/src-foundations";
 import { textSans } from "@guardian/src-foundations/typography";
+import { Link } from "@reach/router";
 import React, { useState } from "react";
 import { trackEvent } from "../analytics";
-import { helpCentreMoreQuestionsConfig } from "./helpCentreConfig";
 import {
   containterCss,
+  h2Css,
   innerSectionCss,
   innerSectionDivCss,
   linkAnchorStyle,
   linkArrowStyle,
   sectionTitleCss
 } from "./helpCentreStyles";
+import { MoreTopics } from "./HelpCentreTypes";
 
-const moreTopicsStyles = css({
-  marginBottom: "10px",
-  display: "flex",
-  flexWrap: "wrap",
-  textAlign: "left",
-  fontWeight: "normal"
-});
+const moreTopicsStyles = css`
+  margin-bottom: "10px";
+  display: "flex";
+  flex-wrap: "wrap";
+  text-align: "left";
+  font-weight: "normal";
+`;
 
-export const HelpCentreMoreTopics = () => {
-  const [indexOfOpenSection, setIndexOfOpenSection] = useState<number>();
-
-  const showHideCss = `
-    ${textSans.xsmall()};
-    margin-left: ${space[3]}px;
-    @media only screen and (max-width: 375px) {
+const showHideCss = css`
+  ${textSans.xsmall()};
+  margin-left: ${space[3]}px;
+  @media only screen and (max-width: 375px) {
     display: none;
   }
-  `;
+`;
 
-  const handleSectionClick = (sectionNum: number) => () => {
-    setIndexOfOpenSection(indexOfOpenSection === sectionNum ? -1 : sectionNum);
-  };
+interface HelpCentreMoreTopicsProps {
+  id: string;
+  moreTopics: MoreTopics;
+}
+
+export const HelpCentreMoreTopics = (props: HelpCentreMoreTopicsProps) => {
+  const [openSection, setOpenSection] = useState<number>();
+
   return (
-    <div css={moreTopicsStyles}>
-      <div
-        css={css`
-          ${containterCss}
-        `}
-      >
-        {helpCentreMoreQuestionsConfig.map((topic, topicIndex) => {
-          const isOpen = topicIndex === indexOfOpenSection;
-          const isNotFirstOption = topicIndex > 0;
-          return (
-            <div key={topic.id}>
-              <h2
-                css={css`
-                  ${sectionTitleCss(isOpen, isNotFirstOption)};
-                `}
-                onClick={handleSectionClick(topicIndex)}
-              >
-                {topic.title}
-                <span
+    <>
+      <h2 css={h2Css}>{props.moreTopics.title}</h2>
+      <div css={moreTopicsStyles}>
+        <div
+          css={css`
+            ${containterCss}
+          `}
+        >
+          {props.moreTopics.topics.map((topic, topicIndex) => {
+            const isOpen = topicIndex === openSection;
+            const isNotFirstOption = topicIndex > 0;
+
+            return (
+              <div key={topic.path}>
+                <h2
                   css={css`
-                    ${showHideCss};
+                    ${sectionTitleCss(isOpen, isNotFirstOption)};
+                  `}
+                  onClick={() =>
+                    setOpenSection(openSection === topicIndex ? -1 : topicIndex)
+                  }
+                >
+                  {topic.title}
+                  <span css={showHideCss}>{isOpen ? "Hide" : "Show"}</span>
+                </h2>
+                <ul
+                  css={css`
+                    ${innerSectionCss(isOpen)};
                   `}
                 >
-                  {isOpen ? "Hide" : "Show"}
-                </span>
-              </h2>
-              <ul
-                css={css`
-                  ${innerSectionCss(isOpen)};
-                `}
-              >
-                {topic.links.map((question, questionIndex) => (
-                  <li
-                    key={`${topic.id}Question-${questionIndex}`}
-                    css={css`
-                      ${innerSectionDivCss};
-                      ${questionIndex < topic.links.length - 1 &&
-                        "border-bottom: 1px solid #DCDCDC"};
-                    `}
-                  >
-                    <a
-                      href={question.link}
-                      target="_blank"
-                      css={linkAnchorStyle}
-                      onClick={() => {
-                        trackEvent({
-                          eventCategory: "help-centre",
-                          eventAction: "more-topics-q-click",
-                          eventLabel: `${topic.id}-${question.id}`
-                        });
-                      }}
+                  {topic.articles.map((article, articleIndex) => (
+                    <li
+                      key={article.path}
+                      css={css`
+                        ${innerSectionDivCss};
+                        ${articleIndex < topic.articles.length - 1 &&
+                          "border-bottom: 1px solid #DCDCDC"};
+                      `}
                     >
-                      {question.title}
-                    </a>
-                    <span css={linkArrowStyle} />
-                  </li>
-                ))}
-              </ul>
-            </div>
-          );
-        })}
+                      <Link
+                        css={linkAnchorStyle}
+                        to={`/help-centre/article/${article.path}`}
+                        replace={false}
+                        onClick={() => {
+                          trackEvent({
+                            eventCategory: "help-centre",
+                            eventAction: "article-click",
+                            eventLabel: `${topic.path}:${article.path}`
+                          });
+                        }}
+                      >
+                        {article.title}
+                      </Link>
+                      <span css={linkArrowStyle} />
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            );
+          })}
+        </div>
       </div>
-    </div>
+    </>
   );
 };

--- a/app/client/components/helpCentre/helpCentreMoreTopics.tsx
+++ b/app/client/components/helpCentre/helpCentreMoreTopics.tsx
@@ -4,6 +4,7 @@ import { neutral } from "@guardian/src-foundations/palette";
 import { textSans } from "@guardian/src-foundations/typography";
 import { Link } from "@reach/router";
 import React, { useState } from "react";
+import { maxWidth } from "../../styles/breakpoints";
 import { trackEvent } from "../analytics";
 import {
   containterCss,
@@ -27,7 +28,7 @@ const moreTopicsStyles = css`
 const showHideCss = css`
   ${textSans.xsmall()};
   margin-left: ${space[3]}px;
-  @media only screen and (max-width: 375px) {
+  ${maxWidth.mobileMedium} {
     display: none;
   }
 `;

--- a/app/client/components/helpCentre/helpCentreNav.tsx
+++ b/app/client/components/helpCentre/helpCentreNav.tsx
@@ -115,11 +115,7 @@ const HelpCentreNav = (props: HelpCentreNavProps) => {
         <h2 css={h2Css} onClick={handleSectionClick}>
           Topics
         </h2>
-        <ul
-          css={css`
-            ${innerSectionCss(open)};
-          `}
-        >
+        <ul css={innerSectionCss(open)}>
           {helpCentreNavConfig.map((topic, topicIndex) => {
             return (
               <Link to={`/help-centre/topic/${topic.id}`} key={topic.id}>

--- a/app/client/components/helpCentre/helpCentreNav.tsx
+++ b/app/client/components/helpCentre/helpCentreNav.tsx
@@ -7,7 +7,6 @@ import React, { useState } from "react";
 import { maxWidth, minWidth } from "../../styles/breakpoints";
 import { HelpCentreNavConfig, helpCentreNavConfig } from "./helpCentreConfig";
 import {
-  containterCss,
   innerSectionCss,
   innerSectionDivCss,
   linkAnchorStyle,
@@ -60,7 +59,8 @@ const mobileLiCss = (topicIndex: number) => css`
 `;
 
 const divCss = css`
-  ${containterCss};
+  width: 100%;
+  border: 1px solid ${neutral["86"]};
   ${minWidth.desktop} {
     display: none;
   }

--- a/app/client/components/helpCentre/helpCentreSingleTopic.tsx
+++ b/app/client/components/helpCentre/helpCentreSingleTopic.tsx
@@ -1,51 +1,54 @@
 import { css } from "@emotion/core";
+import { Link } from "@reach/router";
 import React from "react";
 import { trackEvent } from "../analytics";
 import {
+  h2Css,
   linkAnchorStyle,
   linkArrowStyle,
   linkListItemStyle,
   linksListStyle
 } from "./helpCentreStyles";
-import { SingleTopic } from "./helpCentreTopic";
+import { SingleTopic } from "./HelpCentreTypes";
 
 interface HelpCentreSingleTopicProps {
-  topic: SingleTopic | undefined;
+  id: string;
+  topic: SingleTopic;
 }
 
-const liCss = (questionIndex: number) => css`
+const liCss = (index: number) => css`
   ${linkListItemStyle};
-  border-top: ${questionIndex === 0 ? "1px solid #DCDCDC" : "none"};
+  border-top: ${index === 0 ? "1px solid #DCDCDC" : "none"};
 `;
 
-const HelpCentreSingleTopic = (props: HelpCentreSingleTopicProps) => {
+export const HelpCentreSingleTopic = (props: HelpCentreSingleTopicProps) => {
   return (
-    <ul css={linksListStyle}>
-      {props.topic?.articles?.map((question, questionIndex) => (
-        <li
-          key={`${props.topic?.title}Question-${questionIndex}`}
-          css={liCss(questionIndex)}
-        >
-          <a
-            // add path to article page here
-            // href={question.path}
-            target="_blank"
-            css={linkAnchorStyle}
-            onClick={() => {
-              trackEvent({
-                eventCategory: "help-centre",
-                eventAction: "popular-topic-q-click",
-                eventLabel: `${props.topic?.title}-${question.title}`
-              });
-            }}
+    <>
+      <h2 css={h2Css}>{props.topic.title}</h2>
+      <ul css={linksListStyle}>
+        {props.topic.articles.map((article, articleIndex) => (
+          <li
+            key={`${props.id}Article-${articleIndex}`}
+            css={liCss(articleIndex)}
           >
-            {question.title}
-          </a>
-          <span css={linkArrowStyle} />
-        </li>
-      ))}
-    </ul>
+            <Link
+              css={linkAnchorStyle}
+              to={`/help-centre/article/${article.path}`}
+              replace={false}
+              onClick={() => {
+                trackEvent({
+                  eventCategory: "help-centre",
+                  eventAction: "article-click",
+                  eventLabel: `${props.id}:${article.path}`
+                });
+              }}
+            >
+              {article.title}
+            </Link>
+            <span css={linkArrowStyle} />
+          </li>
+        ))}
+      </ul>
+    </>
   );
 };
-
-export default HelpCentreSingleTopic;

--- a/app/client/components/helpCentre/helpCentreSingleTopic.tsx
+++ b/app/client/components/helpCentre/helpCentreSingleTopic.tsx
@@ -1,16 +1,16 @@
 import { css } from "@emotion/core";
 import React from "react";
 import { trackEvent } from "../analytics";
-import { HelpCentreTopic } from "./helpCentreConfig";
 import {
   linkAnchorStyle,
   linkArrowStyle,
   linkListItemStyle,
   linksListStyle
 } from "./helpCentreStyles";
+import { SingleTopic } from "./helpCentreTopic";
 
 interface HelpCentreSingleTopicProps {
-  topic: HelpCentreTopic;
+  topic: SingleTopic | undefined;
 }
 
 const liCss = (questionIndex: number) => css`
@@ -21,20 +21,21 @@ const liCss = (questionIndex: number) => css`
 const HelpCentreSingleTopic = (props: HelpCentreSingleTopicProps) => {
   return (
     <ul css={linksListStyle}>
-      {props.topic.links.map((question, questionIndex) => (
+      {props.topic?.articles?.map((question, questionIndex) => (
         <li
-          key={`${props.topic.id}Question-${questionIndex}`}
+          key={`${props.topic?.title}Question-${questionIndex}`}
           css={liCss(questionIndex)}
         >
           <a
-            href={question.link}
+            // add path to article page here
+            // href={question.path}
             target="_blank"
             css={linkAnchorStyle}
             onClick={() => {
               trackEvent({
                 eventCategory: "help-centre",
                 eventAction: "popular-topic-q-click",
-                eventLabel: `${props.topic.id}-${question.id}`
+                eventLabel: `${props.topic?.title}-${question.title}`
               });
             }}
           >

--- a/app/client/components/helpCentre/helpCentreStyles.tsx
+++ b/app/client/components/helpCentre/helpCentreStyles.tsx
@@ -37,7 +37,7 @@ export const linkListItemStyle = css`
   position: relative;
 `;
 
-export const containterCss = `
+export const containterCss = css`
   width: 100%;
   border: 1px solid ${neutral["86"]};
 `;
@@ -87,17 +87,22 @@ export const innerSectionDivCss = `
   position: relative;
 `;
 
-export const innerSectionCss = (isOpen: boolean) => `
+export const innerSectionCss = (isOpen: boolean) => css`
   display: ${isOpen ? "block" : "none"};
   margin: 0;
   padding: 0;
   list-style: none;
   background-color: rgba(193, 216, 252, 0.3);
-  border-top: 1px solid #DCDCDC;
+  border-top: 1px solid #dcdcdc;
 `;
 
 export const h2Css = css`
+  margin-top: 0;
   margin-bottom: ${space[9]}px;
   border-top: 1px solid ${neutral["86"]};
   ${headline.small({ fontWeight: "bold" })}
+`;
+
+export const contentDivStyles = css`
+  margin: 0 ${space[3]}px ${space[24]}px ${space[3]}px;
 `;

--- a/app/client/components/helpCentre/helpCentreStyles.tsx
+++ b/app/client/components/helpCentre/helpCentreStyles.tsx
@@ -42,7 +42,10 @@ export const containterCss = css`
   border: 1px solid ${neutral["86"]};
 `;
 
-export const sectionTitleCss = (isOpen: boolean, isNotFirstOption: boolean) => `
+export const sectionTitleCss = (
+  isOpen: boolean,
+  isNotFirstOption: boolean
+) => css`
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -77,9 +80,10 @@ export const sectionTitleCss = (isOpen: boolean, isNotFirstOption: boolean) => `
       height: 1px;
       background-color: ${neutral["86"]}
     }
-`}`;
+`}
+`;
 
-export const innerSectionDivCss = `
+export const innerSectionDivCss = css`
   ${textSans.medium()};
   margin-bottom: 0;
   padding: ${space[3]}px ${space[5]}px ${space[3]}px 0;

--- a/app/client/components/helpCentre/helpCentreStyles.tsx
+++ b/app/client/components/helpCentre/helpCentreStyles.tsx
@@ -93,7 +93,7 @@ export const innerSectionCss = (isOpen: boolean) => css`
   padding: 0;
   list-style: none;
   background-color: rgba(193, 216, 252, 0.3);
-  border-top: 1px solid #dcdcdc;
+  border-top: 1px solid ${neutral[86]};
 `;
 
 export const h2Css = css`

--- a/app/client/components/helpCentre/helpCentreStyles.tsx
+++ b/app/client/components/helpCentre/helpCentreStyles.tsx
@@ -27,12 +27,12 @@ export const linkArrowStyle = css`
 
 export const linksListStyle = css`
   list-style: none;
-  margin: 0 0 20px;
+  margin: 0 0 ${space[5]}px 0;
   padding: 0;
 `;
 
 export const linkListItemStyle = css`
-  padding: 12px 20px 12px 0;
+  padding: ${space[3]}px ${space[5]}px ${space[3]}px 0;
   border-bottom: 1px solid ${neutral["86"]};
   position: relative;
 `;

--- a/app/client/components/helpCentre/helpCentreStyles.tsx
+++ b/app/client/components/helpCentre/helpCentreStyles.tsx
@@ -28,7 +28,7 @@ export const linkArrowStyle = css`
 export const linksListStyle = css`
   list-style: none;
   margin: 0 0 20px;
-  padding: 0 12px;
+  padding: 0;
 `;
 
 export const linkListItemStyle = css`
@@ -97,7 +97,7 @@ export const innerSectionCss = (isOpen: boolean) => `
 `;
 
 export const h2Css = css`
-  margin: 0 ${space[3]}px ${space[9]}px ${space[3]}px;
+  margin-bottom: ${space[9]}px;
   border-top: 1px solid ${neutral["86"]};
   ${headline.small({ fontWeight: "bold" })}
 `;

--- a/app/client/components/helpCentre/helpCentreStyles.tsx
+++ b/app/client/components/helpCentre/helpCentreStyles.tsx
@@ -1,7 +1,7 @@
 import { css } from "@emotion/core";
 import { space } from "@guardian/src-foundations";
 import { neutral } from "@guardian/src-foundations/palette";
-import { textSans } from "@guardian/src-foundations/typography";
+import { headline, textSans } from "@guardian/src-foundations/typography";
 
 export const linkAnchorStyle = css`
   display: inline-block;
@@ -38,47 +38,46 @@ export const linkListItemStyle = css`
 `;
 
 export const containterCss = `
-width: 100%;
-border: 1px solid ${neutral["86"]};
+  width: 100%;
+  border: 1px solid ${neutral["86"]};
 `;
 
 export const sectionTitleCss = (isOpen: boolean, isNotFirstOption: boolean) => `
-display: flex;
-justify-content: space-between;
-align-items: center;
-color: ${neutral["7"]};
-${textSans.medium()};
-margin: 0;
-padding: ${space[3]}px ${space[3] * 2 + 15}px ${space[3]}px ${space[3]}px;
-position: relative;
-cursor: pointer;
-:after {
-  content: "";
-  display: block;
-  width: 7px;
-  height: 7px;
-  border-top: 2px solid ${neutral["7"]};
-  border-right: 2px solid ${neutral["7"]};
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%) ${isOpen ? "rotate(-45deg)" : "rotate(135deg)"};
-  transition: transform 0.4s;
-  right: 17px;
-}
-${isNotFirstOption &&
-  `
-  :before {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: ${neutral["7"]};
+  ${textSans.medium()};
+  margin: 0;
+  padding: ${space[3]}px ${space[3] * 2 + 15}px ${space[3]}px ${space[3]}px;
+  position: relative;
+  cursor: pointer;
+  :after {
     content: "";
     display: block;
+    width: 7px;
+    height: 7px;
+    border-top: 2px solid ${neutral["7"]};
+    border-right: 2px solid ${neutral["7"]};
     position: absolute;
-    top: 0;
-    left: 0px;
-    width: 100%;
-    height: 1px;
-    background-color: ${neutral["86"]}
+    top: 50%;
+    transform: translateY(-50%) ${isOpen ? "rotate(-45deg)" : "rotate(135deg)"};
+    transition: transform 0.4s;
+    right: 17px;
   }
-`}
-`;
+  ${isNotFirstOption &&
+    `
+    :before {
+      content: "";
+      display: block;
+      position: absolute;
+      top: 0;
+      left: 0px;
+      width: 100%;
+      height: 1px;
+      background-color: ${neutral["86"]}
+    }
+`}`;
 
 export const innerSectionDivCss = `
   ${textSans.medium()};
@@ -95,4 +94,10 @@ export const innerSectionCss = (isOpen: boolean) => `
   list-style: none;
   background-color: rgba(193, 216, 252, 0.3);
   border-top: 1px solid #DCDCDC;
+`;
+
+export const h2Css = css`
+  margin: 0 ${space[3]}px ${space[9]}px ${space[3]}px;
+  border-top: 1px solid ${neutral["86"]};
+  ${headline.small({ fontWeight: "bold" })}
 `;

--- a/app/client/components/helpCentre/helpCentreTopic.tsx
+++ b/app/client/components/helpCentre/helpCentreTopic.tsx
@@ -1,5 +1,5 @@
 import { navigate, RouteComponentProps } from "@reach/router";
-import { captureMessage, captureException } from "@sentry/browser";
+import { captureException, captureMessage } from "@sentry/browser";
 import React, { useEffect, useState } from "react";
 import { SectionContent } from "../sectionContent";
 import { SectionHeader } from "../sectionHeader";

--- a/app/client/components/helpCentre/helpCentreTopic.tsx
+++ b/app/client/components/helpCentre/helpCentreTopic.tsx
@@ -1,5 +1,5 @@
 import { navigate, RouteComponentProps } from "@reach/router";
-import * as Sentry from "@sentry/browser";
+import { captureMessage, captureException } from "@sentry/browser";
 import React, { useEffect, useState } from "react";
 import { SectionContent } from "../sectionContent";
 import { SectionHeader } from "../sectionHeader";
@@ -31,7 +31,7 @@ const HelpCentreTopic = (props: HelpCentreTopicProps) => {
         if (response.ok) {
           return response.json();
         } else {
-          Sentry.captureMessage(
+          captureMessage(
             `Fetching topic ${props.topicCode} returned ${response.status}.`
           );
           navigate("/help-centre");
@@ -43,7 +43,7 @@ const HelpCentreTopic = (props: HelpCentreTopicProps) => {
           : setSingleTopic(topicData as SingleTopic);
       })
       .catch(error =>
-        Sentry.captureException(
+        captureException(
           `Failed to fetch topic ${props.topicCode}. Error: ${error}`
         )
       );

--- a/app/client/components/helpCentre/helpCentreTopic.tsx
+++ b/app/client/components/helpCentre/helpCentreTopic.tsx
@@ -1,5 +1,3 @@
-import { css } from "@emotion/core";
-import { space } from "@guardian/src-foundations";
 import { navigate, RouteComponentProps } from "@reach/router";
 import * as Sentry from "@sentry/browser";
 import React, { useEffect, useState } from "react";
@@ -59,14 +57,8 @@ const HelpCentreTopic = (props: HelpCentreTopicProps) => {
     <>
       <SectionHeader title="How can we help you?" pageHasNav={true} />
       <SectionContent hasNav={true} selectedTopicObject={selectedNavTopic}>
-        <div
-          css={css`
-            margin: 0 ${space[3]}px ${space[24]}px ${space[3]}px;
-          `}
-        >
-          {getTopicComponent(props.topicCode, singleTopic, moreTopics)}
-          <BackToHelpCentreButton />
-        </div>
+        {getTopicComponent(props.topicCode, singleTopic, moreTopics)}
+        <BackToHelpCentreButton />
       </SectionContent>
     </>
   );

--- a/app/client/components/helpCentre/helpCentreTopic.tsx
+++ b/app/client/components/helpCentre/helpCentreTopic.tsx
@@ -61,7 +61,7 @@ const HelpCentreTopic = (props: HelpCentreTopicProps) => {
       <SectionContent hasNav={true} selectedTopicObject={selectedNavTopic}>
         <div
           css={css`
-            margin-bottom: ${space[24]}px;
+            margin: 0 ${space[3]}px ${space[24]}px ${space[3]}px;
           `}
         >
           {getTopicComponent(props.topicCode, singleTopic, moreTopics)}

--- a/app/client/components/sectionContent.tsx
+++ b/app/client/components/sectionContent.tsx
@@ -52,6 +52,7 @@ const containerCss = css`
 `;
 
 const divCss = (hasNav: boolean | undefined) => css`
+  margin-bottom: ${space[24]}px;
   ${{ ...gridBase }};
   padding-bottom: 1rem;
   ${minWidth.desktop} {

--- a/app/server/helpCentreApi.ts
+++ b/app/server/helpCentreApi.ts
@@ -1,0 +1,27 @@
+import { captureMessage } from "@sentry/node";
+import { Request, Response } from "express";
+import { s3FilePromise } from "./awsIntegration";
+import { conf } from "./config";
+import { log } from "./log";
+
+export const getTopicHandler = async (req: Request, res: Response) => {
+  const { topic } = req.params;
+  const bucketName = "manage-help-content";
+  const filePath = `${conf.STAGE}/topics/${topic}.json`;
+  s3FilePromise(bucketName, filePath)
+    .then(data => {
+      if (!data) {
+        const errorMessage = `File ${filePath} was empty`;
+        log.error(errorMessage);
+        captureMessage(errorMessage);
+      }
+      const statusCode = data ? 200 : 404;
+      res.status(statusCode).json(data || []);
+    })
+    .catch(error => {
+      const errorMessage = `File ${filePath} not found`;
+      log.error(errorMessage, error);
+      captureMessage(errorMessage);
+      res.status(404).send();
+    });
+};

--- a/app/server/helpCentreApi.ts
+++ b/app/server/helpCentreApi.ts
@@ -4,6 +4,28 @@ import { s3FilePromise } from "./awsIntegration";
 import { conf } from "./config";
 import { log } from "./log";
 
+export const getArticleHandler = async (req: Request, res: Response) => {
+  const { article } = req.params;
+  const bucketName = "manage-help-content";
+  const filePath = `${conf.STAGE}/articles/${article}.json`;
+  s3FilePromise(bucketName, filePath)
+    .then(data => {
+      if (!data) {
+        const errorMessage = `File ${filePath} was empty`;
+        log.error(errorMessage);
+        captureMessage(errorMessage);
+      }
+      const statusCode = data ? 200 : 404;
+      res.status(statusCode).json(data || []);
+    })
+    .catch(error => {
+      const errorMessage = `File ${filePath} not found`;
+      log.error(errorMessage, error);
+      captureMessage(errorMessage);
+      res.status(404).send();
+    });
+};
+
 export const getTopicHandler = async (req: Request, res: Response) => {
   const { topic } = req.params;
   const bucketName = "manage-help-content";

--- a/app/server/routes/api.ts
+++ b/app/server/routes/api.ts
@@ -21,7 +21,7 @@ import { s3FilePromise } from "../awsIntegration";
 import { conf } from "../config";
 import { contactUsFormHandler } from "../contactUsApi";
 import { augmentProductDetailWithDeliveryAddressChangeEffectiveDateForToday } from "../fulfilmentDateCalculatorReader";
-import { getTopicHandler } from "../helpCentreApi";
+import { getArticleHandler, getTopicHandler } from "../helpCentreApi";
 import { log } from "../log";
 import { withIdentity } from "../middleware/identityMiddleware";
 import {
@@ -230,6 +230,7 @@ router.get("/known-issues", async (_, response) => {
   response.json(data || []);
 });
 
+router.get("/help-centre/article/:article", getArticleHandler);
 router.get("/help-centre/topic/:topic", getTopicHandler);
 
 router.post("/contact-us", contactUsFormHandler);

--- a/app/server/routes/api.ts
+++ b/app/server/routes/api.ts
@@ -230,7 +230,7 @@ router.get("/known-issues", async (_, response) => {
   response.json(data || []);
 });
 
-router.get("/help-centre/topics/:topic", getTopicHandler);
+router.get("/help-centre/topic/:topic", getTopicHandler);
 
 router.post("/contact-us", contactUsFormHandler);
 

--- a/app/server/routes/api.ts
+++ b/app/server/routes/api.ts
@@ -21,6 +21,7 @@ import { s3FilePromise } from "../awsIntegration";
 import { conf } from "../config";
 import { contactUsFormHandler } from "../contactUsApi";
 import { augmentProductDetailWithDeliveryAddressChangeEffectiveDateForToday } from "../fulfilmentDateCalculatorReader";
+import { getTopicHandler } from "../helpCentreApi";
 import { log } from "../log";
 import { withIdentity } from "../middleware/identityMiddleware";
 import {
@@ -228,6 +229,8 @@ router.get("/known-issues", async (_, response) => {
   const data = await s3FilePromise(bucketName, filePath);
   response.json(data || []);
 });
+
+router.get("/help-centre/topics/:topic", getTopicHandler);
 
 router.post("/contact-us", contactUsFormHandler);
 

--- a/app/shared/requiresSignin.ts
+++ b/app/shared/requiresSignin.ts
@@ -5,6 +5,7 @@ const publicPaths = [
   "/api/contact-us/",
   "/api/known-issues/",
   "/api/reminders/cancel/",
+  "/api/help-centre/",
   "/cancel-reminders/",
   "/help-centre/"
 ];


### PR DESCRIPTION
## What does this change?
This PR implements the Topic and Article pages, as well as corresponding endpoints.

The endpoints fetch the corresponding file from S3 and serve it as the body of the response. The page read the response from the endpoint to render the Topic or Article.

## Screenshots
### Article Page
![image](https://user-images.githubusercontent.com/48949546/112817723-a8f57300-907a-11eb-87aa-0eb4ae3873b5.png)

### Topic Page
![image](https://user-images.githubusercontent.com/48949546/112817779-ba3e7f80-907a-11eb-9ac4-6df223d3de98.png)

### More Topics Page
![image](https://user-images.githubusercontent.com/48949546/112817808-c1658d80-907a-11eb-9763-cdb56e9cb2f8.png)
