### PR TITLE
[RB] - help centre nav amends

### DIFF
--- a/app/client/components/helpCentre/helpCentreNav.tsx
+++ b/app/client/components/helpCentre/helpCentreNav.tsx
@@ -22,6 +22,8 @@ const desktopUlCss = css`
   list-style: none;
   margin: 0 0 ${space[6]}px 0;
   padding: 0;
+  position: sticky;
+  top: 1rem;
   ${maxWidth.desktop} {
     display: none;
   }
@@ -35,6 +37,9 @@ const desktopLiCss = (isSelectedTopic: boolean, isFirstTopic: boolean) => css`
     : `${space[2]}px solid #dcdcdc`};
   font-weight: ${isSelectedTopic ? "700" : "normal"};
   cursor: pointer;
+  :hover {
+    background-color: ${isSelectedTopic ? "transparent" : neutral["93"]};
+  }
   ::after {
     content: "";
     display: block;
@@ -116,7 +121,11 @@ const HelpCentreNav = (props: HelpCentreNavProps) => {
         <ul css={innerSectionCss(open)}>
           {helpCentreNavConfig.map((topic, topicIndex) => {
             return (
-              <Link to={`/help-centre/topic/${topic.id}`} key={topic.id}>
+              <Link
+                to={`/help-centre/topic/${topic.id}`}
+                key={topic.id}
+                onClick={() => setOpen(false)}
+              >
                 <li key={topic.id} css={mobileLiCss(topicIndex)}>
                   <span css={spanCss(topic.id)}>{topic.title}</span>
                   <span css={linkArrowStyle} />

--- a/app/client/components/sectionContent.tsx
+++ b/app/client/components/sectionContent.tsx
@@ -10,7 +10,11 @@ interface SectionContentProps {
   hasNav?: boolean;
 }
 
-const sectionCss = (hasNav: boolean, isNavSection: boolean) => ({
+const sectionCss = (
+  hasNav: boolean,
+  isNavSection: boolean,
+  isStickyOnMobile?: boolean
+) => ({
   ...gridItemPlacement(1, 4),
   ...(isNavSection && { marginRight: "-13px", marginLeft: "-13px" }),
 
@@ -34,7 +38,15 @@ const sectionCss = (hasNav: boolean, isNavSection: boolean) => ({
       : hasNav
       ? gridItemPlacement(5, 9)
       : gridItemPlacement(3, 12))
-  }
+  },
+  ...(isStickyOnMobile && {
+    [maxWidth.tablet]: {
+      position: "sticky",
+      top: 0,
+      backgroundColor: palette.neutral[100],
+      zIndex: 2
+    }
+  })
 });
 
 const containerCss = css`
@@ -76,7 +88,7 @@ export const SectionContent = (props: SectionContentProps) => {
     <div css={containerCss}>
       <div css={divCss(props.hasNav)}>
         {props.hasNav && (
-          <section css={sectionCss(props.hasNav || false, true)}>
+          <section css={sectionCss(props.hasNav || false, true, true)}>
             <HelpCentreNav selectedTopicId={selectedTopicId} />
           </section>
         )}


### PR DESCRIPTION
## What does this change?
- Hover state of left hand nav should have a light grey colour
- mobile topic selection nav should be closed on page load and on selection of topic
- mobile topic selection nav should be sticky
- left hand nav should be sticky

## Images

#### Before
![Screenshot 2021-09-01 at 09 54 53](https://user-images.githubusercontent.com/2510683/131645051-1a687db2-aba8-4d64-8e5b-f18b2089feff.png)


#### After
![Screenshot 2021-09-01 at 09 55 16](https://user-images.githubusercontent.com/2510683/131645085-5b520de2-899a-4cc8-959c-b89bc927efca.png)

![Screenshot 2021-09-01 at 10 12 48](https://user-images.githubusercontent.com/2510683/131645640-906b103a-6e0e-4837-a1ed-53ffba066d09.png)

![Screenshot 2021-09-01 at 10 15 45](https://user-images.githubusercontent.com/2510683/131645929-1c2de3a4-4ca6-4e30-9d2f-e098173cfcf3.png)

![Screenshot 2021-09-01 at 10 17 48](https://user-images.githubusercontent.com/2510683/131646189-f05b60d4-6f8d-4c32-99bf-ce58cec7520e.png)

