### PR TITLE
[RB] - add furniture around the contact details component in the arti…

### DIFF
--- a/app/client/components/helpCentre/helpCentreArticle.tsx
+++ b/app/client/components/helpCentre/helpCentreArticle.tsx
@@ -7,6 +7,7 @@ import { captureException, captureMessage } from "@sentry/browser";
 import React, { useEffect, useState } from "react";
 import { minWidth } from "../../styles/breakpoints";
 import { trackEvent } from "../analytics";
+import { LinkButton } from "../buttons";
 import { CallCentreEmailAndNumbers } from "../callCenterEmailAndNumbers";
 import { SelectedTopicObjectContext } from "../sectionContent";
 import { Spinner } from "../spinner";
@@ -70,7 +71,19 @@ const HelpCentreArticle = (props: HelpCentreArticleProps) => {
               articleCode={props.articleCode ?? ""}
             />
             <ArticleFeedbackWidget articleCode={props.articleCode ?? ""} />
+            <h2 css={h2Css}>Still can’t find what you’re looking for?</h2>
             <CallCentreEmailAndNumbers />
+            <p>
+              Or use our contact form to get in touch and we’ll get back to you
+              as soon as possible.
+            </p>
+            <LinkButton
+              to="/help-centre/contact-us"
+              text={"Contact us"}
+              fontWeight={"bold"}
+              textColour={`${brand["400"]}`}
+              colour={`${brand["800"]}`}
+            />
           </>
         ) : (
           <Loading />


### PR DESCRIPTION
## What does this change?
Add furniture around the contact details component in the article pages;
- section title
- contact us form link button and description

## Images
![Screenshot 2021-07-01 at 13 37 26](https://user-images.githubusercontent.com/2510683/124126330-7b053d80-da72-11eb-894b-6f804f717842.png)
