### PR TITLE
Payments form style updates

### DIFF
--- a/app/client/components/payment/update/CurrentPaymentDetail.tsx
+++ b/app/client/components/payment/update/CurrentPaymentDetail.tsx
@@ -66,7 +66,7 @@ const CurrentPaymentDetails = (props: ProductDetail) => {
     <div
       css={css`
         border: 1px solid ${neutral[86]};
-        margin-bottom: ${space[6]}px;
+        margin-bottom: ${space[4]}px;
       `}
     >
       <div

--- a/app/client/components/payment/update/card/stripeCardInputForm.tsx
+++ b/app/client/components/payment/update/card/stripeCardInputForm.tsx
@@ -76,7 +76,16 @@ export const StripeCardInputForm = (props: StripeCardInputFormProps) => {
           const sentenceEnd = sentence.includes(".") ? "" : ".";
 
           return (
-            <div key={index}>
+            <div
+              key={index}
+              css={css`
+                margin-top: ${space[4]}px;
+
+                :first-of-type {
+                  margin-top: 0;
+                }
+              `}
+            >
               <ErrorSummary message={sentence + sentenceEnd} />
             </div>
           );

--- a/app/client/components/payment/update/dd/directDebitInputForm.tsx
+++ b/app/client/components/payment/update/dd/directDebitInputForm.tsx
@@ -4,7 +4,7 @@ import { maxWidth } from "../../../../styles/breakpoints";
 import { space } from "@guardian/src-foundations";
 import { sans } from "../../../../styles/fonts";
 import { Button } from "@guardian/src-button";
-import { Checkbox } from "../../../checkbox";
+import { Checkbox } from "@guardian/src-checkbox";
 import { cleanSortCode } from "../../directDebitDisplay";
 import { FieldWrapper } from "../fieldWrapper";
 import { NewPaymentMethodDetail } from "../newPaymentMethodDetail";
@@ -155,7 +155,7 @@ export const DirectDebitInputForm = (props: DirectDebitUpdateFormProps) => {
         css={css`
           display: flex;
           justify-content: flex-start;
-          margin-bottom: ${space[3]}px;
+          margin-bottom: 10px;
 
           ${minWidth.tablet} {
             margin-top: ${space[4]}px;
@@ -195,11 +195,22 @@ export const DirectDebitInputForm = (props: DirectDebitUpdateFormProps) => {
           />
         </FieldWrapper>{" "}
       </div>
+
       <Checkbox
-        onChange={(newValue) => setSoleAccountHolderConfirmed(newValue)}
+        onChange={(e) => setSoleAccountHolderConfirmed(e.target.checked)}
         checked={soleAccountHolderConfirmed}
         label="I confirm that I am the account holder and I am solely able to authorise debit from the account"
         required
+        value="I confirm that I am the account holder and I am solely able to authorise debit from the account"
+        cssOverrides={css`
+          div {
+            padding: 10px 0;
+          }
+
+          :focus {
+            box-shadow: none !important;
+          }
+        `}
       />
 
       <DirectDebitLegal />

--- a/app/client/components/payment/update/dd/directDebitInputForm.tsx
+++ b/app/client/components/payment/update/dd/directDebitInputForm.tsx
@@ -210,11 +210,6 @@ export const DirectDebitInputForm = (props: DirectDebitUpdateFormProps) => {
           label="I confirm that I am the account holder and I am solely able to authorise debit from the account"
           required
           value="I confirm that I am the account holder and I am solely able to authorise debit from the account"
-          cssOverrides={css`
-            :focus {
-              box-shadow: none !important;
-            }
-          `}
         />
       </div>
 

--- a/app/client/components/payment/update/dd/directDebitInputForm.tsx
+++ b/app/client/components/payment/update/dd/directDebitInputForm.tsx
@@ -210,6 +210,11 @@ export const DirectDebitInputForm = (props: DirectDebitUpdateFormProps) => {
           label="I confirm that I am the account holder and I am solely able to authorise debit from the account"
           required
           value="I confirm that I am the account holder and I am solely able to authorise debit from the account"
+          cssOverrides={css`
+            & + span {
+              top: calc(50% - 8px);
+            }
+          `}
         />
       </div>
 

--- a/app/client/components/payment/update/dd/directDebitInputForm.tsx
+++ b/app/client/components/payment/update/dd/directDebitInputForm.tsx
@@ -155,7 +155,6 @@ export const DirectDebitInputForm = (props: DirectDebitUpdateFormProps) => {
         css={css`
           display: flex;
           justify-content: flex-start;
-          margin-bottom: 10px;
 
           ${minWidth.tablet} {
             margin-top: ${space[4]}px;
@@ -196,22 +195,28 @@ export const DirectDebitInputForm = (props: DirectDebitUpdateFormProps) => {
         </FieldWrapper>{" "}
       </div>
 
-      <Checkbox
-        onChange={(e) => setSoleAccountHolderConfirmed(e.target.checked)}
-        checked={soleAccountHolderConfirmed}
-        label="I confirm that I am the account holder and I am solely able to authorise debit from the account"
-        required
-        value="I confirm that I am the account holder and I am solely able to authorise debit from the account"
-        cssOverrides={css`
-          div {
-            padding: 10px 0;
-          }
+      <div
+        css={css`
+          margin: 14px 0;
 
-          :focus {
-            box-shadow: none !important;
+          ${minWidth.tablet} {
+            margin: 4px 0;
           }
         `}
-      />
+      >
+        <Checkbox
+          onChange={(e) => setSoleAccountHolderConfirmed(e.target.checked)}
+          checked={soleAccountHolderConfirmed}
+          label="I confirm that I am the account holder and I am solely able to authorise debit from the account"
+          required
+          value="I confirm that I am the account holder and I am solely able to authorise debit from the account"
+          cssOverrides={css`
+            :focus {
+              box-shadow: none !important;
+            }
+          `}
+        />
+      </div>
 
       <DirectDebitLegal />
 

--- a/app/client/components/payment/update/dd/directDebitLegal.tsx
+++ b/app/client/components/payment/update/dd/directDebitLegal.tsx
@@ -6,7 +6,7 @@ import { neutral } from "@guardian/src-foundations/palette";
 const hrefStyle = {
   color: palette.neutral["3"],
   textDecoration: "underline",
-  cursor: "pointer"
+  cursor: "pointer",
 };
 
 const baseStyle = {
@@ -14,7 +14,7 @@ const baseStyle = {
   fontSize: "12px",
   fontFamily: sans,
   flexGrow: 1,
-  marginTop: "25px"
+  marginTop: "10px",
 };
 
 export class GoCardlessGuarantee extends React.Component<
@@ -22,7 +22,7 @@ export class GoCardlessGuarantee extends React.Component<
   { expanded: boolean }
 > {
   public state = {
-    expanded: false
+    expanded: false,
   };
 
   public render(): React.ReactNode {
@@ -40,7 +40,7 @@ export class GoCardlessGuarantee extends React.Component<
         <ul
           css={{
             display: this.state.expanded ? "block" : "none",
-            paddingLeft: "30px"
+            paddingLeft: "30px",
           }}
         >
           <li>
@@ -80,7 +80,7 @@ export class GoCardlessGuarantee extends React.Component<
 
   private toggleGuaranteeDisplay = () =>
     this.setState({
-      expanded: !this.state.expanded
+      expanded: !this.state.expanded,
     });
 }
 
@@ -92,7 +92,7 @@ export const DirectDebitLegal = (props: DirectDebitLegalProps) => (
   <div
     css={{
       ...baseStyle,
-      maxWidth: "590px"
+      maxWidth: "590px",
     }}
   >
     <p>

--- a/app/client/components/payment/update/fieldWrapper.tsx
+++ b/app/client/components/payment/update/fieldWrapper.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { css } from "@emotion/core";
 import palette from "../../../colours";
 import { textSans } from "@guardian/src-foundations/typography";
-import { neutral, error } from "@guardian/src-foundations/palette";
+import { neutral, error, brand } from "@guardian/src-foundations/palette";
 import { InlineError } from "@guardian/src-user-feedback";
 
 interface FieldWrapperProps {
@@ -31,18 +31,21 @@ export class FieldWrapper extends React.Component<
     super(props);
     this.state = {
       error: {},
-      focus: false
+      focus: false,
     };
   }
 
   public render(): React.ReactNode {
-    const hydratedChildren = React.Children.map(this.props.children, child => {
-      return React.cloneElement(child as React.ReactElement<any>, {
-        onChange: this.validateField(this.props.onChange),
-        onFocus: this.toggleFocus,
-        onBlur: this.toggleFocus
-      });
-    });
+    const hydratedChildren = React.Children.map(
+      this.props.children,
+      (child) => {
+        return React.cloneElement(child as React.ReactElement<any>, {
+          onChange: this.validateField(this.props.onChange),
+          onFocus: this.toggleFocus,
+          onBlur: this.toggleFocus,
+        });
+      }
+    );
 
     return (
       <div
@@ -52,8 +55,8 @@ export class FieldWrapper extends React.Component<
           marginBottom: "10px",
           textAlign: "left",
           ":not(:first-of-type)": {
-            marginLeft: "20px"
-          }
+            marginLeft: "20px",
+          },
         }}
       >
         <div
@@ -93,9 +96,9 @@ export class FieldWrapper extends React.Component<
         <div
           css={{
             border: `${
-              this.state.error?.message
-                ? "4px solid " + error[400]
-                : "2px solid " + neutral[60]
+              (this.state.error?.message && "4px solid " + error[400]) ||
+              (this.state.focus && "2px solid " + brand[500]) ||
+              "2px solid " + neutral[60]
             }`,
             display: "block",
             fontWeight: 400,
@@ -105,9 +108,9 @@ export class FieldWrapper extends React.Component<
             width: "100%",
             transition: "all .2s ease-in-out",
             "&:hover": {
-              boxShadow: `0 0 0 3px ${palette.neutral["6"]}`
+              boxShadow: `0 0 0 3px ${palette.neutral["6"]}`,
             },
-            outline: 0
+            outline: 0,
           }}
         >
           {hydratedChildren}
@@ -116,20 +119,20 @@ export class FieldWrapper extends React.Component<
     );
   }
 
-  private validateField = (otherOnChange?: (event: any) => void) => (field: {
-    error: StripeError;
-  }) => {
-    if (otherOnChange) {
-      otherOnChange(field);
-    }
-    this.setState({
-      error: field.error?.message ? field.error : {}
-    });
-  };
+  private validateField =
+    (otherOnChange?: (event: any) => void) =>
+    (field: { error: StripeError }) => {
+      if (otherOnChange) {
+        otherOnChange(field);
+      }
+      this.setState({
+        error: field.error?.message ? field.error : {},
+      });
+    };
 
   private toggleFocus = () => {
     this.setState({
-      focus: !this.state.focus
+      focus: !this.state.focus,
     });
   };
 }

--- a/app/client/components/payment/update/fieldWrapper.tsx
+++ b/app/client/components/payment/update/fieldWrapper.tsx
@@ -1,11 +1,13 @@
 import { StripeError } from "@stripe/stripe-js";
 import React from "react";
 import { css } from "@emotion/core";
-import palette from "../../../colours";
 import { textSans } from "@guardian/src-foundations/typography";
-import { neutral, error, brand } from "@guardian/src-foundations/palette";
+import { neutral, error } from "@guardian/src-foundations/palette";
+import { focusHalo } from "@guardian/src-foundations/accessibility";
+import { FocusStyleManager } from "@guardian/src-foundations/utils";
 import { InlineError } from "@guardian/src-user-feedback";
 
+FocusStyleManager.onlyShowFocusOnTabs();
 interface FieldWrapperProps {
   label: string;
   width: string;
@@ -51,8 +53,6 @@ export class FieldWrapper extends React.Component<
 
     if (this.state.error?.message) {
       borderCss = "4px solid " + error[400];
-    } else if (this.state.focus) {
-      borderCss = "2px solid " + brand[500];
     } else {
       borderCss = "2px solid " + neutral[60];
     }
@@ -104,21 +104,17 @@ export class FieldWrapper extends React.Component<
         </div>
 
         <div
-          css={{
-            border: borderCss,
-            boxShadow: `${this.state.focus && "0 0 0 5px " + brand[500]}`,
-            display: "block",
-            fontWeight: 400,
-            marginTop: "3px",
-            lineHeight: "20px",
-            padding: "10px",
-            width: "100%",
-            transition: "all .2s ease-in-out",
-            "&:hover": {
-              boxShadow: `0 0 0 3px ${palette.neutral["6"]}`,
-            },
-            outline: 0,
-          }}
+          css={css`
+            border: ${borderCss};
+            display: block;
+            font-weight: 400;
+            margin-top: 3px;
+            line-height: 20px;
+            padding: 10px;
+            width: 100%;
+            transition: all 0.2s ease-in-out;
+            ${this.state.focus && focusHalo};
+          `}
         >
           {hydratedChildren}
         </div>

--- a/app/client/components/payment/update/fieldWrapper.tsx
+++ b/app/client/components/payment/update/fieldWrapper.tsx
@@ -47,6 +47,16 @@ export class FieldWrapper extends React.Component<
       }
     );
 
+    let borderCss: string;
+
+    if (this.state.error?.message) {
+      borderCss = "4px solid " + error[400];
+    } else if (this.state.focus) {
+      borderCss = "2px solid " + brand[500];
+    } else {
+      borderCss = "2px solid " + neutral[60];
+    }
+
     return (
       <div
         css={{
@@ -95,11 +105,8 @@ export class FieldWrapper extends React.Component<
 
         <div
           css={{
-            border: `${
-              (this.state.error?.message && "4px solid " + error[400]) ||
-              (this.state.focus && "2px solid " + brand[500]) ||
-              "2px solid " + neutral[60]
-            }`,
+            border: borderCss,
+            boxShadow: `${this.state.focus && "0 0 0 5px " + brand[500]}`,
             display: "block",
             fontWeight: 400,
             marginTop: "3px",

--- a/app/client/components/payment/update/updatePaymentFlow.tsx
+++ b/app/client/components/payment/update/updatePaymentFlow.tsx
@@ -7,6 +7,7 @@ import { neutral, brand } from "@guardian/src-foundations/palette";
 import { space } from "@guardian/src-foundations";
 import { headline } from "@guardian/src-foundations/typography";
 import { Radio } from "@guardian/src-radio";
+import { textSans } from "@guardian/src-foundations/typography";
 import { Button } from "@guardian/src-button";
 import { NavigateFn } from "@reach/router";
 import * as Sentry from "@sentry/browser";
@@ -128,42 +129,20 @@ const PaymentMethodRadioButton = (props: PaymentMethodRadioButtonProps) => {
     }
   `;
 
-  return (
+  const label = () => (
     <div
       css={css`
         display: flex;
-        border-radius: 4px;
-        padding: ${space[4]}px;
-        margin-bottom: ${space[4]}px;
-        ${isChecked ? radioIsChecked : radioDefault}
-
-        label {
-          min-height: 0;
-          flex: 1;
-
-          div {
-            font-weight: bold;
-          }
-        }
-
-        .src-radio-label-text {
-          line-height: 1;
-        }
+        align-items: center;
       `}
     >
-      <Radio
-        checked={isChecked}
-        label={props.paymentMethod}
-        supporting=""
-        onChange={(changeEvent: React.ChangeEvent<HTMLInputElement>) =>
-          props.updatePaymentMethod(changeEvent.target.value as PaymentMethod)
-        }
-        cssOverrides={css`
-          box-shadow: none !important;
-          line-height: 1;
+      <span
+        css={css`
+          flex: 1;
         `}
-        value={props.paymentMethod}
-      />
+      >
+        {props.paymentMethod}
+      </span>
       <div
         css={css`
           display: none;
@@ -181,6 +160,50 @@ const PaymentMethodRadioButton = (props: PaymentMethodRadioButtonProps) => {
           {getLogos(props.paymentMethod)}
         </div>
       </div>
+    </div>
+  );
+
+  return (
+    <div
+      css={css`
+        border-radius: 4px;
+
+        margin-bottom: ${space[4]}px;
+        ${isChecked ? radioIsChecked : radioDefault}
+
+        label {
+          min-height: 0;
+          padding: ${space[4]}px;
+
+          div {
+            font-weight: bold;
+          }
+        }
+
+        :hover {
+          -webkit-box-shadow: inset 0px 0px 0px 4px ${brand[500]};
+          -moz-box-shadow: inset 0px 0px 0px 4px ${brand[500]};
+          box-shadow: inset 0px 0px 0px 4px ${brand[500]};
+        }
+
+        .src-radio-label-text {
+          line-height: 1;
+        }
+      `}
+    >
+      <Radio
+        checked={isChecked}
+        label={label()}
+        supporting=""
+        onChange={(changeEvent: React.ChangeEvent<HTMLInputElement>) =>
+          props.updatePaymentMethod(changeEvent.target.value as PaymentMethod)
+        }
+        cssOverrides={css`
+          box-shadow: none !important;
+          line-height: 1;
+        `}
+        value={props.paymentMethod}
+      />
     </div>
   );
 };
@@ -419,20 +442,24 @@ export class PaymentUpdaterStep extends React.Component<
               Your current payment method
             </h3>
             <CurrentPaymentDetails {...this.props.productDetail} />
-            <p>
-              {this.props.productDetail.subscription.payPalEmail && (
-                <>
-                  To update your payment details, please login to your PayPal
-                  account. Alternatively, you can switch to a card based payment
-                  method below.
-                </>
-              )}
-            </p>
+            {this.props.productDetail.subscription.payPalEmail && (
+              <p
+                css={css`
+                  ${textSans.medium()}
+                `}
+              >
+                To update your payment details, please login to your PayPal
+                account. Alternatively, you can switch to a card based payment
+                method below.
+              </p>
+            )}
           </div>
 
           <h3
             css={css`
               ${subHeadingCss}
+              ${this.props.productDetail.subscription.payPalEmail &&
+              "margin-top: 36px"}
             `}
           >
             {this.state.selectedPaymentMethod === PaymentMethod.unknown


### PR DESCRIPTION
## What does this change?

UI updates to the payments form found here: https://www.figma.com/file/judOZzoY74FjzBdvu98Bvb/MMA-since-2020?node-id=6569%3A281466. 

Have also added vertical margin between the error messages which wasn't included when first pushing this live:

<img width="1344" alt="Screenshot 2022-01-05 at 15 46 38" src="https://user-images.githubusercontent.com/91546670/148246737-79a75448-cd9b-45a9-ab25-c204b3afe5e4.png">



