### PR TITLE
[RB] Add callCenterEmailAndNumbers component to the bottom of the help centre article pages

### DIFF
--- a/app/client/components/helpCentre/helpCentreArticle.tsx
+++ b/app/client/components/helpCentre/helpCentreArticle.tsx
@@ -7,6 +7,7 @@ import { captureException, captureMessage } from "@sentry/browser";
 import React, { useEffect, useState } from "react";
 import { minWidth } from "../../styles/breakpoints";
 import { trackEvent } from "../analytics";
+import { CallCentreEmailAndNumbers } from "../callCenterEmailAndNumbers";
 import { SelectedTopicObjectContext } from "../sectionContent";
 import { Spinner } from "../spinner";
 import { ThumbsUpIcon } from "../svgs/thumbsUpIcon";
@@ -69,6 +70,7 @@ const HelpCentreArticle = (props: HelpCentreArticleProps) => {
               articleCode={props.articleCode ?? ""}
             />
             <ArticleFeedbackWidget articleCode={props.articleCode ?? ""} />
+            <CallCentreEmailAndNumbers />
           </>
         ) : (
           <Loading />


### PR DESCRIPTION
## What does this change?
Add callCenterEmailAndNumbers component to the bottom of the help centre article pages

## Images
Before             |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/2510683/124097752-c5c38d00-da53-11eb-97ed-55d8342fd3c1.png)  |  ![](https://user-images.githubusercontent.com/2510683/124097698-b8a69e00-da53-11eb-84b4-d3abb9b5e501.png)

