### PR TITLE
[RB] - manually scroll the privacy notice into view in order to mitig…

### DIFF
--- a/app/client/components/liveChat/liveChatPrivacyNotice.tsx
+++ b/app/client/components/liveChat/liveChatPrivacyNotice.tsx
@@ -67,7 +67,18 @@ export const LiveChatPrivacyNoticeLink = () => {
   `;
   return (
     <div css={privacyNoticeLinkCss}>
-      <a href="#livechatPrivacyNotice">data privacy notice</a>
+      <a
+        href="#livechatPrivacyNotice"
+        onClick={e => {
+          e.preventDefault();
+          const privacyNoticeElement = document.getElementById(
+            "livechatPrivacyNotice"
+          );
+          privacyNoticeElement && privacyNoticeElement.scrollIntoView();
+        }}
+      >
+        data privacy notice
+      </a>
     </div>
   );
 };


### PR DESCRIPTION
## What does this change?
On the help centre page with live chat enabled, manually scroll the privacy notice into view when the link is clicked in order to mitigate reach router from firing a location change event and calling the `ScrollToTop` function in `client/components/scrollToTop.tsx `

In the longer term a more elegant solution would be to refactor the scrollToTop functionality so that it only performs this action if the target page (minus any hash) is different from the previous page. However this would require reach router / our code to have access to the the url history of manage for comparison.

## How to test
- run manage-frontend locally
- visit the help centre page with live chat enabled:
  - https://manage.thegulocal.com/help-centre/?liveChat=1
- Find the `data privacy notice` link above the chat with us box
- click on this link and it should scroll you down the page to the privacy notice