### PR TITLE
[RB] - fix svg transform rotate bug in safari

### DIFF
--- a/app/client/components/svgs/thumbsUpIcon.tsx
+++ b/app/client/components/svgs/thumbsUpIcon.tsx
@@ -7,16 +7,12 @@ interface ThumbsUpIconProps {
 }
 
 export const ThumbsUpIcon = (props: ThumbsUpIconProps) => (
-  <svg
-    width="20"
-    height="24"
-    viewBox="0 0 20 24"
-    fill="none"
-    {...(props.invertIcon && { transform: "rotate(175)" })}
-  >
-    <path
-      d="M19.2261 13.3474L16.3955 22.7067L15.3096 23.4317L0 21.1823V8.70523L5.22193 7.68963L12.9156 0H14.0028L15.959 1.95889L12.9142 7.76327H12.9859L20 8.64029"
-      fill={props.overrideFillColor || neutral[100]}
-    />
+  <svg width="20" height="24" viewBox="0 0 20 24" fill="none">
+    <g {...(props.invertIcon && { transform: "rotate(175 10 12)" })}>
+      <path
+        d="M19.2261 13.3474L16.3955 22.7067L15.3096 23.4317L0 21.1823V8.70523L5.22193 7.68963L12.9156 0H14.0028L15.959 1.95889L12.9142 7.76327H12.9859L20 8.64029"
+        fill={props.overrideFillColor || neutral[100]}
+      />
+    </g>
   </svg>
 );


### PR DESCRIPTION
## What does this change?
Safari does not support transformation of the base svg tag 😖. It does however support transform of a group (g) tag. This pr wraps the inner contents of the thumbs up icon in a g tag and moves the rotation transform from the parent svg tag into the g tag.

## How to test
- run manage-frontend locally
- visit an article page:
  - https://manage.thegulocal.com/help-centre/article/i-need-to-pause-my-delivery

## Images

### Before
![Screenshot 2021-09-16 at 09 37 41](https://user-images.githubusercontent.com/2510683/133579828-169ea4d8-4ddf-4248-9168-5c3dffe88226.png)

### After
![Screenshot 2021-09-16 at 09 38 32](https://user-images.githubusercontent.com/2510683/133579863-07248ee1-a889-4796-a6b8-8f9d84e68732.png)



