### PR TITLE
Add robots.txt to control site indexing

### DIFF
--- a/app/server/routes/core.ts
+++ b/app/server/routes/core.ts
@@ -1,5 +1,6 @@
 import { Request, Response, Router } from "express";
 import { authKeysAreFetchableMemoisedHealthcheck } from "../apiGatewayDiscovery";
+import { Environments } from "../config";
 import { withIdentity } from "../middleware/identityMiddleware";
 
 const router = Router();
@@ -19,6 +20,25 @@ router.get(
 
 router.get("/_prout", (_, res: Response) => {
   res.send(`<pre>${GIT_COMMIT_HASH}</pre>`);
+});
+
+router.get("/robots.txt", (_, res: Response) => {
+  const disallowAll = "UserAgent: *\n" + "Disallow: /\n\n";
+  const allowHelpCentre =
+    "UserAgent: *\n" +
+    "Allow: /help-centre\n" +
+    "Allow: /help-centre/\n" +
+    "Disallow: /\n\n";
+  const disallowGoogleAdsBots =
+    "User-agent: AdsBot-Google\n" +
+    "User-agent: AdsBot-Google-Mobile\n" +
+    "Disallow: /\n\n";
+  const prodAccessList = allowHelpCentre + disallowGoogleAdsBots;
+  const preProdAccessList = disallowAll;
+  const accessList = Environments.PRODUCTION
+    ? prodAccessList
+    : preProdAccessList;
+  res.contentType("text/plain").send(accessList);
 });
 
 export default router;


### PR DESCRIPTION
This should regulate well-behaved bots indexing our content to ensure that, in production, they only try to access the new Help Centre content.

In pre-prod stages no content is allowed to be indexed.

Prod:
```
UserAgent: *
Allow: /help-centre
Allow: /help-centre/
Disallow: /

User-agent: AdsBot-Google
User-agent: AdsBot-Google-Mobile
Disallow: /
```

Pre-prod:
```
UserAgent: *
Disallow: /
```

See:
* https://www.theguardian.com/robots.txt
* https://developers.google.com/search/docs/advanced/robots/create-robots-txt
* https://developers.google.com/search/docs/advanced/crawling/overview-google-crawlers
* https://en.wikipedia.org/wiki/Robots_exclusion_standard
