### PR TITLE
Live chat privacy notice

### DIFF
--- a/app/client/components/helpCentre/helpCentre.tsx
+++ b/app/client/components/helpCentre/helpCentre.tsx
@@ -12,15 +12,20 @@ import {
   LiveChatPrivacyNoticeLink
 } from "../liveChat/liveChatPrivacyNotice";
 import { helpCentreConfig } from "./helpCentreConfig";
-import { HelpCentreEmailAndLiveChat } from "./helpCentreEmailAndLiveChat";
+import {
+  EmailAndLiveChatSubHeading,
+  HelpCentreEmailAndLiveChat
+} from "./helpCentreEmailAndLiveChat";
 import { HelpCentreLandingMoreTopics } from "./helpCentreLandingMoreTopics";
 import { HelpCentrePhoneNumbers } from "./helpCentrePhoneNumbers";
 import { HelpTopicBox } from "./HelpTopicBox";
 
 const subtitleStyles = css`
   border-top: 1px solid ${neutral["86"]};
+  margin-bottom: ${isLiveChatFeatureEnabled() ? space[3] : space[6]}px;
   margin-top: 30px;
   ${minWidth.tablet} {
+    margin-bottom: ${space[6]}px;
     margin-top: 40px;
   }
   ${headline.small({ fontWeight: "bold" })};
@@ -54,6 +59,7 @@ const HelpCentre = (_: RouteComponentProps) => {
         <h2 css={subtitleStyles}>Still can’t find what you’re looking for?</h2>
         {isLiveChatFeatureEnabled() ? (
           <>
+            <EmailAndLiveChatSubHeading />
             <LiveChatPrivacyNoticeLink />
             <HelpCentreEmailAndLiveChat />
             <HelpCentrePhoneNumbers />

--- a/app/client/components/helpCentre/helpCentre.tsx
+++ b/app/client/components/helpCentre/helpCentre.tsx
@@ -1,14 +1,16 @@
 import { css } from "@emotion/core";
 import { space } from "@guardian/src-foundations";
-import { brand, neutral } from "@guardian/src-foundations/palette";
-import { headline, textSans } from "@guardian/src-foundations/typography";
+import { neutral } from "@guardian/src-foundations/palette";
+import { headline } from "@guardian/src-foundations/typography";
 import { RouteComponentProps } from "@reach/router";
 import React from "react";
 import { minWidth } from "../../styles/breakpoints";
-import { trackEvent } from "../analytics";
-import { LinkButton } from "../buttons";
 import { CallCentreEmailAndNumbers } from "../callCenterEmailAndNumbers";
 import { isLiveChatFeatureEnabled } from "../liveChat/liveChatFeatureSwitch";
+import {
+  LiveChatPrivacyNotice,
+  LiveChatPrivacyNoticeLink
+} from "../liveChat/liveChatPrivacyNotice";
 import { helpCentreConfig } from "./helpCentreConfig";
 import { HelpCentreEmailAndLiveChat } from "./helpCentreEmailAndLiveChat";
 import { HelpCentreLandingMoreTopics } from "./helpCentreLandingMoreTopics";
@@ -52,34 +54,15 @@ const HelpCentre = (_: RouteComponentProps) => {
         <h2 css={subtitleStyles}>Still can’t find what you’re looking for?</h2>
         {isLiveChatFeatureEnabled() ? (
           <>
+            <LiveChatPrivacyNoticeLink />
             <HelpCentreEmailAndLiveChat />
             <HelpCentrePhoneNumbers />
           </>
         ) : (
           <CallCentreEmailAndNumbers />
         )}
-        <p
-          css={css`
-            ${textSans.medium()};
-            margin-top: ${space[5]}px;
-          `}
-        >
-          Or use our contact form to get in touch and we’ll get back to you as
-          soon as possible.
-        </p>
-        <LinkButton
-          colour={brand[800]}
-          textColour={brand[400]}
-          fontWeight={"bold"}
-          text="Take me to the form"
-          to="/help-centre/contact-us/"
-          onClick={() =>
-            trackEvent({
-              eventCategory: "help-centre",
-              eventAction: "contact-us-cta-click"
-            })
-          }
-        />
+
+        {isLiveChatFeatureEnabled() && <LiveChatPrivacyNotice />}
       </div>
     </>
   );

--- a/app/client/components/helpCentre/helpCentreEmailAndLiveChat.tsx
+++ b/app/client/components/helpCentre/helpCentreEmailAndLiveChat.tsx
@@ -155,13 +155,16 @@ const emailAndLiveChatButtonCss = css`
   margin-top: ${space[1]}px;
 `;
 
+export const EmailAndLiveChatSubHeading = () => (
+  <p css={emailAndLiveChatSubheadingCss}>
+    Get in touch with one of our customer service agents.
+  </p>
+);
+
 export const HelpCentreEmailAndLiveChat = () => {
   const [isLiveChatAvailable, setIsLiveChatAvailable] = useState<boolean>(true);
   return (
     <>
-      <p css={emailAndLiveChatSubheadingCss}>
-        Get in touch with one of our customer service agents.
-      </p>
       <div css={emailAndLiveChatFlexContainerCss}>
         <HelpCentreContactBox
           iconId="email-us"

--- a/app/client/components/liveChat/liveChatPrivacyNotice.tsx
+++ b/app/client/components/liveChat/liveChatPrivacyNotice.tsx
@@ -3,6 +3,7 @@ import { brand, space } from "@guardian/src-foundations";
 import { textSans } from "@guardian/src-foundations/typography";
 import React from "react";
 import { conf } from "../../../server/config";
+import { minWidth } from "../../styles/breakpoints";
 
 export const LiveChatPrivacyNotice = () => {
   let domain: string;
@@ -14,7 +15,10 @@ export const LiveChatPrivacyNotice = () => {
 
   const containerCss = css`
     margin-top: ${space[9]}px;
-    padding: ${space[6]}px;
+    padding: ${space[3]}px;
+    ${minWidth.desktop} {
+      padding: ${space[6]}px;
+    }
     background-color: #ecf3fe;
   `;
   const titleCss = css`
@@ -23,6 +27,7 @@ export const LiveChatPrivacyNotice = () => {
   `;
   const paragraphCss = css`
     ${textSans.small()};
+    max-width: 830px;
     margin: 0;
     a {
       color: ${brand[500]};

--- a/app/client/components/liveChat/liveChatPrivacyNotice.tsx
+++ b/app/client/components/liveChat/liveChatPrivacyNotice.tsx
@@ -38,7 +38,7 @@ export const LiveChatPrivacyNotice = () => {
     <div css={containerCss} id="livechatPrivacyNotice">
       <h2 css={titleCss}>Data privacy note</h2>
       <p css={paragraphCss}>
-        We use a type of cookie technology called an SDK(Software Development
+        We use a type of cookie technology called an SDK (Software Development
         Kit) to ensure that our live chat services work correctly and meet your
         expectations. It cannot be switched off but it is removed at the end of
         the chat. If you do not wish for this cookie to be dropped on your

--- a/app/client/components/liveChat/liveChatPrivacyNotice.tsx
+++ b/app/client/components/liveChat/liveChatPrivacyNotice.tsx
@@ -1,0 +1,68 @@
+import { css } from "@emotion/core";
+import { brand, space } from "@guardian/src-foundations";
+import { textSans } from "@guardian/src-foundations/typography";
+import React from "react";
+import { conf } from "../../../server/config";
+
+export const LiveChatPrivacyNotice = () => {
+  let domain: string;
+  if (typeof window !== "undefined" && window.guardian) {
+    domain = window.guardian.domain;
+  } else {
+    domain = conf.DOMAIN;
+  }
+
+  const containerCss = css`
+    margin-top: ${space[9]}px;
+    padding: ${space[6]}px;
+    background-color: #ecf3fe;
+  `;
+  const titleCss = css`
+    margin: 0;
+    ${textSans.small({ fontWeight: "bold" })};
+  `;
+  const paragraphCss = css`
+    ${textSans.small()};
+    margin: 0;
+    a {
+      color: ${brand[500]};
+      text-decoration: underline;
+    }
+  `;
+  return (
+    <div css={containerCss} id="livechatPrivacyNotice">
+      <h2 css={titleCss}>Data privacy note</h2>
+      <p css={paragraphCss}>
+        We use a type of cookie technology, called an SDK (Software Development
+        Kit), to ensure that our live chat services work correctly and meet your
+        expectations. It cannot be switched off but it is removed at the end of
+        the chat. If you do not wish for this cookie to be dropped on your
+        device, please email us or phone us instead. Live chats and phone calls
+        will be recorded for monitoring and training purposes. Please do not
+        disclose personal data of a sensitive nature in the live chat, such as
+        health or financial information. You can choose to receive a transcript
+        of the chat by the 'Download transcript of the conversation' link. Click
+        to find out more in our{" "}
+        <a href={`https://${domain}/info/privacy`}>privacy policy</a> and{" "}
+        <a href={`https://${domain}/info/cookies`}>cookie policy</a>.
+      </p>
+    </div>
+  );
+};
+
+export const LiveChatPrivacyNoticeLink = () => {
+  const privacyNoticeLinkCss = css`
+    margin-bottom: ${space[2]}px;
+    text-align: right;
+    a {
+      ${textSans.small()};
+      color: ${brand[500]};
+      text-decoration: underline;
+    }
+  `;
+  return (
+    <div css={privacyNoticeLinkCss}>
+      <a href="#livechatPrivacyNotice">data privacy note</a>
+    </div>
+  );
+};

--- a/app/client/components/liveChat/liveChatPrivacyNotice.tsx
+++ b/app/client/components/liveChat/liveChatPrivacyNotice.tsx
@@ -38,16 +38,16 @@ export const LiveChatPrivacyNotice = () => {
     <div css={containerCss} id="livechatPrivacyNotice">
       <h2 css={titleCss}>Data privacy note</h2>
       <p css={paragraphCss}>
-        We use a type of cookie technology, called an SDK (Software Development
-        Kit), to ensure that our live chat services work correctly and meet your
+        We use a type of cookie technology called an SDK(Software Development
+        Kit) to ensure that our live chat services work correctly and meet your
         expectations. It cannot be switched off but it is removed at the end of
         the chat. If you do not wish for this cookie to be dropped on your
-        device, please email us or phone us instead. Live chats and phone calls
-        will be recorded for monitoring and training purposes. Please do not
+        device, please email or phone us instead. Live chats and phone calls
+        will be recorded for monitoring and training purposes. Please do not
         disclose personal data of a sensitive nature in the live chat, such as
-        health or financial information. You can choose to receive a transcript
-        of the chat by the 'Download transcript of the conversation' link. Click
-        to find out more in our{" "}
+        health or financial information. A copy of the chat transcript will be
+        emailed to you unless the chat contains payment card information, in
+        which case no transcript will be sent. Click to find out more in our{" "}
         <a href={`https://${domain}/info/privacy`}>privacy policy</a> and{" "}
         <a href={`https://${domain}/info/cookies`}>cookie policy</a>.
       </p>


### PR DESCRIPTION
## What does this change?
Adds live chat privacy notice to the bottom of the help center home page along with an anchor link further up the page. Hidden behind url param 'feature flag'

## How to test
- run manage-frontend locally
- visit https://manage.thegulocal.com/help-centre/?liveChat=1
- scroll down to the bottom of the page to see the privacy notice

## Images
![Screenshot 2021-09-07 at 11 40 02](https://user-images.githubusercontent.com/2510683/132332385-25bb4e6c-a7d8-4930-a271-49e861dd6299.png)
