### PR TITLE
'Dating' and 'Discount codes' removed from Manage footer

### DIFF
--- a/app/client/__tests__/__snapshots__/main.tsx.snap
+++ b/app/client/__tests__/__snapshots__/main.tsx.snap
@@ -1097,81 +1097,9 @@ exports[`Main renders something 1`] = `
                         "toString": [Function],
                       }
                     }
-                    href="https://soulmates.thegulocal.com/?INTCMP=NGW_FOOTER_UK_GU_SOULMATES"
-                  >
-                    Dating
-                  </a>
-                </li>
-                <li
-                  css={
-                    Object {
-                      "map": undefined,
-                      "name": "66iazq",
-                      "next": undefined,
-                      "styles": "
-  list-style: none;
-",
-                      "toString": [Function],
-                    }
-                  }
-                >
-                  <a
-                    css={
-                      Object {
-                        "map": undefined,
-                        "name": "1x52xav",
-                        "next": undefined,
-                        "styles": "
-  display: inline-block;
-  padding: 6px 0;
-  color: #ffffff;
-  :hover {
-    color: #ffe500;
-    cursor: pointer;
-  }
-",
-                        "toString": [Function],
-                      }
-                    }
                     href="https://patrons.thegulocal.com/?INTCMP=footer_patrons"
                   >
                     Patrons
-                  </a>
-                </li>
-                <li
-                  css={
-                    Object {
-                      "map": undefined,
-                      "name": "66iazq",
-                      "next": undefined,
-                      "styles": "
-  list-style: none;
-",
-                      "toString": [Function],
-                    }
-                  }
-                >
-                  <a
-                    css={
-                      Object {
-                        "map": undefined,
-                        "name": "1x52xav",
-                        "next": undefined,
-                        "styles": "
-  display: inline-block;
-  padding: 6px 0;
-  color: #ffffff;
-  :hover {
-    color: #ffe500;
-    cursor: pointer;
-  }
-",
-                        "toString": [Function],
-                      }
-                    }
-                    href="https://discountcode.thegulocal.com/uk?INTCMP=guardian_footer"
-                  >
-                    Discount Codes
                   </a>
                 </li>
               </ul>

--- a/app/client/components/footer/footerlinks.tsx
+++ b/app/client/components/footer/footerlinks.tsx
@@ -98,16 +98,8 @@ export const footerLinks: FooterLink[][] = [
       link: `https://jobs.${domain}/?INTCMP=NGW_FOOTER_UK_GU_JOBS`
     },
     {
-      title: "Dating",
-      link: `https://soulmates.${domain}/?INTCMP=NGW_FOOTER_UK_GU_SOULMATES`
-    },
-    {
       title: "Patrons",
       link: `https://patrons.${domain}/?INTCMP=footer_patrons`
-    },
-    {
-      title: "Discount Codes",
-      link: `https://discountcode.${domain}/uk?INTCMP=guardian_footer`
     }
   ]
 ];


### PR DESCRIPTION
The footer used on Manage contains links to 'Dating' and 'Discount codes' - both links are now redundant.

This PR removes these links.

Trello: https://trello.com/c/x9pyP8Fx

URL: https://manage.theguardian.com/