### PR TITLE
Give all bots access to sitemap

### DIFF
--- a/app/server/routes/core.ts
+++ b/app/server/routes/core.ts
@@ -26,9 +26,10 @@ router.get("/_prout", (_, res: Response) => {
 });
 
 router.get("/robots.txt", (_, res: Response) => {
-  const disallowAll = "UserAgent: *\n" + "Disallow: /\n\n";
+  const disallowAll = "User-agent: *\n" + "Disallow: /\n\n";
   const allowHelpCentre =
-    "UserAgent: *\n" +
+    "User-agent: *\n" +
+    "Allow: /sitemap.txt\n" +
     "Allow: /help-centre\n" +
     "Allow: /help-centre/\n" +
     "Disallow: /\n\n";


### PR DESCRIPTION
A small oversight in the robots.txt file meant that the sitemap couldn't be read.

Google Search Console told me that Google couldn't read the sitemap and [this tool](https://www.google.com/webmasters/tools/robots-testing-tool) told me why.