### PR TITLE
Integrate live chat

### DIFF
--- a/app/client/components/helpCentre/helpCentre.tsx
+++ b/app/client/components/helpCentre/helpCentre.tsx
@@ -3,7 +3,8 @@ import { space } from "@guardian/src-foundations";
 import { brand, neutral } from "@guardian/src-foundations/palette";
 import { headline, textSans } from "@guardian/src-foundations/typography";
 import { RouteComponentProps } from "@reach/router";
-import React from "react";
+import React, { useEffect } from "react";
+import { initLiveChat } from "../../liveChat";
 import { minWidth } from "../../styles/breakpoints";
 import { trackEvent } from "../analytics";
 import { LinkButton } from "../buttons";
@@ -24,60 +25,83 @@ const subtitleStyles = css`
   ${headline.small({ fontWeight: "bold" })};
 `;
 
-const HelpCentre = (_: RouteComponentProps) => (
-  <>
-    <SectionHeader title="How can we help you?" />
-    <KnownIssues />
-    <SectionContent>
-      <div
-        css={css`
-          margin-bottom: ${space[24]}px;
-        `}
-      >
-        <h2 css={subtitleStyles}>Most popular topics</h2>
+const HelpCentre = (_: RouteComponentProps) => {
+  useEffect(() => {
+    const queryString = window.location.search.slice(1);
+
+    const liveChatRegex = /liveChat.+?(?=\&|$)/g;
+    const match = queryString.match(liveChatRegex);
+
+    if (match) {
+      const liveChatKeyValueArray = match[0].split("=");
+      window.sessionStorage.setItem(
+        liveChatKeyValueArray[0],
+        liveChatKeyValueArray[1]
+      );
+    }
+
+    if (window.sessionStorage.getItem("liveChat") === "1") {
+      initLiveChat();
+    }
+  }, []);
+
+  return (
+    <>
+      <SectionHeader title="How can we help you?" />
+      <KnownIssues />
+      <SectionContent>
         <div
           css={css`
-            display: flex;
-            flex-wrap: wrap;
-            align-items: stretch;
-            justify-content: space-between;
+            margin-bottom: ${space[24]}px;
           `}
         >
-          {helpCentreConfig.map(topic => (
-            <HelpTopicBox key={topic.id} topic={topic} />
-          ))}
-        </div>
-        <h2 css={subtitleStyles}>More Topics</h2>
-        {/* HelpCentreMoreTopics will replace HelpCentreLandingMoreTopics
+          <h2 css={subtitleStyles}>Most popular topics</h2>
+          <div
+            css={css`
+              display: flex;
+              flex-wrap: wrap;
+              align-items: stretch;
+              justify-content: space-between;
+            `}
+          >
+            {helpCentreConfig.map(topic => (
+              <HelpTopicBox key={topic.id} topic={topic} />
+            ))}
+          </div>
+          <h2 css={subtitleStyles}>More Topics</h2>
+          {/* HelpCentreMoreTopics will replace HelpCentreLandingMoreTopics
         once we convert the landing page to loading dynamic content */}
-        <HelpCentreLandingMoreTopics />
-        <h2 css={subtitleStyles}>Still can’t find what you’re looking for?</h2>
-        <CallCentreEmailAndNumbers />
-        <p
-          css={css`
-            ${textSans.medium()};
-            margin-top: ${space[5]}px;
-          `}
-        >
-          Or use our contact form to get in touch and we’ll get back to you as
-          soon as possible.
-        </p>
-        <LinkButton
-          colour={brand[800]}
-          textColour={brand[400]}
-          fontWeight={"bold"}
-          text="Take me to the form"
-          to="/help-centre/contact-us/"
-          onClick={() =>
-            trackEvent({
-              eventCategory: "help-centre",
-              eventAction: "contact-us-cta-click"
-            })
-          }
-        />
-      </div>{" "}
-    </SectionContent>
-  </>
-);
+          <HelpCentreLandingMoreTopics />
+          <h2 css={subtitleStyles}>
+            Still can’t find what you’re looking for?
+          </h2>
+          <CallCentreEmailAndNumbers />
+          <p
+            css={css`
+              ${textSans.medium()};
+              margin-top: ${space[5]}px;
+            `}
+          >
+            Or use our contact form to get in touch and we’ll get back to you as
+            soon as possible.
+          </p>
+          <LinkButton
+            colour={brand[800]}
+            textColour={brand[400]}
+            fontWeight={"bold"}
+            text="Take me to the form"
+            to="/help-centre/contact-us/"
+            onClick={() =>
+              trackEvent({
+                eventCategory: "help-centre",
+                eventAction: "contact-us-cta-click"
+              })
+            }
+          />
+        </div>{" "}
+      </SectionContent>
+    </>
+  );
+};
 
 export default HelpCentre;

--- a/app/client/liveChat.ts
+++ b/app/client/liveChat.ts
@@ -8,10 +8,11 @@
 //     }
 // </style>
 
-// tslint:disable:variable-name
-// tslint:disable:no-object-mutation
+// tslint:disable-next-line:variable-name
 const initESW = (gslbBaseUrl: string | null, embedded_svc: any) => {
+  // tslint:disable-next-line:no-object-mutation
   embedded_svc.settings.displayHelpButton = true; // Or false
+  // tslint:disable-next-line:no-object-mutation
   embedded_svc.settings.language = ""; // For example, enter 'en' or 'en-US'
 
   // embedded_svc.settings.defaultMinimizedText = '...'; //(Defaults to Chat with an Expert)
@@ -29,7 +30,9 @@ const initESW = (gslbBaseUrl: string | null, embedded_svc: any) => {
   // embedded_svc.settings.fallbackRouting = []; //An array of button IDs, user IDs, or userId_buttonId
   // embedded_svc.settings.offlineSupportMinimizedText = '...'; //(Defaults to Contact Us)
 
+  // tslint:disable-next-line:no-object-mutation
   embedded_svc.settings.enabledFeatures = ["LiveAgent"];
+  // tslint:disable-next-line:no-object-mutation
   embedded_svc.settings.entryFeature = "LiveAgent";
 
   embedded_svc.init(
@@ -58,6 +61,7 @@ export const initLiveChat = () => {
       "src",
       "https://gnmtouchpoint.my.salesforce.com/embeddedservice/5.0/esw.min.js"
     );
+    // tslint:disable-next-line:no-object-mutation
     s.onload = () => {
       initESW(null, window.embedded_svc);
     };

--- a/app/client/liveChat.ts
+++ b/app/client/liveChat.ts
@@ -8,34 +8,33 @@
 //     }
 // </style>
 
-// tslint:disable-next-line:variable-name
-const initESW = (gslbBaseUrl: string | null, embedded_svc: any) => {
+const initESW = (gslbBaseUrl: string | null, liveChatAPI: any) => {
   // tslint:disable-next-line:no-object-mutation
-  embedded_svc.settings.displayHelpButton = true; // Or false
+  liveChatAPI.settings.displayHelpButton = true; // Or false
   // tslint:disable-next-line:no-object-mutation
-  embedded_svc.settings.language = ""; // For example, enter 'en' or 'en-US'
+  liveChatAPI.settings.language = ""; // For example, enter 'en' or 'en-US'
 
-  // embedded_svc.settings.defaultMinimizedText = '...'; //(Defaults to Chat with an Expert)
-  // embedded_svc.settings.disabledMinimizedText = '...'; //(Defaults to Agent Offline)
+  // liveChatAPI.settings.defaultMinimizedText = '...'; //(Defaults to Chat with an Expert)
+  // liveChatAPI.settings.disabledMinimizedText = '...'; //(Defaults to Agent Offline)
 
-  // embedded_svc.settings.loadingText = ''; //(Defaults to Loading)
-  // embedded_svc.settings.storageDomain = 'yourdomain.com'; //(Sets the domain for your deployment so that visitors can navigate subdomains during a chat session)
+  // liveChatAPI.settings.loadingText = ''; //(Defaults to Loading)
+  // liveChatAPI.settings.storageDomain = 'yourdomain.com'; //(Sets the domain for your deployment so that visitors can navigate subdomains during a chat session)
 
   // Settings for Chat
-  // embedded_svc.settings.directToButtonRouting = function(prechatFormData) {
+  // liveChatAPI.settings.directToButtonRouting = function(prechatFormData) {
   // Dynamically changes the button ID based on what the visitor enters in the pre-chat form.
   // Returns a valid button ID.
   // };
-  // embedded_svc.settings.prepopulatedPrechatFields = {}; //Sets the auto-population of pre-chat form fields
-  // embedded_svc.settings.fallbackRouting = []; //An array of button IDs, user IDs, or userId_buttonId
-  // embedded_svc.settings.offlineSupportMinimizedText = '...'; //(Defaults to Contact Us)
+  // liveChatAPI.settings.prepopulatedPrechatFields = {}; //Sets the auto-population of pre-chat form fields
+  // liveChatAPI.settings.fallbackRouting = []; //An array of button IDs, user IDs, or userId_buttonId
+  // liveChatAPI.settings.offlineSupportMinimizedText = '...'; //(Defaults to Contact Us)
 
   // tslint:disable-next-line:no-object-mutation
-  embedded_svc.settings.enabledFeatures = ["LiveAgent"];
+  liveChatAPI.settings.enabledFeatures = ["LiveAgent"];
   // tslint:disable-next-line:no-object-mutation
-  embedded_svc.settings.entryFeature = "LiveAgent";
+  liveChatAPI.settings.entryFeature = "LiveAgent";
 
-  embedded_svc.init(
+  liveChatAPI.init(
     "https://gnmtouchpoint.my.salesforce.com",
     "https://guardiansurveys.secure.force.com",
     gslbBaseUrl,

--- a/app/client/liveChat.ts
+++ b/app/client/liveChat.ts
@@ -1,0 +1,68 @@
+// <style type='text/css'>
+//     .embeddedServiceHelpButton .helpButton .uiButton {
+//         background-color: #005290;
+//         font-family: "Arial", sans-serif;
+//     }
+//     .embeddedServiceHelpButton .helpButton .uiButton:focus {
+//         outline: 1px solid #005290;
+//     }
+// </style>
+
+// tslint:disable:variable-name
+// tslint:disable:no-object-mutation
+const initESW = (gslbBaseUrl: string | null, embedded_svc: any) => {
+  embedded_svc.settings.displayHelpButton = true; // Or false
+  embedded_svc.settings.language = ""; // For example, enter 'en' or 'en-US'
+
+  // embedded_svc.settings.defaultMinimizedText = '...'; //(Defaults to Chat with an Expert)
+  // embedded_svc.settings.disabledMinimizedText = '...'; //(Defaults to Agent Offline)
+
+  // embedded_svc.settings.loadingText = ''; //(Defaults to Loading)
+  // embedded_svc.settings.storageDomain = 'yourdomain.com'; //(Sets the domain for your deployment so that visitors can navigate subdomains during a chat session)
+
+  // Settings for Chat
+  // embedded_svc.settings.directToButtonRouting = function(prechatFormData) {
+  // Dynamically changes the button ID based on what the visitor enters in the pre-chat form.
+  // Returns a valid button ID.
+  // };
+  // embedded_svc.settings.prepopulatedPrechatFields = {}; //Sets the auto-population of pre-chat form fields
+  // embedded_svc.settings.fallbackRouting = []; //An array of button IDs, user IDs, or userId_buttonId
+  // embedded_svc.settings.offlineSupportMinimizedText = '...'; //(Defaults to Contact Us)
+
+  embedded_svc.settings.enabledFeatures = ["LiveAgent"];
+  embedded_svc.settings.entryFeature = "LiveAgent";
+
+  embedded_svc.init(
+    "https://gnmtouchpoint.my.salesforce.com",
+    "https://guardiansurveys.secure.force.com",
+    gslbBaseUrl,
+    "00D20000000nq5g",
+    "Chat_Team",
+    {
+      baseLiveAgentContentURL:
+        "https://c.la2-c2-cdg.salesforceliveagent.com/content",
+      deploymentId: "5725I0000004RYv",
+      buttonId: "5735I0000004Rj7",
+      baseLiveAgentURL: "https://d.la2-c2-cdg.salesforceliveagent.com/chat",
+      eswLiveAgentDevName:
+        "EmbeddedServiceLiveAgent_Parent04I5I0000004LLTUA2_1797a9534a2",
+      isOfflineSupportEnabled: false
+    }
+  );
+};
+
+export const initLiveChat = () => {
+  if (!window.embedded_svc) {
+    const s = document.createElement("script");
+    s.setAttribute(
+      "src",
+      "https://gnmtouchpoint.my.salesforce.com/embeddedservice/5.0/esw.min.js"
+    );
+    s.onload = () => {
+      initESW(null, window.embedded_svc);
+    };
+    document.body.appendChild(s);
+  } else {
+    initESW("https://service.force.com", window.embedded_svc);
+  }
+};

--- a/app/shared/globals.ts
+++ b/app/shared/globals.ts
@@ -28,6 +28,7 @@ export interface Globals extends CommonGlobals {
 declare global {
   interface Window {
     guardian: Globals;
+    embedded_svc: any;
   }
 }
 


### PR DESCRIPTION
## What does this change?
This adds in a script to test the live chat functionality when a certain query parameter and value is included.
When you navigate the site the query string is erased so to to save the flag set in the URL param the key value pair is added to session storage. 

## How to test
- Navigate to the help centre on manage front end ```/help-centre```
- Add the following query parameter to the url ```?liveChat=1```
- You should then see the "Agent Offline" button appear in the bottom right corner of the screen
- Change the value of the liveChat parameter in the url to anything but 1 and the button should not appear

## Images
![image](https://user-images.githubusercontent.com/44685872/119367506-eefd3a80-bca9-11eb-8523-7d46aaa8f93a.png)
