### PR TITLE
Fix deployment pipeline/update compression used for build files

### DIFF
--- a/app/artifact.json
+++ b/app/artifact.json
@@ -10,7 +10,7 @@
     {
       "action": "manage-frontend",
       "path": "dist",
-      "compress": "tar"
+      "compress": "zip"
     }
   ]
 }

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -95,7 +95,7 @@ Resources:
       ImageId: !Ref AMI
       SecurityGroups:
         - !Ref InstanceSecurityGroup
-        - !Ref WazuhSecurityGroup 
+        - !Ref WazuhSecurityGroup
       InstanceType: !FindInMap [StageVariables, !Ref Stage, InstanceType]
       IamInstanceProfile: !Ref InstanceProfile
       AssociatePublicIpAddress: false
@@ -105,9 +105,9 @@ Resources:
             #!/bin/bash -ev
 
             # get runnable tar from S3
-            aws --region ${AWS::Region} s3 cp s3://membership-dist/${Stack}/${Stage}/${App}/manage-frontend.tgz /tmp
+            aws --region ${AWS::Region} s3 cp s3://membership-dist/${Stack}/${Stage}/${App}/manage-frontend.zip /tmp
             mkdir /etc/gu
-            tar -xvzf /tmp/manage-frontend.tgz --directory /etc/gu/
+            unzip /tmp/manage-frontend.zip -d /etc/gu/dist/
 
             # add user
             groupadd manage-frontend
@@ -229,15 +229,15 @@ Resources:
       PolicyName: describe-ec2-policy
       PolicyDocument:
         Statement:
-        - Effect: Allow
-          Resource: "*"
-          Action:
-          - ec2:DescribeTags
-          - ec2:DescribeInstances
-          - autoscaling:DescribeAutoScalingGroups
-          - autoscaling:DescribeAutoScalingInstances
+          - Effect: Allow
+            Resource: "*"
+            Action:
+              - ec2:DescribeTags
+              - ec2:DescribeInstances
+              - autoscaling:DescribeAutoScalingGroups
+              - autoscaling:DescribeAutoScalingInstances
       Roles:
-      - !Ref AppRole
+        - !Ref AppRole
 
   ReadFromDistBucketPolicy:
     Type: AWS::IAM::Policy
@@ -245,13 +245,13 @@ Resources:
       PolicyName: read-from-dist-bucket-policy
       PolicyDocument:
         Statement:
-        - Effect: Allow
-          Action: s3:GetObject
-          Resource:
-          - arn:aws:s3::*:membership-dist/*
+          - Effect: Allow
+            Action: s3:GetObject
+            Resource:
+              - arn:aws:s3::*:membership-dist/*
       Roles:
-      - !Ref AppRole
-        
+        - !Ref AppRole
+
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
@@ -353,10 +353,10 @@ Resources:
       VpcId:
         Ref: VpcId
       SecurityGroupEgress:
-      - IpProtocol: tcp
-        FromPort: 1514
-        ToPort: 1515
-        CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 1514
+          ToPort: 1515
+          CidrIp: 0.0.0.0/0
 
   ManageFrontendLogGroup:
     Type: "AWS::Logs::LogGroup"


### PR DESCRIPTION
## What does this change?
Updates the build compression to ZIP and fixes a deployment bug introduced in #653.

The library we upgraded to in #653 made us change the compression of the built files to tar (tgz isn't supported). However we did not update the bash scripts in the CloudFormation to reflect this change. This caused the deployment to succeed but instead of deploying the latest build (inside `manage-frontend.tar`) it was deploying the last version deployed before #653 was merged (inside `manage-frontend.tgz`). This was detected because @prout-bot (🙇 ) warned us that the PR was overdue on PROD. No other PRs were merged since so that was the only merge affected. This bug is now fixed.

While researching the cause of this bug we realised that while the average compressed file size was 16.5MB when using tgz compression, tar compression increases that to 108.5. We tested zip compression, which lower it to 26MB. Because tgz is not longer an updates, zip compression was used instead.

Big thank you to @twrichards for pairing with me on this.

Note: There were a number of linting changed done to this file. I will mark them to make it easier to review.