### PR TITLE
[RB] - Help centre FAQ/More topics page design amends.

### DIFF
--- a/app/client/components/helpCentre/BackToHelpCentreButton.tsx
+++ b/app/client/components/helpCentre/BackToHelpCentreButton.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import { LinkButton } from "../buttons";
 
 const buttonDivCss = css`
-  margin-top: ${space[12]}px;
+  margin-top: 60px;
   padding-top: ${space[4]}px;
   border-top: 1px solid ${neutral["86"]};
 `;

--- a/app/client/components/helpCentre/helpCentreLandingMoreTopics.tsx
+++ b/app/client/components/helpCentre/helpCentreLandingMoreTopics.tsx
@@ -42,18 +42,25 @@ export const HelpCentreLandingMoreTopics = () => {
   const handleSectionClick = (sectionNum: number) => () => {
     setIndexOfOpenSection(indexOfOpenSection === sectionNum ? -1 : sectionNum);
   };
+
   return (
     <div css={moreTopicsStyles}>
       <div css={containterCss}>
         {helpCentreMoreQuestionsConfig.map((topic, topicIndex) => {
           const isOpen = topicIndex === indexOfOpenSection;
           const isNotFirstOption = topicIndex > 0;
+          const titleCss = css`
+            ${sectionTitleCss(isOpen, isNotFirstOption)};
+            ${maxWidth.desktop} {
+              :after {
+                right: 17px;
+              }
+              padding-right: 31px;
+            }
+          `;
           return (
             <div key={topic.id}>
-              <h2
-                css={sectionTitleCss(isOpen, isNotFirstOption)}
-                onClick={handleSectionClick(topicIndex)}
-              >
+              <h2 css={titleCss} onClick={handleSectionClick(topicIndex)}>
                 {topic.title}
                 <span css={showHideCss}>{isOpen ? "Hide" : "Show"}</span>
               </h2>

--- a/app/client/components/helpCentre/helpCentreMoreTopics.tsx
+++ b/app/client/components/helpCentre/helpCentreMoreTopics.tsx
@@ -7,7 +7,6 @@ import React, { useState } from "react";
 import { maxWidth } from "../../styles/breakpoints";
 import { trackEvent } from "../analytics";
 import {
-  containterCss,
   h2Css,
   innerSectionCss,
   innerSectionDivCss,
@@ -45,20 +44,28 @@ interface HelpCentreMoreTopicsProps {
 
 export const HelpCentreMoreTopics = (props: HelpCentreMoreTopicsProps) => {
   const [openSection, setOpenSection] = useState<number>();
-
+  const moreTopicContainterCss = css`
+    width: 100%;
+    border-top: 1px solid ${neutral["86"]};
+    border-bottom: 1px solid ${neutral["86"]};
+  `;
   return (
     <>
       <h2 css={h2Css}>{props.moreTopics.title}</h2>
       <div css={moreTopicsStyles}>
-        <div css={containterCss}>
+        <div css={moreTopicContainterCss}>
           {props.moreTopics.topics.map((topic, topicIndex) => {
             const isOpen = topicIndex === openSection;
             const isNotFirstOption = topicIndex > 0;
+            const moreTopicSectionTitleCss = css`
+              ${sectionTitleCss(isOpen, isNotFirstOption)};
+              padding-left: 0;
+            `;
 
             return (
               <div key={topic.path}>
                 <h2
-                  css={sectionTitleCss(isOpen, isNotFirstOption)}
+                  css={moreTopicSectionTitleCss}
                   onClick={() =>
                     setOpenSection(openSection === topicIndex ? -1 : topicIndex)
                   }

--- a/app/client/components/helpCentre/helpCentreStyles.tsx
+++ b/app/client/components/helpCentre/helpCentreStyles.tsx
@@ -53,7 +53,10 @@ export const sectionTitleCss = (
   color: ${neutral["7"]};
   ${textSans.medium()};
   margin: 0;
-  padding: ${space[3]}px ${space[3] * 2 + 15}px ${space[3]}px ${space[3]}px;
+  padding: ${space[4]}px 14px ${space[4]}px ${space[3]}px;
+  ${minWidth.desktop} {
+    padding: ${space[4]}px 31px ${space[4]}px ${space[3]}px;
+  }
   position: relative;
   cursor: pointer;
   :after {
@@ -65,9 +68,13 @@ export const sectionTitleCss = (
     border-right: 2px solid ${neutral["7"]};
     position: absolute;
     top: 50%;
-    transform: translateY(-50%) ${isOpen ? "rotate(-45deg)" : "rotate(135deg)"};
+    transform: translateY(${isOpen ? "-10%" : "-50%"})
+      ${isOpen ? "rotate(-45deg)" : "rotate(135deg)"};
     transition: transform 0.4s;
-    right: 17px;
+    right: 0;
+    ${minWidth.desktop} {
+      right: 17px;
+    }
   }
   ${isNotFirstOption &&
     `
@@ -81,13 +88,13 @@ export const sectionTitleCss = (
       height: 1px;
       background-color: ${neutral["86"]}
     }
-`}
+  `}
 `;
 
 export const innerSectionDivCss = css`
   ${textSans.medium()};
   margin-bottom: 0;
-  padding: ${space[3]}px ${space[5]}px ${space[3]}px 0;
+  padding: ${space[4]}px ${space[5]}px ${space[4]}px 0;
   margin: 0 ${space[3]}px;
   position: relative;
 `;


### PR DESCRIPTION
## What does this change?
Design review amends to the help centre faq/More topics page:
- Margin around 'Back to Help Centre' button
- Height of list items in accordian nav
- positioning of 'show/hide' and chevrons for list items
- borders for accordian

https://www.figma.com/file/Ykab3YX9tU5PDByPOADrB5/SX---Help-Centre-MVP2?node-id=1262%3A29200

## How to test
- run manage-frontend locally
- visit the more topics page:
  - https://manage.thegulocal.com/help-centre/topic/more-topics

## Images
<img width="1322" alt="Screenshot 2021-09-16 at 09 27 06" src="https://user-images.githubusercontent.com/2510683/133578895-6782a26a-cfa6-4809-8dda-94ebdc94981f.png">

