### PR TITLE
[RB] - set explicit date values in tests when comparing

### DIFF
--- a/app/client/__tests__/dates.ts
+++ b/app/client/__tests__/dates.ts
@@ -59,8 +59,7 @@ describe("dateIsBefore", () => {
   const inputDate = judgementDay;
   const comparisonDate = judgementDay;
   it("returns true if input date is before comparison date", () => {
-    comparisonDate.setMinutes(comparisonDate.getMinutes() + 5);
-    expect(dateIsBefore(inputDate, comparisonDate)).toBeTruthy();
+    expect(dateIsBefore(inputDate, new Date())).toBeTruthy();
   });
   it("returns false if input date is after comparison date", () => {
     comparisonDate.setMinutes(comparisonDate.getMinutes() - 10);

--- a/app/client/__tests__/dates.ts
+++ b/app/client/__tests__/dates.ts
@@ -22,6 +22,9 @@ import {
 // formatting date-fns strings documentation here:
 // https://date-fns.org/v2.17.0/docs/format
 
+const judgementDay = new Date(1997, 7, 29);
+const backToTheFutureDay = new Date(1985, 9, 26);
+
 describe("parseDate", () => {
   it("parses date strings correctly", () => {
     const pd = parseDate("2020-11-30");
@@ -53,8 +56,8 @@ describe("dateString", () => {
 });
 
 describe("dateIsBefore", () => {
-  const inputDate = new Date(1997, 7, 29);
-  const comparisonDate = new Date(1997, 7, 29);
+  const inputDate = judgementDay;
+  const comparisonDate = judgementDay;
   it("returns true if input date is before comparison date", () => {
     comparisonDate.setMinutes(comparisonDate.getMinutes() + 5);
     expect(dateIsBefore(inputDate, comparisonDate)).toBeTruthy();
@@ -71,18 +74,18 @@ describe("dateIsBefore", () => {
 
 describe("dateIsSameOrBefore", () => {
   it("returns true if date is the same as comparison date", () => {
-    const inputDate = new Date(1997, 7, 29);
-    const comparisonDate = new Date(1997, 7, 29);
+    const inputDate = judgementDay;
+    const comparisonDate = judgementDay;
     expect(dateIsSameOrBefore(inputDate, comparisonDate)).toBe(true);
   });
   it("returns true if date is the before comparison date", () => {
-    const inputDate = new Date(1985, 9, 26);
+    const inputDate = backToTheFutureDay;
     const comparisonDate = new Date();
     expect(dateIsSameOrBefore(inputDate, comparisonDate)).toBe(true);
   });
   it("returns false if date is the after comparison date", () => {
     const inputDate = new Date();
-    const comparisonDate = new Date(1985, 9, 26);
+    const comparisonDate = backToTheFutureDay;
     expect(dateIsSameOrBefore(inputDate, comparisonDate)).toBe(false);
   });
 });
@@ -90,21 +93,19 @@ describe("dateIsSameOrBefore", () => {
 describe("dateIsAfter", () => {
   it("returns true if date is after comparison date", () => {
     const inputDate = new Date();
-    const comparisonDate = new Date(1985, 9, 26);
+    const comparisonDate = backToTheFutureDay;
     expect(dateIsAfter(inputDate, comparisonDate)).toBe(true);
   });
   it("returns false if date is not after comparison date", () => {
-    const inputDate = new Date(1997, 7, 29);
-    const comparisonDate = new Date(1997, 7, 29);
+    const inputDate = judgementDay;
+    const comparisonDate = judgementDay;
     expect(dateIsAfter(inputDate, comparisonDate)).toBe(false);
   });
 });
 
 describe("dateIsSameOrAfter", () => {
   it("returns true if dates match", () => {
-    expect(
-      dateIsSameOrAfter(new Date(1997, 7, 29), new Date(1997, 7, 29))
-    ).toBeTruthy();
+    expect(dateIsSameOrAfter(judgementDay, judgementDay)).toBeTruthy();
   });
   it("returns true if input date is after comparison date", () => {
     const futureInputDate = new Date();
@@ -120,9 +121,7 @@ describe("dateIsSameOrAfter", () => {
 
 describe("dateIsSame", () => {
   it("returns true if 2 dates match", () => {
-    expect(
-      dateIsSame(new Date(1997, 7, 29), new Date(1997, 7, 29))
-    ).toBeTruthy();
+    expect(dateIsSame(judgementDay, judgementDay)).toBeTruthy();
   });
   it("returns false if the 2 dates do not match", () => {
     expect(dateIsSame(new Date(), new Date(1969, 6, 16))).toBeFalsy();
@@ -181,13 +180,13 @@ describe("dateIsLeapYear", () => {
 
 describe("dateAddDays", () => {
   it("returns modified date with the additional days subtracted from it", () => {
-    const inputDate = new Date(1985, 9, 26);
+    const inputDate = backToTheFutureDay;
     expect(dateAddDays(inputDate, -10941).toLocaleDateString()).toEqual(
       "11/12/1955"
     );
   });
   it("returns modified date with the additional days added to it", () => {
-    const inputDate = new Date(1985, 9, 26);
+    const inputDate = backToTheFutureDay;
     expect(dateAddDays(inputDate, 10952).toLocaleDateString()).toEqual(
       "10/21/2015"
     );
@@ -196,13 +195,13 @@ describe("dateAddDays", () => {
 
 describe("dateAddMonths", () => {
   it("returns modified date with months subtracted from it", () => {
-    const inputDate = new Date(1985, 9, 26);
+    const inputDate = backToTheFutureDay;
     expect(dateAddMonths(inputDate, -1).toLocaleDateString()).toEqual(
       "9/26/1985"
     );
   });
   it("returns modified date with months added to it", () => {
-    const inputDate = new Date(1985, 9, 26);
+    const inputDate = backToTheFutureDay;
     expect(dateAddMonths(inputDate, 1).toLocaleDateString()).toEqual(
       "11/26/1985"
     );
@@ -211,13 +210,13 @@ describe("dateAddMonths", () => {
 
 describe("dateAddYears", () => {
   it("returns modified date with years subtracted from it", () => {
-    const inputDate = new Date(1985, 9, 26);
+    const inputDate = backToTheFutureDay;
     expect(dateAddYears(inputDate, -1).toLocaleDateString()).toEqual(
       "10/26/1984"
     );
   });
   it("returns modified date with years added to it", () => {
-    const inputDate = new Date(1985, 9, 26);
+    const inputDate = backToTheFutureDay;
     expect(dateAddYears(inputDate, 1).toLocaleDateString()).toEqual(
       "10/26/1986"
     );
@@ -240,7 +239,7 @@ describe("numberOfDaysInMonth", () => {
 describe("getWeekDay", () => {
   it("returns the weekday in long string form from an input date", () => {
     // Saturday 26th Oct 1985
-    expect(getWeekDay(new Date(1985, 9, 26))).toEqual("Saturday");
+    expect(getWeekDay(backToTheFutureDay)).toEqual("Saturday");
   });
 });
 

--- a/app/client/__tests__/dates.ts
+++ b/app/client/__tests__/dates.ts
@@ -53,8 +53,8 @@ describe("dateString", () => {
 });
 
 describe("dateIsBefore", () => {
-  const inputDate = new Date();
-  const comparisonDate = new Date();
+  const inputDate = new Date(1997, 7, 29);
+  const comparisonDate = new Date(1997, 7, 29);
   it("returns true if input date is before comparison date", () => {
     comparisonDate.setMinutes(comparisonDate.getMinutes() + 5);
     expect(dateIsBefore(inputDate, comparisonDate)).toBeTruthy();
@@ -71,8 +71,8 @@ describe("dateIsBefore", () => {
 
 describe("dateIsSameOrBefore", () => {
   it("returns true if date is the same as comparison date", () => {
-    const inputDate = new Date();
-    const comparisonDate = new Date();
+    const inputDate = new Date(1997, 7, 29);
+    const comparisonDate = new Date(1997, 7, 29);
     expect(dateIsSameOrBefore(inputDate, comparisonDate)).toBe(true);
   });
   it("returns true if date is the before comparison date", () => {
@@ -94,15 +94,17 @@ describe("dateIsAfter", () => {
     expect(dateIsAfter(inputDate, comparisonDate)).toBe(true);
   });
   it("returns false if date is not after comparison date", () => {
-    const inputDate = new Date();
-    const comparisonDate = new Date();
+    const inputDate = new Date(1997, 7, 29);
+    const comparisonDate = new Date(1997, 7, 29);
     expect(dateIsAfter(inputDate, comparisonDate)).toBe(false);
   });
 });
 
 describe("dateIsSameOrAfter", () => {
   it("returns true if dates match", () => {
-    expect(dateIsSameOrAfter(new Date(), new Date())).toBeTruthy();
+    expect(
+      dateIsSameOrAfter(new Date(1997, 7, 29), new Date(1997, 7, 29))
+    ).toBeTruthy();
   });
   it("returns true if input date is after comparison date", () => {
     const futureInputDate = new Date();
@@ -118,7 +120,9 @@ describe("dateIsSameOrAfter", () => {
 
 describe("dateIsSame", () => {
   it("returns true if 2 dates match", () => {
-    expect(dateIsSame(new Date(), new Date())).toBeTruthy();
+    expect(
+      dateIsSame(new Date(1997, 7, 29), new Date(1997, 7, 29))
+    ).toBeTruthy();
   });
   it("returns false if the 2 dates do not match", () => {
     expect(dateIsSame(new Date(), new Date(1969, 6, 16))).toBeFalsy();


### PR DESCRIPTION
## What does this change?
When comparing 2 dates like the following:

`dateIsSameOrAfter(new Date(), new Date())`

There seems to be a small chance the the 2 dates will not be the same, eg off by a fraction of a second.

Where 2 dates that are supposed to be equal are being compared in the tests I have set them explicitly to be the date of judgement day in Terminator!

This only affected the test run and has no effect on the code.

![thumbsup](https://user-images.githubusercontent.com/2510683/122756536-6f559200-d28e-11eb-8068-8273fa4bcaa7.jpg)
