### PR TITLE
[RB] - livechat overflow-y scroll for small breakpoints

### DIFF
--- a/app/client/components/liveChat/liveChatCssOverrides.ts
+++ b/app/client/components/liveChat/liveChatCssOverrides.ts
@@ -13,20 +13,22 @@ export const liveChatCss = css`
       top: 0;
       width: 100%;
       max-width: 100%;
-      height: 100vh;
-      max-height: 100vh;
+      min-height: 100vh;
       margin-top: 0;
     }
     .embeddedServiceLiveAgentSidebarFeature
       .embeddedServiceSidebarState
       [c-prechatform_prechatform-host]
-      > div {
+      > div:not(.prechat--hide) {
       display: flex;
       flex-direction: column;
       min-height: 100%;
     }
     .prechat--button-holder[c-prechatForm_prechatForm] {
       margin-top: auto;
+    }
+    .stateBody {
+      overflow-y: scroll;
     }
   }
   .embeddedServiceSidebar.layout-docked .dockableContainer {


### PR DESCRIPTION
## What does this change?
The live chat window should have overflow-y set to scroll on smaller breakpoints where the content is taller than the window height.

## Images
<img width="671" alt="Screenshot 2021-08-27 at 15 11 44" src="https://user-images.githubusercontent.com/2510683/131140923-a5a305af-c031-4059-982f-92acad0e7251.png">
