### PR TITLE
[RB] - remove the contact us form prompt from the email box on the he…

### DIFF
--- a/app/client/components/helpCentre/helpCentreEmailAndLiveChat.tsx
+++ b/app/client/components/helpCentre/helpCentreEmailAndLiveChat.tsx
@@ -1,7 +1,6 @@
 import { css } from "@emotion/core";
-import { brand, neutral, space, text } from "@guardian/src-foundations";
+import { neutral, space, text } from "@guardian/src-foundations";
 import { textSans } from "@guardian/src-foundations/typography";
-import { Link } from "@reach/router";
 import React, { ReactNode, useState } from "react";
 import { maxWidth, minWidth } from "../../styles/breakpoints";
 import { StartLiveChatButton } from "../liveChat/liveChat";
@@ -152,10 +151,6 @@ const emailAndLiveChatPCss = css`
   margin-bottom: ${space[9]}px !important;
 `;
 
-const emailAndLiveChatLinkCss = css`
-  color: ${brand[500]};
-`;
-
 const emailAndLiveChatButtonCss = css`
   margin-bottom: ${space[5]}px;
   margin-top: ${space[1]}px;
@@ -181,13 +176,6 @@ export const HelpCentreEmailAndLiveChat = () => {
           subtitle="Send a message to one of our customer service agents."
         >
           <p css={emailAndLiveChatPCss}>customer.help@theguardian.com</p>
-          <p>
-            Use our{" "}
-            <Link to="/help-centre/contact-us/" css={emailAndLiveChatLinkCss}>
-              contact form
-            </Link>{" "}
-            to send us a message.
-          </p>
         </HelpCentreContactBox>
         <HelpCentreContactBox
           title="Chat with us"


### PR DESCRIPTION
## What does this change?

Remove the contact us form prompt from the email box on the help center landing page

### Images
<img width="1156" alt="Screenshot 2021-11-25 at 16 13 40" src="https://user-images.githubusercontent.com/2510683/143476340-3f45e44f-2aca-48f9-9ec3-41b55b7fa460.png">

-mobile
<img width="233" alt="Screenshot 2021-11-25 at 16 48 34" src="https://user-images.githubusercontent.com/2510683/143478899-7657843c-797f-485e-aabf-47f9d34c8ad7.png">

