### PR TITLE
[RB] - update to liveagent embed url

### DIFF
--- a/app/client/components/liveChat/liveChat.tsx
+++ b/app/client/components/liveChat/liveChat.tsx
@@ -29,7 +29,7 @@ const initESW = (
     defaultMinimizedText: "Live chat",
     disabledMinimizedText: "Live chat",
     prepopulatedPrechatFields: {
-      SuppliedEmail: loginEmail,
+      SuppliedEmail: loginEmail
     },
     enabledFeatures: ["LiveAgent"],
     entryFeature: "LiveAgent",
@@ -39,29 +39,29 @@ const initESW = (
     extraPrechatFormDetails: [
       {
         label: "Origin Channel",
-        value: "Live Chat",
+        value: "Live Chat"
       },
       {
         label: "Identity ID",
-        value: identityID,
+        value: identityID
       },
       {
         label: "Contact Identity Id",
         value: identityID,
-        transcriptFields: ["Contact_Identity_Id__c"],
+        transcriptFields: ["Contact_Identity_Id__c"]
       },
       {
         label: "First Name",
-        transcriptFields: ["Contact_First_Name__c"],
+        transcriptFields: ["Contact_First_Name__c"]
       },
       {
         label: "Last Name",
-        transcriptFields: ["Contact_Last_Name__c"],
+        transcriptFields: ["Contact_Last_Name__c"]
       },
       {
         label: "Web Email",
-        transcriptFields: ["Contact_Email__c"],
-      },
+        transcriptFields: ["Contact_Email__c"]
+      }
     ],
     extraPrechatInfo: [
       {
@@ -71,24 +71,24 @@ const initESW = (
             doFind: false,
             fieldName: "LastName",
             isExactMatch: true,
-            label: "Last Name",
+            label: "Last Name"
           },
           {
             doCreate: false,
             doFind: false,
             fieldName: "FirstName",
             isExactMatch: true,
-            label: "First Name",
+            label: "First Name"
           },
           {
             doCreate: false,
             doFind: true,
             fieldName: "IdentityID__c",
             isExactMatch: true,
-            label: "Identity ID",
-          },
+            label: "Identity ID"
+          }
         ],
-        entityName: "Contact",
+        entityName: "Contact"
       },
       {
         entityFieldMaps: [
@@ -97,12 +97,12 @@ const initESW = (
             doFind: false,
             fieldName: "Origin_Channel__c",
             isExactMatch: true,
-            label: "Origin Channel",
-          },
+            label: "Origin Channel"
+          }
         ],
-        entityName: "Case",
-      },
-    ],
+        entityName: "Case"
+      }
+    ]
   };
 
   // tslint:disable-next-line:no-object-mutation
@@ -111,7 +111,7 @@ const initESW = (
   // Initialise live chat API in production
   //   liveChatAPI.init(
   //     "https://gnmtouchpoint.my.salesforce.com",
-  //     "https://guardiansurveys.secure.force.com",
+  //     "https://guardiansurveys.secure.force.com/liveagent",
   //     gslbBaseUrl,
   //     "00D20000000nq5g",
   //     "Chat_Team",
@@ -131,7 +131,7 @@ const initESW = (
   // Initialise live chat API for DEV1 test sandbox
   liveChatAPI.init(
     "https://gnmtouchpoint--dev1.my.salesforce.com",
-    "https://dev1-guardiansurveys.cs88.force.com",
+    "https://dev1-guardiansurveys.cs88.force.com/liveagent",
     gslbBaseUrl,
     "00D9E0000004jvh",
     "Chat_Team",
@@ -143,7 +143,7 @@ const initESW = (
       baseLiveAgentURL: "https://d.la2-c1cs-fra.salesforceliveagent.com/chat",
       eswLiveAgentDevName:
         "EmbeddedServiceLiveAgent_Parent04I9E0000008OxDUAU_1797a576c18",
-      isOfflineSupportEnabled: false,
+      isOfflineSupportEnabled: false
     }
   );
 };


### PR DESCRIPTION
## What does this change?
As a consequence of the following work:

https://trello.com/c/D5K0PO1h/2446-live-agent-create-dedicated-site

The embed url needs updating slightly 🔗 

`https://guardiansurveys.secure.force.com/liveagent` and `https://dev1-guardiansurveys.cs88.force.com/liveagent` are the new urls.

The other changes are linting corrections that override a previous forced push
