### PR TITLE
 local phone number in the settings form is a number

### DIFF
--- a/app/client/components/identity/idapi/user.ts
+++ b/app/client/components/identity/idapi/user.ts
@@ -76,7 +76,9 @@ export const isErrorResponse = (error: any): error is UserAPIErrorResponse => {
 const toUserApiRequest = (user: Partial<User>): UserAPIRequest => {
   const { countryCode: countryCode, localNumber: localNumber } = user;
   const telephoneNumber =
-    countryCode && localNumber ? { countryCode, localNumber } : undefined;
+    countryCode && localNumber
+      ? { countryCode, localNumber: `${localNumber}` }
+      : undefined;
 
   return {
     publicFields: {

--- a/app/client/components/identity/models.ts
+++ b/app/client/components/identity/models.ts
@@ -38,7 +38,7 @@ export interface User {
   postcode: string;
   country: string;
   countryCode: string;
-  localNumber: string;
+  localNumber: number;
 }
 
 export interface UserError {


### PR DESCRIPTION

## What does this change?

- local phone number in the settings form is a number and needs to be converted to string before sending to IDAPI endpoint

## Why

Identity API is becoming less tolerant of numbers being passed in place of strings