### PR TITLE
[RB] - correct styling/text colour of the end chat button

### DIFF
--- a/app/client/components/liveChat/liveChatCssOverrides.ts
+++ b/app/client/components/liveChat/liveChatCssOverrides.ts
@@ -84,23 +84,23 @@ export const liveChatCss = css`
   .embeddedServiceSidebarButton {
     border-radius: 0;
   }
-  .dialogButtonContainer button:not(:last-of-type) {
+  .dialogButtonContainer button:nth-of-type(odd) {
     background: ${brand["500"]};
   }
   .dialogButtonContainer button .label {
     font-weight: bold;
   }
-  .dialogButtonContainer button:not(:last-of-type) .label {
+  .dialogButtonContainer button:nth-of-type(odd) .label {
     color: ${neutral["100"]};
   }
-  .dialogButtonContainer button:not(:last-of-type):focus {
+  .dialogButtonContainer button:nth-of-type(odd):focus {
     text-decoration: none;
   }
-  .dialogButtonContainer button:last-of-type {
+  .dialogButtonContainer button:nth-of-type(even) {
     border: 1px solid ${brand["500"]};
     background: ${neutral["100"]};
   }
-  .dialogButtonContainer button:last-of-type span {
+  .dialogButtonContainer button:nth-of-type(even) span {
     color: ${brand["500"]};
   }
   .embeddedServiceLiveAgentStateWaiting .embeddedServiceLoadingBalls {
@@ -131,7 +131,7 @@ export const liveChatCss = css`
   .endChatContainer button + button {
     margin-top: ${space[3]}px;
   }
-  .endChatContainer button:is(:last-of-type) .label {
+  .endChatContainer button:nth-of-type(even) .label {
     color: ${brand["500"]};
     text-decoration: underline;
   }


### PR DESCRIPTION
## What does this change?
Fixes a bug where only 1 button exists at the end of a conversation where previously there were 2 expected. Now uses even and odd slectors to ensure that the button background and text colours are correct.

## How to test
- log into the dev salesforce envirmonment
- from the App Launcher menu select LiveChatTestApp
- in the omni channel window set your self as Busy
- run manage locally and visit the help center with the live chat url param: `https://manage.thegulocal.com/help-centre/?liveChat=1` 
- click on the `Start live chat` button
- fill in the pre-chat form
- click on the `Start chatting` button
- go back to salesforce and end the chat from there
- go back to manage and you should now see the close chat button with the correct button text colour

## Images
Before                           |  After
:-------------------------:|:-------------------------:
![Screenshot 2021-09-13 at 12 08 31](https://user-images.githubusercontent.com/2510683/133074549-0bee41de-90ed-4ce7-ab42-3424fe8f818d.png)  |  ![Screenshot 2021-09-13 at 12 09 26](https://user-images.githubusercontent.com/2510683/133074611-0b22f126-b03d-4977-b134-6fcc9580a80d.png)
