### PR TITLE
Include ref params on newsletter subs

### DIFF
--- a/app/client/components/identity/idapi/newsletters.ts
+++ b/app/client/components/identity/idapi/newsletters.ts
@@ -34,20 +34,8 @@ const newsletterToConsentOption = (
   };
 };
 
-const addTrackingQueryParams = (path: string): string => {
-  const params = new URLSearchParams({
-    ref: window.location.href,
-    refViewId:
-      (window.guardian &&
-        window.guardian.ophan &&
-        window.guardian.ophan.viewId) ||
-      ""
-  });
-  return `${path}?${params.toString()}`;
-};
-
 export const read = async (): Promise<ConsentOption[]> => {
-  const url = addTrackingQueryParams("/newsletters");
+  const url = "/newsletters";
 
   return (await identityFetch<NewsletterAPIResponse[]>(url)).map(
     newsletterToConsentOption
@@ -55,17 +43,25 @@ export const read = async (): Promise<ConsentOption[]> => {
 };
 
 export const readRestricted = async (): Promise<ConsentOption[]> => {
-  const url = addTrackingQueryParams("/newsletters/restricted");
+  const url = "/newsletters/restricted";
   return (await identityFetch<NewsletterAPIResponse[]>(url)).map(
     newsletterToConsentOption
   );
 };
 
 export const update = async (id: string, subscribed: boolean = true) => {
-  const url = addTrackingQueryParams("/users/me/newsletters");
+  const ref = window.location.href;
+  const refViewId =
+    (window.guardian &&
+      window.guardian.ophan &&
+      window.guardian.ophan.viewId) ||
+    "";
+  const url = "/users/me/newsletters";
   const payload = {
     id,
-    subscribed
+    subscribed,
+    ref,
+    refViewId
   };
   identityFetch(url, APIUseCredentials(APIPatchOptions(payload)));
 };


### PR DESCRIPTION
## What does this change?
Adds two properties to the payload sent when a user subscribes or unsubscribes from a newsletter on https://manage.thegulocal.com/email-prefs

## Why?
Because we want to include these two pieces of data in ophan to enable us to identify the places from where readers are subscribing to our newsletter content

## Before
```js
PATCH https://manage.thegulocal.com/idapicodeproxy/users/me/newsletters
{
  "id":"4164",
  "subscribed":true
}
```

## After
```js
PATCH https://manage.thegulocal.com/idapicodeproxy/users/me/newsletters
{
  "id":"4164",
  "subscribed":true,
  "ref":"https://manage.thegulocal.com/email-prefs",
  "refViewId":"kuwo7zztf0r09l6emyvv"
}
```

## What next?
I also need examine the code for the application that receives this `PATCH` request to ensure that this data is passed along as needed
