### PR TITLE
Fix logic to choose a robots.txt

### DIFF
--- a/app/server/routes/core.ts
+++ b/app/server/routes/core.ts
@@ -1,6 +1,6 @@
 import { Request, Response, Router } from "express";
 import { authKeysAreFetchableMemoisedHealthcheck } from "../apiGatewayDiscovery";
-import { Environments } from "../config";
+import { conf, Environments } from "../config";
 import { withIdentity } from "../middleware/identityMiddleware";
 
 const router = Router();
@@ -35,9 +35,10 @@ router.get("/robots.txt", (_, res: Response) => {
     "Disallow: /\n\n";
   const prodAccessList = allowHelpCentre + disallowGoogleAdsBots;
   const preProdAccessList = disallowAll;
-  const accessList = Environments.PRODUCTION
-    ? prodAccessList
-    : preProdAccessList;
+  const accessList =
+    conf.ENVIRONMENT === Environments.PRODUCTION
+      ? prodAccessList
+      : preProdAccessList;
   res.contentType("text/plain").send(accessList);
 });
 


### PR DESCRIPTION
There was a small bug in my logic!

[Environments](https://github.com/guardian/manage-frontend/blob/main/app/server/config.ts#L23-L26) is just an enum so `Environments.PRODUCTION` is always false.

