### PR TITLE
Help centre header alignment fix

### DIFF
--- a/app/client/components/helpCentre/helpCentreHeader.tsx
+++ b/app/client/components/helpCentre/helpCentreHeader.tsx
@@ -66,11 +66,6 @@ const HelpCentreHeader = (props: HelpCentreHeaderProps) => {
     color: ${palette.neutral["100"]};
     white-space: nowrap;
     margin: auto 0;
-    ${minWidth.desktop} {
-      position: relative;
-      left: 0.5rem;
-      margin-left: auto;
-    }
   `;
 
   return (
@@ -85,7 +80,6 @@ const HelpCentreHeader = (props: HelpCentreHeaderProps) => {
                 </Link>
               </h1>
             )}
-
             <DropdownNav />
           </div>
         )}


### PR DESCRIPTION
## What does this change?
This PR fixes the alignment issues of the help centre header for signed out users by removing superfluous code. 

## Images
| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/44685872/126318478-c3b6fafd-6d0a-4e54-8f26-98a6613e2022.png) | ![image](https://user-images.githubusercontent.com/44685872/126318363-60ee900c-7c1d-4bba-b075-f53526f85b74.png)  |