### PR TITLE
Fake date to avoid failure each new year

### DIFF
--- a/app/client/__tests__/__snapshots__/main.tsx.snap
+++ b/app/client/__tests__/__snapshots__/main.tsx.snap
@@ -1342,7 +1342,7 @@ exports[`Main renders something 1`] = `
               }
             >
               © 
-              2021
+              2022
                Guardian News and Media Limited or its affiliated companies. All rights reserved.
             </div>
           </div>

--- a/app/client/__tests__/main.tsx
+++ b/app/client/__tests__/main.tsx
@@ -1,20 +1,27 @@
-import "dom-testing-library/extend-expect";
 import React from "react";
-
 import serializer from "jest-emotion";
+import renderer from "react-test-renderer";
+import { Main } from "../components/main";
 
 expect.addSnapshotSerializer(serializer);
 
-import renderer from "react-test-renderer";
+describe("Main", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2022-01-01"));
+  });
 
-import { Main } from "../components/main";
+  afterEach(() => {
+    jest.useRealTimers();
+  });
 
-test("Main renders something", () => {
-  const rendered = renderer.create(
-    <Main>
-      <p>hi</p>
-    </Main>
-  );
+  it("renders something", () => {
+    const rendered = renderer.create(
+      <Main>
+        <p>hi</p>
+      </Main>
+    );
 
-  expect(rendered.toJSON()).toMatchSnapshot();
+    expect(rendered.toJSON()).toMatchSnapshot();
+  });
 });

--- a/app/client/components/footer/footer.tsx
+++ b/app/client/components/footer/footer.tsx
@@ -8,8 +8,6 @@ import { headline } from "../../styles/fonts";
 import { SupportTheGuardianButton } from "../supportTheGuardianButton";
 import { footerLinks } from "./footerlinks";
 
-const TODAY = new Date();
-
 const footerColourStyles = css`
   background-color: ${palette.blue.header};
   color: ${palette.white};
@@ -195,6 +193,8 @@ const fillEmailSignup = (_: SyntheticEvent<HTMLIFrameElement>) => {
 };
 
 export const Footer = () => {
+  const TODAY = new Date(Date.now());
+
   const [isInUSA, setIsInUSA] = useState<boolean>(false);
   const [importedCmp, setImportedCmp] = useState<CMP | null>(null);
 
@@ -224,7 +224,7 @@ export const Footer = () => {
                   data-form-success-desc="We will send you our picks of the most important headlines tomorrow morning."
                   data-node-uid="2"
                   height="86px"
-                  onLoad={emailForm => fillEmailSignup(emailForm)}
+                  onLoad={(emailForm) => fillEmailSignup(emailForm)}
                   css={emailSignUpIframeStyles}
                 />
               </div>
@@ -240,9 +240,9 @@ export const Footer = () => {
                               href: "#",
                               onClick: () => {
                                 importedCmp?.showPrivacyManager();
-                              }
+                              },
                             }
-                          : { href: link })
+                          : { href: link }),
                       };
 
                       return (


### PR DESCRIPTION
## What does this change?

Fakes the current date when testing the `<Main>` component as this renders the `<Footer>` component which displays a copyright message with the current year. This is implicitly tested via a snapshot test so failed as the year rolled over to 2022. Faking the date will prevent this failing next year (and in subsequent years).

## Images

<img width="490" alt="Screenshot 2022-01-04 at 17 39 01" src="https://user-images.githubusercontent.com/1166188/148100756-8ad514b5-b154-4dfb-8b88-f2f1d2506757.png">

