### PR TITLE
Removed id s18 'report vulnerabilities'

### DIFF
--- a/app/shared/contactUsConfig.ts
+++ b/app/shared/contactUsConfig.ts
@@ -298,10 +298,6 @@ export const contactUsConfig: Topic[] = [
         ]
       },
       {
-        id: "s18",
-        name: "I’d like to report a suspected vulnerability"
-      },
-      {
         id: "s19",
         name: "I’d like to feedback about the advertisements you’re using"
       },


### PR DESCRIPTION
Contact form erroneously included option to report vulnerabilities (id s18). This is not a secure route and had to be removed.

https://manage.theguardian.com/help-centre/contact-us/tech

https://trello.com/c/UmqQxkMX

