### PR TITLE
Refactor `DateInput` and fix month display bugs

### DIFF
--- a/app/client/__tests__/components/dateInput.tsx
+++ b/app/client/__tests__/components/dateInput.tsx
@@ -1,0 +1,44 @@
+import Enzyme, { mount } from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import { DateInput } from "../../components/dateInput";
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe("DateInput", () => {
+  it.each([
+    {
+      date: new Date("10 Jan 2022"),
+      expectedDay: 10,
+      expectedMonth: 1,
+      expectedYear: 2022
+    },
+    {
+      date: new Date("16 Mar 2022"),
+      expectedDay: 16,
+      expectedMonth: 3,
+      expectedYear: 2022
+    },
+    {
+      date: new Date("4 Dec 2023"),
+      expectedDay: 4,
+      expectedMonth: 12,
+      expectedYear: 2023
+    }
+  ])(
+    "shows correct date for $date",
+    ({ date, expectedDay, expectedMonth, expectedYear }) => {
+      const wrapper = mount(<DateInput date={date} labelText="My Label" />);
+
+      expect(wrapper.find("[aria-label='day']").props().value).toEqual(
+        expectedDay
+      );
+      expect(wrapper.find("[aria-label='month']").props().value).toEqual(
+        expectedMonth
+      );
+      expect(wrapper.find("[aria-label='year']").props().value).toEqual(
+        expectedYear
+      );
+    }
+  );
+});

--- a/app/client/__tests__/components/dateInput.tsx
+++ b/app/client/__tests__/components/dateInput.tsx
@@ -8,26 +8,27 @@ Enzyme.configure({ adapter: new Adapter() });
 describe("DateInput", () => {
   it.each([
     {
-      date: new Date("10 Jan 2022"),
+      givenDate: "10 Jan 2022",
       expectedDay: 10,
       expectedMonth: 1,
       expectedYear: 2022
     },
     {
-      date: new Date("16 Mar 2022"),
+      givenDate: "16 Mar 2022",
       expectedDay: 16,
       expectedMonth: 3,
       expectedYear: 2022
     },
     {
-      date: new Date("4 Dec 2023"),
+      givenDate: "4 Dec 2023",
       expectedDay: 4,
       expectedMonth: 12,
       expectedYear: 2023
     }
   ])(
-    "shows correct date for $date",
-    ({ date, expectedDay, expectedMonth, expectedYear }) => {
+    "Displays the correct day, month and year for $givenDate",
+    ({ givenDate, expectedDay, expectedMonth, expectedYear }) => {
+      const date = new Date(givenDate);
       const wrapper = mount(<DateInput date={date} labelText="My Label" />);
 
       expect(wrapper.find("[aria-label='day']").props().value).toEqual(

--- a/app/client/components/dateInput.tsx
+++ b/app/client/components/dateInput.tsx
@@ -27,123 +27,56 @@ const dividerCss = {
   margin: 0
 };
 
-const adjustZeroIndexedMonth = (date: Date) => {
-  const modifiedDate = new Date(date.valueOf());
-  modifiedDate.setMonth(modifiedDate.getMonth() + 1);
-  return modifiedDate;
-}
-
 interface DateInputProps {
-  selectedDate?: Date;
-  defaultDate: Date;
+  date: Date;
   labelText: string;
   disabled?: boolean;
-  // onChange: (newValue: DateInputState) => void; // TODO: UNCOMMENT WHEN INPUT ACTIVATED
 }
 
-interface DateInputState {
-  day: number;
-  month: number;
-  year: number;
-  dateVisible: boolean;
-}
-
-export class DateInput extends React.Component<DateInputProps, DateInputState> {
-  public state: DateInputState = {
-    day: this.props.defaultDate.getDate(),
-    month: adjustZeroIndexedMonth(this.props.defaultDate).getMonth(),
-    year: this.props.defaultDate.getFullYear(),
-    dateVisible: false
-  };
-
-  public componentDidUpdate = (prevProps: DateInputProps) => {
-    if (
-      // prevProps.selectedDate && // TODO: may be required when input activated
-      this.props.selectedDate &&
-      prevProps.selectedDate !== this.props.selectedDate
-    ) {
-      this.setState({
-        day: this.props.selectedDate.getDate(),
-        month: adjustZeroIndexedMonth(this.props.selectedDate).getMonth(),
-        year: this.props.selectedDate.getFullYear(),
-        dateVisible: true
-      });
-    }
-  };
-
-  public render = () => (
-    <>
-      <div
-        css={{
-          fontFamily: sans,
-          fontSize: "14px",
-          [maxWidth.desktop]: {
-            display: "none"
-          }
-        }}
-      >
-        {this.props.labelText}
-        <br />
-      </div>
-      <fieldset
-        css={{
-          // display: "inline-block",
-          border: "1px solid" + palette.neutral["5"],
-          padding: "5px",
-          whiteSpace: "nowrap",
-          margin: 0
-        }}
-        aria-describedby="validation-message"
-        disabled={this.props.disabled}
-      >
-        <input
-          css={dayMonthCss}
-          // type="number"
-          aria-label="day"
-          value={this.state.day}
-          // onChange={event => {
-
-          //   const day = parseInt(event.target.value, 10);
-          //   if (day > 0) {
-          //     this.setState({ day }, this.pushStateUpwards);
-          //   }
-          // }}
-          readOnly // TODO: remove and replace with onChange when input boxes become active
-        />
-        <div css={dividerCss}>/</div>
-        <input
-          css={dayMonthCss}
-          // type="number"
-          aria-label="month"
-          value={this.state.month}
-          // onChange={event => {
-          //   const month = parseInt(event.target.value, 10);
-          //   if (month > 0) {
-          //     this.setState(
-          //       { month: parseInt(event.target.value, 10) },
-          //       this.pushStateUpwards
-          //     );
-          //   }
-          // }}
-          readOnly // TODO: remove and replace with onChange when input boxes become active
-        />
-        <div css={dividerCss}>/</div>
-        <input
-          css={inputBoxCss}
-          // type="number"
-          arial-label="year"
-          value={this.state.year}
-          // onChange={event => {
-          //   const year = parseInt(event.target.value, 10);
-          //   if (year > 0) {
-          //     this.setState({ year }, this.pushStateUpwards);
-          //   }
-          // }}
-          readOnly // TODO: remove and replace with onChange when input boxes become active
-        />
-      </fieldset>
-    </>
-  );
-
-  // private pushStateUpwards = () => this.props.onChange(this.state);
-}
+export const DateInput = (props: DateInputProps) => (
+  <>
+    <div
+      css={{
+        fontFamily: sans,
+        fontSize: "14px",
+        [maxWidth.desktop]: {
+          display: "none"
+        }
+      }}
+    >
+      {props.labelText}
+      <br />
+    </div>
+    <fieldset
+      css={{
+        border: "1px solid" + palette.neutral["5"],
+        padding: "5px",
+        whiteSpace: "nowrap",
+        margin: 0
+      }}
+      aria-describedby="validation-message"
+      disabled={props.disabled}
+    >
+      <input
+        css={dayMonthCss}
+        aria-label="day"
+        value={props.date.getDate()}
+        readOnly // TODO: remove and replace with onChange when input boxes become active
+      />
+      <div css={dividerCss}>/</div>
+      <input
+        css={dayMonthCss}
+        aria-label="month"
+        value={props.date.getMonth() + 1}
+        readOnly // TODO: remove and replace with onChange when input boxes become active
+      />
+      <div css={dividerCss}>/</div>
+      <input
+        css={inputBoxCss}
+        arial-label="year"
+        value={props.date.getFullYear()}
+        readOnly // TODO: remove and replace with onChange when input boxes become active
+      />
+    </fieldset>
+  </>
+);

--- a/app/client/components/dateInput.tsx
+++ b/app/client/components/dateInput.tsx
@@ -73,7 +73,7 @@ export const DateInput = (props: DateInputProps) => (
       <div css={dividerCss}>/</div>
       <input
         css={inputBoxCss}
-        arial-label="year"
+        aria-label="year"
         value={props.date.getFullYear()}
         readOnly // TODO: remove and replace with onChange when input boxes become active
       />

--- a/app/client/components/datePicker.tsx
+++ b/app/client/components/datePicker.tsx
@@ -225,8 +225,11 @@ export const DatePicker = (props: DatePickerProps) => (
         >
           <div>
             <DateInput
-              selectedDate={props.selectedRange && props.selectedRange.start}
-              defaultDate={props.firstAvailableDate}
+              date={
+                props.selectedRange
+                  ? props.selectedRange.start
+                  : props.firstAvailableDate
+              }
               labelText="From"
               disabled={!!props.maybeLockedStartDate}
             />
@@ -238,8 +241,11 @@ export const DatePicker = (props: DatePickerProps) => (
           </span>
           <div css={{ [minWidth.desktop]: { marginTop: "8px" } }}>
             <DateInput
-              selectedDate={props.selectedRange && props.selectedRange.end}
-              defaultDate={props.firstAvailableDate}
+              date={
+                props.selectedRange
+                  ? props.selectedRange.end
+                  : props.firstAvailableDate
+              }
               labelText="To"
             />
           </div>


### PR DESCRIPTION
## What does this change?

Updates the `DateInput` component so that December is displayed as 12 rather than 0. (Other months are not affected and already display correctly.)

As part of the fix the component has been converted from a class component to a functional component, the `defaultDate` and `selectedDate` props have been combined into a single `date` prop, and a basic test suite has been added.

Removing the `selectedDate` prop also fixes a separate bug where if you amend the chosen dates the date inputs will revert to showing the first available date rather than the selected dates.

## How to test

- [ ] Run `manage-frontend` locally.
- [ ] Go to ['Manage suspensions'](https://manage.thegulocal.com/suspend/homedelivery).
- [ ] If the first available date is in December then the month in the _From_ and _To_ date inputs should be shown as 12.
- [ ] Select a date range beginning and / or ending in December. Dates in December should be shown as 12, and other months should also be displayed correctly.
- [ ] With a date range selected click on 'Review details'.
- [ ] From the 'Review details' page click 'Amend' to go back and amend the chosen dates. The dates shown in the _From_ and _To_ date inputs should match the already selected dates rather than reverting to the first available date.

## Images

### Before

Date inputs showing a first available date in December:

<img width="869" alt="Screenshot 2021-11-29 at 16 37 07" src="https://user-images.githubusercontent.com/1166188/143912055-8fff2fd7-1457-45d5-9fff-2056dd805f06.png">

Selected dates are in December, but month is still shown as 0:

<img width="858" alt="Screenshot 2021-11-29 at 16 37 19" src="https://user-images.githubusercontent.com/1166188/143912156-a2db7151-9761-4b10-817f-3afbbf98ab3f.png">

When amending the selected dates the date inputs revert to the first available date:

<img width="850" alt="Screenshot 2021-11-29 at 16 37 42" src="https://user-images.githubusercontent.com/1166188/143912440-f5275de0-ec8e-4e2c-b639-528632808463.png">

### After

December correctly shown as 12:

<img width="862" alt="Screenshot 2021-11-29 at 16 38 25" src="https://user-images.githubusercontent.com/1166188/143912509-cb21ddde-5062-4b6e-aee2-2d475008342b.png">

When amending, the previously selected dates are shown, matching the calendar:

<img width="848" alt="Screenshot 2021-11-29 at 16 38 37" src="https://user-images.githubusercontent.com/1166188/143912578-6fe26d47-b2ed-477a-8947-09c44577d8a2.png">
