### PR TITLE
[RB] - Help centre topic nav fix

### DIFF
--- a/app/client/components/helpCentre/helpCentreConfig.ts
+++ b/app/client/components/helpCentre/helpCentreConfig.ts
@@ -127,7 +127,7 @@ export const helpCentreConfig: HelpCentreTopic[] = [
       "https://www.theguardian.com/help/2021/feb/03/all-accounts-sign-in-topics"
   },
   {
-    id: "the-guardian-website",
+    id: "website",
     title: "The Guardian Website",
     links: [
       {
@@ -203,7 +203,7 @@ export const helpCentreConfig: HelpCentreTopic[] = [
       "https://www.theguardian.com/help/2021/feb/03/all-journalism-topics"
   },
   {
-    id: "print-subscriptions",
+    id: "subscriptions",
     title: "Print Subscriptions",
     links: [
       {
@@ -410,8 +410,8 @@ export const helpCentreNavConfig: HelpCentreNavConfig[] = [
   { id: "delivery", title: "Delivery" },
   { id: "billing", title: "Billing" },
   { id: "accounts", title: "Accounts & Sign in" },
-  { id: "the-guardian-website", title: "The Guardian Website" },
+  { id: "website", title: "The Guardian Website" },
   { id: "journalism", title: "Journalism" },
-  { id: "print-subscriptions", title: "Print Subscriptions" },
+  { id: "subscriptions", title: "Print Subscriptions" },
   { id: "more-topics", title: "More Topics" }
 ];

--- a/app/client/components/helpCentre/helpCentreTopic.tsx
+++ b/app/client/components/helpCentre/helpCentreTopic.tsx
@@ -21,6 +21,8 @@ const HelpCentreTopic = (props: HelpCentreTopicProps) => {
     undefined
   );
 
+  const setSelectedTopicObject = React.useContext(SelectedTopicObjectContext);
+
   useEffect(() => {
     setSingleTopic(undefined);
     setMoreTopics(undefined);
@@ -45,12 +47,8 @@ const HelpCentreTopic = (props: HelpCentreTopicProps) => {
           `Failed to fetch topic ${props.topicCode}. Error: ${error}`
         )
       );
-  }, [props.topicCode]);
-
-  const setSelectedTopicObject = React.useContext(SelectedTopicObjectContext);
-  useEffect(() => {
     setSelectedTopicObject(props.topicCode);
-  }, []);
+  }, [props.topicCode]);
 
   return (
     <>

--- a/app/client/components/svgs/helpSectionIcons.tsx
+++ b/app/client/components/svgs/helpSectionIcons.tsx
@@ -12,11 +12,11 @@ export const getHelpSectionIcon = (sectionId: string) => {
       return <BillingIcon />;
     case "accounts-and-sign-in":
       return <AccountsAndSignInIcon />;
-    case "the-guardian-website":
+    case "website":
       return <TheGuardianWebsiteIcon />;
     case "journalism":
       return <JournalismIcon />;
-    case "print-subscriptions":
+    case "subscriptions":
       return <PrintSubscriptionsIcon />;
     default:
       return <SvgWrapper />;


### PR DESCRIPTION
## What does this change?
Sync the `website` and `subscriptions` id's in the `helpCentreConfig.ts` to match the json object structure in s3. 

Update the highlight of the selected nav item when navigating between options so that the selected option is always highlighted

## Images
![Screenshot 2021-06-28 at 10 44 25](https://user-images.githubusercontent.com/2510683/123633443-1eefae80-d811-11eb-92ac-26c3f3665633.png)
