### PR TITLE
Fetch wrapper function

### DIFF
--- a/app/client/components/accountoverview/accountOverview.tsx
+++ b/app/client/components/accountoverview/accountOverview.tsx
@@ -26,6 +26,7 @@ import { AccountOverviewCancelledCard } from "./accountOverviewCancelledCard";
 import { AccountOverviewCard } from "./accountOverviewCard";
 import { EmptyAccountOverview } from "./emptyAccountOverview";
 import { SupportTheGuardianSection } from "./supportTheGuardianSection";
+import { fetchWithDefaultParameters } from "../../fetch";
 
 const AccountOverviewRenderer = ([mdaResponse, cancelledProductsResponse]: [
   MembersDataApiItem[],
@@ -138,10 +139,7 @@ class AccountOverviewAsyncLoader extends AsyncLoader<
 const AccountOverviewFetcher = () =>
   Promise.all([
     allProductsDetailFetcher(),
-    fetch("/api/cancelled/", {
-      credentials: "include",
-      mode: "same-origin"
-    })
+    fetchWithDefaultParameters("/api/cancelled/")
   ]);
 
 export default AccountOverview;

--- a/app/client/components/accountoverview/contributionUpdateAmountForm.tsx
+++ b/app/client/components/accountoverview/contributionUpdateAmountForm.tsx
@@ -14,6 +14,7 @@ import { ProductType } from "../../../shared/productTypes";
 import { trackEvent } from "../analytics";
 import AsyncLoader from "../asyncLoader";
 import { Button } from "../buttons";
+import { fetchWithDefaultParameters } from "../../fetch";
 
 type ContributionUpdateAmountFormMode = "MANAGE" | "CANCELLATION_SAVE";
 
@@ -208,12 +209,10 @@ export const ContributionUpdateAmountForm = (
     productType: ProductType,
     subscriptionName: string
   ) => async () =>
-    await fetch(
+    await fetchWithDefaultParameters(
       `/api/update/amount/${productType.urlPart}/${subscriptionName}`,
       {
-        credentials: "include",
         method: "POST",
-        mode: "same-origin",
         body: JSON.stringify({ newPaymentAmount: newAmount })
       }
     );

--- a/app/client/components/billing/billing.tsx
+++ b/app/client/components/billing/billing.tsx
@@ -35,6 +35,7 @@ import { PaymentFailureAlertIfApplicable } from "../payment/paymentFailureAlertI
 import { ErrorIcon } from "../svgs/errorIcon";
 import { GiftIcon } from "../svgs/giftIcon";
 import { InvoicesTable } from "./invoicesTable";
+import { fetchWithDefaultParameters } from "../../fetch";
 
 type MMACategoryToProductDetails = {
   [mmaCategory in GroupedProductTypeKeys]: ProductDetail[];
@@ -270,10 +271,7 @@ const Billing = (_: RouteComponentProps) => {
 const billingFetcher = () =>
   Promise.all([
     allProductsDetailFetcher(),
-    fetch("/api/invoices", {
-      credentials: "include",
-      mode: "same-origin"
-    })
+    fetchWithDefaultParameters("/api/invoices")
   ]);
 
 export default Billing;

--- a/app/client/components/cancel/cancellationDateResponse.ts
+++ b/app/client/components/cancel/cancellationDateResponse.ts
@@ -3,6 +3,7 @@ import {
   X_GU_ID_FORWARDED_SCOPE
 } from "../../../shared/identity";
 import AsyncLoader from "../asyncLoader";
+import { fetchWithDefaultParameters } from "../../fetch";
 
 export interface CancellationDateResponse {
   cancellationEffectiveDate: string;
@@ -13,9 +14,7 @@ export class CancellationDateAsyncLoader extends AsyncLoader<
 > {}
 
 export const cancellationDateFetcher = (subscriptionName: string) => () =>
-  fetch("/api/cancellation-date/" + subscriptionName, {
-    credentials: "include",
-    mode: "same-origin",
+  fetchWithDefaultParameters("/api/cancellation-date/" + subscriptionName, {
     headers: {
       [X_GU_ID_FORWARDED_SCOPE]: getScopeFromRequestPathOrEmptyString(
         window.location.href

--- a/app/client/components/cancel/caseCreationWrapper.tsx
+++ b/app/client/components/cancel/caseCreationWrapper.tsx
@@ -7,6 +7,7 @@ import AsyncLoader from "../asyncLoader";
 import { CancellationCaseIdContext } from "./cancellationContexts";
 import { CancellationReasonContext } from "./cancellationContexts";
 import { OptionalCancellationReasonId } from "./cancellationReason";
+import { fetchWithDefaultParameters } from "../../fetch";
 
 interface CaseCreationResponse {
   id: string;
@@ -17,10 +18,8 @@ const getCreateCaseFunc = (
   sfCaseProduct: string,
   productDetail: ProductDetail
 ) => async () =>
-  await fetch("/api/case", {
-    credentials: "include",
+  await fetchWithDefaultParameters("/api/case", {
     method: "POST",
-    mode: "same-origin",
     body: JSON.stringify({
       reason,
       product: sfCaseProduct,

--- a/app/client/components/cancel/caseUpdate.tsx
+++ b/app/client/components/cancel/caseUpdate.tsx
@@ -1,6 +1,7 @@
 import { LOGGING_CODE_SUFFIX_HEADER } from "../../../shared/globals";
 import { MDA_TEST_USER_HEADER } from "../../../shared/productResponse";
 import AsyncLoader from "../asyncLoader";
+import { fetchWithDefaultParameters } from "../../fetch";
 
 interface CaseUpdateResponse {
   message: string;
@@ -14,10 +15,8 @@ export const getUpdateCasePromise = (
   caseId: string,
   body: object
 ) =>
-  fetch("/api/case/" + caseId, {
-    credentials: "include",
+  fetchWithDefaultParameters("/api/case/" + caseId, {
     method: "PATCH",
-    mode: "same-origin",
     body: JSON.stringify(body),
     headers: {
       "Content-Type": "application/json",

--- a/app/client/components/cancel/stages/executeCancellation.tsx
+++ b/app/client/components/cancel/stages/executeCancellation.tsx
@@ -25,6 +25,7 @@ import { CancellationFlowEscalationCheck } from "../cancellationFlowEscalationCh
 import { OptionalCancellationReasonId } from "../cancellationReason";
 import { getCancellationSummary, isCancelled } from "../cancellationSummary";
 import { CaseUpdateAsyncLoader, getUpdateCasePromise } from "../caseUpdate";
+import { fetchWithDefaultParameters } from "../../../fetch";
 
 class PerformCancelAsyncLoader extends AsyncLoader<ProductDetail[]> {}
 
@@ -33,10 +34,8 @@ const getCancelFunc = (
   reason: OptionalCancellationReasonId,
   withSubscriptionResponseFetcher: () => Promise<Response>
 ) => async () => {
-  await fetch("/api/cancel/" + subscriptionName, {
-    credentials: "include",
+  await fetchWithDefaultParameters("/api/cancel/" + subscriptionName, {
     method: "POST",
-    mode: "same-origin",
     body: JSON.stringify({ reason }),
     headers: { "Content-Type": "application/json" }
   }); // response is either empty or 404 - neither is useful so fetch subscription to determine cancellation result...

--- a/app/client/components/delivery/records/deliveryRecordsApi.ts
+++ b/app/client/components/delivery/records/deliveryRecordsApi.ts
@@ -4,6 +4,7 @@ import {
   Subscription
 } from "../../../../shared/productResponse";
 import AsyncLoader from "../../asyncLoader";
+import { fetchWithDefaultParameters } from "../../../fetch";
 
 interface DeliveryProblem {
   problemType: string;
@@ -84,9 +85,7 @@ export const createDeliveryRecordsFetcher = (
   subscriptionId: string,
   isTestUser: boolean
 ) => () =>
-  fetch(`/api/delivery-records/${subscriptionId}`, {
-    credentials: "include",
-    mode: "same-origin",
+  fetchWithDefaultParameters(`/api/delivery-records/${subscriptionId}`, {
     headers: {
       [MDA_TEST_USER_HEADER]: `${isTestUser}`
     }

--- a/app/client/components/holiday/holidayReview.tsx
+++ b/app/client/components/holiday/holidayReview.tsx
@@ -48,6 +48,7 @@ import {
   ReloadableGetHolidayStopsResponse
 } from "./holidayStopApi";
 import { SummaryTable } from "./summaryTable";
+import { fetchWithDefaultParameters } from "../../fetch";
 
 const getPerformCreateOrAmendFetcher = (
   selectedRange: DateRange,
@@ -55,16 +56,14 @@ const getPerformCreateOrAmendFetcher = (
   isTestUser: boolean,
   existingHolidayStopToAmend?: HolidayStopRequest
 ) => () =>
-  fetch(
+  fetchWithDefaultParameters(
     `/api/holidays${
       existingHolidayStopToAmend
         ? `/${subscriptionName}/${existingHolidayStopToAmend.id}`
         : ""
     }`,
     {
-      credentials: "include",
       method: existingHolidayStopToAmend ? "PATCH" : "POST",
-      mode: "same-origin",
       body: JSON.stringify({
         startDate: dateString(selectedRange.start, DATE_FNS_INPUT_FORMAT),
         endDate: dateString(selectedRange.end, DATE_FNS_INPUT_FORMAT),

--- a/app/client/components/identity/idapi/supportReminders.ts
+++ b/app/client/components/identity/idapi/supportReminders.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/browser";
 import { ConsentOption, ConsentOptionType } from "../models";
+import { fetchWithDefaultParameters } from "../../../fetch";
 
 interface ReminderStatusApiResponse {
   recurringStatus: "NotSet" | "Active" | "Cancelled";
@@ -22,10 +23,7 @@ const getConsent = (isActive: boolean): ConsentOption => ({
 });
 
 export const read = async (): Promise<ConsentOption[]> => {
-  const response = await fetch(REMINDERS_STATUS_ENDPOINT, {
-    credentials: "include",
-    mode: "same-origin"
-  });
+  const response = await fetchWithDefaultParameters(REMINDERS_STATUS_ENDPOINT);
   const reminderStatus = (await response.json()) as ReminderStatusApiResponse;
   if (reminderStatus.recurringStatus === "NotSet") {
     return [];

--- a/app/client/components/resubscribeThrasher.tsx
+++ b/app/client/components/resubscribeThrasher.tsx
@@ -8,11 +8,10 @@ import { minWidth } from "../styles/breakpoints";
 import { trackEvent } from "./analytics";
 import AsyncLoader from "./asyncLoader";
 import { SupportTheGuardianButton } from "./supportTheGuardianButton";
+import { fetchWithDefaultParameters } from "../fetch";
 
 const fetchExistingPaymentOptions = () =>
-  fetch("/api/existing-payment-options", {
-    credentials: "include",
-    mode: "same-origin",
+  fetchWithDefaultParameters("/api/existing-payment-options", {
     headers: {
       [X_GU_ID_FORWARDED_SCOPE]: getScopeFromRequestPathOrEmptyString(
         window.location.href

--- a/app/client/fetch.ts
+++ b/app/client/fetch.ts
@@ -1,0 +1,8 @@
+const fetchDefaultParameters: RequestInit = {
+  credentials: "include",
+  mode: "same-origin"
+};
+
+export const fetchWithDefaultParameters: typeof fetch = (url, options) => {
+  return fetch(url, { ...fetchDefaultParameters, ...options });
+};

--- a/app/client/productUtils.tsx
+++ b/app/client/productUtils.tsx
@@ -8,6 +8,7 @@ import {
   ProductTypeWithDeliveryRecordsProperties,
   ProductTypeWithHolidayStopsFlow
 } from "../shared/productTypes";
+import { fetchWithDefaultParameters } from "./fetch";
 
 export const shouldHaveHolidayStopsFlow = (
   productType: ProductType
@@ -34,9 +35,7 @@ export const createProductDetailFetcher = (
   );
 
 export const allProductsDetailFetcher = () =>
-  fetch("/api/me/mma", {
-    credentials: "include",
-    mode: "same-origin",
+  fetchWithDefaultParameters("/api/me/mma", {
     headers: {
       [X_GU_ID_FORWARDED_SCOPE]: getScopeFromRequestPathOrEmptyString(
         window.location.href

--- a/app/client/productUtils.tsx
+++ b/app/client/productUtils.tsx
@@ -18,14 +18,12 @@ export const createProductDetailFetcher = (
   productType: ProductType,
   subscriptionName?: string
 ) => () =>
-  fetch(
+  fetchWithDefaultParameters(
     "/api/me/mma" +
       (subscriptionName
         ? `/${subscriptionName}`
         : `?productType=${productType.allProductsProductTypeFilterString}`),
     {
-      credentials: "include",
-      mode: "same-origin",
       headers: {
         [X_GU_ID_FORWARDED_SCOPE]: getScopeFromRequestPathOrEmptyString(
           window.location.href


### PR DESCRIPTION
## What does this change?
`credentials` and `mode` parameters were introduced in several fetch calls to avoid the Safari bug issued in this PR: https://github.com/guardian/manage-frontend/pull/572. This is a wrapper function that injects these parameters so they do not have to be written for every fetch call.

## How to test
Tested visually through dev tools network tab using Safari 11 and 12 on Browserstack.

_Any suggestions on a better name for the function?_