### PR TITLE
Change modern slavery link to the new pdf

### DIFF
--- a/app/client/__tests__/__snapshots__/main.tsx.snap
+++ b/app/client/__tests__/__snapshots__/main.tsx.snap
@@ -809,7 +809,7 @@ exports[`Main renders something 1`] = `
                         "toString": [Function],
                       }
                     }
-                    href="https://thegulocal.com/info/2016/jul/27/modern-slavery-and-our-supply-chains?INTCMP=NGW_FOOTER_UK_GU_MODERN_SLAVERY_ACT"
+                    href="https://uploads.guim.co.uk/2021/07/27/STL_&_GMG_Modern_Slavery_Act_Statement_2021.pdf"
                   >
                     Modern Slavery Act
                   </a>

--- a/app/client/components/footer/footerlinks.tsx
+++ b/app/client/components/footer/footerlinks.tsx
@@ -69,7 +69,7 @@ export const footerLinks: FooterLink[][] = [
     },
     {
       title: "Modern Slavery Act",
-      link: `https://${domain}/info/2016/jul/27/modern-slavery-and-our-supply-chains?INTCMP=NGW_FOOTER_UK_GU_MODERN_SLAVERY_ACT`
+      link: `https://uploads.guim.co.uk/2021/07/27/STL_&_GMG_Modern_Slavery_Act_Statement_2021.pdf`
     },
     {
       title: "Digital newspaper archive",


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

The [article from 2016](https://www.theguardian.com/info/2016/jul/27/modern-slavery-and-our-supply-chains?INTCMP=NGW_FOOTER_UK_GU_MODERN_SLAVERY_ACT) which contains a link to an old copy of the modern slavery statement is no longer used on dotcom. This PR replaces that footer link with a link to the pdf to keep parity with [theguardian.com](https://www.theguardian.com). 


## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Click the link and open a pdf.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We open a pdf.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

The pdf location may change in future.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
