### PR TITLE
Enable bots to access API to load pages

### DIFF
--- a/app/server/routes/core.ts
+++ b/app/server/routes/core.ts
@@ -31,6 +31,7 @@ router.get("/robots.txt", (_, res: Response) => {
     "User-agent: *\n" +
     "Allow: /sitemap.txt\n" +
     "Allow: /static/\n" +
+    "Allow: /api/\n" +
     "Allow: /help-centre\n" +
     "Allow: /help-centre/\n" +
     "Disallow: /\n\n";


### PR DESCRIPTION
Google still can't quite build clientside-composed pages as it needs access to api paths.

If this doesn't work, I'll give full access to the site.  That was how it was until last week anyway so shouldn't cause any unexpected problems.
