### PR TITLE
Update Snyk workflow to monitor, rather than test, dependencies

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,31 +1,26 @@
-# This action runs every day at 6 AM and on every push
-# If the branch it's running on is main then it will run snyk monitor (reports vulnerabilities to snyk.io)
-# Otherwise it will run snyk test
+# This action runs Snyk Monitor every day at 6 AM and on every push to main
 name: Snyk
 
 on:
   schedule:
-    - cron: "0 6 * * *"
+    - cron: 0 6 * * *
   push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
   security:
     runs-on: ubuntu-latest
-    env:
-      SNYK_COMMAND: test
+
     steps:
       - name: Checkout branch
         uses: actions/checkout@v2
 
-      - name: Set command to monitor
-        if: github.ref == 'refs/heads/main'
-        run: echo "SNYK_COMMAND=monitor" >> $GITHUB_ENV
-
-      - name: Run Snyk to check for vulnerabilities
+      - name: Update Snyk UI with current vulnerabilities
         uses: snyk/actions/node@0.3.0
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
+          command: monitor
           args: --org=the-guardian-cuu --project-name=${{ github.repository }} --file=./app/yarn.lock
-          command: ${{ env.SNYK_COMMAND }}


### PR DESCRIPTION
Failing tests because of unrelated dependencies isn't helpful.
Instead we just want to keep Snyk up to date with the latest state of the codebase.