### PR TITLE
Update 'data privacy note' references to 'data privacy notice'

### DIFF
--- a/app/client/components/liveChat/liveChatPrivacyNotice.tsx
+++ b/app/client/components/liveChat/liveChatPrivacyNotice.tsx
@@ -36,7 +36,7 @@ export const LiveChatPrivacyNotice = () => {
   `;
   return (
     <div css={containerCss} id="livechatPrivacyNotice">
-      <h2 css={titleCss}>Data privacy note</h2>
+      <h2 css={titleCss}>Data privacy notice</h2>
       <p css={paragraphCss}>
         We use a type of cookie technology called an SDK (Software Development
         Kit) to ensure that our live chat services work correctly and meet your
@@ -67,7 +67,7 @@ export const LiveChatPrivacyNoticeLink = () => {
   `;
   return (
     <div css={privacyNoticeLinkCss}>
-      <a href="#livechatPrivacyNotice">data privacy note</a>
+      <a href="#livechatPrivacyNotice">data privacy notice</a>
     </div>
   );
 };


### PR DESCRIPTION
## What does this change?
This is a very minor copy tweak updating references to the data privacy _note_ to data privacy _notice_ instead (as requested by the DPO team via their 9 September email).

## How to test
Check the copy is displaying as expected.

## Images
Here's what the page looks like with the updated copy:

![image](https://user-images.githubusercontent.com/55701358/132834192-bf8dcaf3-3d84-4e62-b0d3-c51f9eea1cb5.png)
