### PR TITLE
remove report vulnerability from contact us page

### DIFF
--- a/app/shared/contactUsConfig.ts
+++ b/app/shared/contactUsConfig.ts
@@ -298,10 +298,6 @@ export const contactUsConfig: Topic[] = [
         ]
       },
       {
-        id: "s18",
-        name: "I’d like to report a suspected vulnerability"
-      },
-      {
         id: "s19",
         name: "I’d like to feedback about the advertisements you’re using"
       },


### PR DESCRIPTION
This PR removes the "report vulnability" option from the contact us page.

This is needed because infosec prefer they are reported via the established channels.

https://manage.theguardian.com/help-centre/contact-us/tech

https://trello.com/c/UmqQxkMX