### PR TITLE
Serve Help Centre sitemap from S3

### DIFF
--- a/app/server/awsIntegration.ts
+++ b/app/server/awsIntegration.ts
@@ -99,6 +99,25 @@ export const s3FilePromise = <ConfigInterface>(
     );
   })();
 
+export const s3TextFilePromise = (
+  bucket: string,
+  fileKey: string
+): Promise<string | undefined> =>
+  (async () => {
+    const filePath: GetObjectRequest = {
+      Bucket: bucket,
+      Key: fileKey
+    };
+    const s3PromiseResult = await S3.getObject(filePath).promise();
+    if (s3PromiseResult.Body && s3PromiseResult.ContentType === "text/plain") {
+      return s3PromiseResult.Body.toString();
+    }
+    handleAwsRelatedError(
+      `S3 error fetching ${fileKey} in '${bucket}'`,
+      s3PromiseResult
+    );
+  })();
+
 interface MetricDimensions {
   [name: string]: string;
 }

--- a/app/server/routes/core.ts
+++ b/app/server/routes/core.ts
@@ -45,7 +45,7 @@ router.get("/robots.txt", (_, res: Response) => {
   res.contentType("text/plain").send(accessList);
 });
 
-router.get("/help-centre/sitemap.txt", async (_, res: Response) => {
+router.get("/sitemap.txt", async (_, res: Response) => {
   const bucketName = "manage-help-content";
   const filePath = `${conf.STAGE}/sitemap.txt`;
   s3TextFilePromise(bucketName, filePath)


### PR DESCRIPTION
This change enables us to [read a text/plain file from S3](https://github.com/guardian/manage-frontend/compare/kc-sitemap?expand=1#diff-62a24087ea863ccce38811f99ae580255284a941e7a14330927046efd0413514R102-R119) and serve it.  
In particular, it gives us [a sitemap on the path `/help-centre/sitemap.txt`](https://github.com/guardian/manage-frontend/compare/kc-sitemap?expand=1#diff-86bcdb7857d4c2fdb564aac4765f0a284e62fae9452da60431d0fa3ede65c357R48-R70).
This sitemap is specifically for help-centre content, hence it isn't at the site root.

See also:
* guardian/manage-help-content-publisher#114
* guardian/manage-help-content-publisher#119
* https://developers.google.com/search/docs/advanced/sitemaps/build-sitemap
