### PR TITLE
Add data for structured search results

### DIFF
--- a/app/client/components/HelpCentrePage.tsx
+++ b/app/client/components/HelpCentrePage.tsx
@@ -6,6 +6,7 @@ import global from "../styles/global";
 import { AnalyticsTracker } from "./analytics";
 import { CMPBanner } from "./consent/CMPBanner";
 import { PageTitle } from "./helpCentre/pageTitle";
+import { SeoData } from "./helpCentre/seoData";
 import HelpCentrePageSkeleton from "./HelpCentrePageSkeleton";
 import { Main } from "./main";
 import { ScrollToTop } from "./scrollToTop";
@@ -63,6 +64,7 @@ const HelpCentreRouter = () => {
 export const HelpCentrePage = (
   <>
     <PageTitle />
+    <SeoData />
     <AnalyticsTracker />
     <HelpCentreRouter />
     <CMPBanner />

--- a/app/client/components/helpCentre/helpCentreArticle.tsx
+++ b/app/client/components/helpCentre/helpCentreArticle.tsx
@@ -16,6 +16,7 @@ import {
   TextNode
 } from "./HelpCentreTypes";
 import { PageTitle } from "./pageTitle";
+import { SeoData } from "./seoData";
 
 interface HelpCentreArticleProps extends RouteComponentProps {
   articleCode?: string;
@@ -52,6 +53,7 @@ const HelpCentreTopic = (props: HelpCentreArticleProps) => {
   return (
     <>
       <PageTitle title={article?.title} />
+      <SeoData article={article} />
       <SectionHeader title="How can we help you?" pageHasNav={true} />
       <SectionContent hasNav={true} selectedTopicObject={selectedNavTopic}>
         <h2 css={h2Css}>{article?.title}</h2>

--- a/app/client/components/helpCentre/seoData.tsx
+++ b/app/client/components/helpCentre/seoData.tsx
@@ -1,0 +1,42 @@
+import { Location } from "@reach/router";
+import React from "react";
+import { Article } from "./HelpCentreTypes";
+
+interface SeoDataProps {
+  article?: Article;
+}
+
+const ELEMENT_ID = "seodata";
+
+const addStructuredData = (article: Article) => {
+  const data = {
+    "@context": "https://schema.org/",
+    "@type": "Article",
+    headline: article.title
+  };
+  const scriptElt = document.createElement("script");
+  // tslint:disable-next-line:no-object-mutation
+  scriptElt.id = ELEMENT_ID;
+  // tslint:disable-next-line:no-object-mutation
+  scriptElt.type = "application/ld+json";
+  // tslint:disable-next-line:no-object-mutation
+  scriptElt.innerHTML = JSON.stringify(data);
+  document.head.appendChild(scriptElt);
+};
+
+export const SeoData = (props: SeoDataProps) => (
+  <Location>
+    {() => {
+      if (document) {
+        const scriptElt = document.getElementById(ELEMENT_ID);
+        if (scriptElt) {
+          scriptElt.remove();
+        }
+        if (props.article) {
+          addStructuredData(props.article);
+        }
+      }
+      return null;
+    }}
+  </Location>
+);


### PR DESCRIPTION
This adds some quite meagre structured data to Help Centre articles for search engine results.

It clears the data on all Help Centre pages and then creates a new element containing the structured data for articles.

This has been tested in Google's [rich results testing tool](https://search.google.com/test/rich-results):

![image](https://user-images.githubusercontent.com/1722550/120001768-0864f600-bfcc-11eb-91b6-ff834403d185.png)

And also in the [Schema markup validator](https://validator.schema.org/):

![image](https://user-images.githubusercontent.com/1722550/120002248-8923f200-bfcc-11eb-88c0-068c6f56d51f.png)
