### PR TITLE
[RB] - update client web socket url to include missing /ws path

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -12,7 +12,7 @@
     "bundle-dev-client": "webpack --config webpack.dev.client.js",
     "bundle-check-client": "webpack --config webpack.prod.client.bundle-check.js",
     "bundle-check-client-if-changed": "((git diff --name-only --cached | grep 'yarn.lock') && yarn bundle-check-client) || true",
-    "serve-dev": "webpack-dev-server --config ./webpack.dev.client.js --client-web-socket-url https://manage.thegulocal.com --open https://manage.thegulocal.com/",
+    "serve-dev": "webpack-dev-server --config ./webpack.dev.client.js --client-web-socket-url https://manage.thegulocal.com/ws --open https://manage.thegulocal.com/",
     "watch": "yarn bundle-dev-server && (yarn bundle-dev-server -w & yarn start & yarn serve-dev)",
     "test": "jest --coverage && yarn type-check && yarn lint ",
     "jest": "jest",


### PR DESCRIPTION
## What does this change?

The webpack dev server websocket connection has been failing since the webpack version bump. This appeared to be affecting  hot reloading and potentially some chunk loading errors (not noticed this error since implementing this fix).

Looks as though the socket-url param was wrong (missing the /ws path)
