### PR TITLE
Allow bots to index pages built on clientside

### DIFF
--- a/app/server/routes/core.ts
+++ b/app/server/routes/core.ts
@@ -30,6 +30,7 @@ router.get("/robots.txt", (_, res: Response) => {
   const allowHelpCentre =
     "User-agent: *\n" +
     "Allow: /sitemap.txt\n" +
+    "Allow: /static/\n" +
     "Allow: /help-centre\n" +
     "Allow: /help-centre/\n" +
     "Disallow: /\n\n";


### PR DESCRIPTION
Currently, Google bots are only indexing the serverside-built content of pages because they are blocked from accessing `/static/helpcentre.js`.  This is to give access to static resources so that all pages can be meaningfully indexed.