### PR TITLE
Explicitly pass credentials on fetch requests

### DIFF
--- a/app/client/components/identity/idapi/supportReminders.ts
+++ b/app/client/components/identity/idapi/supportReminders.ts
@@ -22,7 +22,10 @@ const getConsent = (isActive: boolean): ConsentOption => ({
 });
 
 export const read = async (): Promise<ConsentOption[]> => {
-  const response = await fetch(REMINDERS_STATUS_ENDPOINT);
+  const response = await fetch(REMINDERS_STATUS_ENDPOINT, {
+    credentials: "include",
+    mode: "same-origin"
+  });
   const reminderStatus = (await response.json()) as ReminderStatusApiResponse;
   if (reminderStatus.recurringStatus === "NotSet") {
     return [];


### PR DESCRIPTION
## What does this change?
The `api/reminders/status` introduced in PR #604 did not include the fix introduced in PR #572 so users with older Safari versions accessing the Email & Marketing section of MMA were seeing an error and were unable to change their settings. This PR adds the fix to the relevant endpoint and restores access.