### PR TITLE
[RB] - Add tracking to the start live chat button press

### DIFF
--- a/app/client/components/liveChat/liveChat.tsx
+++ b/app/client/components/liveChat/liveChat.tsx
@@ -5,6 +5,7 @@ import React, { Dispatch, SetStateAction, useState } from "react";
 import { LoadingCircleIcon } from "../svgs/loadingCircleIcon";
 import { avatarImg } from "./liveChatBase64Images";
 import { liveChatCss } from "./liveChatCssOverrides";
+import { trackEvent } from "../analytics";
 
 const initESW = (
   gslbBaseUrl: string | null,
@@ -247,7 +248,14 @@ export const StartLiveChatButton = (props: StartLiveChatButtonProps) => {
   return (
     <Button
       priority="secondary"
-      onClick={() => bootstrapChat()}
+      onClick={() => {
+        trackEvent({
+          eventCategory: "livechat",
+          eventAction: "click",
+          eventLabel: "start_live_chat"
+        });
+        bootstrapChat();
+      }}
       css={props.liveChatButtonCss}
       icon={
         liveChatIsLoading ? (


### PR DESCRIPTION
## What does this change?
The `Start live chat` button on the help centre homepage (with live chat enabled) should fire a GA event when clicked.

## How to test
- visit the help centre page with live chat enabled:
  - https://manage.theguardian.com/help-centre/?liveChat=1
- click on the "Start live chat button"
- log into google analytics and look for an event with the following properties:
  - eventCategory: "livechat"
  - eventAction: "click"
  - eventLabel: "start_live_chat"