### PR TITLE
Permanently activate Soft Opt-In feature

### DIFF
--- a/app/client/components/identity/EmailAndMarketing/ConsentSection.tsx
+++ b/app/client/components/identity/EmailAndMarketing/ConsentSection.tsx
@@ -11,9 +11,8 @@ interface ConsentSectionProps {
   consents: ConsentOption[];
 }
 
-const releaseSoftOptIns = false;
 const softOptInEmailConsents = (consents: ConsentOption[]): ConsentOption[] =>
-  consents.filter(consent => !!consent.isProduct && releaseSoftOptIns);
+  consents.filter(consent => !!consent.isProduct);
 
 const supportReminderConsent = (consents: ConsentOption[]): ConsentOption[] =>
   ConsentOptions.findByIds(consents, ["support_reminder"]);


### PR DESCRIPTION
## What does this change?
The Soft Opt-In features in MMA sit behind a sort of feature switch introduced in #587. This PR removes that switch so that these features can be made permanently available to our users ahead of the Soft Opt-In emails starting to be sent out tomorrow.


## How to test
Sign in with an account that has active products and the email preferences page should show options to activate/deactivate the Soft Opt-Ins assigned to the active products.