### PR TITLE
Remove typo in "Why am I still seeing banners/ads"

### DIFF
--- a/app/client/components/helpCentre/helpCentreConfig.ts
+++ b/app/client/components/helpCentre/helpCentreConfig.ts
@@ -114,7 +114,7 @@ export const helpCentreConfig: HelpCentreTopic[] = [
     links: [
       {
         id: "q1",
-        title: "Why am I still seeings ads/banners?",
+        title: "Why am I still seeing ads/banners?",
         link: "/help-centre/article/why-am-i-still-seeing-adsbanners"
       },
       {


### PR DESCRIPTION
Originally said "seeings"
