### PR TITLE
Make article and topic pages available

### DIFF
--- a/app/client/components/HelpCentrePage.tsx
+++ b/app/client/components/HelpCentrePage.tsx
@@ -17,17 +17,17 @@ const HelpCentre = lazy(() =>
   import(/* webpackChunkName: "HelpCentre" */ "./helpCentre/helpCentre")
 );
 
-// const HelpCentreArticle = lazy(() =>
-//   import(
-//     /* webpackChunkName: "HelpCentreArticle" */ "./helpCentre/helpCentreArticle"
-//   )
-// );
+const HelpCentreArticle = lazy(() =>
+  import(
+    /* webpackChunkName: "HelpCentreArticle" */ "./helpCentre/helpCentreArticle"
+  )
+);
 
-// const HelpCentreTopic = lazy(() =>
-//   import(
-//     /* webpackChunkName: "HelpCentreTopic" */ "./helpCentre/helpCentreTopic"
-//   )
-// );
+const HelpCentreTopic = lazy(() =>
+  import(
+    /* webpackChunkName: "HelpCentreTopic" */ "./helpCentre/helpCentreTopic"
+  )
+);
 
 const ContactUs = lazy(() =>
   import(/* webpackChunkName: "ContactUs" */ "./contactUs/contactUs")
@@ -42,8 +42,8 @@ const HelpCentreRouter = () => {
         <Router primary={true} css={{ height: "100%" }}>
           <HelpCentre path="/help-centre" />
 
-          {/* <HelpCentreArticle path="/help-centre/article/:articleCode" />
-          <HelpCentreTopic path="/help-centre/topic/:topicCode" /> */}
+          <HelpCentreArticle path="/help-centre/article/:articleCode" />
+          <HelpCentreTopic path="/help-centre/topic/:topicCode" />
 
           <ContactUs path="/help-centre/contact-us" />
           <ContactUs path="/help-centre/contact-us/:urlTopicId" />


### PR DESCRIPTION
## What does this change?
This PR makes the Help Centre's article and topic pages accessible so they can be tested in PROD. Given that they are not linked to from anywhere crawlers should not pick up on them (we don't want them to for now) and users shouldn't stumble upon them.