### PR TITLE
Populate Storybook with first batch of generic components

### DIFF
--- a/app/client/components/BasicProductInfoTable.stories.tsx
+++ b/app/client/components/BasicProductInfoTable.stories.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import { BasicProductInfoTable } from "./basicProductInfoTable";
+import { newspaperVoucherPaypal } from "../fixtures/productDetail";
+import { GROUPED_PRODUCT_TYPES } from "../../shared/productTypes";
+
+export default {
+  title: "Components/BasicProductInfoTable",
+  component: BasicProductInfoTable,
+  parameters: {
+    controls: { hideNoControlsWarning: true },
+  },
+} as ComponentMeta<typeof BasicProductInfoTable>;
+
+export const Default: ComponentStory<typeof BasicProductInfoTable> = () => (
+  <BasicProductInfoTable
+    groupedProductType={GROUPED_PRODUCT_TYPES.subscriptions}
+    productDetail={newspaperVoucherPaypal}
+  />
+);

--- a/app/client/components/FormError.stories.tsx
+++ b/app/client/components/FormError.stories.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import { FormError, FormErrorProps } from "./FormError";
+
+export default {
+  title: "Components/FormError",
+  component: FormError,
+  args: {
+    title: "Something went wrong when submitting your form",
+    messages: [
+      "Please try again or if the problem persists please contact Customer Service",
+    ],
+  },
+} as ComponentMeta<typeof FormError>;
+
+const Template: ComponentStory<typeof FormError> = (args: FormErrorProps) => {
+  return <FormError {...args} />;
+};
+
+export const Default = Template.bind({});

--- a/app/client/components/FormError.tsx
+++ b/app/client/components/FormError.tsx
@@ -5,11 +5,6 @@ import { textSans } from "@guardian/src-foundations/typography";
 import React, { ReactElement } from "react";
 import { ErrorIcon } from "./svgs/errorIcon";
 
-interface FormErrorProps {
-  title?: string;
-  messages: Array<string | ReactElement>;
-}
-
 const dlStyles = css`
   position: relative;
   padding: ${space[5]}px ${space[5]}px ${space[5]}px 50px;
@@ -36,6 +31,11 @@ const ulStyles = css`
   margin: 0;
   padding: 0;
 `;
+
+export interface FormErrorProps {
+  title?: string;
+  messages: Array<string | ReactElement>;
+}
 
 export const FormError = (props: FormErrorProps) => (
   <dl css={dlStyles}>

--- a/app/client/components/WithStandardTopMargin.stories.tsx
+++ b/app/client/components/WithStandardTopMargin.stories.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { css } from "@emotion/core";
+
+import { WithStandardTopMargin } from "./WithStandardTopMargin";
+
+export default {
+  title: "Components/WithStandardTopMargin",
+  component: WithStandardTopMargin,
+  parameters: {
+    controls: { disabled: true },
+  },
+} as ComponentMeta<typeof WithStandardTopMargin>;
+
+export const Default: ComponentStory<typeof WithStandardTopMargin> = () => (
+  <div
+    css={css`
+      outline: 1px dotted red;
+    `}
+  >
+    <WithStandardTopMargin>
+      <div
+        css={css`
+          outline: 1px dotted green;
+        `}
+      >
+        Content with standard top margin
+      </div>
+    </WithStandardTopMargin>
+    <WithStandardTopMargin>
+      <div
+        css={css`
+          outline: 1px dotted green;
+        `}
+      >
+        More content with standard top margin
+      </div>
+    </WithStandardTopMargin>
+  </div>
+);

--- a/app/client/components/WithStandardTopMargin.tsx
+++ b/app/client/components/WithStandardTopMargin.tsx
@@ -1,7 +1,7 @@
 import { css } from "@emotion/core";
 import React from "react";
 
-interface WithStandardTopMarginProps {
+export interface WithStandardTopMarginProps {
   children: React.ReactNode;
 }
 export const WithStandardTopMargin = (props: WithStandardTopMarginProps) => (

--- a/app/client/components/accountoverview/accountOverview.stories.tsx
+++ b/app/client/components/accountoverview/accountOverview.stories.tsx
@@ -14,7 +14,7 @@ export default {
   title: "Pages/AccountOverview",
   component: AccountOverview,
   parameters: {
-    controls: { hideNoControlsWarning: true },
+    controls: { disabled: true },
     layout: "fullscreen",
   },
 } as ComponentMeta<typeof AccountOverview>;

--- a/app/client/components/accountoverview/manageProduct.stories.tsx
+++ b/app/client/components/accountoverview/manageProduct.stories.tsx
@@ -14,7 +14,7 @@ export default {
   title: "Pages/ManageProduct",
   component: ManageProduct,
   parameters: {
-    controls: { hideNoControlsWarning: true },
+    controls: { disabled: true },
     layout: "fullscreen",
   },
 } as ComponentMeta<typeof ManageProduct>;

--- a/app/client/components/accountoverview/manageProduct.stories.tsx
+++ b/app/client/components/accountoverview/manageProduct.stories.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import ManageProduct from "./manageProduct";
+import { GROUPED_PRODUCT_TYPES } from "../../../shared/productTypes";
+
+import {
+  guardianWeeklyCard,
+  digitalDD,
+  newspaperVoucherPaypal,
+} from "../../fixtures/productDetail";
+
+export default {
+  title: "Pages/ManageProduct",
+  component: ManageProduct,
+  parameters: {
+    controls: { hideNoControlsWarning: true },
+    layout: "fullscreen",
+  },
+} as ComponentMeta<typeof ManageProduct>;
+
+export const GuardianWeekly: ComponentStory<typeof ManageProduct> = () => (
+  <ManageProduct
+    path="/"
+    groupedProductType={GROUPED_PRODUCT_TYPES.subscriptions}
+    location={{ state: { productDetail: guardianWeeklyCard } }}
+  />
+);
+
+export const NewspaperSubscriptionCard: ComponentStory<
+  typeof ManageProduct
+> = () => (
+  <ManageProduct
+    path="/"
+    groupedProductType={GROUPED_PRODUCT_TYPES.subscriptions}
+    location={{ state: { productDetail: digitalDD } }}
+  />
+);
+
+export const DigitalSubscription: ComponentStory<typeof ManageProduct> = () => (
+  <ManageProduct
+    path="/"
+    groupedProductType={GROUPED_PRODUCT_TYPES.subscriptions}
+    location={{ state: { productDetail: newspaperVoucherPaypal } }}
+  />
+);

--- a/app/client/components/basicProductInfoTable.tsx
+++ b/app/client/components/basicProductInfoTable.tsx
@@ -4,10 +4,11 @@ import { ProductDetail } from "../../shared/productResponse";
 import { GroupedProductType } from "../../shared/productTypes";
 import { ProductDescriptionListTable } from "./productDescriptionListTable";
 
-interface BasicProductInfoTableProps {
+export interface BasicProductInfoTableProps {
   groupedProductType: GroupedProductType;
   productDetail: ProductDetail;
 }
+
 export const BasicProductInfoTable = (props: BasicProductInfoTableProps) => {
   return (
     <ProductDescriptionListTable
@@ -16,33 +17,33 @@ export const BasicProductInfoTable = (props: BasicProductInfoTableProps) => {
           ? [
               {
                 title: "Subscription ID",
-                value: props.productDetail.subscription.subscriptionId
-              }
+                value: props.productDetail.subscription.subscriptionId,
+              },
             ]
           : []),
         ...(props.groupedProductType.tierLabel
           ? [
               {
                 title: props.groupedProductType.tierLabel,
-                value: props.productDetail.tier
-              }
+                value: props.productDetail.tier,
+              },
             ]
           : []),
         ...(props.groupedProductType.shouldShowJoinDateNotStartDate
           ? [
               {
                 title: "Join date",
-                value: parseDate(props.productDetail.joinDate).dateStr()
-              }
+                value: parseDate(props.productDetail.joinDate).dateStr(),
+              },
             ]
           : [
               {
                 title: "Start date",
                 value: props.productDetail.subscription.start
                   ? parseDate(props.productDetail.subscription.start).dateStr()
-                  : "-"
-              }
-            ])
+                  : "-",
+              },
+            ]),
       ]}
     />
   );

--- a/app/client/components/billing/billing.stories.tsx
+++ b/app/client/components/billing/billing.stories.tsx
@@ -14,7 +14,7 @@ export default {
   title: "Pages/Billing",
   component: Billing,
   parameters: {
-    controls: { hideNoControlsWarning: true },
+    controls: { disabled: true },
     layout: "fullscreen",
   },
 } as ComponentMeta<typeof Billing>;

--- a/app/client/components/button.stories.tsx
+++ b/app/client/components/button.stories.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import { Button, ButtonProps } from "./buttons";
+
+export default {
+  title: "Components/Button",
+  component: Button,
+  args: {
+    text: "Button",
+    height: "",
+    fontWeight: undefined,
+    left: false,
+    right: false,
+    disabled: false,
+    colour: undefined,
+    textColour: undefined,
+    primary: undefined,
+    hide: false,
+    forceCircle: undefined,
+    hoverColour: undefined,
+    leftTick: undefined,
+    alert: false,
+    type: "button",
+  },
+  argTypes: {
+    fontWeight: {
+      options: ["bold"],
+    },
+    primary: {
+      control: { type: "boolean" },
+    },
+    hollow: {
+      control: { type: "boolean" },
+    },
+    forceCircle: {
+      control: { type: "boolean" },
+    },
+    leftTick: {
+      control: { type: "boolean" },
+    },
+    colour: {
+      control: { type: "color" },
+    },
+    textColour: {
+      control: { type: "color" },
+    },
+    hoverColour: {
+      control: { type: "color" },
+    },
+  },
+} as ComponentMeta<typeof Button>;
+
+const Template: ComponentStory<typeof Button> = (args: ButtonProps) => (
+  <Button {...args} />
+);
+
+export const Default = Template.bind({});
+
+export const Primary = Template.bind({});
+Primary.args = {
+  primary: true,
+};

--- a/app/client/components/button.stories.tsx
+++ b/app/client/components/button.stories.tsx
@@ -8,7 +8,7 @@ export default {
   component: Button,
   args: {
     text: "Button",
-    height: "",
+    height: undefined,
     fontWeight: undefined,
     left: false,
     right: false,
@@ -16,6 +16,7 @@ export default {
     colour: undefined,
     textColour: undefined,
     primary: undefined,
+    hollow: undefined,
     hide: false,
     forceCircle: undefined,
     hoverColour: undefined,
@@ -25,19 +26,24 @@ export default {
   },
   argTypes: {
     fontWeight: {
-      options: ["bold"],
+      options: ["bold", undefined],
+      control: { type: "inline-radio" },
     },
     primary: {
-      control: { type: "boolean" },
+      options: [true, undefined],
+      control: { type: "inline-radio" },
     },
     hollow: {
-      control: { type: "boolean" },
+      options: [true, undefined],
+      control: { type: "inline-radio" },
     },
     forceCircle: {
-      control: { type: "boolean" },
+      options: [true, undefined],
+      control: { type: "inline-radio" },
     },
     leftTick: {
-      control: { type: "boolean" },
+      options: [true, undefined],
+      control: { type: "inline-radio" },
     },
     colour: {
       control: { type: "color" },
@@ -48,6 +54,10 @@ export default {
     hoverColour: {
       control: { type: "color" },
     },
+    type: {
+      options: ["button", "submit", "reset"],
+      control: { type: "inline-radio" },
+    },
   },
 } as ComponentMeta<typeof Button>;
 
@@ -57,7 +67,24 @@ const Template: ComponentStory<typeof Button> = (args: ButtonProps) => (
 
 export const Default = Template.bind({});
 
-export const Primary = Template.bind({});
-Primary.args = {
+export const Bold = Template.bind({});
+Bold.args = {
+  fontWeight: "bold",
+};
+
+export const WithRightArrow = Template.bind({});
+WithRightArrow.args = {
+  right: true,
+};
+
+export const PrimaryWithRightArrow = Template.bind({});
+PrimaryWithRightArrow.args = {
   primary: true,
+  right: true,
+};
+
+export const HollowWithLeftArrow = Template.bind({});
+HollowWithLeftArrow.args = {
+  hollow: true,
+  left: true,
 };

--- a/app/client/components/buttons.tsx
+++ b/app/client/components/buttons.tsx
@@ -10,7 +10,7 @@ import { ArrowIcon } from "./svgs/arrowIcon";
 import { ErrorIcon } from "./svgs/errorIcon";
 import { TickIcon } from "./svgs/tickIcon";
 
-interface ButtonProps {
+export interface ButtonProps {
   text: string;
   onClick?: () => void;
   height?: string;
@@ -52,11 +52,11 @@ const applyIconStyleIfApplicable = (
     return hover ? styles.rightHover : styles.right;
   } else if (leftTick) {
     return {
-      padding: "4px 21px 3px 16px"
+      padding: "4px 21px 3px 16px",
     };
   }
   return {
-    padding: "1px 15px 0 15px"
+    padding: "1px 15px 0 15px",
   };
 };
 
@@ -104,7 +104,7 @@ const buttonCss = ({
   hide,
   forceCircle,
   hoverColour,
-  leftTick
+  leftTick,
 }: ButtonProps) => {
   const backgroundColour = calcBackgroundColour(
     disabled,
@@ -119,7 +119,7 @@ const buttonCss = ({
     alignItems: "center",
     position: "relative",
     ":active": {
-      outline: "none"
+      outline: "none",
     },
     minHeight: height || "36px",
     height: height || "36px", // this is required in addition to 'min-height' because IE - see https://github.com/philipwalton/flexbugs/issues/231
@@ -131,7 +131,7 @@ const buttonCss = ({
     ...applyIconStyleIfApplicable(false, left, right, leftTick),
     ...(forceCircle
       ? {
-          padding: "1px 18px 0 18px"
+          padding: "1px 18px 0 18px",
         }
       : {}),
     ":hover": disabled
@@ -142,16 +142,16 @@ const buttonCss = ({
             Color(backgroundColour)
               .darken(backgroundColour === defaultColour ? 0.3 : 0.1)
               .string(),
-          ...applyIconStyleIfApplicable(true, left, right, leftTick)
+          ...applyIconStyleIfApplicable(true, left, right, leftTick),
         },
     cursor: disabled ? "not-allowed" : "pointer",
-    maxWidth: "calc(100vw - 40px)"
+    maxWidth: "calc(100vw - 40px)",
   });
 };
 
 const styles = {
   leftHover: {
-    svg: { transform: "translate(-3px, -50%) rotate(180deg)" }
+    svg: { transform: "translate(-3px, -50%) rotate(180deg)" },
   },
   left: {
     padding: "1px 18px 0 40px",
@@ -163,11 +163,11 @@ const styles = {
       top: "50%",
       transform: "translate(0, -50%) rotate(180deg)",
       transition: "transform .3s, background .3s",
-      width: "36px"
-    }
+      width: "36px",
+    },
   },
   rightHover: {
-    svg: { transform: "translate(3px, -50%)" }
+    svg: { transform: "translate(3px, -50%)" },
   },
   right: {
     padding: "1px 40px 0 18px",
@@ -179,9 +179,9 @@ const styles = {
       top: "50%",
       transform: "translate(0, -50%)",
       transition: "transform .3s, background .3s",
-      width: "36px"
-    }
-  }
+      width: "36px",
+    },
+  },
 };
 
 export const LinkButton = (props: LinkButtonProps) => (

--- a/app/client/components/buttons.tsx
+++ b/app/client/components/buttons.tsx
@@ -35,7 +35,7 @@ interface LinkButtonState {
   flowReferrer?: { title: string; link: string };
 }
 
-interface LinkButtonProps extends ButtonProps {
+export interface LinkButtonProps extends ButtonProps {
   to: string;
   state?: LinkButtonState | ProductDetail;
 }

--- a/app/client/components/callCenterEmailAndNumbers.tsx
+++ b/app/client/components/callCenterEmailAndNumbers.tsx
@@ -77,7 +77,7 @@ const PHONE_DATA: PhoneRegion[] = [
   },
 ];
 
-interface CallCentreEmailAndNumbersProps extends CallCentreNumbersProps {
+export interface CallCentreEmailAndNumbersProps extends CallCentreNumbersProps {
   hideEmailAddress?: boolean;
   phoneRegionFilterKeys?: PhoneRegionKey[];
   compactLayout?: boolean;

--- a/app/client/components/callCentreEmailAndNumbers.stories.tsx
+++ b/app/client/components/callCentreEmailAndNumbers.stories.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import {
+  CallCentreEmailAndNumbers,
+  CallCentreEmailAndNumbersProps,
+} from "./callCenterEmailAndNumbers";
+
+export default {
+  title: "Components/CallCentreEmailAndNumbers",
+  component: CallCentreEmailAndNumbers,
+  args: {
+    prefixText: "",
+    hideEmailAddress: false,
+    compactLayout: false,
+    phoneRegionFilterKeys: undefined,
+  },
+} as ComponentMeta<typeof CallCentreEmailAndNumbers>;
+
+const Template: ComponentStory<typeof CallCentreEmailAndNumbers> = (
+  args: CallCentreEmailAndNumbersProps
+) => {
+  return <CallCentreEmailAndNumbers {...args} />;
+};
+
+export const Default = Template.bind({});
+
+export const WithEmailHidden = Template.bind({});
+WithEmailHidden.args = {
+  hideEmailAddress: true,
+};
+
+export const WithCompactLayout = Template.bind({});
+WithCompactLayout.args = {
+  compactLayout: true,
+};

--- a/app/client/components/callCentreNumbers.stories.tsx
+++ b/app/client/components/callCentreNumbers.stories.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import { CallCentreNumbers, CallCentreNumbersProps } from "./callCentreNumbers";
+
+export default {
+  title: "Components/CallCentreNumbers",
+  component: CallCentreNumbers,
+  args: {
+    prefixText: "",
+  },
+} as ComponentMeta<typeof CallCentreNumbers>;
+
+const Template: ComponentStory<typeof CallCentreNumbers> = (
+  args: CallCentreNumbersProps
+) => {
+  return <CallCentreNumbers {...args} />;
+};
+
+export const Default = Template.bind({});
+
+export const WithCustomPrefix = Template.bind({});
+WithCustomPrefix.args = {
+  prefixText:
+    "If you’re not sure what’s best for you or would like help, to contact us",
+};

--- a/app/client/components/cancel/cancellationFlow.stories.tsx
+++ b/app/client/components/cancel/cancellationFlow.stories.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import CancellationFlow from "./cancellationFlow";
+import { PRODUCT_TYPES } from "../../../shared/productTypes";
+
+import { guardianWeeklyCard } from "../../fixtures/productDetail";
+
+export default {
+  title: "Pages/CancellationFlow",
+  component: CancellationFlow,
+  parameters: {
+    controls: { hideNoControlsWarning: true },
+    layout: "fullscreen",
+  },
+} as ComponentMeta<typeof CancellationFlow>;
+
+export const GuardianWeekly: ComponentStory<typeof CancellationFlow> = () => (
+  <CancellationFlow
+    path="/"
+    productType={PRODUCT_TYPES.guardianweekly}
+    location={{ state: { productDetail: guardianWeeklyCard } }}
+  />
+);

--- a/app/client/components/cancel/cancellationFlow.stories.tsx
+++ b/app/client/components/cancel/cancellationFlow.stories.tsx
@@ -10,7 +10,7 @@ export default {
   title: "Pages/CancellationFlow",
   component: CancellationFlow,
   parameters: {
-    controls: { hideNoControlsWarning: true },
+    controls: { disabled: true },
     layout: "fullscreen",
   },
 } as ComponentMeta<typeof CancellationFlow>;

--- a/app/client/components/cancelReminders.stories.tsx
+++ b/app/client/components/cancelReminders.stories.tsx
@@ -8,7 +8,7 @@ export default {
   title: "Pages/CancelReminders",
   component: CancelReminders,
   parameters: {
-    controls: { hideNoControlsWarning: true },
+    controls: { disabled: true },
     layout: "fullscreen",
   },
 } as ComponentMeta<typeof CancelReminders>;

--- a/app/client/components/checkbox.stories.tsx
+++ b/app/client/components/checkbox.stories.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import { Checkbox, CheckboxProps } from "./checkbox";
+
+export default {
+  title: "Components/Checkbox",
+  component: Checkbox,
+  args: {
+    checked: false,
+    required: undefined,
+    label: "",
+    checkboxFill: undefined,
+    maxWidth: "",
+  },
+  argTypes: {
+    required: {
+      options: [true, undefined],
+      control: { type: "inline-radio" },
+    },
+    checkboxFill: {
+      control: { type: "color" },
+    },
+  },
+} as ComponentMeta<typeof Checkbox>;
+
+const Template: ComponentStory<typeof Checkbox> = (args: CheckboxProps) => (
+  <Checkbox {...args} />
+);
+
+export const Default = Template.bind({});
+
+export const Checked = Template.bind({});
+Checked.args = {
+  checked: true,
+};
+
+export const WithLabel = Template.bind({});
+WithLabel.args = {
+  label: "Guardian Weekly newsletter",
+};
+
+export const WithMaxWidth = Template.bind({});
+WithMaxWidth.args = {
+  label: "Guardian Weekly newsletter",
+  maxWidth: "8ch",
+};

--- a/app/client/components/checkbox.tsx
+++ b/app/client/components/checkbox.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import palette from "../colours";
 
-interface CheckboxProps {
+export interface CheckboxProps {
   checked: boolean;
   required?: true;
   onChange: (newValue: boolean) => void;
@@ -18,8 +18,8 @@ export const Checkbox = (props: CheckboxProps) => (
       cursor: "pointer",
       userSelect: "none",
       ":hover .checkbox": {
-        boxShadow: `0 0 0 3px ${palette.neutral["6"]}`
-      }
+        boxShadow: `0 0 0 3px ${palette.neutral["6"]}`,
+      },
     }}
   >
     <div
@@ -38,8 +38,8 @@ export const Checkbox = (props: CheckboxProps) => (
         position: "relative",
         outline: 0,
         ":focus": {
-          boxShadow: `0 0 0 3px ${palette.yellow.medium}`
-        }
+          boxShadow: `0 0 0 3px ${palette.yellow.medium}`,
+        },
       }}
       // accessibility props below
       role="checkbox"
@@ -53,7 +53,7 @@ export const Checkbox = (props: CheckboxProps) => (
           position: "absolute",
           zIndex: -999999,
           overflow: "hidden",
-          opacity: 0
+          opacity: 0,
         }}
         onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
           props.onChange(event.target.checked)
@@ -70,7 +70,7 @@ export const Checkbox = (props: CheckboxProps) => (
           width: "12px",
           height: "6px",
           transform: "rotate(-45deg)",
-          textAlign: "right"
+          textAlign: "right",
         }}
       >
         <div
@@ -81,7 +81,7 @@ export const Checkbox = (props: CheckboxProps) => (
             borderWidth: "0 0 2px 2px",
             borderStyle: "solid",
             transition: "all .2s ease-in-out",
-            transitionDelay: ".1s"
+            transitionDelay: ".1s",
           }}
         />
       </div>

--- a/app/client/components/contactUs/contactUs.stories.tsx
+++ b/app/client/components/contactUs/contactUs.stories.tsx
@@ -11,7 +11,7 @@ export default {
   title: "Pages/ContactUs",
   component: ContactUs,
   parameters: {
-    controls: { hideNoControlsWarning: true },
+    controls: { disabled: true },
     layout: "fullscreen",
   },
 } as ComponentMeta<typeof ContactUs>;

--- a/app/client/components/datePicker.stories.tsx
+++ b/app/client/components/datePicker.stories.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import { DatePicker, DatePickerProps } from "./datePicker";
+
+export default {
+  title: "Components/DatePicker",
+  component: DatePicker,
+  parameters: {
+    controls: { disabled: true },
+    chromatic: {
+      viewports: [320, 740, 1300],
+    },
+  },
+  args: {
+    firstAvailableDate: new Date("2022-01-10"),
+    issueDaysOfWeek: [1, 2, 3, 4, 5],
+    issueKeyword: "Issue",
+    existingDates: [],
+  },
+} as ComponentMeta<typeof DatePicker>;
+
+const Template: ComponentStory<typeof DatePicker> = (args: DatePickerProps) => {
+  return <DatePicker {...args} />;
+};
+
+export const Default = Template.bind({});
+
+export const WithExistingDates = Template.bind({});
+WithExistingDates.args = {
+  existingDates: [
+    { start: new Date("2022-01-24"), end: new Date("2022-01-26") },
+    { start: new Date("2022-02-14"), end: new Date("2022-02-18") },
+  ],
+};
+
+export const WithAmendment = Template.bind({});
+WithAmendment.args = {
+  amendableDateRange: {
+    start: new Date("2022-02-21"),
+    end: new Date("2022-02-23"),
+  },
+};

--- a/app/client/components/datePicker.tsx
+++ b/app/client/components/datePicker.tsx
@@ -7,7 +7,7 @@ import {
   dateIsLeapYear,
   dateIsSame,
   DateRange,
-  dateRange
+  dateRange,
 } from "../../shared/dates";
 import palette from "../colours";
 import { maxWidth, minWidth } from "../styles/breakpoints";
@@ -19,18 +19,18 @@ const stateDefinitions = {
   available: {
     selectable: true,
     color: "white",
-    label: ""
+    label: "",
   },
   existing: {
     selectable: false,
     color: palette.labs.main,
-    label: "Existing suspensions"
+    label: "Existing suspensions",
   },
   amend: {
     selectable: true,
     color: brandAlt[400],
-    label: "Suspension you're amending"
-  }
+    label: "Suspension you're amending",
+  },
 };
 
 interface LegendItemProps {
@@ -57,10 +57,10 @@ const legendItems = (
     transform: rotate(-45deg);
   }
   `,
-    label: `${issueKeyword} day`
+    label: `${issueKeyword} day`,
   },
   ...(includeExisting ? [stateDefinitions.existing] : []),
-  ...(includeAmend ? [stateDefinitions.amend] : [])
+  ...(includeAmend ? [stateDefinitions.amend] : []),
 ];
 
 const mergeAdjacentDateRanges = (
@@ -88,7 +88,7 @@ const LegendItem = (props: LegendItemProps) => (
     css={{
       display: "flex",
       alignItems: "center",
-      marginBottom: "10px"
+      marginBottom: "10px",
     }}
   >
     <div
@@ -99,9 +99,9 @@ const LegendItem = (props: LegendItemProps) => (
           backgroundColor: props.color,
           display: "inline-block",
           marginRight: "10px",
-          border: "0 !important"
+          border: "0 !important",
         },
-        css(props.extraCss)
+        css(props.extraCss),
       ]}
       className="DateRangePicker__Date"
     />
@@ -109,7 +109,7 @@ const LegendItem = (props: LegendItemProps) => (
       css={{
         marginRight: "20px",
         fontFamily: sans,
-        fontSize: "14px"
+        fontSize: "14px",
       }}
     >
       {props.label}
@@ -117,7 +117,7 @@ const LegendItem = (props: LegendItemProps) => (
   </div>
 );
 
-interface DatePickerProps {
+export interface DatePickerProps {
   firstAvailableDate: Date;
   issueDaysOfWeek: number[];
   issueKeyword: string;
@@ -136,14 +136,14 @@ export const DatePicker = (props: DatePickerProps) => (
       css={{
         display: "flex",
         alignItems: "center",
-        flexWrap: "wrap"
+        flexWrap: "wrap",
       }}
     >
       {legendItems(
         props.issueKeyword,
         props.existingDates.length > 0,
         !!props.amendableDateRange
-      ).map(itemProps => (
+      ).map((itemProps) => (
         <LegendItem key={itemProps.label} {...itemProps} />
       ))}
     </div>
@@ -151,8 +151,8 @@ export const DatePicker = (props: DatePickerProps) => (
       css={{
         display: "flex",
         [maxWidth.desktop]: {
-          flexDirection: "column-reverse"
-        }
+          flexDirection: "column-reverse",
+        },
       }}
     >
       <div css={{ flexGrow: 1 }}>
@@ -168,18 +168,18 @@ export const DatePicker = (props: DatePickerProps) => (
           dateStates={[
             ...props.existingDates
               .reduce(mergeAdjacentDateRanges, []) // TODO check if they need to be merged across different types of 'date state'
-              .map(range => ({
+              .map((range) => ({
                 state: "existing",
-                range
+                range,
               })),
             ...(props.amendableDateRange
               ? [
                   {
                     state: "amend",
-                    range: props.amendableDateRange
-                  }
+                    range: props.amendableDateRange,
+                  },
                 ]
-              : [])
+              : []),
           ].sort((a, b) => a.range.start.valueOf() - b.range.start.valueOf())}
           handleRangeChoosen={props.onChange}
         />
@@ -209,8 +209,8 @@ export const DatePicker = (props: DatePickerProps) => (
             marginBottom: "15px",
             marginLeft: "-20px",
             marginRight: "-20px",
-            boxShadow: "0 3px 5px -3px " + palette.neutral["4"]
-          }
+            boxShadow: "0 3px 5px -3px " + palette.neutral["4"],
+          },
         }}
       >
         <div
@@ -219,8 +219,8 @@ export const DatePicker = (props: DatePickerProps) => (
               display: "flex",
               alignItems: "center",
               marginRight: "10px",
-              marginTop: "10px"
-            }
+              marginTop: "10px",
+            },
           }}
         >
           <div>

--- a/app/client/components/expanderButton.stories.tsx
+++ b/app/client/components/expanderButton.stories.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { css } from "@emotion/core";
+
+import { ExpanderButton } from "./expanderButton";
+
+export default {
+  title: "Components/ExpanderButton",
+  component: ExpanderButton,
+  parameters: {
+    controls: { disabled: true },
+  },
+} as ComponentMeta<typeof ExpanderButton>;
+
+export const Default: ComponentStory<typeof ExpanderButton> = () => (
+  <ExpanderButton buttonLabel="2 issues">
+    <ul
+      css={css`
+        margin: 0;
+        padding: 0;
+        list-style: none;
+      `}
+    >
+      <li>18 March 2022 (£-2.89)</li>
+      <li>18 March 2022 (£-2.89)</li>
+    </ul>
+  </ExpanderButton>
+);

--- a/app/client/components/expanderButton.tsx
+++ b/app/client/components/expanderButton.tsx
@@ -1,53 +1,51 @@
 import { css } from "@emotion/core";
 import React from "react";
 
-export const expanderButtonCss = (
-  mainColour?: string,
-  highlightColour?: string
-) => (isExpanded: boolean) =>
-  css({
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "space-between",
-    cursor: "pointer",
-    border: "0",
-    background: "none",
-    textAlign: "left",
-    fontFamily: "inherit",
-    fontSize: "16px",
-    padding: "10px 1px 10px 0",
-    position: "relative",
-    transform: "translateY(-1px)",
-    "::after": {
-      content: "''",
-      display: "block",
-      width: "5px",
-      height: "5px",
-      border: "1px solid currentColor",
-      borderLeft: "transparent",
-      borderTop: "transparent",
-      marginLeft: "8px",
-      transform: `translateY(${isExpanded ? 0 : -2}px) rotate(${
-        isExpanded ? "225deg" : "45deg"
-      })`
-    },
-    ":hover, :focus": {
-      color: highlightColour
-    },
-    ":hover": {
+export const expanderButtonCss =
+  (mainColour?: string, highlightColour?: string) => (isExpanded: boolean) =>
+    css({
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "space-between",
+      cursor: "pointer",
+      border: "0",
+      background: "none",
+      textAlign: "left",
+      fontFamily: "inherit",
+      fontSize: "16px",
+      padding: "10px 1px 10px 0",
+      position: "relative",
+      transform: "translateY(-1px)",
       "::after": {
-        transform: `translateY(${isExpanded ? -2 : 0}px) rotate(${
+        content: "''",
+        display: "block",
+        width: "5px",
+        height: "5px",
+        border: "1px solid currentColor",
+        borderLeft: "transparent",
+        borderTop: "transparent",
+        marginLeft: "8px",
+        transform: `translateY(${isExpanded ? 0 : -2}px) rotate(${
           isExpanded ? "225deg" : "45deg"
         })`,
-        transitionProperty: "transform",
-        transitionDuration: "250ms",
-        transitionTimingFunction: "ease-in-out"
-      }
-    },
-    color: isExpanded ? highlightColour : mainColour
-  });
+      },
+      ":hover, :focus": {
+        color: highlightColour,
+      },
+      ":hover": {
+        "::after": {
+          transform: `translateY(${isExpanded ? -2 : 0}px) rotate(${
+            isExpanded ? "225deg" : "45deg"
+          })`,
+          transitionProperty: "transform",
+          transitionDuration: "250ms",
+          transitionTimingFunction: "ease-in-out",
+        },
+      },
+      color: isExpanded ? highlightColour : mainColour,
+    });
 
-interface ExpanderButtonProps {
+export interface ExpanderButtonProps {
   buttonLabel: string | React.ReactElement;
   children: React.ReactElement | React.ReactElement[];
 }
@@ -61,7 +59,7 @@ export class ExpanderButton extends React.Component<
   ExpanderButtonState
 > {
   public state = {
-    isExpanded: false
+    isExpanded: false,
   };
 
   public render = () => (
@@ -71,7 +69,7 @@ export class ExpanderButton extends React.Component<
         type="button"
         aria-expanded={this.state.isExpanded}
         onClick={() =>
-          this.setState(prevState => ({ isExpanded: !prevState.isExpanded }))
+          this.setState((prevState) => ({ isExpanded: !prevState.isExpanded }))
         }
       >
         {this.props.buttonLabel}

--- a/app/client/components/help.stories.tsx
+++ b/app/client/components/help.stories.tsx
@@ -7,7 +7,7 @@ export default {
   title: "Pages/Help",
   component: Help,
   parameters: {
-    controls: { hideNoControlsWarning: true },
+    controls: { disabled: true },
     layout: "fullscreen",
     chromatic: {
       viewports: [320, 1300],

--- a/app/client/components/helpCentre/helpCentre.stories.tsx
+++ b/app/client/components/helpCentre/helpCentre.stories.tsx
@@ -9,7 +9,7 @@ export default {
   title: "Pages/HelpCentre",
   component: HelpCentre,
   parameters: {
-    controls: { hideNoControlsWarning: true },
+    controls: { disabled: true },
     layout: "fullscreen",
   },
 } as ComponentMeta<typeof HelpCentre>;

--- a/app/client/components/helpCentre/helpCentreArticle.stories.tsx
+++ b/app/client/components/helpCentre/helpCentreArticle.stories.tsx
@@ -10,7 +10,7 @@ export default {
   title: "Pages/HelpCentreArticle",
   component: HelpCentreArticle,
   parameters: {
-    controls: { hideNoControlsWarning: true },
+    controls: { disabled: true },
     layout: "fullscreen",
     chromatic: {
       viewports: [320, 1300],

--- a/app/client/components/helpCentre/helpCentreTopic.stories.tsx
+++ b/app/client/components/helpCentre/helpCentreTopic.stories.tsx
@@ -10,7 +10,7 @@ export default {
   title: "Pages/HelpCentreTopic",
   component: HelpCentreTopic,
   parameters: {
-    controls: { hideNoControlsWarning: true },
+    controls: { disabled: true },
     layout: "fullscreen",
   },
 } as ComponentMeta<typeof HelpCentreTopic>;

--- a/app/client/components/identity/EmailAndMarketing/EmailAndMarketing.stories.tsx
+++ b/app/client/components/identity/EmailAndMarketing/EmailAndMarketing.stories.tsx
@@ -17,7 +17,7 @@ export default {
   title: "Pages/EmailAndMarketing",
   component: EmailAndMarketing,
   parameters: {
-    controls: { hideNoControlsWarning: true },
+    controls: { disabled: true },
     layout: "fullscreen",
   },
 } as ComponentMeta<typeof EmailAndMarketing>;

--- a/app/client/components/identity/PublicProfile/PublicProfile.stories.tsx
+++ b/app/client/components/identity/PublicProfile/PublicProfile.stories.tsx
@@ -9,7 +9,7 @@ export default {
   title: "Pages/Profile",
   component: PublicProfile,
   parameters: {
-    controls: { hideNoControlsWarning: true },
+    controls: { disabled: true },
     layout: "fullscreen",
   },
 } as ComponentMeta<typeof PublicProfile>;

--- a/app/client/components/identity/Settings/Settings.stories.tsx
+++ b/app/client/components/identity/Settings/Settings.stories.tsx
@@ -9,7 +9,7 @@ export default {
   title: "Pages/Settings",
   component: Settings,
   parameters: {
-    controls: { hideNoControlsWarning: true },
+    controls: { disabled: true },
     layout: "fullscreen",
   },
 } as ComponentMeta<typeof Settings>;

--- a/app/client/components/linkButton.stories.tsx
+++ b/app/client/components/linkButton.stories.tsx
@@ -1,14 +1,15 @@
 import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { brand } from "@guardian/src-foundations/palette";
+import { brand, neutral } from "@guardian/src-foundations/palette";
 
-import { Button, ButtonProps } from "./buttons";
+import { LinkButton, LinkButtonProps } from "./buttons";
 
 export default {
-  title: "Components/Button",
-  component: Button,
+  title: "Components/LinkButton",
+  component: LinkButton,
   args: {
-    text: "Button",
+    text: "Link Button",
+    to: "/example",
     height: undefined,
     fontWeight: undefined,
     left: false,
@@ -60,28 +61,27 @@ export default {
       control: { type: "inline-radio" },
     },
   },
-} as ComponentMeta<typeof Button>;
+} as ComponentMeta<typeof LinkButton>;
 
-const Template: ComponentStory<typeof Button> = (args: ButtonProps) => (
-  <Button {...args} />
+const Template: ComponentStory<typeof LinkButton> = (args: LinkButtonProps) => (
+  <LinkButton {...args} />
 );
 
 export const Default = Template.bind({});
 
-export const Bold = Template.bind({});
-Bold.args = {
+export const BoldWithBrandColours = Template.bind({});
+BoldWithBrandColours.args = {
   fontWeight: "bold",
-};
-
-export const Disabled = Template.bind({});
-Disabled.args = {
-  disabled: true,
-};
-
-export const WithBrandColours = Template.bind({});
-WithBrandColours.args = {
   colour: brand[800],
   textColour: brand[400],
+};
+
+export const WithAlert = Template.bind({});
+WithAlert.args = {
+  alert: true,
+  fontWeight: "bold",
+  colour: brand[400],
+  textColour: neutral[100],
 };
 
 export const WithRightArrow = Template.bind({});
@@ -89,10 +89,9 @@ WithRightArrow.args = {
   right: true,
 };
 
-export const DisabledWithRightArrow = Template.bind({});
-DisabledWithRightArrow.args = {
-  disabled: true,
-  right: true,
+export const WithLeftArrow = Template.bind({});
+WithLeftArrow.args = {
+  left: true,
 };
 
 export const PrimaryWithRightArrow = Template.bind({});

--- a/app/client/components/maintenance.stories.tsx
+++ b/app/client/components/maintenance.stories.tsx
@@ -7,7 +7,7 @@ export default {
   title: "Pages/Maintenance",
   component: Maintenance,
   parameters: {
-    controls: { hideNoControlsWarning: true },
+    controls: { disabled: true },
     layout: "fullscreen",
   },
 } as ComponentMeta<typeof Maintenance>;

--- a/app/client/components/radioButton.stories.tsx
+++ b/app/client/components/radioButton.stories.tsx
@@ -7,7 +7,7 @@ export default {
   title: "Components/RadioButton",
   component: RadioButton,
   parameters: {
-    controls: { hideNoControlsWarning: true },
+    controls: { disabled: true },
   },
 } as ComponentMeta<typeof RadioButton>;
 

--- a/app/client/components/radioButton.stories.tsx
+++ b/app/client/components/radioButton.stories.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import { RadioButton } from "./radioButton";
+
+export default {
+  title: "Components/RadioButton",
+  component: RadioButton,
+  parameters: {
+    controls: { hideNoControlsWarning: true },
+  },
+} as ComponentMeta<typeof RadioButton>;
+
+export const Default: ComponentStory<typeof RadioButton> = () => (
+  <>
+    <RadioButton
+      value="directdebit"
+      label="Direct debit"
+      checked={true}
+      groupName="payment"
+      onChange={() => undefined}
+    />
+    <RadioButton
+      value="creditcard"
+      label="Credit/Debit card"
+      checked={false}
+      groupName="payment"
+      onChange={() => undefined}
+    />
+    <RadioButton
+      value="paypal"
+      label="PayPal"
+      checked={false}
+      groupName="payment"
+      onChange={() => undefined}
+    />
+  </>
+);

--- a/app/client/components/radioButton.tsx
+++ b/app/client/components/radioButton.tsx
@@ -2,7 +2,7 @@ import { css } from "@emotion/core";
 import React, { ChangeEvent } from "react";
 import palette from "../colours";
 
-interface RadioButtonProps {
+export interface RadioButtonProps {
   value: string;
   label: string;
   checked: boolean;
@@ -28,7 +28,7 @@ export class RadioButton extends React.Component<
         css={css({
           display: "block",
           cursor: "pointer",
-          marginBottom: "7px"
+          marginBottom: "7px",
         })}
       >
         <input
@@ -43,7 +43,7 @@ export class RadioButton extends React.Component<
             position: "absolute",
             width: 0,
             height: 0,
-            opacity: 0
+            opacity: 0,
           }}
         />
         <div css={{ position: "relative" }}>
@@ -66,13 +66,13 @@ export class RadioButton extends React.Component<
                   this.state.focus
                     ? palette.yellow.medium
                     : palette.neutral["6"]
-                }`
+                }`,
               },
               top: "2.5px",
               ...(this.props.checked && {
                 backgroundColor: palette.green.dark,
-                borderColor: palette.green.dark
-              })
+                borderColor: palette.green.dark,
+              }),
             })}
           />
           <div css={{ marginLeft: "1.5rem" }}>{this.props.label}</div>

--- a/app/client/components/spinner.stories.tsx
+++ b/app/client/components/spinner.stories.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import { Spinner, LoadingProps } from "./spinner";
+
+export default {
+  title: "Components/Spinner",
+  component: Spinner,
+  args: {
+    loadingMessage: "",
+    scale: 1,
+    inline: undefined,
+    alignCenter: undefined,
+  },
+  argTypes: {
+    inline: {
+      options: [true, undefined],
+      control: { type: "inline-radio" },
+    },
+    alignCenter: {
+      options: [true, undefined],
+      control: { type: "inline-radio" },
+    },
+  },
+} as ComponentMeta<typeof Spinner>;
+
+const Template: ComponentStory<typeof Spinner> = (args: LoadingProps) => (
+  <Spinner {...args} />
+);
+
+export const Default = Template.bind({});
+
+export const Scaled = Template.bind({});
+Scaled.args = {
+  scale: 2,
+};
+
+export const WithLoadingMessage = Template.bind({});
+WithLoadingMessage.args = {
+  loadingMessage: "Loading your account details...",
+};


### PR DESCRIPTION
## What does this change?

This continues the task of building out Storybook by adding stories for some of the app's generic components. There are no functional changes to components in this PR other than adding an `export` to the props interface so that it can be imported by the corresponding story. (The diff for some components is larger due to Prettier reformatting.)

## Images

<img width="697" alt="Screenshot 2022-02-04 at 10 09 21" src="https://user-images.githubusercontent.com/1166188/152511192-4da09e4b-612f-466d-8b37-a095b3454b03.png">

