### PR TITLE
Add lang attribute to docs

### DIFF
--- a/app/server/html.ts
+++ b/app/server/html.ts
@@ -22,7 +22,7 @@ const html: (_: {
   readonly globals: Globals;
 }) => string = ({ title, src, globals }) => `
   <!DOCTYPE html>
-  <html>
+  <html lang="en">
     <head>
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
Apparently, without a `lang` attribute screen readers will interpret text as being in the default language.
https://www.w3.org/WAI/WCAG21/Understanding/language-of-page

I'm not sure whether that's true but this is my first PR in the repo!
