### PR TITLE
Link to new Help Centre articles and topics

### DIFF
--- a/app/client/components/helpCentre/HelpTopicBox.tsx
+++ b/app/client/components/helpCentre/HelpTopicBox.tsx
@@ -111,9 +111,8 @@ export const HelpTopicBox = (props: HelpTopicBoxProps) => (
         margin: auto 11px 20px 11px;
       `}
     >
-      <a
-        href={props.topic.seeAllLink}
-        target={"_blank"}
+      <Link
+        to={props.topic.seeAllLink}
         css={seeAllAnchorStyle}
         onClick={() => {
           trackEvent({
@@ -124,7 +123,7 @@ export const HelpTopicBox = (props: HelpTopicBoxProps) => (
         }}
       >
         See all
-      </a>
+      </Link>
     </div>
   </div>
 );

--- a/app/client/components/helpCentre/HelpTopicBox.tsx
+++ b/app/client/components/helpCentre/HelpTopicBox.tsx
@@ -2,6 +2,7 @@ import { css } from "@emotion/core";
 import { space } from "@guardian/src-foundations";
 import { brand, neutral } from "@guardian/src-foundations/palette";
 import { textSans } from "@guardian/src-foundations/typography";
+import { Link } from "@reach/router";
 import Color from "color";
 import React from "react";
 import { minWidth } from "../../styles/breakpoints";
@@ -88,9 +89,8 @@ export const HelpTopicBox = (props: HelpTopicBoxProps) => (
           key={`${props.topic.id}Question-${questionIndex}`}
           css={linkListItemStyle}
         >
-          <a
-            href={question.link}
-            target="_blank"
+          <Link
+            to={question.link}
             css={linkAnchorStyle}
             onClick={() => {
               trackEvent({
@@ -101,7 +101,7 @@ export const HelpTopicBox = (props: HelpTopicBoxProps) => (
             }}
           >
             {question.title}
-          </a>
+          </Link>
           <span css={linkArrowStyle} />
         </li>
       ))}

--- a/app/client/components/helpCentre/helpCentreConfig.ts
+++ b/app/client/components/helpCentre/helpCentreConfig.ts
@@ -19,36 +19,30 @@ export const helpCentreConfig: HelpCentreTopic[] = [
       {
         id: "q1",
         title: "I need to pause my delivery",
-        link:
-          "https://www.theguardian.com/help/2020/nov/17/i-need-to-pause-my-delivery"
+        link: "/help-centre/article/i-need-to-pause-my-delivery"
       },
       {
         id: "q2",
         title: "My delivery is late or missing",
-        link:
-          "https://www.theguardian.com/help/2020/nov/17/my-delivery-is-late-or-missing"
+        link: "/help-centre/article/my-delivery-is-late-or-missing"
       },
       {
         id: "q3",
         title: "I need to change my delivery address",
-        link:
-          "https://www.theguardian.com/help/2020/nov/17/i-need-to-change-my-delivery-address"
+        link: "/help-centre/article/i-need-to-change-my-delivery-address"
       },
       {
         id: "q4",
         title: "I need to redirect my delivery",
-        link:
-          "https://www.theguardian.com/help/2020/nov/17/how-can-i-redirect-my-delivery"
+        link: "/help-centre/article/how-can-i-redirect-my-delivery"
       },
       {
         id: "q5",
         title: "My paper is missing a section",
-        link:
-          "https://www.theguardian.com/help/2020/nov/17/my-paper-is-missing-a-section"
+        link: "/help-centre/article/my-paper-is-missing-a-section"
       }
     ],
-    seeAllLink:
-      "https://www.theguardian.com/help/2021/feb/03/all-delivery-topics"
+    seeAllLink: "/help-centre/topic/delivery"
   },
   {
     id: "billing",
@@ -57,36 +51,30 @@ export const helpCentreConfig: HelpCentreTopic[] = [
       {
         id: "q1",
         title: "How do I update my payment details?",
-        link:
-          "https://www.theguardian.com/help/2020/nov/17/how-do-i-update-my-payment-details"
+        link: "/help-centre/article/how-do-i-update-my-payment-details"
       },
       {
         id: "q2",
         title: "Where can I see my payments?",
-        link:
-          "https://www.theguardian.com/help/2020/nov/18/where-can-i-see-my-payments"
+        link: "/help-centre/article/where-can-i-see-my-payments"
       },
       {
         id: "q3",
         title: "I want to cancel my regular payments to you",
-        link:
-          "https://www.theguardian.com/help/2020/nov/18/i-want-to-cancel-my-regular-payments-to-you"
+        link: "/help-centre/article/i-want-to-cancel-my-regular-payments-to-you"
       },
       {
         id: "q4",
         title: "What payment methods do you accept?",
-        link:
-          "https://www.theguardian.com/help/2020/nov/18/what-payment-methods-do-you-accept"
+        link: "/help-centre/article/what-payment-methods-do-you-accept"
       },
       {
         id: "q5",
         title: "Changing my contribution amount",
-        link:
-          "https://www.theguardian.com/help/2021/jan/27/changing-my-contribution-amount"
+        link: "/help-centre/article/changing-my-contribution-amount"
       }
     ],
-    seeAllLink:
-      "https://www.theguardian.com/help/2021/feb/03/all-billing-topics"
+    seeAllLink: "/help-centre/topic/billing"
   },
   {
     id: "accounts-and-sign-in",
@@ -95,36 +83,30 @@ export const helpCentreConfig: HelpCentreTopic[] = [
       {
         id: "q1",
         title: "I need help signing in",
-        link:
-          "https://www.theguardian.com/help/2020/nov/19/i-need-help-signing-in-on-your-website"
+        link: "/help-centre/article/i-need-help-signing-in-on-your-website"
       },
       {
         id: "q2",
         title: "I've forgotten my password",
-        link:
-          "https://www.theguardian.com/help/2020/nov/19/ive-forgotten-my-password"
+        link: "/help-centre/article/ive-forgotten-my-password"
       },
       {
         id: "q3",
         title: "I need to change my contact details",
-        link:
-          "https://www.theguardian.com/help/2020/nov/19/i-need-to-change-my-contact-details"
+        link: "/help-centre/article/i-need-to-change-my-contact-details"
       },
       {
         id: "q4",
         title: "I want to delete my account",
-        link:
-          "https://www.theguardian.com/help/2021/jan/28/i-want-to-delete-my-account"
+        link: "/help-centre/article/i-want-to-delete-my-account"
       },
       {
         id: "q5",
         title: "Signing in on multiple devices",
-        link:
-          "https://www.theguardian.com/help/2021/jan/28/signing-in-on-multiple-devices"
+        link: "/help-centre/article/signing-in-on-multiple-devices"
       }
     ],
-    seeAllLink:
-      "https://www.theguardian.com/help/2021/feb/03/all-accounts-sign-in-topics"
+    seeAllLink: "/help-centre/topic/accounts"
   },
   {
     id: "website",
@@ -133,36 +115,31 @@ export const helpCentreConfig: HelpCentreTopic[] = [
       {
         id: "q1",
         title: "Why am I still seeings ads/banners?",
-        link:
-          "https://www.theguardian.com/help/2020/nov/19/why-am-i-still-seeing-adsbanners"
+        link: "/help-centre/article/why-am-i-still-seeing-adsbanners"
       },
       {
         id: "q2",
         title: "I need to report a bug with your app/website",
-        link:
-          "https://www.theguardian.com/help/2020/nov/18/ive-found-a-bug-how-can-i-report-it"
+        link: "/help-centre/article/ive-found-a-bug-how-can-i-report-it"
       },
       {
         id: "q3",
         title: "I'm unable to comment and need help",
-        link:
-          "https://www.theguardian.com/help/2020/nov/19/im-unable-to-comment-and-need-help"
+        link: "/help-centre/article/im-unable-to-comment-and-need-help"
       },
       {
         id: "q4",
         title: "I'd like to complain about an advertisement",
         link:
-          "https://www.theguardian.com/help/2021/feb/03/id-like-to-make-a-complaint-about-an-advertisement"
+          "/help-centre/article/id-like-to-make-a-complaint-about-an-advertisement"
       },
       {
         id: "q5",
         title: "Can I read your paper/magazines online?",
-        link:
-          "https://www.theguardian.com/help/2021/jan/28/can-i-read-your-papermagazines-online"
+        link: "/help-centre/article/can-i-read-your-papermagazines-online"
       }
     ],
-    seeAllLink:
-      "https://www.theguardian.com/help/2021/feb/03/all-website-topics"
+    seeAllLink: "/help-centre/topic/website"
   },
   {
     id: "journalism",
@@ -172,7 +149,7 @@ export const helpCentreConfig: HelpCentreTopic[] = [
         id: "q1",
         title: "I need to submit a correction or report a broken link",
         link:
-          "https://www.theguardian.com/help/2020/nov/19/i-need-to-submit-a-correction-or-report-a-broken-link"
+          "/help-centre/article/i-need-to-submit-a-correction-or-report-a-broken-link"
       },
       {
         id: "q2",
@@ -196,11 +173,10 @@ export const helpCentreConfig: HelpCentreTopic[] = [
         id: "q5",
         title:
           "I'd like to contact one of your journalists or desks for another reason",
-        link: "https://www.theguardian.com/help/contact-us"
+        link: "/help-centre/contact-us"
       }
     ],
-    seeAllLink:
-      "https://www.theguardian.com/help/2021/feb/03/all-journalism-topics"
+    seeAllLink: "/help-centre/topic/journalism"
   },
   {
     id: "subscriptions",
@@ -209,37 +185,33 @@ export const helpCentreConfig: HelpCentreTopic[] = [
       {
         id: "q1",
         title: "Where do you deliver and when?",
-        link:
-          "https://www.theguardian.com/help/2021/jan/13/where-and-when-we-deliver"
+        link: "/help-centre/article/where-and-when-we-deliver"
       },
       {
         id: "q2",
         title: "Where can I pick up my papers?",
         link:
-          "https://www.theguardian.com/help/2020/nov/20/im-a-print-subscriber-where-can-i-pick-up-my-papers"
+          "/help-centre/article/im-a-print-subscriber-where-can-i-pick-up-my-papers"
       },
       {
         id: "q3",
         title: "I'm having trouble redeeming my paper",
         link:
-          "https://www.theguardian.com/help/2021/jan/13/what-to-do-if-youre-having-trouble-redeeming"
+          "/help-centre/article/what-to-do-if-youre-having-trouble-redeeming"
       },
       {
         id: "q4",
         title: "I've lost my vouchers",
-        link:
-          "https://www.theguardian.com/help/2021/jan/15/ive-lost-my-vouchers"
+        link: "/help-centre/article/ive-lost-my-vouchers"
       },
       {
         id: "q5",
         title: "I want to cancel my subscription",
         // update?
-        link:
-          "https://www.theguardian.com/help/2020/nov/20/i-want-to-cancel-my-subscription"
+        link: "/help-centre/article/i-want-to-cancel-my-subscription"
       }
     ],
-    seeAllLink:
-      "https://www.theguardian.com/help/2021/feb/03/all-print-subscriptions-topics"
+    seeAllLink: "/help-centre/topic/subscriptions"
   }
 ];
 
@@ -258,31 +230,29 @@ export const helpCentreMoreQuestionsConfig: HelpCentreMoreQuestionsTopic[] = [
         id: "q1",
         title: "Premium tier access",
         link:
-          "https://www.theguardian.com/help/2020/nov/18/how-can-i-gain-access-to-the-premium-tier-of-your-app"
+          "/help-centre/article/how-can-i-gain-access-to-the-premium-tier-of-your-app"
       },
       {
         id: "q2",
         title: "Apple/Google subscriptions",
         link:
-          "https://www.theguardian.com/help/2020/nov/20/i-have-a-googleitunes-subscription-that-i-need-help-with"
+          "/help-centre/article/i-have-a-googleitunes-subscription-that-i-need-help-with"
       },
       {
         id: "q3",
         title: "Personalising your apps",
-        link:
-          "https://www.theguardian.com/help/2018/apr/18/making-your-app-more-personal"
+        link: "/help-centre/article/making-your-app-more-personal"
       },
       {
         id: "q4",
         title: "Device compatability",
-        link:
-          "https://www.theguardian.com/help/2020/nov/18/what-devices-are-compatible-with-your-apps"
+        link: "/help-centre/article/what-devices-are-compatible-with-your-apps"
       },
       {
         id: "q5",
         title: "Getting started with your Digital Subscription",
         link:
-          "https://www.theguardian.com/help/2021/feb/08/getting-started-with-your-digital-subscription"
+          "/help-centre/article/getting-started-with-your-digital-subscription"
       }
     ]
   },
@@ -294,19 +264,17 @@ export const helpCentreMoreQuestionsConfig: HelpCentreMoreQuestionsTopic[] = [
         id: "q1",
         title: "I'm not receiving any emails from you but think I should be",
         link:
-          "https://www.theguardian.com/help/2021/jan/13/im-not-receiving-emails-from-you-but-think-i-should-be"
+          "/help-centre/article/im-not-receiving-emails-from-you-but-think-i-should-be"
       },
       {
         id: "q2",
         title: "Manage your email preferences",
-        link:
-          "https://www.theguardian.com/help/2020/nov/19/i-need-to-update-my-email-preferences"
+        link: "/help-centre/article/i-need-to-update-my-email-preferences"
       },
       {
         id: "q3",
         title: "Subscribe to our newsletters",
-        link:
-          "https://www.theguardian.com/help/2021/jan/15/subscribe-to-our-newsletters-and-emails"
+        link: "/help-centre/article/subscribe-to-our-newsletters-and-emails"
       }
     ]
   },
@@ -319,27 +287,27 @@ export const helpCentreMoreQuestionsConfig: HelpCentreMoreQuestionsTopic[] = [
         title:
           "I can no longer attend the live online event, can I have a refund?",
         link:
-          "https://www.theguardian.com/help/2021/jan/15/i-can-no-longer-attend-the-live-online-event-can-i-have-a-refund"
+          "/help-centre/article/i-can-no-longer-attend-the-live-online-event-can-i-have-a-refund"
       },
       {
         id: "q2",
         title:
           "I can’t find my original confirmation email, can you resend me the event link?",
         link:
-          "https://www.theguardian.com/help/2021/jan/15/i-cant-find-my-original-confirmation-email-can-you-resend-me-the-event-link"
+          "/help-centre/article/i-cant-find-my-original-confirmation-email-can-you-resend-me-the-event-link"
       },
       {
         id: "q3",
         title:
           "Once I have purchased a ticket, how will I attend the online event?",
         link:
-          "https://www.theguardian.com/help/2021/jan/15/once-i-have-purchased-a-ticket-how-will-i-attend-the-online-event"
+          "/help-centre/article/once-i-have-purchased-a-ticket-how-will-i-attend-the-online-event"
       },
       {
         id: "q4",
         title: "I purchased a book with my ticket, when will I receive this?",
         link:
-          "https://www.theguardian.com/help/2021/jan/15/i-purchased-a-book-with-my-ticket-when-will-i-receive-this"
+          "/help-centre/article/i-purchased-a-book-with-my-ticket-when-will-i-receive-this"
       }
     ]
   },
@@ -351,33 +319,29 @@ export const helpCentreMoreQuestionsConfig: HelpCentreMoreQuestionsTopic[] = [
       {
         id: "q1",
         title: "Gifting a Digital Subscription",
-        link:
-          "https://www.theguardian.com/help/2021/jan/15/gifting-a-digital-subscription"
+        link: "/help-centre/article/gifting-a-digital-subscription"
       },
       {
         id: "q2",
         title: "Gifting the Guardian Weekly",
-        link:
-          "https://www.theguardian.com/help/2021/jan/12/gifting-the-guardian-weekly"
+        link: "/help-centre/article/gifting-the-guardian-weekly"
       },
       {
         id: "q3",
         title: "My gift recipient hasn't recieved their gift",
-        link:
-          "https://www.theguardian.com/help/2021/jan/15/my-gift-recipient-hasnt-received-their-gift"
+        link: "/help-centre/article/my-gift-recipient-hasnt-received-their-gift"
       },
       {
         id: "q4",
         title: "I've accidentally entered the wrong details when gifting",
-        link:
-          "https://www.theguardian.com/help/2021/jan/15/ive-accidentally-entered-the-wrong-details"
+        link: "/help-centre/article/ive-accidentally-entered-the-wrong-details"
       },
       {
         id: "q5",
         title:
           "The person I bought a gift for already has a subscription, can I get a refund?",
         link:
-          "https://www.theguardian.com/help/2021/jan/15/the-person-i-bought-a-gift-for-already-has-a-subscription-can-i-get-a-refund"
+          "/help-centre/article/the-person-i-bought-a-gift-for-already-has-a-subscription-can-i-get-a-refund"
       }
     ]
   },
@@ -389,13 +353,12 @@ export const helpCentreMoreQuestionsConfig: HelpCentreMoreQuestionsTopic[] = [
         id: "q1",
         title: "Finding articles from the past in digital format",
         link:
-          "https://www.theguardian.com/help/2021/jan/15/finding-articles-from-the-past-in-digital-format"
+          "/help-centre/article/finding-articles-from-the-past-in-digital-format"
       },
       {
         id: "q2",
         title: "Old newspapers in physical format",
-        link:
-          "https://www.theguardian.com/help/2021/jan/15/old-newspapers-in-physical-format"
+        link: "/help-centre/article/old-newspapers-in-physical-format"
       }
     ]
   }


### PR DESCRIPTION
This rewrites all the links to legacy help pages from the Help Centre landing page so that they point at new pages in the Help Centre.
Eventually, this page will be published in the same way as the article and topic pages but at the moment it has to be built manually.

I've tested the links in Code.