### PR TITLE
[RB] - queue position number styles

### DIFF
--- a/app/client/components/liveChat/liveChatCssOverrides.ts
+++ b/app/client/components/liveChat/liveChatCssOverrides.ts
@@ -50,6 +50,37 @@ export const liveChatCss = css`
   .dialogState .dialogTextContainer {
     justify-content: normal;
   }
+  .waitingStateContainer .queuePositionContent .queuePositionChatIcon .icon {
+    display: none;
+  }
+  .embeddedServiceLiveAgentQueuePosition
+    .queuePositionChatIcon
+    .embeddedServiceLoadingBalls {
+    left: 0;
+    transform: translate(0, -50%);
+  }
+  .waitingStateContainer .queuePositionContent {
+    justify-content: start;
+    align-self: start;
+  }
+  .embeddedServiceLiveAgentQueuePosition.queuePositionWaiting
+    .queuePositionNumber,
+  .embeddedServiceLiveAgentQueuePosition.queuePositionWaiting
+    .youAreNextMessage {
+    color: #767676;
+    text-align: left;
+    font-size: 20px;
+    font-weight: 700;
+  }
+  .embeddedServiceLiveAgentQueuePosition .queuePositionMessage p {
+    color: #767676;
+    text-align: left;
+  }
+  .embeddedServiceLiveAgentStateWaiting
+    .waitingStateContent
+    .reconnectingContent {
+    margin-top: ${space[6]}px;
+  }
   .embeddedServiceSidebarButton {
     border-radius: 0;
   }


### PR DESCRIPTION
## What does this change?
Adds custom css styling to the queue position state of live chat.

## How to test
- log into the dev salesforce envirmonment
- from the App Launcher menu select LiveChatTestApp
- in the omni channel window set your self as Available - chat
- run manage-frontend locally
- visit https://manage.thegulocal.com/help-centre/?liveChat=1
- click on Start live chat button
- fill in the pre chat form
- click on the 'Start chatting' button
- Before the chat starts you should see something similar to the below image

## Images
![Screenshot 2021-09-06 at 15 37 34](https://user-images.githubusercontent.com/2510683/132233930-2674f008-b1ee-492a-aa05-5bf2107010cc.png)

