### PR TITLE
[RB] - fix the wrong email address showing up in the help centre

### DIFF
--- a/app/client/components/helpCentre/helpCentreEmailAndLiveChat.tsx
+++ b/app/client/components/helpCentre/helpCentreEmailAndLiveChat.tsx
@@ -180,7 +180,7 @@ export const HelpCentreEmailAndLiveChat = () => {
           title="Email us"
           subtitle="Send a message to one of our customer service agents."
         >
-          <p css={emailAndLiveChatPCss}>customers@theguardian.com</p>
+          <p css={emailAndLiveChatPCss}>customer.help@theguardian.com</p>
           <p>
             Use our{" "}
             <Link to="/help-centre/contact-us/" css={emailAndLiveChatLinkCss}>


### PR DESCRIPTION
## What does this change?
The wrong customer help email address was being shown to the user on the help centre page

## Images
Before             |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/2510683/137892027-e2016666-b6ef-4c0f-a43a-b7348d3d8a8c.png)  |  ![](https://user-images.githubusercontent.com/2510683/137892080-c874b0dd-61f6-4c15-a65f-ac2e7d8418d0.png)

