### PR TITLE
Give read access to membership-dist bucket

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -239,6 +239,19 @@ Resources:
       Roles:
       - !Ref AppRole
 
+  ReadFromDistBucketPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: read-from-dist-bucket-policy
+      PolicyDocument:
+        Statement:
+        - Effect: Allow
+          Action: s3:GetObject
+          Resource:
+          - arn:aws:s3::*:membership-dist/*
+      Roles:
+      - !Ref AppRole
+        
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:


### PR DESCRIPTION
To allow the bucket's access to be restricted.