### PR TITLE
Upgrade CMP to v6.11.3

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -129,8 +129,8 @@
   "dependencies": {
     "@emotion/core": "^10.0.35",
     "@emotion/styled": "^10.0.27",
-    "@guardian/consent-management-platform": "^6.11.2",
-    "@guardian/libs": "^1.6.2",
+    "@guardian/consent-management-platform": "^6.11.3",
+    "@guardian/libs": "^1.7.1",
     "@guardian/src-button": "^2.8.2",
     "@guardian/src-checkbox": "^2.8.2",
     "@guardian/src-choice-card": "^2.8.2",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1432,15 +1432,15 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
-"@guardian/consent-management-platform@^6.11.2":
-  version "6.11.2"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.11.2.tgz#668d0f911aff5c3bc42cb54c606b07640d18f0b8"
-  integrity sha512-tX+lZZFgn9PP8RUj14MnsYa7ikBAyTWfQJPNls4o2Q5c+o0uRVYHnlgifvspj0k1m05rFEmYjnmj7rxwpnH2Xw==
+"@guardian/consent-management-platform@^6.11.3":
+  version "6.11.3"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.11.3.tgz#92a7a6221587bcd86851e6a90198ad618f51b1e9"
+  integrity sha512-xKocfioFtkq5v9MuupT1ugo290NfSD4yIMl7m89xek6W+7B2fKjh0cAMHj4u2LQSXmEoyQ76vs2IaB3w5+98ZQ==
 
-"@guardian/libs@^1.6.2":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-1.6.3.tgz#71ad9a5160708ae75d3bc182afb3f235b9c4de1f"
-  integrity sha512-CMTvDbIrfvla8OWHdO+tyjUUEp9XGGr2fQ8XDJptSiiJr1gKJsWV6NvFXQi1ypqDRsPYiJ8h1DxvBtyuyWATOA==
+"@guardian/libs@^1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-1.7.1.tgz#8fe4abd10d4ab5f4cdf397f84f416fe6c698f662"
+  integrity sha512-gafm04w/ETycDBb8rRDdt+MYhBAiA5aJ5JHYe2s2Q+0fk0npyWDJFvQB0Rttm1qblWlaHimLLfzZNNoAReKwLA==
 
 "@guardian/src-button@^2.8.2":
   version "2.8.2"


### PR DESCRIPTION
## What does this change?
Upgrades the `@guardian/consent-management-platform` to the latest version (v6.11.3), fixing the issue reported in guardian/consent-management-platform#412
Also upgrades `@guardian/libs` to the latest version.