### PR TITLE
log stripe public keys fetched from AWS

### DIFF
--- a/app/server/routes/frontendCommon.ts
+++ b/app/server/routes/frontendCommon.ts
@@ -2,6 +2,7 @@ import * as Sentry from "@sentry/node";
 import { conf, Environments } from "../config";
 import { log } from "../log";
 import { recaptchaConfigPromise } from "../recaptchaConfig";
+import { stripePublicKeysPromise } from "../stripeSetupIntentConfig";
 
 export const clientDSN =
   conf.ENVIRONMENT === Environments.PRODUCTION && conf.CLIENT_DSN
@@ -24,6 +25,26 @@ export const getRecaptchaPublicKey = async () => {
   } catch (err) {
     log.error(
       "could not provide recaptcha public key to client, client-side errors will ensue",
+      err
+    );
+    Sentry.captureException(err);
+  }
+};
+
+export const getStripePublicKeys = async () => {
+  try {
+    const stripePublicKeys = await stripePublicKeysPromise;
+
+    Sentry.captureException(`stripe public key is '${stripePublicKeys}'`);
+
+    if (!stripePublicKeys) {
+      throw new Error(`stripe public key is '${stripePublicKeys}'`);
+    }
+
+    return stripePublicKeys;
+  } catch (err) {
+    log.error(
+      "could not provide stripe public key to client, client-side errors may ensue when attempting to switch to card payment method",
       err
     );
     Sentry.captureException(err);

--- a/app/server/routes/mmaFrontend.ts
+++ b/app/server/routes/mmaFrontend.ts
@@ -2,7 +2,11 @@ import { Request, Response, Router } from "express";
 import { conf } from "../config";
 import html from "../html";
 import { withIdentity } from "../middleware/identityMiddleware";
-import { clientDSN, getRecaptchaPublicKey } from "./frontendCommon";
+import {
+  clientDSN,
+  getRecaptchaPublicKey,
+  getStripePublicKeys,
+} from "./frontendCommon";
 
 const router = Router();
 
@@ -18,8 +22,9 @@ router.use(withIdentity(), async (_: Request, res: Response) => {
         domain: conf.DOMAIN,
         dsn: clientDSN,
         identityDetails: res.locals.identity,
-        recaptchaPublicKey: await getRecaptchaPublicKey()
-      }
+        recaptchaPublicKey: await getRecaptchaPublicKey(),
+        ...(await getStripePublicKeys()),
+      },
     })
   );
 });

--- a/app/server/stripeSetupIntentConfig.ts
+++ b/app/server/stripeSetupIntentConfig.ts
@@ -1,13 +1,22 @@
 import { s3ConfigPromise } from "./awsIntegration";
-
 interface StripePublicToSecretKeyMapping {
   [publicKey: string]: string;
 }
+export interface StripePublicKeySet {
+  uat: string;
+  default: string;
+}
+export interface StripePublicKeys {
+  stripeKeyAustralia: StripePublicKeySet;
+  stripeKeyDefaultCurrencies: StripePublicKeySet;
+}
 
+// The first key from this object is the Australian/AUD one, the second key is for rest of the world
 export const stripeSetupIntentConfigPromise: Promise<
   StripePublicToSecretKeyMapping | undefined
 > = s3ConfigPromise<StripePublicToSecretKeyMapping>()(
   "stripe-public-to-private-key-mapping"
 );
 
-
+export const stripePublicKeysPromise: Promise<StripePublicKeys | undefined> =
+  s3ConfigPromise<StripePublicKeys>()("stripe-public-keys");


### PR DESCRIPTION
## What does this change?

Logging Stripe keys fetched from AWS as we believe they are not being returned properly.
