### PR TITLE
Add support for SEPA

### DIFF
--- a/app/client/components/accountoverview/accountOverviewCard.tsx
+++ b/app/client/components/accountoverview/accountOverviewCard.tsx
@@ -20,6 +20,7 @@ import {
   NewPaymentPriceAlert
 } from "../payment/nextPaymentDetails";
 import { PayPalDisplay } from "../payment/paypalDisplay";
+import { SepaDisplay } from "../payment/sepaDisplay";
 import { ErrorIcon } from "../svgs/errorIcon";
 import { GiftIcon } from "../svgs/giftIcon";
 import { SixForSixExplainerIfApplicable } from "./sixForSixExplainer";
@@ -381,6 +382,14 @@ export const AccountOverviewCard = (props: AccountOverviewCardProps) => {
                   {props.productDetail.subscription.payPalEmail && (
                     <PayPalDisplay
                       payPalId={props.productDetail.subscription.payPalEmail}
+                    />
+                  )}
+                  {props.productDetail.subscription.sepaMandate && (
+                    <SepaDisplay
+                      accountName={
+                        props.productDetail.subscription.sepaMandate.accountName
+                      }
+                      iban={props.productDetail.subscription.sepaMandate.iban}
                     />
                   )}
                   {props.productDetail.subscription.mandate && (

--- a/app/client/components/billing/invoicesTable.tsx
+++ b/app/client/components/billing/invoicesTable.tsx
@@ -12,13 +12,15 @@ import { Pagination } from "../pagination";
 import { CardDisplay } from "../payment/cardDisplay";
 import { DirectDebitDisplay } from "../payment/directDebitDisplay";
 import { PayPalDisplay } from "../payment/paypalDisplay";
+import { SepaDisplay } from "../payment/sepaDisplay";
 import { DownloadIcon } from "../svgs/downloadIcon";
 import { InvoiceTableYearSelect } from "./invoiceTableYearSelect";
 
 const invoicePaymentMethods = {
   CARD: "card",
   DIRECT_DEBIT: "directdebit",
-  PAYPAL: "paypal"
+  PAYPAL: "paypal",
+  SEPA: "sepa"
 };
 
 interface InvoiceInfo extends InvoiceDataApiItem {
@@ -289,11 +291,17 @@ export const InvoicesTable = (props: InvoicesTableProps) => {
                             onlyAccountEnding
                           />
                         )}
+                      {paymentMethodLowercase === invoicePaymentMethods.SEPA &&
+                        tableRow.last4 && (
+                          <SepaDisplay accountName="" iban={tableRow.last4} />
+                        )}
                       {paymentMethodLowercase !== invoicePaymentMethods.CARD &&
                         paymentMethodLowercase !==
                           invoicePaymentMethods.PAYPAL &&
                         paymentMethodLowercase !==
-                          invoicePaymentMethods.DIRECT_DEBIT && (
+                          invoicePaymentMethods.DIRECT_DEBIT &&
+                        paymentMethodLowercase !==
+                          invoicePaymentMethods.SEPA && (
                           <span>No Payment Method</span>
                         )}
                     </div>

--- a/app/client/components/payment/paymentDetailsTable.tsx
+++ b/app/client/components/payment/paymentDetailsTable.tsx
@@ -6,6 +6,7 @@ import { CardDisplay } from "./cardDisplay";
 import { DirectDebitDisplay } from "./directDebitDisplay";
 import { NewPaymentPriceAlert, NextPaymentDetails } from "./nextPaymentDetails";
 import { PayPalDisplay } from "./paypalDisplay";
+import { SepaDisplay } from "./sepaDisplay";
 
 interface PaymentDetailsTableProps {
   productDetail: ProductDetail;
@@ -64,6 +65,9 @@ export const PaymentDetailsTable = (props: PaymentDetailsTableProps) => (
                 inErrorState={!!props.productDetail.alertText}
                 {...props.productDetail.subscription.mandate}
               />
+            )}
+            {props.productDetail.subscription.sepaMandate && (
+              <SepaDisplay {...props.productDetail.subscription.sepaMandate} />
             )}
             {props.productDetail.subscription
               .stripePublicKeyForCardAddition && <span>No Payment Method</span>}

--- a/app/client/components/payment/sepaDisplay.tsx
+++ b/app/client/components/payment/sepaDisplay.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+interface SepaDisplayProps {
+  accountName: string;
+  iban: string;
+}
+
+export const SepaDisplay = ({ accountName, iban }: SepaDisplayProps) => {
+  return (
+    <div>
+      <div>SEPA</div>
+
+      <div>
+        {accountName}
+        <br />
+        {iban}
+      </div>
+    </div>
+  );
+};

--- a/app/client/components/payment/update/currentPaymentDetails.tsx
+++ b/app/client/components/payment/update/currentPaymentDetails.tsx
@@ -3,6 +3,7 @@ import { Subscription } from "../../../../shared/productResponse";
 import { CardDisplay } from "../cardDisplay";
 import { DirectDebitDisplay } from "../directDebitDisplay";
 import { PayPalDisplay } from "../paypalDisplay";
+import { SepaDisplay } from "../sepaDisplay";
 
 export const CurrentPaymentDetails = (subscription: Subscription) => {
   if (subscription.card) {
@@ -11,6 +12,8 @@ export const CurrentPaymentDetails = (subscription: Subscription) => {
     return <PayPalDisplay payPalId={subscription.payPalEmail} />;
   } else if (subscription.mandate) {
     return <DirectDebitDisplay {...subscription.mandate} />;
+  } else if (subscription.sepaMandate) {
+    return <SepaDisplay {...subscription.sepaMandate} />;
   }
   return <span>No Payment Method</span>;
 };

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -83,6 +83,11 @@ export interface DirectDebitDetails {
   sortCode: string;
 }
 
+export interface SepaDetails {
+  accountName: string;
+  iban: string;
+}
+
 export interface SubscriptionPlan {
   name: string | null;
   start?: string;
@@ -148,6 +153,7 @@ export interface Subscription {
   card?: Card;
   payPalEmail?: string;
   mandate?: DirectDebitDetails;
+  sepaMandate?: SepaDetails;
   autoRenew: boolean;
   currentPlans: SubscriptionPlan[];
   futurePlans: SubscriptionPlan[];


### PR DESCRIPTION
## What does this change?
Add support for SEPA payment method. This PR depends on a couple of other PRs when fetching user data: 

- `mdapi` PR: https://github.com/guardian/members-data-api/pull/589 
- `invoicing-api` PR: https://github.com/guardian/invoicing-api/pull/71

Specifically, this PR makes MMA correctly display a users payment method for SEPA. A user can update their contribution amount, but cannot switch payment method.

## Images
<img width="833" alt="Screenshot 2021-06-10 at 13 41 24" src="https://user-images.githubusercontent.com/17720442/121661765-744f6000-ca9c-11eb-9c4e-75bf576c9967.png">

<img width="686" alt="Screenshot 2021-06-10 at 13 40 49" src="https://user-images.githubusercontent.com/17720442/121661730-6ac5f800-ca9c-11eb-93e4-4ace97c91480.png">

<img width="833" alt="Screenshot 2021-06-10 at 13 43 34" src="https://user-images.githubusercontent.com/17720442/121661769-75808d00-ca9c-11eb-96e5-b1f5f66012af.png">
