### PR TITLE
Payments switching confirmation page

### DIFF
--- a/app/client/__tests__/components/payment/currentPaymentDetails.tsx
+++ b/app/client/__tests__/components/payment/currentPaymentDetails.tsx
@@ -55,7 +55,6 @@ const cardProductDetail: ProductDetail = {
       }
     ],
     readerType: "Direct",
-    cancellationEffectiveDate: undefined,
     deliveryAddressChangeEffectiveDate: "2021-11-26"
   },
   isTestUser: false

--- a/app/client/__tests__/components/payment/paymentUpdated.tsx
+++ b/app/client/__tests__/components/payment/paymentUpdated.tsx
@@ -370,7 +370,7 @@ const tests = [
       "ending 4242",
       "4 / 2024",
       "£135.00 / annual",
-      "December 10, 2021"
+      "10 December 2021"
     ]
   },
   {
@@ -384,7 +384,7 @@ const tests = [
       "ending 911",
       "20-00-00",
       "£99.00 / annual",
-      "December 18, 2021"
+      "18 December 2021"
     ]
   }
 ];

--- a/app/client/__tests__/components/payment/paymentUpdated.tsx
+++ b/app/client/__tests__/components/payment/paymentUpdated.tsx
@@ -1,0 +1,407 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import {
+  ProductDetail,
+  Subscription
+} from "../../../../shared/productResponse";
+import { ConfirmedNewPaymentDetailsRenderer } from "../../../components/payment/update/paymentUpdated";
+import { NewPaymentMethodDetail } from "../../../components/payment/update/newPaymentMethodDetail";
+
+// mock functions for NewPaymentMethodDetail type
+const matchesResponse = (_: any) => true;
+const subHasExpectedPaymentType = (_?: Subscription) => true;
+const detailToPayloadObject = () => {
+  return {};
+};
+const newPaymentMethodDetailRender = () => <></>;
+const confirmButtonWrapper = () => <></>;
+
+const gwSubscription: Subscription = {
+  paymentMethod: "Card",
+  card: {
+    last4: "4242",
+    expiry: {
+      month: 4,
+      year: 2024
+    },
+    type: "Visa",
+    stripePublicKeyForUpdate: "pk_test_Qm3CGRdrV4WfGYCpm0sftR0f",
+    email: "jon.flynn+code@guardian.co.uk"
+  },
+  contactId: "0039E00001KA26BQAT",
+  deliveryAddress: {
+    addressLine1: "71 Valnay Street",
+    addressLine2: "",
+    town: "London",
+    postcode: "SW17 8PS",
+    country: "United Kingdom"
+  },
+  safeToUpdatePaymentMethod: true,
+  start: "2021-12-10",
+  end: "2022-11-29",
+  nextPaymentPrice: 13500,
+  nextPaymentDate: "2021-12-10",
+  lastPaymentDate: null,
+  chargedThroughDate: null,
+  renewalDate: "2022-11-29",
+  anniversaryDate: "2022-12-10",
+  cancelledAt: false,
+  subscriptionId: "A-S00286635",
+  subscriberId: "A-S00286635",
+  trialLength: 9,
+  autoRenew: true,
+  plan: {
+    name: "Guardian Weekly - Domestic",
+    amount: 15000,
+    currency: "£",
+    currencyISO: "GBP",
+    interval: "year"
+  },
+  currentPlans: [],
+  futurePlans: [
+    {
+      name: null,
+      start: "2021-12-10",
+      end: "2022-11-29",
+      shouldBeVisible: true,
+      chargedThrough: null,
+      amount: 15000,
+      currency: "£",
+      currencyISO: "GBP",
+      interval: "year"
+    }
+  ],
+  readerType: "Direct",
+  accountId: "8ad0965d7d585497017d6ce786026089",
+  deliveryAddressChangeEffectiveDate: "2021-12-10"
+};
+
+const newPaymentMethodDetailCard: NewPaymentMethodDetail = {
+  apiUrlPart: "card",
+  name: "card",
+  friendlyName: "payment card",
+  paymentFailureRecoveryMessage:
+    "We will take the outstanding payment within 24 hours, using your new card details.",
+  matchesResponse,
+  subHasExpectedPaymentType,
+  render: newPaymentMethodDetailRender,
+  detailToPayloadObject,
+  confirmButtonWrapper
+  /* add the following property as a new type, look at members-data-api to see if we use a default response from Stripe or build our own
+
+    "stripePaymentMethod": {
+        "id": "pm_0K1vCEItVxyc3Q6ndAt3Sc4l",
+        "object": "payment_method",
+        "billing_details": {
+            "address": {
+                "city": null,
+                "country": null,
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+            },
+            "email": "jon.flynn+code@guardian.co.uk",
+            "name": "jon.flynn+code@guardian.co.uk",
+            "phone": null
+        },
+        "card": {
+            "brand": "visa",
+            "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": null
+            },
+            "country": "US",
+            "exp_month": 4,
+            "exp_year": 2024,
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+                "available": [
+                    "visa"
+                ],
+                "preferred": null
+            },
+            "three_d_secure_usage": {
+                "supported": true
+            },
+            "wallet": null
+        },
+        "created": 1638374294,
+        "customer": null,
+        "livemode": false,
+        "type": "card"
+    },
+    "stripePublicKeyForUpdate": "pk_test_Qm3CGRdrV4WfGYCpm0sftR0f"
+    */
+};
+
+const gwCard: ProductDetail = {
+  mmaCategory: "subscriptions",
+  tier: "Guardian Weekly - Domestic",
+  isPaidTier: true,
+  selfServiceCancellation: {
+    isAllowed: false,
+    shouldDisplayEmail: false,
+    phoneRegionsToDisplay: ["UK & ROW"]
+  },
+  joinDate: "2021-11-29",
+  optIn: true,
+  subscription: {
+    paymentMethod: "Card",
+    card: {
+      last4: "4242",
+      expiry: {
+        month: 4,
+        year: 2024
+      },
+      type: "Visa",
+      stripePublicKeyForUpdate: "pk_test_Qm3CGRdrV4WfGYCpm0sftR0f",
+      email: "jon.flynn+code@guardian.co.uk"
+    },
+    contactId: "0039E00001KA26BQAT",
+    deliveryAddress: {
+      addressLine1: "71 Valnay Street",
+      addressLine2: "",
+      town: "London",
+      postcode: "SW17 8PS",
+      country: "United Kingdom"
+    },
+    safeToUpdatePaymentMethod: true,
+    start: "2021-12-10",
+    end: "2022-11-29",
+    nextPaymentPrice: 13500,
+    nextPaymentDate: "2021-12-10",
+    lastPaymentDate: null,
+    chargedThroughDate: null,
+    renewalDate: "2022-11-29",
+    anniversaryDate: "2022-12-10",
+    cancelledAt: false,
+    subscriberId: "A-S00286635",
+    subscriptionId: "A-S00286635",
+    trialLength: 9,
+    autoRenew: true,
+    plan: {
+      name: "Guardian Weekly - Domestic",
+      amount: 15000,
+      currency: "£",
+      currencyISO: "GBP",
+      interval: "year"
+    },
+    currentPlans: [],
+    futurePlans: [
+      {
+        name: null,
+        start: "2021-12-10",
+        end: "2022-11-29",
+        shouldBeVisible: true,
+        chargedThrough: null,
+        amount: 15000,
+        currency: "£",
+        currencyISO: "GBP",
+        interval: "year"
+      }
+    ],
+    readerType: "Direct",
+    accountId: "8ad0965d7d585497017d6ce786026089",
+    deliveryAddressChangeEffectiveDate: "2021-12-10"
+  },
+  isTestUser: false,
+  key: "1638374153759"
+};
+
+const digitalSubscription: Subscription = {
+  paymentMethod: "DirectDebit",
+  account: {
+    accountName: "asfd"
+  },
+  mandate: {
+    accountName: "asfd",
+    accountNumber: "****9911",
+    sortCode: "200000"
+  },
+  contactId: "0039E00001KA26BQAT",
+  deliveryAddress: {
+    addressLine1: "71 Valnay Street",
+    addressLine2: "",
+    town: "London",
+    postcode: "SW17 8PS",
+    country: "United Kingdom"
+  },
+  safeToUpdatePaymentMethod: true,
+  start: "2021-12-18",
+  end: "2022-12-02",
+  nextPaymentPrice: 9900,
+  nextPaymentDate: "2021-12-18",
+  lastPaymentDate: null,
+  chargedThroughDate: null,
+  renewalDate: "2022-12-02",
+  anniversaryDate: "2022-12-18",
+  cancelledAt: false,
+  subscriberId: "A-S00287957",
+  subscriptionId: "A-S00287957",
+  trialLength: 16,
+  autoRenew: true,
+  plan: {
+    name: "Digital Pack",
+    amount: 11900,
+    currency: "£",
+    currencyISO: "GBP",
+    interval: "year"
+  },
+  currentPlans: [],
+  futurePlans: [
+    {
+      name: null,
+      start: "2021-12-18",
+      end: "2022-12-02",
+      shouldBeVisible: true,
+      chargedThrough: null,
+      amount: 11900,
+      currency: "£",
+      currencyISO: "GBP",
+      interval: "year"
+    }
+  ],
+  readerType: "Direct",
+  accountId: "8ad08c0f7d768472017d7bc3e5960b20"
+};
+
+const newPaymentMethodDetailDD: NewPaymentMethodDetail = {
+  apiUrlPart: "dd",
+  name: "direct_debit",
+  friendlyName: "direct debit",
+  /*
+    "ddDetail": {
+        "accountName": "asfd",
+        "accountNumber": "55779911",
+        "sortCode": "200000"
+    },
+    */
+  matchesResponse,
+  subHasExpectedPaymentType,
+  render: newPaymentMethodDetailRender,
+  detailToPayloadObject,
+  confirmButtonWrapper
+};
+
+const digitalSubDD: ProductDetail = {
+  mmaCategory: "subscriptions",
+  tier: "Digital Pack",
+  isPaidTier: true,
+  selfServiceCancellation: {
+    isAllowed: false,
+    shouldDisplayEmail: false,
+    phoneRegionsToDisplay: ["UK & ROW"]
+  },
+  joinDate: "2021-12-02",
+  optIn: true,
+  subscription: {
+    paymentMethod: "DirectDebit",
+    account: {
+      accountName: "sdfa"
+    },
+    mandate: {
+      accountName: "sdfa",
+      accountNumber: "****9911",
+      sortCode: "200000"
+    },
+    contactId: "0039E00001KA26BQAT",
+    deliveryAddress: {
+      addressLine1: "71 Valnay Street",
+      addressLine2: "",
+      town: "London",
+      postcode: "SW17 8PS",
+      country: "United Kingdom"
+    },
+    safeToUpdatePaymentMethod: true,
+    start: "2021-12-18",
+    end: "2022-12-02",
+    nextPaymentPrice: 9900,
+    nextPaymentDate: "2021-12-18",
+    lastPaymentDate: null,
+    chargedThroughDate: null,
+    renewalDate: "2022-12-02",
+    anniversaryDate: "2022-12-18",
+    cancelledAt: false,
+    subscriberId: "A-S00287957",
+    subscriptionId: "A-S00287957",
+    trialLength: 16,
+    autoRenew: true,
+    plan: {
+      name: "Digital Pack",
+      amount: 11900,
+      currency: "£",
+      currencyISO: "GBP",
+      interval: "year"
+    },
+    currentPlans: [],
+    futurePlans: [
+      {
+        name: null,
+        start: "2021-12-18",
+        end: "2022-12-02",
+        shouldBeVisible: true,
+        chargedThrough: null,
+        amount: 11900,
+        currency: "£",
+        currencyISO: "GBP",
+        interval: "year"
+      }
+    ],
+    readerType: "Direct",
+    accountId: "8ad08c0f7d768472017d7bc3e5960b20"
+  },
+  isTestUser: false,
+  key: "1638458999023"
+};
+
+const tests = [
+  {
+    data: {
+      subscription: gwSubscription,
+      newPaymentMethodDetail: newPaymentMethodDetailCard,
+      previousProductDetail: gwCard
+    },
+    expectations: [
+      "Guardian Weekly",
+      "ending 4242",
+      "4 / 2024",
+      "£135.00 / annual",
+      "December 10, 2021"
+    ]
+  },
+  {
+    data: {
+      subscription: digitalSubscription,
+      newPaymentMethodDetail: newPaymentMethodDetailDD,
+      previousProductDetail: digitalSubDD
+    },
+    expectations: [
+      "Digital Subscription",
+      "ending 911",
+      "20-00-00",
+      "£99.00 / annual",
+      "December 18, 2021"
+    ]
+  }
+];
+
+describe("ConfirmedNewPaymentDetailsRenderer component in paymentMethodUpdated.tsx", () => {
+  test.each(tests)(
+    "Summary table shows correct data for %s",
+    ({ data, expectations }) => {
+      const { getByText } = render(
+        <ConfirmedNewPaymentDetailsRenderer
+          subscription={data.subscription}
+          newPaymentMethodDetail={data.newPaymentMethodDetail}
+          previousProductDetail={data.previousProductDetail}
+        />
+      );
+
+      expectations.map(toTest => getByText(toTest));
+    }
+  );
+});

--- a/app/client/components/payment/update/paymentUpdated.tsx
+++ b/app/client/components/payment/update/paymentUpdated.tsx
@@ -1,7 +1,9 @@
-import { neutral } from "@guardian/src-foundations/palette";
+import { css } from "@emotion/core";
+import { space } from "@guardian/src-foundations";
+import { brand, neutral, news } from "@guardian/src-foundations/palette";
+import { maxWidth, minWidth } from "../../../styles/breakpoints";
 import React from "react";
 import {
-  augmentInterval,
   formatDate,
   getMainPlan,
   isPaidSubscriptionPlan,
@@ -11,10 +13,9 @@ import {
   Subscription,
   WithSubscription
 } from "../../../../shared/productResponse";
-import { ProductType } from "../../../../shared/productTypes";
-import { Button, LinkButton } from "../../buttons";
+import { GROUPED_PRODUCT_TYPES } from "../../../../shared/productTypes";
+import { LinkButton } from "../../buttons";
 import { GenericErrorScreen } from "../../genericErrorScreen";
-import { NAV_LINKS } from "../../nav/navConfig";
 import {
   ReturnToAccountOverviewButton,
   RouteableStepProps,
@@ -27,6 +28,11 @@ import {
   NewPaymentMethodDetail
 } from "./newPaymentMethodDetail";
 import { NewSubscriptionContext } from "./newSubscriptionDetail";
+import { textSans } from "@guardian/src-foundations/typography";
+import { CardDisplay } from "../cardDisplay";
+import { DirectDebitDisplay } from "../directDebitDisplay";
+import { PayPalDisplay } from "../paypalDisplay";
+import { SepaDisplay } from "../sepaDisplay";
 
 interface ConfirmedNewPaymentDetailsRendererProps {
   subscription: Subscription;
@@ -34,38 +40,262 @@ interface ConfirmedNewPaymentDetailsRendererProps {
   previousProductDetail: ProductDetail;
 }
 
-const ConfirmedNewPaymentDetailsRenderer = ({
+const keyValuePairCss = css`
+  list-style: none;
+  margin: 0;
+  padding: 0;
+`;
+
+const keyCss = css`
+  ${textSans.medium({ fontWeight: "bold" })};
+  padding: 0 ${space[2]}px 0 0;
+  display: inline-block;
+  vertical-align: top;
+  width: 14ch;
+`;
+
+const valueCss = css`
+  ${textSans.medium()};
+  padding: 0;
+  display: inline-block;
+  vertical-align: top;
+  width: calc(100% - 15ch);
+`;
+
+function getPaymentInterval(interval: string) {
+  if (interval === "year") {
+    return "annual";
+  } else if (interval === "month") {
+    return "monthly";
+  }
+}
+
+export const ConfirmedNewPaymentDetailsRenderer = ({
   subscription,
   newPaymentMethodDetail,
   previousProductDetail
 }: ConfirmedNewPaymentDetailsRendererProps) => {
+  console.log(subscription);
+  console.log(newPaymentMethodDetail);
+  console.log(previousProductDetail);
   const mainPlan = getMainPlan(subscription);
+  const groupedProductType =
+    GROUPED_PRODUCT_TYPES[previousProductDetail.mmaCategory];
+  const specificProductType = groupedProductType.mapGroupedToSpecific(
+    previousProductDetail
+  );
+
+  const hasPaymentFailure: boolean = !!previousProductDetail.alertText;
+
   if (
     newPaymentMethodDetail.subHasExpectedPaymentType(subscription) &&
     isPaidSubscriptionPlan(mainPlan)
   ) {
     return (
-      <>
-        {newPaymentMethodDetail.render(subscription)}
-        {previousProductDetail.alertText &&
-        newPaymentMethodDetail.paymentFailureRecoveryMessage ? (
-          <div>{newPaymentMethodDetail.paymentFailureRecoveryMessage}</div>
-        ) : (
-          <>
-            {subscription.nextPaymentPrice && subscription.nextPaymentDate && (
-              <div>
-                <b>Next Payment:</b> {mainPlan.currency}
-                {(subscription.nextPaymentPrice / 100.0).toFixed(2)} on{" "}
-                {formatDate(subscription.nextPaymentDate)}
-              </div>
+      <div
+        css={css`
+          border: 1px solid ${neutral[86]};
+          margin-bottom: ${space[6]}px;
+        `}
+      >
+        <div
+          css={css`
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            background-color: ${brand[400]};
+            ${minWidth.mobileLandscape} {
+              align-items: center;
+            }
+          `}
+        >
+          <h2
+            css={css`
+              font-size: 17px;
+              font-weight: bold;
+              margin: 0;
+              padding: ${space[3]}px;
+              color: ${neutral[100]};
+              ${maxWidth.mobileLandscape} {
+                padding: ${space[3]}px;
+              }
+              ${minWidth.tablet} {
+                font-size: 20px;
+                padding: ${space[3]}px ${space[5]}px;
+              }
+            `}
+          >
+            {specificProductType.productTitle(mainPlan)}
+          </h2>
+        </div>
+        <div
+          css={css`
+            padding: ${space[5]}px ${space[3]}px;
+            ${minWidth.tablet} {
+              padding: ${space[5]}px;
+              display: flex;
+            }
+          `}
+        >
+          <div
+            css={css`
+              ${minWidth.tablet} {
+                margin: ${space[6]}px 0 0 0;
+                padding: ${space[6]}px 0 0 0;
+                flex: 1;
+                display: flex;
+                flex-flow: column nowrap;
+                padding: 0;
+                margin: 0;
+              }
+            `}
+          >
+            {previousProductDetail.isPaidTier && (
+              <>
+                <ul css={keyValuePairCss}>
+                  <li css={keyCss}>Payment method</li>
+                  <li css={valueCss}>
+                    {subscription.card && (
+                      <CardDisplay
+                        inErrorState={false}
+                        margin="0"
+                        {...subscription.card}
+                      />
+                    )}
+                    {subscription.payPalEmail && (
+                      <PayPalDisplay payPalId={subscription.payPalEmail} />
+                    )}
+                    {subscription.sepaMandate && (
+                      <SepaDisplay
+                        accountName={subscription.sepaMandate.accountName}
+                        iban={subscription.sepaMandate.iban}
+                      />
+                    )}
+                    {subscription.mandate && (
+                      <DirectDebitDisplay
+                        inErrorState={false}
+                        {...subscription.mandate}
+                      />
+                    )}
+                    {subscription.stripePublicKeyForCardAddition && (
+                      <span>No Payment Method</span>
+                    )}
+                  </li>
+                </ul>
+              </>
             )}
-            <div>
-              <b>Payment Frequency:</b> {augmentInterval(mainPlan.interval)}
+          </div>
+          {subscription.card && (
+            <div
+              css={css`
+                padding: ${space[6]}px 0 0 0;
+                ${minWidth.tablet} {
+                  margin: ${space[6]}px 0 0 0;
+                  flex: 1;
+                  display: inline-block;
+                  flex-flow: column nowrap;
+                  padding: 0 0 0 ${space[5]}px;
+                  margin: 0;
+                  padding: 0 0 0 ${space[5]}px;
+                }
+                ul:last-of-type {
+                  margin-bottom: ${space[5]}px;
+                }
+              `}
+            >
+              {subscription.card.expiry && (
+                <>
+                  <span
+                    css={css`
+                      ${keyCss};
+                      ${minWidth.tablet} {
+                        text-align: right;
+                      }
+                    `}
+                  >
+                    Expiry
+                  </span>
+                  <span
+                    css={css`
+                      ${valueCss};
+                      color: ${hasPaymentFailure ? news[400] : neutral[7]};
+                    `}
+                  >
+                    {subscription.card.expiry.month} /{" "}
+                    {subscription.card.expiry.year}
+                  </span>
+                </>
+              )}
             </div>
-          </>
+          )}
+        </div>
+
+        {subscription.nextPaymentPrice && subscription.nextPaymentDate && (
+          <div
+            css={css`
+              padding: ${space[5]}px ${space[3]}px;
+              border-top: 1px solid ${neutral[86]};
+              ${minWidth.tablet} {
+                padding: ${space[5]}px;
+                display: flex;
+              }
+            `}
+          >
+            <div
+              css={css`
+                ${minWidth.tablet} {
+                  margin: ${space[6]}px 0 0 0;
+                  padding: ${space[6]}px 0 0 0;
+                  flex: 1;
+                  display: flex;
+                  flex-flow: column nowrap;
+                  padding: 0;
+                  margin: 0;
+                }
+              `}
+            >
+              <>
+                <ul css={keyValuePairCss}>
+                  <li css={keyCss}>Next Payment</li>
+                  <li css={valueCss}>
+                    {mainPlan.currency}
+                    {(subscription.nextPaymentPrice / 100.0).toFixed(2)} /{" "}
+                    {getPaymentInterval(subscription.plan?.interval)}
+                    {subscription.stripePublicKeyForCardAddition && (
+                      <span>No Payment Method</span>
+                    )}
+                  </li>
+                </ul>
+              </>
+            </div>
+
+            <div
+              css={css`
+                padding: ${space[6]}px 0 0 0;
+                ${minWidth.tablet} {
+                  margin: ${space[6]}px 0 0 0;
+                  flex: 1;
+                  display: inline-block;
+                  flex-flow: column nowrap;
+                  padding: 0 0 0 ${space[5]}px;
+                  margin: 0;
+                  padding: 0 0 0 ${space[5]}px;
+                }
+                ul:last-of-type {
+                  margin-bottom: ${space[5]}px;
+                }
+              `}
+            >
+              <>
+                <span css={keyCss}>Next payment date</span>
+                <span css={valueCss}>
+                  {formatDate(subscription.nextPaymentDate)}
+                </span>
+              </>
+            </div>
+          </div>
         )}
-        <div>{newPaymentMethodDetail.updatedSuccessExtras}</div>
-      </>
+      </div>
     );
   }
 
@@ -74,51 +304,49 @@ const ConfirmedNewPaymentDetailsRenderer = ({
 
 interface PaymentMethodUpdatedProps {
   subs: WithSubscription[] | {};
-  productType: ProductType;
   newPaymentMethodDetail: NewPaymentMethodDetail;
   previousProductDetail: ProductDetail;
-  flowReferrer?: { title: string; link: string };
 }
 
 const PaymentMethodUpdated = ({
   subs,
-  productType,
   newPaymentMethodDetail,
-  previousProductDetail,
-  flowReferrer
+  previousProductDetail
 }: PaymentMethodUpdatedProps) =>
   Array.isArray(subs) && subs.length === 1 ? (
     <>
-      <h1>Your payment details were updated successfully</h1>
+      <h1
+        css={css`
+          margin: ${space[9]}px 0 ${space[5]}px 0;
+          ${textSans.large({ fontWeight: "bold" })};
+        `}
+      >
+        Your payment details were updated successfully
+      </h1>
       <ConfirmedNewPaymentDetailsRenderer
         subscription={subs[0].subscription}
         newPaymentMethodDetail={newPaymentMethodDetail}
         previousProductDetail={previousProductDetail}
       />
-      <h2>Thank you. You are helping to support independent journalism.</h2>
-      <div>
-        {flowReferrer?.title === NAV_LINKS.billing.title ? (
-          <LinkButton
-            to={flowReferrer?.link}
-            text="Return to your billing"
-            colour={neutral[100]}
-            textColour={neutral[0]}
-            hollow
-            left
-          />
-        ) : (
-          <LinkButton
-            to={"/" + productType.urlPart}
-            text={"Manage your " + productType.friendlyName}
-            primary
-            right
-          />
-        )}
-      </div>
+      <h2
+        css={css`
+          margin-bottom: 0;
+
+          ${textSans.large({ fontWeight: "bold" })};
+        `}
+      >
+        Thank you
+      </h2>
+      <span> You are helping to support independent journalism.</span>
       <div css={{ marginTop: "20px" }}>
-        <a href="https://www.theguardian.com">
-          <Button text="Explore The Guardian" primary right />
-        </a>
+        <LinkButton
+          to="/"
+          text="Back to Account overview"
+          colour={brand[400]}
+          textColour={neutral[100]}
+          fontWeight="bold"
+          right
+        />
       </div>
     </>
   ) : (
@@ -144,10 +372,8 @@ export const PaymentUpdated = (props: RouteableStepProps) => {
                   <WizardStep routeableStepProps={props}>
                     <PaymentMethodUpdated
                       subs={newSubscriptionData}
-                      productType={props.productType}
                       newPaymentMethodDetail={newPaymentMethodDetail}
                       previousProductDetail={previousProductDetail}
-                      flowReferrer={props.location?.state?.flowReferrer}
                     />
                   </WizardStep>
                 )}

--- a/app/client/components/payment/update/paymentUpdated.tsx
+++ b/app/client/components/payment/update/paymentUpdated.tsx
@@ -75,9 +75,6 @@ export const ConfirmedNewPaymentDetailsRenderer = ({
   newPaymentMethodDetail,
   previousProductDetail
 }: ConfirmedNewPaymentDetailsRendererProps) => {
-  console.log(subscription);
-  console.log(newPaymentMethodDetail);
-  console.log(previousProductDetail);
   const mainPlan = getMainPlan(subscription);
   const groupedProductType =
     GROUPED_PRODUCT_TYPES[previousProductDetail.mmaCategory];

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -52,6 +52,8 @@ export interface ProductDetail extends WithSubscription {
   isTestUser: boolean; // THIS IS NOT PART OF THE members-data-api RESPONSE (but inferred from a header)
   isPaidTier: boolean;
   regNumber?: string;
+  optIn?: boolean;
+  key?: string;
   tier: string;
   joinDate: string;
   mmaCategory: GroupedProductTypeKeys;
@@ -113,7 +115,7 @@ export interface PaidSubscriptionPlan
     CurrencyAndIntervalDetail {
   start: string;
   end: string;
-  chargedThrough?: string;
+  chargedThrough?: string | null;
   amount: number;
 }
 
@@ -137,6 +139,8 @@ export interface DeliveryAddress {
 type ReaderType = "Gift" | "Direct" | "Agent" | "Complementary";
 
 export interface Subscription {
+  accountId?: string;
+  subscriberId?: string; // this has not been removed from the backend yet
   subscriptionId: string;
   start?: string;
   end: string;
@@ -155,12 +159,16 @@ export interface Subscription {
   mandate?: DirectDebitDetails;
   sepaMandate?: SepaDetails;
   autoRenew: boolean;
-  currentPlans: SubscriptionPlan[];
-  futurePlans: SubscriptionPlan[];
+  plan?: any;
+  currentPlans: (SubscriptionPlan | PaidSubscriptionPlan)[];
+  futurePlans: (SubscriptionPlan | PaidSubscriptionPlan)[];
   trialLength: number;
   readerType: ReaderType;
   deliveryAddress?: DeliveryAddress;
   contactId?: string;
+  account?: {
+    accountName: string;
+  };
   // THIS IS NOT PART OF THE members-data-api RESPONSE (it's injected server-side - see server/routes/api.ts)
   deliveryAddressChangeEffectiveDate?: string;
   cancellationEffectiveDate?: string;


### PR DESCRIPTION
****NOTE: I recommend merging the two-step-flow PR first**

## What does this change?

This is the new confirmation page when updating a payment method. Only styles and some refactoring of the JSX has been changed. Currently, the page looks different when the user recovers an expired payment method, and shows the message "We will take the outstanding payment within 24 hours, using your new card details." This is currently being re-thought and re-designed, so I will update this page when we've received reviewed designs.

<img width="407" alt="Screenshot 2021-12-02 at 17 06 40" src="https://user-images.githubusercontent.com/91546670/144576767-7644297e-ba01-4d90-83d8-55c88693d5fc.png">

## How to test

Click on 'manage payment method' on a subscription in account overview. Use card number '4242 4242 4242 4242' to test successful payments. Stripe has many test numbers to test different error states and also 3D Secure/2 factor authentication: https://stripe.com/docs/testing. For Direct Debit, use account number 55779911 and sort code 200000 to test. 

I've included some integration tests. I've manually copy/pasted subscription objects to the test files. I recommend we create a utility file where we export a variety of different subscriptions and payment methods to easily use in our test files.