### PR TITLE
Recovery message added to payments confirmation screen

### DIFF
--- a/app/client/components/payment/update/Summary.tsx
+++ b/app/client/components/payment/update/Summary.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import { Props } from "@guardian/src-helpers";
 import { css, SerializedStyles } from "@emotion/core";
-import { space } from "@guardian/src-foundations";
+import { space, brand as brandColors, text } from "@guardian/src-foundations";
 import { size } from "@guardian/src-foundations/size";
 import { textSans } from "@guardian/src-foundations/typography";
 import { error as errorColors } from "@guardian/src-foundations";
 import { SvgAlertTriangle } from "@guardian/src-icons";
+import { SvgInfo } from "@guardian/src-icons";
 
 interface SummaryProps extends Props {
   /**
@@ -44,8 +45,8 @@ const iconStyles = (color: string): SerializedStyles => css`
 `;
 
 const messageStyles = (color: string, isBold = true): SerializedStyles => css`
-	${textSans.medium({ fontWeight: isBold ? "bold" : "regular" })}
-	color: ${color};
+  ${textSans.medium({ fontWeight: isBold ? "bold" : "regular" })}
+  color: ${color};
 `;
 
 const messageWrapperStyles = css`
@@ -56,7 +57,7 @@ const contextStyles = css`
   ${textSans.medium()}
 `;
 
-const ErrorSummary = ({
+export const ErrorSummary = ({
   message,
   errorReportUrl,
   context,
@@ -79,4 +80,21 @@ const ErrorSummary = ({
   </div>
 );
 
-export default ErrorSummary;
+export type InfoSummaryProps = SummaryProps;
+
+export const InfoSummary = ({
+  message,
+  context,
+  cssOverrides,
+  ...props
+}: InfoSummaryProps): JSX.Element => (
+  <div css={[wrapperStyles(brandColors[500]), cssOverrides]} {...props}>
+    <div css={iconStyles(brandColors[500])}>
+      <SvgInfo />
+    </div>
+    <div css={messageWrapperStyles}>
+      <div css={messageStyles(text.primary)}>{message}</div>
+      {context && <div css={contextStyles}>{context}</div>}
+    </div>
+  </div>
+);

--- a/app/client/components/payment/update/card/stripeCardInputForm.tsx
+++ b/app/client/components/payment/update/card/stripeCardInputForm.tsx
@@ -23,7 +23,7 @@ import {
 } from "./newCardPaymentMethodDetail";
 import Recaptcha from "./Recaptcha";
 import { LoadingCircleIcon } from "../../../svgs/loadingCircleIcon";
-import ErrorSummary from "../ErrorSummary";
+import { ErrorSummary } from "../Summary";
 export interface StripeSetupIntentDetails {
   stripeSetupIntent?: StripeSetupIntent;
   stripeSetupIntentError?: Error;

--- a/app/client/components/payment/update/dd/directDebitInputForm.tsx
+++ b/app/client/components/payment/update/dd/directDebitInputForm.tsx
@@ -13,7 +13,7 @@ import { NewDirectDebitPaymentMethodDetail } from "./newDirectDebitPaymentMethod
 import { processResponse } from "../../../../utils";
 // import { SvgArrowRightStraight } from "@guardian/src-icons/arrow-right-straight";
 import { minWidth } from "../../../../styles/breakpoints";
-import ErrorSummary from "../ErrorSummary";
+import { ErrorSummary } from "../Summary";
 
 const inputBoxBaseStyle = {
   width: "100%",
@@ -23,20 +23,20 @@ const inputBoxBaseStyle = {
   border: "none",
   outline: "none",
   "::placeholder": {
-    color: "#c4c4c4"
+    color: "#c4c4c4",
   },
   ":-ms-input-placeholder": {
-    color: "#c4c4c4"
-  }
+    color: "#c4c4c4",
+  },
 };
 
 const bulletsStyling = {
   "::placeholder": {
-    fontSize: "14px"
+    fontSize: "14px",
   },
   ":-ms-input-placeholder": {
-    fontSize: "14px"
-  }
+    fontSize: "14px",
+  },
 };
 
 interface DirectDebitValidationResponse {
@@ -56,9 +56,8 @@ interface DirectDebitUpdateFormProps {
 export const DirectDebitInputForm = (props: DirectDebitUpdateFormProps) => {
   const [isValidating, setIsValidating] = useState<boolean>(false);
 
-  const [soleAccountHolderConfirmed, setSoleAccountHolderConfirmed] = useState<
-    boolean
-  >(false);
+  const [soleAccountHolderConfirmed, setSoleAccountHolderConfirmed] =
+    useState<boolean>(false);
   const [accountName, setAccountName] = useState<string>("");
   const [accountNumber, setAccountNumber] = useState<string>("");
   const [sortCode, setSortCode] = useState<string>("");
@@ -75,9 +74,9 @@ export const DirectDebitInputForm = (props: DirectDebitUpdateFormProps) => {
           method: "POST",
           body: JSON.stringify({
             accountNumber,
-            sortCode: cleanSortCode(sortCode)
+            sortCode: cleanSortCode(sortCode),
           }),
-          headers: { "Content-Type": "application/json" }
+          headers: { "Content-Type": "application/json" },
         }
       );
       const response = await processResponse<DirectDebitValidationResponse>(
@@ -110,7 +109,7 @@ export const DirectDebitInputForm = (props: DirectDebitUpdateFormProps) => {
     const newPaymentMethod = new NewDirectDebitPaymentMethodDetail({
       accountName,
       accountNumber,
-      sortCode
+      sortCode,
     });
 
     props.newPaymentMethodDetailUpdater(newPaymentMethod);
@@ -197,7 +196,7 @@ export const DirectDebitInputForm = (props: DirectDebitUpdateFormProps) => {
         </FieldWrapper>{" "}
       </div>
       <Checkbox
-        onChange={newValue => setSoleAccountHolderConfirmed(newValue)}
+        onChange={(newValue) => setSoleAccountHolderConfirmed(newValue)}
         checked={soleAccountHolderConfirmed}
         label="I confirm that I am the account holder and I am solely able to authorise debit from the account"
         required
@@ -238,14 +237,12 @@ export const DirectDebitInputForm = (props: DirectDebitUpdateFormProps) => {
           <div
             css={{
               marginTop: `${space[9]}px`,
-              marginBottom: `${space[9]}px`
+              marginBottom: `${space[9]}px`,
             }}
           >
             <ErrorSummary message={error} />
           </div>
-        ) : (
-          undefined
-        )}
+        ) : undefined}
       </div>
     </div>
   );

--- a/app/client/components/payment/update/paymentUpdated.tsx
+++ b/app/client/components/payment/update/paymentUpdated.tsx
@@ -335,7 +335,7 @@ export const PaymentMethodUpdated = ({
         Your payment details were updated successfully
       </h1>
 
-      {!!previousProductDetail.alertText &&
+      {previousProductDetail.alertText &&
         newPaymentMethodDetail.paymentFailureRecoveryMessage && (
           <InfoSummary
             context=""

--- a/app/client/components/payment/update/paymentUpdated.tsx
+++ b/app/client/components/payment/update/paymentUpdated.tsx
@@ -1,6 +1,7 @@
 import { css } from "@emotion/core";
 import { space } from "@guardian/src-foundations";
-import { brand, neutral, news } from "@guardian/src-foundations/palette";
+import { brand, neutral } from "@guardian/src-foundations/palette";
+import { headline } from "@guardian/src-foundations/typography";
 import { maxWidth, minWidth } from "../../../styles/breakpoints";
 import React from "react";
 import {
@@ -11,7 +12,7 @@ import {
   MembersDataApiItemContext,
   ProductDetail,
   Subscription,
-  WithSubscription
+  WithSubscription,
 } from "../../../../shared/productResponse";
 import { GROUPED_PRODUCT_TYPES } from "../../../../shared/productTypes";
 import { LinkButton } from "../../buttons";
@@ -20,12 +21,12 @@ import {
   ReturnToAccountOverviewButton,
   RouteableStepProps,
   visuallyNavigateToParent,
-  WizardStep
+  WizardStep,
 } from "../../wizardRouterAdapter";
 import {
   isNewPaymentMethodDetail,
   NewPaymentMethodContext,
-  NewPaymentMethodDetail
+  NewPaymentMethodDetail,
 } from "./newPaymentMethodDetail";
 import { NewSubscriptionContext } from "./newSubscriptionDetail";
 import { textSans } from "@guardian/src-foundations/typography";
@@ -33,7 +34,7 @@ import { CardDisplay } from "../cardDisplay";
 import { DirectDebitDisplay } from "../directDebitDisplay";
 import { PayPalDisplay } from "../paypalDisplay";
 import { SepaDisplay } from "../sepaDisplay";
-
+import { InfoSummary } from "./Summary";
 interface ConfirmedNewPaymentDetailsRendererProps {
   subscription: Subscription;
   newPaymentMethodDetail: NewPaymentMethodDetail;
@@ -70,6 +71,18 @@ const valueCss = css`
   }
 `;
 
+const subHeadingCss = `
+      border-top: 1px solid ${neutral["86"]};
+      ${headline.small()};
+      font-weight: bold;
+      margin-top: ${space[9]}px;
+
+      ${maxWidth.tablet} {
+        font-size: 1.25rem;
+        line-height: 1.6;
+      };
+    `;
+
 function getPaymentInterval(interval: string) {
   if (interval === "year") {
     return "annual";
@@ -81,7 +94,7 @@ function getPaymentInterval(interval: string) {
 export const ConfirmedNewPaymentDetailsRenderer = ({
   subscription,
   newPaymentMethodDetail,
-  previousProductDetail
+  previousProductDetail,
 }: ConfirmedNewPaymentDetailsRendererProps) => {
   const mainPlan = getMainPlan(subscription);
   const groupedProductType =
@@ -89,8 +102,6 @@ export const ConfirmedNewPaymentDetailsRenderer = ({
   const specificProductType = groupedProductType.mapGroupedToSpecific(
     previousProductDetail
   );
-
-  const hasPaymentFailure: boolean = !!previousProductDetail.alertText;
 
   if (
     newPaymentMethodDetail.subHasExpectedPaymentType(subscription) &&
@@ -219,7 +230,7 @@ export const ConfirmedNewPaymentDetailsRenderer = ({
                   <span
                     css={css`
                       ${valueCss};
-                      color: ${hasPaymentFailure ? news[400] : neutral[7]};
+                      color: ${neutral[7]};
                     `}
                   >
                     {subscription.card.expiry.month} /{" "}
@@ -309,37 +320,51 @@ interface PaymentMethodUpdatedProps {
   previousProductDetail: ProductDetail;
 }
 
-const PaymentMethodUpdated = ({
+export const PaymentMethodUpdated = ({
   subs,
   newPaymentMethodDetail,
-  previousProductDetail
+  previousProductDetail,
 }: PaymentMethodUpdatedProps) =>
   Array.isArray(subs) && subs.length === 1 ? (
     <>
       <h1
         css={css`
-          margin: ${space[9]}px 0 ${space[5]}px 0;
-          ${textSans.large({ fontWeight: "bold" })};
+          ${subHeadingCss}
         `}
       >
         Your payment details were updated successfully
       </h1>
+
+      {!!previousProductDetail.alertText &&
+        newPaymentMethodDetail.paymentFailureRecoveryMessage && (
+          <InfoSummary
+            context=""
+            message={newPaymentMethodDetail.paymentFailureRecoveryMessage}
+            cssOverrides={css`
+              margin-bottom: ${space[6]}px;
+            `}
+          />
+        )}
+
       <ConfirmedNewPaymentDetailsRenderer
         subscription={subs[0].subscription}
         newPaymentMethodDetail={newPaymentMethodDetail}
         previousProductDetail={previousProductDetail}
       />
+
       <h2
         css={css`
-          margin-bottom: 0;
-
-          ${textSans.large({ fontWeight: "bold" })};
+          margin-top: ${space[9]}px;
+          margin-bottom: ${space[1]}px;
+          line-height: 1;
+          font-weight: bold;
+          font-size: 1.75rem;
         `}
       >
         Thank you
       </h2>
       <span> You are helping to support independent journalism.</span>
-      <div css={{ marginTop: "20px" }}>
+      <div css={{ marginTop: `${space[9]}px` }}>
         <LinkButton
           to="/"
           text="Back to Account overview"
@@ -353,8 +378,9 @@ const PaymentMethodUpdated = ({
   ) : (
     <>
       <GenericErrorScreen
-        loggingMessage={`${Array.isArray(subs) &&
-          subs.length} subs returned when one was expected`}
+        loggingMessage={`${
+          Array.isArray(subs) && subs.length
+        } subs returned when one was expected`}
       />
       <ReturnToAccountOverviewButton />
     </>
@@ -363,13 +389,13 @@ const PaymentMethodUpdated = ({
 export const PaymentUpdated = (props: RouteableStepProps) => {
   return (
     <MembersDataApiItemContext.Consumer>
-      {previousProductDetail => (
+      {(previousProductDetail) => (
         <NewPaymentMethodContext.Consumer>
-          {newPaymentMethodDetail =>
+          {(newPaymentMethodDetail) =>
             isNewPaymentMethodDetail(newPaymentMethodDetail) &&
             isProduct(previousProductDetail) ? (
               <NewSubscriptionContext.Consumer>
-                {newSubscriptionData => (
+                {(newSubscriptionData) => (
                   <WizardStep routeableStepProps={props}>
                     <PaymentMethodUpdated
                       subs={newSubscriptionData}

--- a/app/client/components/payment/update/updatePaymentFlow.tsx
+++ b/app/client/components/payment/update/updatePaymentFlow.tsx
@@ -37,7 +37,7 @@ import { createProductDetailFetch } from "../../../productUtils";
 import { NewSubscriptionContext } from "./newSubscriptionDetail";
 import { processResponse } from "../../../utils";
 import { trackEvent } from "../../analytics";
-import ErrorSummary from "./ErrorSummary";
+import { ErrorSummary } from "./Summary";
 import { DirectDebitLogo } from "../directDebitLogo";
 import { cardTypeToSVG } from "../cardDisplay";
 import ContactUs from "./ContactUs";


### PR DESCRIPTION
## What does this change?

<img width="1049" alt="Screenshot 2021-12-23 at 17 46 49" src="https://user-images.githubusercontent.com/91546670/147345328-349d41bf-7532-400d-b83b-c3d9712320c8.png">

The recovery message has been added back into the confirmation page. This message wasn't included in the initial deploy as UX work was being done on it, but has now been added back in. Previous code showing this message found here: https://github.com/guardian/manage-frontend/blob/15fe3b15c6597575c918cc62ae45f59586bc17f2/app/client/components/payment/update/paymentUpdated.tsx#L56
