### PR TITLE
Fix scrollToTop incorrectly triggering in the Contact Us form

### DIFF
--- a/app/client/components/scrollToTop.tsx
+++ b/app/client/components/scrollToTop.tsx
@@ -1,7 +1,7 @@
 import { Location } from "@reach/router";
 import React from "react";
 
-const exceptions: string[] = ["/contact-us/"];
+const exceptions: string[] = ["/help-centre/contact-us/"];
 
 export const ScrollToTop = () => (
   <Location>


### PR DESCRIPTION
## What does this change?
Fixes a bug introduced when we moved the Contact Us path from `/contact-us/` to `/help-centre/contact-us/` in #585 and forgot to update the exception in `scrollToTop`.
This bug made the page jump to the top when a user made a selection in the form.