### PR TITLE
[RB] - secondary buton styling for 'agents offline' section

### DIFF
--- a/app/client/components/liveChat/liveChatCssOverrides.ts
+++ b/app/client/components/liveChat/liveChatCssOverrides.ts
@@ -63,6 +63,7 @@ export const liveChatCss = css`
   }
   .dialogButtonContainer button:last-of-type {
     border: 1px solid ${brand["500"]};
+    background: ${neutral["100"]};
   }
   .dialogButtonContainer button:last-of-type span {
     color: ${brand["500"]};


### PR DESCRIPTION
## What does this change?
Fixes the background colour of secondary button backgrounds for pairs of buttons inside `dialogButtonContainer` container.

## How to test
## How to test
- log into the dev salesforce envirmonment
- from the App Launcher menu select LiveChatTestApp
- in the omni channel window set your self as Busy
- run manage locally and visit the help center with the live chat url param: `https://manage.thegulocal.com/help-centre/?liveChat=1` 
- click on the `Start live chat` button
- fill in the pre-chat form
- click on the `Start chatting` button

## Images
Before                           |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/2510683/130237564-f63b810b-409c-47df-abc2-66c16b0a1d28.png)  |  ![](https://user-images.githubusercontent.com/2510683/130237491-18aae00c-097b-48c5-9e63-f9dcb6e647db.png)

