### PR TITLE
payment error screens styling

### DIFF
--- a/app/client/components/payment/update/PaymentFailed.tsx
+++ b/app/client/components/payment/update/PaymentFailed.tsx
@@ -18,6 +18,7 @@ import {
 } from "./newPaymentMethodDetail";
 import { CallCentreNumbers } from "../../callCentreNumbers";
 import { textSans } from "@guardian/src-foundations/typography";
+import { SvgArrowRightStraight } from "@guardian/src-icons";
 
 export default function PaymentFailed(props: RouteableStepProps) {
   return (
@@ -52,15 +53,7 @@ export default function PaymentFailed(props: RouteableStepProps) {
                 <Button
                   priority="primary"
                   onClick={() => visuallyNavigateToParent(props)}
-                  icon={
-                    <svg viewBox="0 0 30 30" xmlns="http://www.w3.org/2000/svg">
-                      <path
-                        fillRule="evenodd"
-                        clipRule="evenodd"
-                        d="M4 15.95h19.125l-7.5 8.975.975.975 10.425-10.45v-1L16.6 4l-.975.975 7.5 8.975H4v2z"
-                      />
-                    </svg>
-                  }
+                  icon={<SvgArrowRightStraight />}
                   iconSide="right"
                 >
                   Try again

--- a/app/client/components/payment/update/PaymentFailed.tsx
+++ b/app/client/components/payment/update/PaymentFailed.tsx
@@ -1,37 +1,91 @@
 import React from "react";
 import {
   isProduct,
-  MembersDataApiItemContext
+  MembersDataApiItemContext,
 } from "../../../../shared/productResponse";
 import {
   RouteableStepProps,
-  visuallyNavigateToParent
+  visuallyNavigateToParent,
 } from "../../wizardRouterAdapter";
+import { css } from "@emotion/core";
+import { neutral, brand } from "@guardian/src-foundations/palette";
+import { space } from "@guardian/src-foundations";
+import { minWidth } from "../../../styles/breakpoints";
+import { Button } from "@guardian/src-button";
 import {
   isNewPaymentMethodDetail,
-  NewPaymentMethodContext
+  NewPaymentMethodContext,
 } from "./newPaymentMethodDetail";
 import { CallCentreNumbers } from "../../callCentreNumbers";
+import { textSans } from "@guardian/src-foundations/typography";
 
 export default function PaymentFailed(props: RouteableStepProps) {
   return (
     <MembersDataApiItemContext.Consumer>
-      {previousProductDetail => (
+      {(previousProductDetail) => (
         <NewPaymentMethodContext.Consumer>
-          {newPaymentMethodDetail =>
+          {(newPaymentMethodDetail) =>
             isNewPaymentMethodDetail(newPaymentMethodDetail) &&
             isProduct(previousProductDetail) ? (
-              <div css={{ textAlign: "left", marginTop: "10px" }}>
-                <h2>
-                  Sorry, the {newPaymentMethodDetail.friendlyName} update
-                  failed.
-                </h2>
-                <p>
-                  To try again please go back and re-enter your new{" "}
-                  {newPaymentMethodDetail.friendlyName} details.
-                </p>
-                <CallCentreNumbers prefixText="Alternatively, to contact us" />
-              </div>
+              <>
+                <div
+                  css={css`
+                    border-top: 1px solid ${neutral["86"]};
+                    text-align: left;
+                    margin-top: ${space[9]}px;
+                    margin-bottom: ${space[6]}px;
+                    ${textSans.medium()}
+                  `}
+                >
+                  <p
+                    css={css`
+                      padding-top: ${space[1]}px;
+                    `}
+                  >
+                    Sorry, the {newPaymentMethodDetail.friendlyName} update
+                    failed.
+                    <br />
+                    To try again please go back and re-enter your new{" "}
+                    {newPaymentMethodDetail.friendlyName} details.
+                  </p>
+                </div>
+                <Button
+                  priority="primary"
+                  onClick={() => visuallyNavigateToParent(props)}
+                  icon={
+                    <svg viewBox="0 0 30 30" xmlns="http://www.w3.org/2000/svg">
+                      <path
+                        fillRule="evenodd"
+                        clipRule="evenodd"
+                        d="M4 15.95h19.125l-7.5 8.975.975.975 10.425-10.45v-1L16.6 4l-.975.975 7.5 8.975H4v2z"
+                      />
+                    </svg>
+                  }
+                  iconSide="right"
+                >
+                  Try again
+                </Button>
+                <div
+                  css={css`
+                    border-top: 1px solid ${neutral[86]};
+                    ${textSans.medium()};
+                    color: ${neutral[46]};
+                    padding-top: ${space[4]}px;
+                    margin-top: ${space[6]}px;
+
+                    a {
+                      color: ${brand[500]};
+                    }
+
+                    ${minWidth.tablet} {
+                      padding-top: ${space[9]}px;
+                      margin-top: ${space[9]}px;
+                    }
+                  `}
+                >
+                  <CallCentreNumbers prefixText="Alternatively, to contact us" />
+                </div>
+              </>
             ) : (
               visuallyNavigateToParent(props)
             )

--- a/app/client/components/payment/update/card/stripeCardInputForm.tsx
+++ b/app/client/components/payment/update/card/stripeCardInputForm.tsx
@@ -24,6 +24,7 @@ import {
 import Recaptcha from "./Recaptcha";
 import { LoadingCircleIcon } from "../../../svgs/loadingCircleIcon";
 import { ErrorSummary } from "../Summary";
+import { SvgArrowRightStraight } from "@guardian/src-icons";
 export interface StripeSetupIntentDetails {
   stripeSetupIntent?: StripeSetupIntent;
   stripeSetupIntentError?: Error;
@@ -267,13 +268,7 @@ export const StripeCardInputForm = (props: StripeCardInputFormProps) => {
                     `}
                   />
                 ) : (
-                  <svg viewBox="0 0 30 30" xmlns="http://www.w3.org/2000/svg">
-                    <path
-                      fillRule="evenodd"
-                      clipRule="evenodd"
-                      d="M4 15.95h19.125l-7.5 8.975.975.975 10.425-10.45v-1L16.6 4l-.975.975 7.5 8.975H4v2z"
-                    />
-                  </svg>
+                  <SvgArrowRightStraight />
                 )
               }
               iconSide="right"

--- a/app/client/components/payment/update/dd/directDebitInputForm.tsx
+++ b/app/client/components/payment/update/dd/directDebitInputForm.tsx
@@ -11,7 +11,7 @@ import { NewPaymentMethodDetail } from "../newPaymentMethodDetail";
 import { DirectDebitLegal } from "./directDebitLegal";
 import { NewDirectDebitPaymentMethodDetail } from "./newDirectDebitPaymentMethodDetail";
 import { processResponse } from "../../../../utils";
-// import { SvgArrowRightStraight } from "@guardian/src-icons/arrow-right-straight";
+import { SvgArrowRightStraight } from "@guardian/src-icons";
 import { minWidth } from "../../../../styles/breakpoints";
 import { ErrorSummary } from "../Summary";
 
@@ -218,16 +218,7 @@ export const DirectDebitInputForm = (props: DirectDebitUpdateFormProps) => {
           disabled={isValidating}
           priority="primary"
           onClick={startDirectDebitUpdate}
-          // icon={<SvgArrowRightStraight />}
-          icon={
-            <svg viewBox="0 0 30 30" xmlns="http://www.w3.org/2000/svg">
-              <path
-                fillRule="evenodd"
-                clipRule="evenodd"
-                d="M4 15.95h19.125l-7.5 8.975.975.975 10.425-10.45v-1L16.6 4l-.975.975 7.5 8.975H4v2z"
-              />
-            </svg>
-          }
+          icon={<SvgArrowRightStraight />}
           iconSide="right"
         >
           Update payment method

--- a/app/client/components/payment/update/updatePaymentFlow.tsx
+++ b/app/client/components/payment/update/updatePaymentFlow.tsx
@@ -41,6 +41,7 @@ import { ErrorSummary } from "./Summary";
 import { DirectDebitLogo } from "../directDebitLogo";
 import { cardTypeToSVG } from "../cardDisplay";
 import ContactUs from "./ContactUs";
+import { SvgArrowRightStraight } from "@guardian/src-icons";
 
 export enum PaymentMethod {
   card = "Credit card / debit card",
@@ -463,15 +464,7 @@ export class PaymentUpdaterStep extends React.Component<
                 <Button
                   disabled
                   priority="secondary"
-                  icon={
-                    <svg viewBox="0 0 30 30" xmlns="http://www.w3.org/2000/svg">
-                      <path
-                        fillRule="evenodd"
-                        clipRule="evenodd"
-                        d="M4 15.95h19.125l-7.5 8.975.975.975 10.425-10.45v-1L16.6 4l-.975.975 7.5 8.975H4v2z"
-                      />
-                    </svg>
-                  }
+                  icon={<SvgArrowRightStraight />}
                   iconSide="right"
                   cssOverrides={css`
                     background-color: ${neutral[86]};


### PR DESCRIPTION
## What does this change?

Style updates for error screens found here: https://www.figma.com/file/judOZzoY74FjzBdvu98Bvb/MMA-since-2020?node-id=6735%3A274068

## To force the error screen:

I think the easiest way to do this is to run the branch locally and add `throw Error` on the first line of the try block of the executePaymentUpdate function: https://github.com/guardian/manage-frontend/blob/payments-form-style-updates/app/client/components/payment/update/updatePaymentFlow.tsx#L282