### PR TITLE
[RB] - force the live chat feature check to true. Temporary measure making this easy to roll back quickly after release

### DIFF
--- a/app/client/components/liveChat/liveChatFeatureSwitch.ts
+++ b/app/client/components/liveChat/liveChatFeatureSwitch.ts
@@ -1,3 +1,4 @@
+/*
 const liveChatParamName = "liveChat";
 
 export const isLiveChatFeatureEnabled = () => {
@@ -16,3 +17,6 @@ const setLiveChatSessionStorage = (queryStringMatch: string[]) => {
   const liveChatParamValue = queryStringMatch[0].split("=")[1];
   window.sessionStorage.setItem(liveChatParamName, liveChatParamValue);
 };
+*/
+
+export const isLiveChatFeatureEnabled = () => true;


### PR DESCRIPTION
## What does this change?
Day 1 public release of the live chat feature. 

Forces the `isLiveChatFeatureEnabled` function to return true and comments out the previous functionality, leaving the usage of the `isLiveChatFeatureEnabled` intact and making a post launch rollback as easy as possible (uncommenting the previous `isLiveChatFeatureEnabled` functionality).

Once the release has been and gone and there isn't any potential need to roll back quickly then another pr should be raised to remove the `isLiveChatFeatureEnabled` function entirely from the codebase.