### PR TITLE
Removing Live Chat opening hours copy

### DIFF
--- a/app/client/components/helpCentre/helpCentreEmailAndLiveChat.tsx
+++ b/app/client/components/helpCentre/helpCentreEmailAndLiveChat.tsx
@@ -205,8 +205,6 @@ export const HelpCentreEmailAndLiveChat = () => {
               setIsLiveChatAvailable={setIsLiveChatAvailable}
             />
           )}
-          <p>9am - 10pm, Monday - Friday (GMT/BST)</p>
-          <p>9am - 6pm, Saturday - Sunday (GMT/BST)</p>
         </HelpCentreContactBox>
       </div>
     </>


### PR DESCRIPTION
Opening hours for Live Chat are increasing. We believe we can remove opening hours entirely from the Live Chat component in the Help Centr
![Screenshot 2021-11-16 104040](https://user-images.githubusercontent.com/77791487/141978036-5e45ef91-06dd-4b05-9000-e79062350f7e.png)
![Screenshot 2021-11-16 113231](https://user-images.githubusercontent.com/77791487/141978040-76749baa-21bc-4972-aef2-00045c6ee57a.png)
e.