### PR TITLE
Upgrade url-parser to v1.5.3

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -156,7 +156,7 @@
     "react-dom": "^16.13.1",
     "source-map-support": "^0.5.19",
     "stylis-pxtorem": "^0.0.2",
-    "url-parse": "^1.5.1",
+    "url-parse": "^1.5.3",
     "webpack-node-externals": "^1.7.2",
     "winston": "^3.2.1",
     "yup": "^0.28.2"

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -13258,10 +13258,18 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
-url-parse@^1.4.3, url-parse@^1.5.1:
+url-parse@^1.4.3:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.1.tgz#d5fa9890af8a5e1f274a2c98376510f6425f6e3b"
   integrity sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
+
+url-parse@^1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.3.tgz#71c1303d38fb6639ade183c2992c8cc0686df862"
+  integrity sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"


### PR DESCRIPTION
## What does this change?
Upgrades `url-parser` to v1.5.3 to address a security vulnerability reported by Snyk.

![image](https://user-images.githubusercontent.com/48949546/128691592-cb8dadbc-3577-4704-9228-bbd8aae34d7b.png)
