### PR TITLE
Add Chromatic

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -6,10 +6,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: guardian/actions-setup-node@v2.4.1
+      - uses: actions/setup-node@v2
         with:
-          cache: "yarn"
-          working-directory: app
+          cache: yarn
+          cache-dependency-path: app/yarn.lock
+          node-version-file: app/.nvmrc
 
       - name: Install dependencies
         run: yarn
@@ -18,6 +19,6 @@ jobs:
       - name: Publish to Chromatic
         uses: chromaui/action@v1
         with:
-          workingDir: app
           token: ${{ secrets.GITHUB_TOKEN }}
           projectToken: ${{ secrets.CHROMATIC_APP_CODE }}
+          workingDir: app

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,24 @@
+name: Chromatic
+on: push
+
+jobs:
+  chromatic:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app
+    steps:
+      - uses: actions/checkout@v1
+      - uses: guardian/actions-setup-node@v2.4.1
+        with:
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Publish to Chromatic
+        uses: chromaui/action@v1
+        with:
+          workingDir: app
+          token: ${{ secrets.GITHUB_TOKEN }}
+          projectToken: ${{ secrets.CHROMATIC_APP_CODE }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -4,17 +4,16 @@ on: push
 jobs:
   chromatic:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: app
     steps:
       - uses: actions/checkout@v1
       - uses: guardian/actions-setup-node@v2.4.1
         with:
           cache: "yarn"
+          working-directory: app
 
       - name: Install dependencies
         run: yarn
+        working-directory: app
 
       - name: Publish to Chromatic
         uses: chromaui/action@v1

--- a/app/client/components/dateInput.stories.tsx
+++ b/app/client/components/dateInput.stories.tsx
@@ -7,7 +7,7 @@ export default {
   title: "Components/Date Input",
   component: DateInput,
   args: {
-    date: new Date(),
+    date: new Date("2022-01-25"),
     labelText: "From",
     disabled: false,
   },

--- a/app/client/components/footer/footer.stories.tsx
+++ b/app/client/components/footer/footer.stories.tsx
@@ -9,9 +9,10 @@ export default {
   parameters: {
     controls: { hideNoControlsWarning: true },
     layout: "fullscreen",
+    chromatic: {
+      viewports: [320, 740, 1300],
+    },
   },
 } as ComponentMeta<typeof Footer>;
 
-const Template: ComponentStory<typeof Footer> = () => <Footer />;
-
-export const Default = Template.bind({});
+export const Default: ComponentStory<typeof Footer> = () => <Footer />;

--- a/app/client/components/help.stories.tsx
+++ b/app/client/components/help.stories.tsx
@@ -9,6 +9,9 @@ export default {
   parameters: {
     controls: { hideNoControlsWarning: true },
     layout: "fullscreen",
+    chromatic: {
+      viewports: [320, 1300],
+    },
   },
 } as ComponentMeta<typeof Help>;
 

--- a/app/client/components/helpCentre/helpCentre.stories.tsx
+++ b/app/client/components/helpCentre/helpCentre.stories.tsx
@@ -40,3 +40,9 @@ export const WithKnownIssue: ComponentStory<typeof HelpCentre> = () => {
     </HelpCenterContentWrapper>
   );
 };
+
+WithKnownIssue.parameters = {
+  chromatic: {
+    viewports: [320, 1300],
+  },
+};

--- a/app/client/components/helpCentre/helpCentreArticle.stories.tsx
+++ b/app/client/components/helpCentre/helpCentreArticle.stories.tsx
@@ -12,6 +12,9 @@ export default {
   parameters: {
     controls: { hideNoControlsWarning: true },
     layout: "fullscreen",
+    chromatic: {
+      viewports: [320, 1300],
+    },
   },
 } as ComponentMeta<typeof HelpCentreArticle>;
 

--- a/app/client/components/helpCentre/helpCentrePhoneNumbers.stories.tsx
+++ b/app/client/components/helpCentre/helpCentrePhoneNumbers.stories.tsx
@@ -12,6 +12,11 @@ export default {
   args: {
     compactLayout: false,
   },
+  parameters: {
+    chromatic: {
+      viewports: [320, 1300],
+    },
+  },
 } as ComponentMeta<typeof HelpCentrePhoneNumbers>;
 
 const Template: ComponentStory<typeof HelpCentrePhoneNumbers> = (
@@ -19,3 +24,8 @@ const Template: ComponentStory<typeof HelpCentrePhoneNumbers> = (
 ) => <HelpCentrePhoneNumbers {...args} />;
 
 export const Default = Template.bind({});
+
+export const CompactLayout = Template.bind({});
+CompactLayout.args = {
+  compactLayout: true,
+};

--- a/app/package.json
+++ b/app/package.json
@@ -20,7 +20,8 @@
     "sonar-scanner": "cd .. && app/node_modules/sonar-scanner/bin/sonar-scanner -Dsonar.projectVersion=$(git rev-parse --short HEAD)",
     "fix": "pretty-quick --staged && eslint --fix 'client/**' 'server/**' 'shared/**'",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook",
+    "chromatic": "chromatic"
   },
   "husky": {
     "hooks": {
@@ -93,6 +94,7 @@
     "babel-loader-exclude-node-modules-except": "^1.2.1",
     "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-source-map-support": "^2.1.1",
+    "chromatic": "^6.4.1",
     "copy-node-modules": "^1.0.4",
     "copy-webpack-plugin": "^9.1.0",
     "core-js": "^3.19.1",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -6519,6 +6519,11 @@ chownr@^2.0.0:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
+chromatic@^6.4.1:
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/chromatic/-/chromatic-6.4.1.tgz#fd8fad82282be030f4e4697dd992bbcbcbe75dc9"
+  integrity sha512-i3WLhIORS8vu9OStJwPQ487/MYZiXT7byU5c9we1Vvfus/w1Kwbj/2n11EozokomGEw5o3VAeiRrZkTCXM8xew==
+
 chrome-trace-event@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz#234090ee97c7d4ad1a2c4beae27505deffc608a4"


### PR DESCRIPTION
## What does this change?

Adds Chromatic to enable visual regression testing. Changes are automatically published on push via a GitHub action.

`yarn chromatic` can be used to manually publish changes and start a new build. This relies on the `CHROMATIC_PROJECT_TOKEN` being set. The token can be found in the [`manage-frontend` project in Chromatic](https://www.chromatic.com/manage?appId=61eee3dabb99df003a4090fd&view=configure).

Stories are rendered with a ` 1200px` wide viewport by default, but additional viewport sizes have been added to a handful of stories to test responsive behaviour. The `<Footer>` component, for example, is tested at the `mobile`, `tablet` and `wide` breakpoints.

## How to test

You can log in to [Chromatic](https://www.chromatic.com/builds?appId=61eee3dabb99df003a4090fd) with your GitHub account and view the component library and previous builds.

The simplest way to test the GitHub Action and workflow would be to branch off of this branch and push a change that deliberately changes the UI. Any regressions from the baseline will be shown as a failure in the checks section.

## Images

<img width="1798" alt="Screenshot 2022-01-28 at 09 59 45" src="https://user-images.githubusercontent.com/1166188/151527635-3635742f-bc76-4a33-8da0-7b580054ba83.png">
