### PR TITLE
Expired Recaptcha bug fix on card form

### DIFF
--- a/app/client/components/payment/update/card/Recaptcha.tsx
+++ b/app/client/components/payment/update/card/Recaptcha.tsx
@@ -13,17 +13,17 @@ declare let window: Window & {
 const hrefStyle = {
   textDecoration: "underline",
   color: "inherit",
-  ":visited": { color: "inherit" }
+  ":visited": { color: "inherit" },
 };
 
 export interface RecaptchaProps {
   setStripeSetupIntent: (_: null) => void;
-  setRecaptchaToken: (_: string) => void;
+  setRecaptchaToken: (_: string | undefined) => void;
 }
 
 export default function Recaptcha({
   setStripeSetupIntent,
-  setRecaptchaToken
+  setRecaptchaToken,
 }: RecaptchaProps) {
   useEffect(() => {
     if (window.grecaptcha) {
@@ -40,11 +40,16 @@ export default function Recaptcha({
     }
   }, []);
 
+  const resetRecaptcha = () => {
+    setStripeSetupIntent(null);
+    setRecaptchaToken(undefined);
+  };
+
   const renderReCaptcha = () => {
     window.grecaptcha.render("recaptcha", {
       sitekey: window.guardian?.recaptchaPublicKey,
       callback: (recaptchaToken: string) => setRecaptchaToken(recaptchaToken),
-      "expired-callback": () => setStripeSetupIntent(null)
+      "expired-callback": resetRecaptcha,
     });
   };
 
@@ -59,7 +64,7 @@ export default function Recaptcha({
       </span>
       <div
         css={{
-          marginTop: "4px"
+          marginTop: "4px",
         }}
         id="recaptcha"
       />

--- a/app/client/components/payment/update/card/Recaptcha.tsx
+++ b/app/client/components/payment/update/card/Recaptcha.tsx
@@ -13,7 +13,7 @@ declare let window: Window & {
 const hrefStyle = {
   textDecoration: "underline",
   color: "inherit",
-  ":visited": { color: "inherit" },
+  ":visited": { color: "inherit" }
 };
 
 export interface RecaptchaProps {
@@ -23,7 +23,7 @@ export interface RecaptchaProps {
 
 export default function Recaptcha({
   setStripeSetupIntent,
-  setRecaptchaToken,
+  setRecaptchaToken
 }: RecaptchaProps) {
   useEffect(() => {
     if (window.grecaptcha) {
@@ -49,7 +49,7 @@ export default function Recaptcha({
     window.grecaptcha.render("recaptcha", {
       sitekey: window.guardian?.recaptchaPublicKey,
       callback: (recaptchaToken: string) => setRecaptchaToken(recaptchaToken),
-      "expired-callback": resetRecaptcha,
+      "expired-callback": resetRecaptcha
     });
   };
 
@@ -64,7 +64,7 @@ export default function Recaptcha({
       </span>
       <div
         css={{
-          marginTop: "4px",
+          marginTop: "4px"
         }}
         id="recaptcha"
       />


### PR DESCRIPTION
## What does this change?

I noticed I was not removing the recaptcha token state upon expiry. This means that if the Recaptcha has expired after two minutes, and the user does not complete it, the generic error screen is shown and they have to refresh the page:

<img width="942" alt="Screenshot 2021-12-23 at 10 03 26" src="https://user-images.githubusercontent.com/91546670/147217104-625dfcf3-2db2-42da-a2f4-0e8afe41fb4a.png">

I've checked Sentry and fortunately this has only happened once over the last day it has been deployed. 

<img width="1506" alt="Screenshot 2021-12-23 at 09 59 57" src="https://user-images.githubusercontent.com/91546670/147217217-a0292a3f-127a-41c1-9b52-91476b64d443.png">

Link to the Sentry exception: https://sentry.io/organizations/the-guardian/issues/2875657110/?environment=theguardian.com&project=1208603&query=is%3Aunresolved

Have tested this manually and it correctly shows the 'Recaptcha has not been completed' error message.
