### PR TITLE
[RB] - consolidate font sizes of start chat and chat ended system messages

### DIFF
--- a/app/client/components/liveChat/liveChatCssOverrides.ts
+++ b/app/client/components/liveChat/liveChatCssOverrides.ts
@@ -111,4 +111,8 @@ export const liveChatCss = css`
   .dialogTextContainer h3#dialogTextTitle {
     font-weight: bold;
   }
+  .embeddedServiceLiveAgentStateChatEventMessage .eventMessage,
+  .messageArea .chatSessionStartTime {
+    font-size: 13px;
+  }
 `;


### PR DESCRIPTION
## What does this change?
Consolidate font sizes of start chat and chat ended system messages

## Images
![Screenshot 2021-08-31 at 10 59 08](https://user-images.githubusercontent.com/2510683/131485004-20fe7ad6-7afe-4dcc-86b5-b8609828bf75.png)
