### PR TITLE
[RB] - help centre article css amends

### DIFF
--- a/app/client/components/helpCentre/helpCentreArticle.tsx
+++ b/app/client/components/helpCentre/helpCentreArticle.tsx
@@ -1,7 +1,7 @@
 import css from "@emotion/css";
 import { Button } from "@guardian/src-button";
 import { brand, neutral, space } from "@guardian/src-foundations";
-import { textSans } from "@guardian/src-foundations/typography";
+import { headline, textSans } from "@guardian/src-foundations/typography";
 import { navigate, RouteComponentProps } from "@reach/router";
 import { captureException, captureMessage } from "@sentry/browser";
 import React, { useEffect, useState } from "react";
@@ -58,11 +58,16 @@ const HelpCentreArticle = (props: HelpCentreArticleProps) => {
     setSelectedTopicId(article?.topics[0].path);
   }, [article]);
 
+  const articleContainerCss = css`
+    max-width: 620px;
+    color: ${neutral["7"]};
+  `;
+
   return (
     <>
       <PageTitle title={article?.title} />
       <SeoData article={article} />
-      <>
+      <div css={articleContainerCss}>
         <h2 css={h2Css}>{article?.title}</h2>
         {article ? (
           <>
@@ -89,7 +94,7 @@ const HelpCentreArticle = (props: HelpCentreArticleProps) => {
           <Loading />
         )}
         <BackToHelpCentreButton />
-      </>
+      </div>
     </>
   );
 };
@@ -110,6 +115,34 @@ const ArticleBody = (props: ArticleBodyProps) => {
     color: ${brand[500]};
     text-decoration: underline;
   `;
+  const ulCss = css`
+    padding-left: 0;
+  `;
+  const liCss = css`
+    list-style: none;
+    padding-left: ${space[3] + space[2]}px;
+    position: relative;
+    :before {
+      content: "";
+      position: absolute;
+      top: 6px;
+      left: 0;
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+      background-color: #c4c4c4;
+    }
+  `;
+  const articleBodyH2Css = css`
+    ${headline.xxsmall({ fontWeight: "bold" })};
+    margin: ${space[6]}px 0 ${space[2]}px;
+    b {
+      font-weight: 700;
+    }
+  `;
+  const articleBodyPCss = css`
+    margin: 0 0 ${space[4]}px;
+  `;
 
   // This is to appease React's "Lists need a unique key" error
   let keyCounter = 0;
@@ -125,19 +158,35 @@ const ArticleBody = (props: ArticleBodyProps) => {
           return (body as TextNode).content;
         }
         case "h2": {
-          return <h2 key={key}>{parseBody((body as ElementNode).content)}</h2>;
+          return (
+            <h2 key={key} css={articleBodyH2Css}>
+              {parseBody((body as ElementNode).content)}
+            </h2>
+          );
         }
         case "p": {
-          return <p key={key}>{parseBody((body as ElementNode).content)}</p>;
+          return (
+            <p key={key} css={articleBodyPCss}>
+              {parseBody((body as ElementNode).content)}
+            </p>
+          );
         }
         case "ol": {
           return <ol key={key}>{parseBody((body as ElementNode).content)}</ol>;
         }
         case "ul": {
-          return <ul key={key}>{parseBody((body as ElementNode).content)}</ul>;
+          return (
+            <ul key={key} css={ulCss}>
+              {parseBody((body as ElementNode).content)}
+            </ul>
+          );
         }
         case "li": {
-          return <li key={key}>{parseBody((body as ElementNode).content)}</li>;
+          return (
+            <li key={key} css={liCss}>
+              {parseBody((body as ElementNode).content)}
+            </li>
+          );
         }
         case "b": {
           return <b key={key}>{parseBody((body as ElementNode).content)}</b>;
@@ -169,7 +218,10 @@ const articleFeedbackWidgetCss = css`
   flex-direction: column;
   border: 1px solid ${neutral[86]};
   padding: ${space[4]}px ${space[3]}px;
-  margin: 66px 0;
+  margin: 36px 0 48px;
+  ${minWidth.desktop} {
+    margin: 54px 0 66px;
+  }
   ${minWidth.mobileLandscape} {
     flex-direction: row;
     align-items: center;

--- a/app/client/components/helpCentre/helpCentreArticle.tsx
+++ b/app/client/components/helpCentre/helpCentreArticle.tsx
@@ -125,7 +125,7 @@ const ArticleBody = (props: ArticleBodyProps) => {
     :before {
       content: "";
       position: absolute;
-      top: 6px;
+      top: 8px;
       left: 0;
       width: 12px;
       height: 12px;
@@ -142,6 +142,7 @@ const ArticleBody = (props: ArticleBodyProps) => {
   `;
   const articleBodyPCss = css`
     margin: 0 0 ${space[4]}px;
+    font-size: 17px;
   `;
 
   // This is to appease React's "Lists need a unique key" error

--- a/app/client/components/helpCentre/helpCentreStyles.tsx
+++ b/app/client/components/helpCentre/helpCentreStyles.tsx
@@ -104,6 +104,7 @@ export const innerSectionCss = (isOpen: boolean) => css`
 export const h2Css = css`
   margin-top: 0;
   margin-bottom: ${space[6]}px;
+  padding-top: 2px;
   border-top: 1px solid ${neutral["86"]};
   ${headline.small({ fontWeight: "bold" })};
   ${minWidth.desktop} {

--- a/app/client/components/helpCentre/helpCentreStyles.tsx
+++ b/app/client/components/helpCentre/helpCentreStyles.tsx
@@ -2,6 +2,7 @@ import { css } from "@emotion/core";
 import { space } from "@guardian/src-foundations";
 import { neutral } from "@guardian/src-foundations/palette";
 import { headline, textSans } from "@guardian/src-foundations/typography";
+import { minWidth } from "../../styles/breakpoints";
 
 export const linkAnchorStyle = css`
   display: inline-block;
@@ -102,9 +103,12 @@ export const innerSectionCss = (isOpen: boolean) => css`
 
 export const h2Css = css`
   margin-top: 0;
-  margin-bottom: ${space[9]}px;
+  margin-bottom: ${space[6]}px;
   border-top: 1px solid ${neutral["86"]};
-  ${headline.small({ fontWeight: "bold" })}
+  ${headline.small({ fontWeight: "bold" })};
+  ${minWidth.desktop} {
+    font-size: 32px;
+  }
 `;
 
 export const contentDivStyles = css`


### PR DESCRIPTION
## What does this change?
Various design review amends to the help centre article pages:
- Width of main column
- Headline: font size and colour
- Subtitle: font size and colour
- Body text: font size and colour
- Spacing between text elements
- Spacing between page component
- Styling of list (indend, bullet point, spacing...)

https://www.figma.com/file/Ykab3YX9tU5PDByPOADrB5/SX---Help-Centre-MVP2?node-id=1461%3A96590

## How to test
- run manage-frontend locally
- visit one of the article pages:
  - https://manage.thegulocal.com/help-centre/article/finding-articles-from-the-past-in-digital-format
  - https://manage.thegulocal.com/help-centre/article/i-need-to-pause-my-delivery

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
![Screen Shot 2021-09-09 at 17 24 50](https://user-images.githubusercontent.com/2510683/132725059-341973c5-b694-4640-97d9-e9742bc45a1f.png)

![Screen Shot 2021-09-09 at 17 25 24](https://user-images.githubusercontent.com/2510683/132725085-7ad74178-d577-4176-a322-fef5f3ca0975.png)
