### PR TITLE
Add Google Search Console verification file

### DIFF
--- a/app/server/routes/core.ts
+++ b/app/server/routes/core.ts
@@ -74,7 +74,10 @@ router.get("/sitemap.txt", async (_, res: Response) => {
 
 /*
  * ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
- * Google Search Console verification files
+ * Google Search Console ownership verification files.
+ *
+ * The current owners are listed below.
+ * For each owner, please add github name and verification file.
  */
 
 // kelvin-chappell

--- a/app/server/routes/core.ts
+++ b/app/server/routes/core.ts
@@ -72,4 +72,21 @@ router.get("/sitemap.txt", async (_, res: Response) => {
     });
 });
 
+/*
+ * ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ * Google Search Console verification files
+ */
+
+// kelvin-chappell
+router.get("/google6e3510e8603d6b4c.html", (_, res: Response) => {
+  res
+    .contentType("text/html")
+    .send("google-site-verification: google6e3510e8603d6b4c.html");
+});
+
+/*
+ * end of Google Search Console verification files
+ * ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ */
+
 export default router;


### PR DESCRIPTION
This is to give me access to the [Google Search Console](https://search.google.com/search-console) for manage.theguardian.com.

I'm using the [HTML file upload](https://support.google.com/webmasters/answer/9008080) method.  This appears to be the only way to get access to the search console for a subdomain where the root is authenticated.

Tested access to the file on Code.
