### PR TITLE
Prevent short PayPal IDs from throwing an error

### DIFF
--- a/app/client/__tests__/components/payment/paypalDisplay.ts
+++ b/app/client/__tests__/components/payment/paypalDisplay.ts
@@ -1,12 +1,22 @@
 import { getObfuscatedPayPalId } from "../../../components/payment/paypalDisplay";
 
 test("obfuscate email id", () => {
-  expect(getObfuscatedPayPalId("hiTom@email.com")).toEqual("h***m@email.com");
-  expect(getObfuscatedPayPalId("hiRichard@email.com")).toEqual(
-    "h*******d@email.com"
+  expect(getObfuscatedPayPalId("username@email.com")).toEqual(
+    "u******e@email.com"
   );
+  expect(getObfuscatedPayPalId("last.first@guardian.com")).toEqual(
+    "l********t@guardian.com"
+  );
+  expect(getObfuscatedPayPalId("j@gu.com")).toEqual("j@gu.com");
+  expect(getObfuscatedPayPalId("jm@gu.com")).toEqual("jm@gu.com");
+  expect(getObfuscatedPayPalId("jim@gu.com")).toEqual("j*m@gu.com");
+  expect(getObfuscatedPayPalId("james@gu.com")).toEqual("j***s@gu.com");
 });
 
 test("obfuscate string id", () => {
-  expect(getObfuscatedPayPalId("usernameYo")).toEqual("u********o");
+  expect(getObfuscatedPayPalId("username")).toEqual("u******e");
+  expect(getObfuscatedPayPalId("j")).toEqual("j");
+  expect(getObfuscatedPayPalId("jm")).toEqual("jm");
+  expect(getObfuscatedPayPalId("jim")).toEqual("j*m");
+  expect(getObfuscatedPayPalId("james")).toEqual("j***s");
 });

--- a/app/client/components/payment/paypalDisplay.tsx
+++ b/app/client/components/payment/paypalDisplay.tsx
@@ -7,15 +7,13 @@ interface PayPalProps {
 }
 
 export const getObfuscatedPayPalId = (rawId: string) => {
-  const indexOfAtSymbol = rawId.indexOf("@");
-  if (indexOfAtSymbol > -1) {
-    return `${rawId.charAt(0)}${"*".repeat(indexOfAtSymbol - 2)}${rawId.charAt(
-      indexOfAtSymbol - 1
-    )}${rawId.substring(indexOfAtSymbol)}`;
-  }
-  return `${rawId.charAt(0)}${"*".repeat(rawId.length - 2)}${rawId.charAt(
-    rawId.length - 1
-  )}`;
+  return rawId.replace(
+    /^(.)(.*?)(.?|.?@.+)$/,
+    (_, firstChar, remainingChars, lastChar) => {
+      const maskedRemainingChars = remainingChars.replace(/./g, "*");
+      return firstChar + maskedRemainingChars + lastChar;
+    }
+  );
 };
 
 export const PayPalDisplay = (props: PayPalProps) => (


### PR DESCRIPTION
## What does this change?

## How to test

## Have we considered potential risks?

## Images

![manage thegulocal com__profileReferrer=reauthenticate%3FcomponentEventParams%3DcomponentType%253Didentityauthentication%2526componentId%253Didapi_signin_redirect (4)](https://user-images.githubusercontent.com/1166188/144842362-960b4814-0aeb-4bfa-b143-dbfddd75bd9f.png)

![manage thegulocal com__profileReferrer=reauthenticate%3FcomponentEventParams%3DcomponentType%253Didentityauthentication%2526componentId%253Didapi_signin_redirect (1)](https://user-images.githubusercontent.com/1166188/144842273-78706cc0-0f57-48a0-ab93-748a4a782132.png)

![manage thegulocal com__profileReferrer=reauthenticate%3FcomponentEventParams%3DcomponentType%253Didentityauthentication%2526componentId%253Didapi_signin_redirect (3)](https://user-images.githubusercontent.com/1166188/144842350-fa686768-056a-4881-aebc-85e72861041c.png)

![Uploading manage.thegulocal.com__profileReferrer=reauthenticate%3FcomponentEventParams%3DcomponentType%253Didentityauthentication%2526componentId%253Didapi_signin_redirect (4).png…]()

