### PR TITLE
live chat async js script load

### DIFF
--- a/app/client/components/helpCentre/helpCentreEmailAndLiveChat.tsx
+++ b/app/client/components/helpCentre/helpCentreEmailAndLiveChat.tsx
@@ -1,16 +1,18 @@
 import { css } from "@emotion/core";
-import { brand, neutral, space } from "@guardian/src-foundations";
+import { brand, neutral, space, text } from "@guardian/src-foundations";
 import { textSans } from "@guardian/src-foundations/typography";
 import { Link } from "@reach/router";
-import React, { ReactNode } from "react";
+import React, { ReactNode, useState } from "react";
 import { maxWidth, minWidth } from "../../styles/breakpoints";
 import { StartLiveChatButton } from "../liveChat/liveChat";
+import { ErrorIcon } from "../svgs/errorIcon";
 import { getHelpSectionIcon } from "../svgs/helpSectionIcons";
 
 interface HelpCentreContactBoxProps {
   iconId: string;
   title: string;
   subtitle: string;
+  subTitleIsWarning?: boolean;
   children: ReactNode;
 }
 
@@ -56,8 +58,17 @@ const contactBoxSubtitleCss = css`
   }
 `;
 
-const contactBoxDetailsCss = css`
-  border-top: 1px solid ${neutral[86]};
+const contactBoxSubtitleWarningCss = css`
+  color: ${text.error};
+  font-weight: bold;
+  margin: 0 ${space[4]}px ${space[3]}px ${space[4]}px;
+  @media screen and (min-width: 740px) and (max-width: 1270px) {
+    min-height: 3em;
+  }
+`;
+
+const contactBoxDetailsCss = (includeTopBorder: boolean = true) => css`
+  border-top: ${includeTopBorder ? `1px solid ${neutral[86]}` : "0"};
   padding-top: ${space[3]}px;
   margin: 0 ${space[4]}px ${space[4]}px ${space[4]}px;
   flex-grow: 1;
@@ -66,6 +77,7 @@ const contactBoxDetailsCss = css`
   justify-content: space-between;
   align-items: flex-start;
   & p {
+    margin-top: auto;
     margin-bottom: 0;
   }
   ${maxWidth.desktop} {
@@ -82,9 +94,28 @@ const HelpCentreContactBox = (props: HelpCentreContactBoxProps) => {
           <i css={contactBoxIconCss}>{getHelpSectionIcon(props.iconId)}</i>
           {props.title}
         </h2>
-        <p css={contactBoxSubtitleCss}>{props.subtitle}</p>
+        <p
+          css={
+            props.subTitleIsWarning
+              ? contactBoxSubtitleWarningCss
+              : contactBoxSubtitleCss
+          }
+        >
+          {props.subTitleIsWarning && (
+            <i
+              css={css`
+                margin-right: 8px;
+              `}
+            >
+              <ErrorIcon />
+            </i>
+          )}
+          {props.subtitle}
+        </p>
       </div>
-      <div css={contactBoxDetailsCss}>{props.children}</div>
+      <div css={contactBoxDetailsCss(!props.subTitleIsWarning)}>
+        {props.children}
+      </div>
     </div>
   );
 };
@@ -124,34 +155,47 @@ const emailAndLiveChatButtonCss = css`
   margin-top: ${space[1]}px;
 `;
 
-export const HelpCentreEmailAndLiveChat = () => (
-  <>
-    <p css={emailAndLiveChatSubheadingCss}>
-      Get in touch with one of our customer service agents.
-    </p>
-    <div css={emailAndLiveChatFlexContainerCss}>
-      <HelpCentreContactBox
-        iconId="email-us"
-        title="Email us"
-        subtitle="Send a message to one of our customer service agents."
-      >
-        <p css={emailAndLiveChatPCss}>customers@theguardian.com</p>
-        <p>
-          Use our{" "}
-          <Link to="/help-centre/contact-us/" css={emailAndLiveChatLinkCss}>
-            contact form
-          </Link>{" "}
-          to send us a message.
-        </p>
-      </HelpCentreContactBox>
-      <HelpCentreContactBox
-        title="Chat with us"
-        subtitle="Chat with one of our customer service agents."
-        iconId="chat-with-us"
-      >
-        <StartLiveChatButton liveChatButtonCss={emailAndLiveChatButtonCss} />
-        <p>9am - 6pm, Monday - Sunday (GMT/BST)</p>
-      </HelpCentreContactBox>
-    </div>
-  </>
-);
+export const HelpCentreEmailAndLiveChat = () => {
+  const [isLiveChatAvailable, setIsLiveChatAvailable] = useState<boolean>(true);
+  return (
+    <>
+      <p css={emailAndLiveChatSubheadingCss}>
+        Get in touch with one of our customer service agents.
+      </p>
+      <div css={emailAndLiveChatFlexContainerCss}>
+        <HelpCentreContactBox
+          iconId="email-us"
+          title="Email us"
+          subtitle="Send a message to one of our customer service agents."
+        >
+          <p css={emailAndLiveChatPCss}>customers@theguardian.com</p>
+          <p>
+            Use our{" "}
+            <Link to="/help-centre/contact-us/" css={emailAndLiveChatLinkCss}>
+              contact form
+            </Link>{" "}
+            to send us a message.
+          </p>
+        </HelpCentreContactBox>
+        <HelpCentreContactBox
+          title="Chat with us"
+          subtitle={
+            isLiveChatAvailable
+              ? "Chat with one of our customer service agents."
+              : "We’re sorry but we are unable to load Live chat. Please try again later."
+          }
+          subTitleIsWarning={!isLiveChatAvailable}
+          iconId="chat-with-us"
+        >
+          {isLiveChatAvailable && (
+            <StartLiveChatButton
+              liveChatButtonCss={emailAndLiveChatButtonCss}
+              setIsLiveChatAvailable={setIsLiveChatAvailable}
+            />
+          )}
+          <p>9am - 6pm, Monday - Sunday (GMT/BST)</p>
+        </HelpCentreContactBox>
+      </div>
+    </>
+  );
+};

--- a/app/client/components/liveChat/liveChat.tsx
+++ b/app/client/components/liveChat/liveChat.tsx
@@ -1,11 +1,10 @@
-import { SerializedStyles, css } from "@emotion/core";
+import { css, SerializedStyles } from "@emotion/core";
 import { Button } from "@guardian/src-button";
 import { SvgArrowRightStraight } from "@guardian/src-icons/arrow-right-straight";
-import React, { useEffect, useRef, useState } from "react";
+import React, { Dispatch, SetStateAction, useState } from "react";
+import { LoadingCircleIcon } from "../svgs/loadingCircleIcon";
 import { avatarImg } from "./liveChatBase64Images";
 import { liveChatCss } from "./liveChatCssOverrides";
-import { isLiveChatFeatureEnabled } from "./liveChatFeatureSwitch";
-import { LoadingCircleIcon } from "../svgs/loadingCircleIcon";
 
 const initESW = (
   gslbBaseUrl: string | null,
@@ -14,128 +13,142 @@ const initESW = (
   identityID: string,
   loginEmail: string
 ) => {
-  const liveChatConfig = {
-    displayHelpButton: false,
-    language: "",
-    defaultMinimizedText: "Live chat",
-    disabledMinimizedText: "Live chat",
-    prepopulatedPrechatFields: {
-      SuppliedEmail: loginEmail
-    },
-    enabledFeatures: ["LiveAgent"],
-    entryFeature: "LiveAgent",
-    avatarImgURL: avatarImg,
-    targetElement,
-    extraPrechatFormDetails: [
-      {
-        label: "Origin Channel",
-        value: "Live Chat"
+  return new Promise((resolve, reject) => {
+    const liveChatConfig = {
+      displayHelpButton: false,
+      language: "",
+      defaultMinimizedText: "Live chat",
+      disabledMinimizedText: "Live chat",
+      prepopulatedPrechatFields: {
+        SuppliedEmail: loginEmail
       },
-      {
-        label: "Identity ID",
-        value: identityID
-      },
-      {
-        label: "Contact Identity Id",
-        value: identityID,
-        transcriptFields: ["Contact_Identity_Id__c"]
-      },
-      {
-        label: "First Name",
-        transcriptFields: ["Contact_First_Name__c"]
-      },
-      {
-        label: "Last Name",
-        transcriptFields: ["Contact_Last_Name__c"]
-      },
-      {
-        label: "Web Email",
-        transcriptFields: ["Contact_Email__c"]
-      }
-    ],
-    extraPrechatInfo: [
-      {
-        entityFieldMaps: [
-          {
-            doCreate: false,
-            doFind: false,
-            fieldName: "LastName",
-            isExactMatch: true,
-            label: "Last Name"
-          },
-          {
-            doCreate: false,
-            doFind: false,
-            fieldName: "FirstName",
-            isExactMatch: true,
-            label: "First Name"
-          },
-          {
-            doCreate: false,
-            doFind: true,
-            fieldName: "IdentityID__c",
-            isExactMatch: true,
-            label: "Identity ID"
-          }
-        ],
-        entityName: "Contact"
-      },
-      {
-        entityFieldMaps: [
-          {
-            doCreate: true,
-            doFind: false,
-            fieldName: "Origin_Channel__c",
-            isExactMatch: true,
-            label: "Origin Channel"
-          }
-        ],
-        entityName: "Case"
-      }
-    ]
-  };
+      enabledFeatures: ["LiveAgent"],
+      entryFeature: "LiveAgent",
+      avatarImgURL: avatarImg,
+      targetElement,
+      extraPrechatFormDetails: [
+        {
+          label: "Origin Channel",
+          value: "Live Chat"
+        },
+        {
+          label: "Identity ID",
+          value: identityID
+        },
+        {
+          label: "Contact Identity Id",
+          value: identityID,
+          transcriptFields: ["Contact_Identity_Id__c"]
+        },
+        {
+          label: "First Name",
+          transcriptFields: ["Contact_First_Name__c"]
+        },
+        {
+          label: "Last Name",
+          transcriptFields: ["Contact_Last_Name__c"]
+        },
+        {
+          label: "Web Email",
+          transcriptFields: ["Contact_Email__c"]
+        }
+      ],
+      extraPrechatInfo: [
+        {
+          entityFieldMaps: [
+            {
+              doCreate: false,
+              doFind: false,
+              fieldName: "LastName",
+              isExactMatch: true,
+              label: "Last Name"
+            },
+            {
+              doCreate: false,
+              doFind: false,
+              fieldName: "FirstName",
+              isExactMatch: true,
+              label: "First Name"
+            },
+            {
+              doCreate: false,
+              doFind: true,
+              fieldName: "IdentityID__c",
+              isExactMatch: true,
+              label: "Identity ID"
+            }
+          ],
+          entityName: "Contact"
+        },
+        {
+          entityFieldMaps: [
+            {
+              doCreate: true,
+              doFind: false,
+              fieldName: "Origin_Channel__c",
+              isExactMatch: true,
+              label: "Origin Channel"
+            }
+          ],
+          entityName: "Case"
+        }
+      ]
+    };
 
-  // tslint:disable-next-line:no-object-mutation
-  liveChatAPI.settings = { ...liveChatAPI.settings, ...liveChatConfig };
+    const timeoutTimer = setTimeout(() => {
+      reject(new Error("Promise timed out."));
+    }, 15000);
 
-  // Initialise live chat API in production
-  //   liveChatAPI.init(
-  //     "https://gnmtouchpoint.my.salesforce.com",
-  //     "https://guardiansurveys.secure.force.com/liveagent",
-  //     gslbBaseUrl,
-  //     "00D20000000nq5g",
-  //     "Chat_Team",
-  //     {
-  //       baseLiveAgentContentURL:
-  //         "https://c.la2-c2-cdg.salesforceliveagent.com/content",
-  //       deploymentId: "5725I0000004RYv",
-  //       buttonId: "5735I0000004Rj7",
-  //       baseLiveAgentURL: "https://d.la2-c2-cdg.salesforceliveagent.com/chat",
-  //       eswLiveAgentDevName:
-  //         "EmbeddedServiceLiveAgent_Parent04I5I0000004LLTUA2_1797a9534a2",
-  //       isOfflineSupportEnabled: false,
-  //       myCustomClassname: "greenChat",
-  //     }
-  //   );
+    // tslint:disable-next-line:no-object-mutation
+    liveChatAPI.settings = { ...liveChatAPI.settings, ...liveChatConfig };
 
-  // Initialise live chat API for DEV1 test sandbox
-  liveChatAPI.init(
-    "https://gnmtouchpoint--dev1.my.salesforce.com",
-    "https://dev1-guardiansurveys.cs88.force.com/liveagent",
-    gslbBaseUrl,
-    "00D9E0000004jvh",
-    "Chat_Team",
-    {
-      baseLiveAgentContentURL:
-        "https://c.la2-c1cs-fra.salesforceliveagent.com/content",
-      deploymentId: "5729E000000CbOY",
-      buttonId: "5739E0000008QCo",
-      baseLiveAgentURL: "https://d.la2-c1cs-fra.salesforceliveagent.com/chat",
-      eswLiveAgentDevName:
-        "EmbeddedServiceLiveAgent_Parent04I9E0000008OxDUAU_1797a576c18",
-      isOfflineSupportEnabled: false
+    if (liveChatAPI.isIframeReady) {
+      clearTimeout(timeoutTimer);
+      resolve();
     }
-  );
+    liveChatAPI.addEventHandler("onAvailability", () => {
+      clearTimeout(timeoutTimer);
+      resolve();
+    });
+
+    //   liveChatAPI.init(
+    //     "https://gnmtouchpoint.my.salesforce.com",
+    //     "https://guardiansurveys.secure.force.com/liveagent",
+    //     gslbBaseUrl,
+    //     "00D20000000nq5g",
+    //     "Chat_Team",
+    //     {
+    //       baseLiveAgentContentURL:
+    //         "https://c.la2-c2-cdg.salesforceliveagent.com/content",
+    //       deploymentId: "5725I0000004RYv",
+    //       buttonId: "5735I0000004Rj7",
+    //       baseLiveAgentURL: "https://d.la2-c2-cdg.salesforceliveagent.com/chat",
+    //       eswLiveAgentDevName:
+    //         "EmbeddedServiceLiveAgent_Parent04I5I0000004LLTUA2_1797a9534a2",
+    //       isOfflineSupportEnabled: false,
+    //       myCustomClassname: "greenChat",
+    //     }
+    //   );
+
+    // Initialise live chat API for DEV1 test sandbox
+    liveChatAPI.init(
+      "https://gnmtouchpoint--dev1.my.salesforce.com",
+      "https://dev1-guardiansurveys.cs88.force.com/liveagent",
+      gslbBaseUrl,
+      "00D9E0000004jvh",
+      "Chat_Team",
+      {
+        baseLiveAgentContentURL:
+          "https://c.la2-c1cs-fra.salesforceliveagent.com/content",
+        deploymentId: "5729E000000CbOY",
+        buttonId: "5739E0000008QCo",
+        baseLiveAgentURL: "https://d.la2-c1cs-fra.salesforceliveagent.com/chat",
+        eswLiveAgentDevName:
+          "EmbeddedServiceLiveAgent_Parent04I9E0000008OxDUAU_1797a576c18",
+        isOfflineSupportEnabled: false
+      }
+    );
+  });
 };
 
 const initLiveChat = (
@@ -143,54 +156,54 @@ const initLiveChat = (
   identityID: string,
   loginEmail: string
 ) => {
-  if (!window.embedded_svc) {
-    const liveChatScript = document.createElement("script");
+  return new Promise((resolve, reject) => {
+    if (!window.embedded_svc) {
+      const liveChatScript = document.createElement("script");
+      liveChatScript.setAttribute("id", "liveChatScript");
+      liveChatScript.setAttribute(
+        "src",
+        "https://gnmtouchpoint.my.salesforce.com/embeddedservice/5.0/esw.min.js"
+      );
 
-    liveChatScript.setAttribute(
-      "src",
-      "https://gnmtouchpoint.my.salesforce.com/embeddedservice/5.0/esw.min.js"
-    );
+      // tslint:disable-next-line:no-object-mutation
+      liveChatScript.onload = async () => {
+        await initESW(
+          null,
+          window.embedded_svc,
+          targetElement,
+          identityID,
+          loginEmail
+        ).catch(() => reject());
+        resolve();
+      };
 
-    // tslint:disable-next-line:no-object-mutation
-    liveChatScript.onload = () => {
-      initESW(null, window.embedded_svc, targetElement, identityID, loginEmail);
-    };
+      // tslint:disable-next-line:no-object-mutation
+      liveChatScript.onerror = () => {
+        reject();
+      };
 
-    // tslint:disable-next-line:no-object-mutation
-    liveChatScript.onerror = () => {
-      // Perhaps the user is in an incognito session and the script loading has been blocked
-    };
-
-    document.body.appendChild(liveChatScript);
-  } else {
-    initESW(
-      "https://service.force.com",
-      window.embedded_svc,
-      targetElement,
-      identityID,
-      loginEmail
-    );
-  }
-};
-
-export const LiveChat = () => {
-  const liveChatContainerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (isLiveChatFeatureEnabled() && liveChatContainerRef.current) {
-      initLiveChat(
-        liveChatContainerRef.current,
-        window.guardian?.identityDetails.userId ?? "",
-        window.guardian?.identityDetails.email ?? ""
+      document.body.appendChild(liveChatScript);
+    } else {
+      resolve(
+        initESW(
+          "https://service.force.com",
+          window.embedded_svc,
+          targetElement,
+          identityID,
+          loginEmail
+        )
       );
     }
-  }, []);
-
-  return <div ref={liveChatContainerRef} css={liveChatCss} />;
+  });
 };
+
+export const LiveChat = () => (
+  <div id="liveChatContainerEl" css={liveChatCss} />
+);
 
 interface StartLiveChatButtonProps {
   liveChatButtonCss: SerializedStyles;
+  setIsLiveChatAvailable: Dispatch<SetStateAction<boolean>>;
 }
 
 export const StartLiveChatButton = (props: StartLiveChatButtonProps) => {
@@ -198,6 +211,18 @@ export const StartLiveChatButton = (props: StartLiveChatButtonProps) => {
 
   const bootstrapChat = async () => {
     setLiveChatIsLoading(true);
+    let canLoadLiveChat = true;
+    await initLiveChat(
+      document.getElementById("liveChatContainerEl") as HTMLElement,
+      window.guardian?.identityDetails.userId ?? "",
+      window.guardian?.identityDetails.email ?? ""
+    ).catch(() => {
+      props.setIsLiveChatAvailable(false);
+      canLoadLiveChat = false;
+    });
+    if (!canLoadLiveChat) {
+      return;
+    }
     await window.embedded_svc.bootstrapEmbeddedService();
 
     const preChatEmailField = document.getElementById(

--- a/app/client/components/liveChat/liveChat.tsx
+++ b/app/client/components/liveChat/liveChat.tsx
@@ -1,9 +1,11 @@
-import { SerializedStyles } from "@emotion/core";
+import { SerializedStyles, css } from "@emotion/core";
 import { Button } from "@guardian/src-button";
-import React, { useEffect, useRef } from "react";
+import { SvgArrowRightStraight } from "@guardian/src-icons/arrow-right-straight";
+import React, { useEffect, useRef, useState } from "react";
 import { avatarImg } from "./liveChatBase64Images";
 import { liveChatCss } from "./liveChatCssOverrides";
 import { isLiveChatFeatureEnabled } from "./liveChatFeatureSwitch";
+import { LoadingCircleIcon } from "../svgs/loadingCircleIcon";
 
 const initESW = (
   gslbBaseUrl: string | null,
@@ -192,7 +194,10 @@ interface StartLiveChatButtonProps {
 }
 
 export const StartLiveChatButton = (props: StartLiveChatButtonProps) => {
+  const [liveChatIsLoading, setLiveChatIsLoading] = useState<boolean>(false);
+
   const bootstrapChat = async () => {
+    setLiveChatIsLoading(true);
     await window.embedded_svc.bootstrapEmbeddedService();
 
     const preChatEmailField = document.getElementById(
@@ -203,6 +208,8 @@ export const StartLiveChatButton = (props: StartLiveChatButtonProps) => {
       preChatEmailField.disabled = true;
       preChatEmailField.classList.add("disabledField");
     }
+
+    setLiveChatIsLoading(false);
   };
 
   return (
@@ -210,6 +217,18 @@ export const StartLiveChatButton = (props: StartLiveChatButtonProps) => {
       priority="secondary"
       onClick={() => bootstrapChat()}
       css={props.liveChatButtonCss}
+      icon={
+        liveChatIsLoading ? (
+          <LoadingCircleIcon
+            additionalCss={css`
+              padding: 3px;
+            `}
+          />
+        ) : (
+          <SvgArrowRightStraight />
+        )
+      }
+      iconSide="right"
     >
       Start live chat
     </Button>

--- a/app/client/components/liveChat/liveChatCssOverrides.ts
+++ b/app/client/components/liveChat/liveChatCssOverrides.ts
@@ -5,7 +5,6 @@ import { textSans } from "@guardian/src-foundations/typography";
 import { maxWidth } from "../../styles/breakpoints";
 
 export const liveChatCss = css`
-
   ${maxWidth.desktop} {
     .embeddedServiceSidebar.layout-docked .dockableContainer,
     .embeddedServiceSidebar.layout-float .dockableContainer {
@@ -18,7 +17,10 @@ export const liveChatCss = css`
       max-height: 100vh;
       margin-top: 0;
     }
-    .embeddedServiceLiveAgentSidebarFeature .embeddedServiceSidebarState [c-prechatform_prechatform-host] > div {
+    .embeddedServiceLiveAgentSidebarFeature
+      .embeddedServiceSidebarState
+      [c-prechatform_prechatform-host]
+      > div {
       display: flex;
       flex-direction: column;
       min-height: 100%;
@@ -37,7 +39,7 @@ export const liveChatCss = css`
     font-weight: bold;
   }
   .waitingStateButtonContainer .waitingCancelChat .label {
-    color:${brand["500"]};
+    color: ${brand["500"]};
   }
   .waitingStateButtonContainer .waitingCancelChat:focus {
     text-decoration: none;
@@ -93,7 +95,7 @@ export const liveChatCss = css`
   .endChatContainer button {
     font-weight: bold;
   }
-  .endChatContainer button + button{
+  .endChatContainer button + button {
     margin-top: ${space[3]}px;
   }
   .endChatContainer button:is(:last-of-type) .label {
@@ -103,4 +105,8 @@ export const liveChatCss = css`
   .endChatContainer .endChatButton:focus {
     background: ${brand["500"]};
     text-decoration: none;
+  }
+  .dialogTextContainer h3#dialogTextTitle {
+    font-weight: bold;
+  }
 `;

--- a/app/client/components/svgs/loadingCircleIcon.tsx
+++ b/app/client/components/svgs/loadingCircleIcon.tsx
@@ -1,0 +1,71 @@
+import { css, SerializedStyles } from "@emotion/core";
+import { brand } from "@guardian/src-foundations/palette";
+import React from "react";
+
+/*
+interface ClockIconProps {
+  additionalCss?: SerializedStyles;
+}
+
+export const ClockIcon = (props: ClockIconProps) => (
+  <svg
+    width="13"
+    height="13"
+    viewBox="0 0 13 13"
+    fill="none"
+    css={props.additionalCss}
+  >
+    <path
+      d="M6.5 0C2.91015 0 0 2.91017 0 6.5C0 10.0898 2.91015 13 6.5 13C10.0899 13 13 10.0898 13 6.5C13 2.91017 10.0899 0 6.5 0ZM6.5 2.40741C6.76592 2.40741 6.98148 2.62297 6.98148 2.88889V6.22166L9.44907 7.65103C9.67934 7.78401 9.76259 8.07526 9.62963 8.30556C9.49667 8.53585 9.19791 8.61156 8.96759 8.4786C8.06612 7.95764 7.15701 7.43213 6.25926 6.91379C6.11556 6.83047 6.01852 6.67805 6.01852 6.5V2.88889C6.01852 2.62297 6.23408 2.40741 6.5 2.40741Z"
+      fill="#333333"
+    />
+  </svg>
+);
+ */
+
+interface LoadingCircleIconProps {
+  additionalCss?: SerializedStyles;
+}
+
+const circleLineThickness = 50;
+
+const lightblueStyles = css`
+  stroke: #a5c0e8;
+  stroke-width: ${circleLineThickness};
+  fill: transparent;
+`;
+const darkblueStyles = css`
+  stroke: ${brand["400"]};
+  stroke-dasharray: 820;
+  stroke-dashoffset: 820;
+  stroke-width: ${circleLineThickness};
+  fill: transparent;
+`;
+
+export const LoadingCircleIcon = (props: LoadingCircleIconProps) => (
+  <svg width="300" height="300" viewBox="0 0 300 300" css={props.additionalCss}>
+    <g>
+      <animateTransform
+        attributeName="transform"
+        attributeType="XML"
+        type="rotate"
+        from="0 150 150"
+        to="360 150 150"
+        dur="2.5s"
+        repeatCount="indefinite"
+      />
+      <circle cx="150" cy="150" r="126" css={lightblueStyles} />
+      <path
+        css={darkblueStyles}
+        d="M150,150 m0,-126 a 126,126 0 0,1 0,252 a 126,126 0 0,1 0,-252"
+      >
+        <animate
+          attributeName="stroke-dashoffset"
+          dur="3.5s"
+          to="-820"
+          repeatCount="indefinite"
+        />
+      </path>
+    </g>
+  </svg>
+);

--- a/app/client/components/svgs/loadingCircleIcon.tsx
+++ b/app/client/components/svgs/loadingCircleIcon.tsx
@@ -2,27 +2,6 @@ import { css, SerializedStyles } from "@emotion/core";
 import { brand } from "@guardian/src-foundations/palette";
 import React from "react";
 
-/*
-interface ClockIconProps {
-  additionalCss?: SerializedStyles;
-}
-
-export const ClockIcon = (props: ClockIconProps) => (
-  <svg
-    width="13"
-    height="13"
-    viewBox="0 0 13 13"
-    fill="none"
-    css={props.additionalCss}
-  >
-    <path
-      d="M6.5 0C2.91015 0 0 2.91017 0 6.5C0 10.0898 2.91015 13 6.5 13C10.0899 13 13 10.0898 13 6.5C13 2.91017 10.0899 0 6.5 0ZM6.5 2.40741C6.76592 2.40741 6.98148 2.62297 6.98148 2.88889V6.22166L9.44907 7.65103C9.67934 7.78401 9.76259 8.07526 9.62963 8.30556C9.49667 8.53585 9.19791 8.61156 8.96759 8.4786C8.06612 7.95764 7.15701 7.43213 6.25926 6.91379C6.11556 6.83047 6.01852 6.67805 6.01852 6.5V2.88889C6.01852 2.62297 6.23408 2.40741 6.5 2.40741Z"
-      fill="#333333"
-    />
-  </svg>
-);
- */
-
 interface LoadingCircleIconProps {
   additionalCss?: SerializedStyles;
 }


### PR DESCRIPTION
## What does this change?
The salesforce javascript script `esw.min.js` should only be added/loaded when the user has clicked on the `Start live chat` button on the help center landing page. 

The `Start live chat` should show the loading state of live chat while the script loads and the chat window is instantiated.

## How to test
- run manage-frontend locally
- visit https://manage.thegulocal.com/help-centre/?liveChat=1
- open up dev tools and the network tab
- confirm that `esw.min.js` isn't in the network tab
- click on Start live chat button
- have another look at the network tab, `esw.min.js` should now be there
- party 🎉 

## Images
![Screenshot 2021-08-27 at 10 43 32](https://user-images.githubusercontent.com/2510683/131113494-f39af0f1-34c8-4e43-9260-1ec1d866ca6e.png)

![Screenshot 2021-08-27 at 10 44 10](https://user-images.githubusercontent.com/2510683/131113529-ea9e077b-fe2b-4771-bb88-fce0417f4c71.png)

![Screenshot 2021-08-27 at 11 25 20](https://user-images.githubusercontent.com/2510683/131113780-f0b2d5c2-8ec4-4c65-96f7-0ec97aeb48b2.png)

![Screenshot 2021-08-27 at 11 31 59](https://user-images.githubusercontent.com/2510683/131114494-c79d56cd-2f6d-4d3a-8ad1-4b601a43fc9c.png)

