### PR TITLE
[RB] - update old help centre links to the new urls

### DIFF
--- a/app/client/components/help.tsx
+++ b/app/client/components/help.tsx
@@ -22,37 +22,37 @@ const highlightedQuestions: Question[] = [
     id: "q1",
     title: "Can my delivery be suspended while I'm on holiday?",
     link:
-      "https://www.theguardian.com/help/2020/nov/17/i-need-to-pause-my-delivery"
+      "https://manage.theguardian.com/help-centre/article/i-need-to-pause-my-delivery"
   },
   {
     id: "q2",
     title: "How do I change my delivery address?",
     link:
-      "https://www.theguardian.com/help/2020/nov/17/i-need-to-change-my-delivery-address"
+      "https://manage.theguardian.com/help-centre/article/i-need-to-change-my-delivery-address"
   },
   {
     id: "q3",
     title: "My delivery is late or missing",
     link:
-      "https://www.theguardian.com/help/2020/nov/17/my-delivery-is-late-or-missing"
+      "https://manage.theguardian.com/help-centre/article/my-delivery-is-late-or-missing"
   },
   {
     id: "q4",
     title: "Where can I use my Subscription Card or vouchers?",
     link:
-      "https://www.theguardian.com/help/2020/nov/20/im-a-print-subscriber-where-can-i-pick-up-my-papers"
+      "https://manage.theguardian.com/help-centre/article/im-a-print-subscriber-where-can-i-pick-up-my-papers"
   },
   {
     id: "q5",
     title: "How do I update my payment details?",
     link:
-      "https://www.theguardian.com/help/2020/nov/17/how-do-i-update-my-payment-details"
+      "https://manage.theguardian.com/help-centre/article/how-do-i-update-my-payment-details"
   },
   {
     id: "q6",
     title: "How do I reset my password?",
     link:
-      "https://www.theguardian.com/help/2020/nov/19/ive-forgotten-my-password"
+      "https://manage.theguardian.com/help-centre/article/ive-forgotten-my-password"
   }
 ];
 

--- a/app/client/components/identity/IdentityLocations.ts
+++ b/app/client/components/identity/IdentityLocations.ts
@@ -20,9 +20,9 @@ const AVATAR_URL =
 const getIdentityLocations = (domain: string) => ({
   COMMUNITY_FAQS: url("www", domain, "/community-faqs"),
   CONTACT_AND_DELIVERY_HELP: url(
-    "www",
+    "manage",
     "theguardian.com",
-    "/help/2017/dec/11/help-with-updating-your-contact-or-delivery-details"
+    "/help-centre/article/i-need-to-change-my-delivery-address"
   ),
   CHANGE_EMAIL: url("profile", domain, "/account/edit"),
   RESET_PASSWORD: url("profile", domain, "/reset"),


### PR DESCRIPTION
## What does this change?
updates old `www.theguardian.com/help` links to the new `manage.theguardian.com/help-centre` urls.

It does exactly what is says on the tin.
![ronseal](https://user-images.githubusercontent.com/2510683/128210667-1a9029f4-0227-4647-b47b-500c80efa38b.jpg)

