### PR TITLE
Add help centre article feedback widget

### DIFF
--- a/app/client/components/helpCentre/helpCentreArticle.tsx
+++ b/app/client/components/helpCentre/helpCentreArticle.tsx
@@ -208,8 +208,8 @@ export const ArticleFeedbackWidget = (props: ArticleFeedbackWidgetProps) => {
               onClick={() => {
                 setFeedBackButtonClicked(true);
                 trackEvent({
-                  eventCategory: "help-centre-article-page",
-                  eventAction: "article-feedback-widget-click",
+                  eventCategory: "help-centre",
+                  eventAction: "article-feedback",
                   eventLabel: props.articleCode,
                   eventValue: 1
                 });
@@ -229,8 +229,8 @@ export const ArticleFeedbackWidget = (props: ArticleFeedbackWidgetProps) => {
               onClick={() => {
                 setFeedBackButtonClicked(true);
                 trackEvent({
-                  eventCategory: "help-centre-article-page",
-                  eventAction: "article-feedback-widget-click",
+                  eventCategory: "help-centre",
+                  eventAction: "article-feedback",
                   eventLabel: props.articleCode,
                   eventValue: 0
                 });

--- a/app/client/components/helpCentre/helpCentreArticle.tsx
+++ b/app/client/components/helpCentre/helpCentreArticle.tsx
@@ -1,9 +1,16 @@
+import css from "@emotion/css";
+import { Button } from "@guardian/src-button";
+import { neutral, space } from "@guardian/src-foundations";
+import { textSans } from "@guardian/src-foundations/typography";
 import { navigate, RouteComponentProps } from "@reach/router";
 import { captureException, captureMessage } from "@sentry/browser";
 import React, { useEffect, useState } from "react";
+import { minWidth } from "../../styles/breakpoints";
+import { trackEvent } from "../analytics";
 import { SectionContent } from "../sectionContent";
 import { SectionHeader } from "../sectionHeader";
 import { Spinner } from "../spinner";
+import { ThumbsUpIcon } from "../svgs/thumbsUpIcon";
 import { WithStandardTopMargin } from "../WithStandardTopMargin";
 import { BackToHelpCentreButton } from "./BackToHelpCentreButton";
 import { helpCentreNavConfig } from "./helpCentreConfig";
@@ -58,10 +65,13 @@ const HelpCentreArticle = (props: HelpCentreArticleProps) => {
       <SectionContent hasNav={true} selectedTopicObject={selectedNavTopic}>
         <h2 css={h2Css}>{article?.title}</h2>
         {article ? (
-          <ArticleBody
-            article={article}
-            articleCode={props.articleCode ?? ""}
-          />
+          <>
+            <ArticleBody
+              article={article}
+              articleCode={props.articleCode ?? ""}
+            />
+            <ArticleFeedbackWidget articleCode={props.articleCode ?? ""} />
+          </>
         ) : (
           <Loading />
         )}
@@ -134,6 +144,105 @@ const ArticleBody = (props: ArticleBodyProps) => {
   };
 
   return <div>{parseBody(props.article.body)}</div>;
+};
+
+const articleFeedbackWidgetCss = css`
+  display: flex;
+  flex-direction: column;
+  border: 1px solid ${neutral[86]};
+  padding: ${space[4]}px ${space[3]}px;
+  margin: 66px 0;
+  ${minWidth.mobileLandscape} {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+  & p {
+    margin: 0;
+    ${textSans.medium({ fontWeight: "bold" })}
+  }
+  & .buttonDiv {
+    min-height: 36px;
+    display: flex;
+    align-items: center;
+    margin-top: ${space[4]}px;
+    ${minWidth.mobileLandscape} {
+      margin-top: 0;
+    }
+    & > * {
+      margin-right: ${space[2]}px;
+      ${minWidth.mobileLandscape} {
+        margin-right: ${space[3]}px;
+      }
+    }
+    & p {
+      ${textSans.small({ fontWeight: "regular" })}
+    }
+  }
+`;
+
+interface ArticleFeedbackWidgetProps {
+  articleCode: string;
+}
+
+export const ArticleFeedbackWidget = (props: ArticleFeedbackWidgetProps) => {
+  const [feedBackButtonClicked, setFeedBackButtonClicked] = useState(false);
+
+  return (
+    <div css={articleFeedbackWidgetCss}>
+      <p>Did you find the information you need?</p>
+      <div className="buttonDiv">
+        {feedBackButtonClicked ? (
+          <p>Thank you!</p>
+        ) : (
+          <>
+            <Button
+              icon={<ThumbsUpIcon />}
+              hideLabel={true}
+              size="small"
+              cssOverrides={css`
+                svg {
+                  width: initial;
+                }
+              `}
+              onClick={() => {
+                setFeedBackButtonClicked(true);
+                trackEvent({
+                  eventCategory: "help-centre-article-page",
+                  eventAction: "article-feedback-widget-click",
+                  eventLabel: props.articleCode,
+                  eventValue: 1
+                });
+              }}
+            >
+              Yes
+            </Button>
+            <Button
+              icon={<ThumbsUpIcon invertIcon={true} />}
+              hideLabel={true}
+              size="small"
+              cssOverrides={css`
+                svg {
+                  width: initial;
+                }
+              `}
+              onClick={() => {
+                setFeedBackButtonClicked(true);
+                trackEvent({
+                  eventCategory: "help-centre-article-page",
+                  eventAction: "article-feedback-widget-click",
+                  eventLabel: props.articleCode,
+                  eventValue: 0
+                });
+              }}
+            >
+              No
+            </Button>
+          </>
+        )}
+      </div>
+    </div>
+  );
 };
 
 export default HelpCentreArticle;

--- a/app/client/components/svgs/thumbsUpIcon.tsx
+++ b/app/client/components/svgs/thumbsUpIcon.tsx
@@ -1,0 +1,22 @@
+import { neutral } from "@guardian/src-foundations/palette";
+import React from "react";
+
+interface ThumbsUpIconProps {
+  overrideFillColor?: string;
+  invertIcon?: boolean;
+}
+
+export const ThumbsUpIcon = (props: ThumbsUpIconProps) => (
+  <svg
+    width="20"
+    height="24"
+    viewBox="0 0 20 24"
+    fill="none"
+    {...(props.invertIcon && { transform: "rotate(175)" })}
+  >
+    <path
+      d="M19.2261 13.3474L16.3955 22.7067L15.3096 23.4317L0 21.1823V8.70523L5.22193 7.68963L12.9156 0H14.0028L15.959 1.95889L12.9142 7.76327H12.9859L20 8.64029"
+      fill={props.overrideFillColor || neutral[100]}
+    />
+  </svg>
+);


### PR DESCRIPTION
## What does this change?
This adds the  'Did you find the information you need?' feedback widget at the bottom of Article pages. The buttons track the user's click

## Images
| Desktop  | Mobile | 
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/44685872/122370055-a6f2d000-cf56-11eb-97f6-c3542d1d8abd.png)  | ![image](https://user-images.githubusercontent.com/44685872/122370104-b2de9200-cf56-11eb-9ec6-c8c62e21d9e7.png) |
