### PR TITLE
consecutive live chats bug fix

### DIFF
--- a/app/client/components/liveChat/liveChat.tsx
+++ b/app/client/components/liveChat/liveChat.tsx
@@ -186,7 +186,7 @@ const initLiveChat = (
     } else {
       resolve(
         initESW(
-          "https://service.force.com",
+          null,
           window.embedded_svc,
           targetElement,
           identityID,


### PR DESCRIPTION
## What does this change?
Remove iframe source param passed through to the initESW function the second/subsequent time a live chat message is established. This resolves a cross origin postMessage error when running in the salesforce dev environment. eg:

```Failed to execute ‘postMessage’ on ‘DOMWindow’: The target origin provided (‘https://service.force.com’) does not match the recipient window’s origin (‘https://gnmtouchpoint--dev1.my.salesforce.com’).```