### PR TITLE
Add eslint jest plugin

### DIFF
--- a/app/.eslintrc.js
+++ b/app/.eslintrc.js
@@ -34,7 +34,6 @@ module.exports = {
     "@typescript-eslint/ban-types": ["off"],
     "@typescript-eslint/explicit-module-boundary-types": ["off"],
     "@typescript-eslint/no-inferrable-types": ["off"],
-    "@typescript-eslint/no-explicit-any": ["off"],
     "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "_" }],
     "@typescript-eslint/ban-ts-comment": [
       "error",

--- a/app/.eslintrc.js
+++ b/app/.eslintrc.js
@@ -2,23 +2,31 @@ module.exports = {
   env: {
     browser: true,
     es2021: true,
-    node: true
+    node: true,
   },
   extends: [
     "eslint:recommended",
     "plugin:react/recommended",
-    "plugin:@typescript-eslint/recommended"
+    "plugin:jest/recommended",
+    "plugin:@typescript-eslint/recommended",
   ],
   parser: "@typescript-eslint/parser",
   parserOptions: {
     ecmaFeatures: {
-      jsx: true
+      jsx: true,
     },
     ecmaVersion: 12,
-    sourceType: "module"
+    sourceType: "module",
   },
-  plugins: ["react", "@typescript-eslint"],
-  ignorePatterns: ["client/__tests__/**"],
+  plugins: ["react", "@typescript-eslint", "jest"],
+  overrides: [
+    {
+      files: ["client/__tests__/**"],
+      rules: {
+        "@typescript-eslint/ban-ts-comment": ["off"],
+      },
+    },
+  ],
   rules: {
     "no-prototype-builtins": ["off"],
     "react/no-unescaped-entities": ["off"],
@@ -26,6 +34,7 @@ module.exports = {
     "@typescript-eslint/ban-types": ["off"],
     "@typescript-eslint/explicit-module-boundary-types": ["off"],
     "@typescript-eslint/no-inferrable-types": ["off"],
+    "@typescript-eslint/no-explicit-any": ["off"],
     "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "_" }],
     "@typescript-eslint/ban-ts-comment": [
       "error",
@@ -34,8 +43,8 @@ module.exports = {
         "ts-ignore": "allow-with-description",
         "ts-nocheck": "allow-with-description",
         "ts-check": "allow-with-description",
-        minimumDescriptionLength: 10
-      }
-    ]
-  }
+        minimumDescriptionLength: 10,
+      },
+    ],
+  },
 };

--- a/app/client/__tests__/components/accountoverview/contributionUpdateAmount.tsx
+++ b/app/client/__tests__/components/accountoverview/contributionUpdateAmount.tsx
@@ -1,11 +1,11 @@
 // @ts-nocheck
-import { debug, fireEvent, render, screen } from "@testing-library/react";
+/* eslint jest/no-standalone-expect: "off", jest/no-done-callback: "off" */
+import { fireEvent, render, screen } from "@testing-library/react";
 import each from "jest-each";
-import { before } from "lodash";
 import * as React from "react";
 import { ContributionUpdateAmount } from "../../../components/accountoverview/contributionUpdateAmount";
 
-const mainPlan = interval => ({
+const mainPlan = (interval) => ({
   start: "2019-10-30",
   end: "2050-10-30",
   amount: 500,
@@ -13,13 +13,13 @@ const mainPlan = interval => ({
   shouldBeVisible: false,
   currency: "£",
   currencyISO: "GBP",
-  interval
+  interval,
 });
 
 const productType = {
   productTitle: () => "contribution test",
   friendlyName: "recurring contribution",
-  urlPart: "contributions"
+  urlPart: "contributions",
 };
 
 each`
@@ -45,7 +45,7 @@ each`
 
     const otherInputElem = container.querySelector('input[type="number"]');
     fireEvent.change(otherInputElem, {
-      target: { value: params.expectedMinAmount - 1 }
+      target: { value: params.expectedMinAmount - 1 },
     });
 
     // click on the change amount button again and then check to make sure that the validation error message shows up
@@ -87,7 +87,7 @@ each`
 
     const otherInputElem = container.querySelector('input[type="number"]');
     fireEvent.change(otherInputElem, {
-      target: { value: params.expectedMaxAmount + 1 }
+      target: { value: params.expectedMaxAmount + 1 },
     });
 
     // click on the change amount button again and then check to make sure that the validation error message shows up
@@ -106,7 +106,7 @@ each`
   }
 );
 
-test("renders validation error if blank input is provided", done => {
+test("renders validation error if blank input is provided", (done) => {
   const { container } = render(
     <ContributionUpdateAmount
       subscriptionId="A-123"
@@ -123,7 +123,7 @@ test("renders validation error if blank input is provided", done => {
 
   const otherInputElem = container.querySelector('input[type="number"]');
   fireEvent.change(otherInputElem, {
-    target: { value: "" }
+    target: { value: "" },
   });
 
   // click on the change amount button again and then check to make sure that the validation error message shows up
@@ -139,7 +139,7 @@ test("renders validation error if blank input is provided", done => {
   done();
 });
 
-test("renders validation error if a string is attempted to be input", done => {
+test("renders validation error if a string is attempted to be input", (done) => {
   const { container } = render(
     <ContributionUpdateAmount
       subscriptionId="A-123"
@@ -156,7 +156,7 @@ test("renders validation error if a string is attempted to be input", done => {
 
   const otherInputElem = container.querySelector('input[type="number"]');
   fireEvent.change(otherInputElem, {
-    target: { value: "twelfty" }
+    target: { value: "twelfty" },
   });
 
   // click on the change amount button again and then check to make sure that the validation error message shows up
@@ -172,7 +172,7 @@ test("renders validation error if a string is attempted to be input", done => {
   done();
 });
 
-test("input correct value", done => {
+test("input correct value", (done) => {
   // mock the console error for this test case to mute "Cannot update a component (`Unknown`) while rendering a different component" error
   const mockedError = () => true;
   // tslint:disable-next-line
@@ -194,7 +194,7 @@ test("input correct value", done => {
 
   const otherInputElem = container.querySelector('input[type="number"]');
   fireEvent.change(otherInputElem, {
-    target: { value: 4 }
+    target: { value: 4 },
   });
 
   // click on the change amount button again and then check to make sure that the validation error message shows up
@@ -203,5 +203,3 @@ test("input correct value", done => {
 
   done();
 });
-
-// screen.debug();

--- a/app/client/__tests__/components/delivery/records/deliveryRecords/deliveryRecords.tsx
+++ b/app/client/__tests__/components/delivery/records/deliveryRecords/deliveryRecords.tsx
@@ -1,7 +1,7 @@
 import {
   DATE_FNS_INPUT_FORMAT,
   dateAddDays,
-  dateString
+  dateString,
 } from "../../../../../../shared/dates";
 import { checkForExistingDeliveryProblem } from "../../../../../components/delivery/records/deliveryRecords";
 import { DeliveryRecordDetail } from "../../../../../components/delivery/records/deliveryRecordsApi";
@@ -15,10 +15,10 @@ describe("delivery records unit tests", () => {
     addressCountry: "addressCountry",
     addressPostcode: "addressPostcode",
     hasHolidayStop: false,
-    deliveryDate: dateString(new Date(), DATE_FNS_INPUT_FORMAT)
+    deliveryDate: dateString(new Date(), DATE_FNS_INPUT_FORMAT),
   };
 
-  test("checkForExistingDeliveryProblem returns true if ", () => {
+  test("checkForExistingDeliveryProblem returns true if", () => {
     const deliverRecords = [
       {
         ...baseMockDeliveryRecord,
@@ -26,8 +26,8 @@ describe("delivery records unit tests", () => {
           dateAddDays(new Date(), -7),
           DATE_FNS_INPUT_FORMAT
         ),
-        problemCaseId: "123"
-      }
+        problemCaseId: "123",
+      },
     ];
     expect(checkForExistingDeliveryProblem(deliverRecords)).toEqual(true);
   });

--- a/app/client/__tests__/components/delivery/records/deliveryRecords/step1.tsx
+++ b/app/client/__tests__/components/delivery/records/deliveryRecords/step1.tsx
@@ -1,3 +1,4 @@
+/* eslint jest/no-conditional-expect: "off" */
 import Enzyme, { mount } from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
 import React from "react";
@@ -20,6 +21,7 @@ Enzyme.configure({ adapter: new Adapter() });
    ************************************************** */
 
 declare global {
+  /* eslint-disable-next-line */
   namespace NodeJS {
     interface Global {
       document: Document;

--- a/app/client/__tests__/components/header.tsx
+++ b/app/client/__tests__/components/header.tsx
@@ -3,7 +3,7 @@ import "@testing-library/jest-dom";
 import React from "react";
 import Header from "../../components/header";
 
-describe.only("Header", () => {
+describe("Header", () => {
   it("renders the header in a signed out state", () => {
     render(<Header signInStatus="signedOut" />);
     expect(screen.getByRole("link", { name: "Sign in" })).toBeInTheDocument();

--- a/app/client/__tests__/components/helpCentre/helpCentreContactOptions.tsx
+++ b/app/client/__tests__/components/helpCentre/helpCentreContactOptions.tsx
@@ -69,7 +69,7 @@ describe("HelpCentreContactOptions", () => {
           );
         });
 
-        it("it shows a 'Contact us' button only with contact options hidden", () => {
+        it("shows a 'Contact us' button only with contact options hidden", () => {
           render(
             <HelpCentreContactOptions
               compactLayout={true}

--- a/app/client/__tests__/components/payment/stripe.ts
+++ b/app/client/__tests__/components/payment/stripe.ts
@@ -27,7 +27,7 @@ test("Uses Rest Of World Stripe key for UK delivery address", () => {
   );
 });
 
-test("Uses Australian Stripe key for Autralian delivery address", () => {
+test("Uses Australian Stripe key for Australian delivery address", () => {
   const stripePublicKey = getStripeKey(
     guardianWeeklySubscriptionAustralia.deliveryAddress?.country,
     false

--- a/app/package.json
+++ b/app/package.json
@@ -103,6 +103,7 @@
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.4",
     "eslint": "^7.32.0",
+    "eslint-plugin-jest": "^26.1.0",
     "eslint-plugin-react": "^7.25.3",
     "fetch-mock": "^9.11.0",
     "git-revision-webpack-plugin": "^3.0.6",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -4299,7 +4299,7 @@
   resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-2.2.3.tgz#30525e93231074d4a092d9f5608c25d5c7a72085"
   integrity sha512-gfrTQ6xQhPch+Jew+GVUXa7W2Wssh6EbxXDV8xkLD+Pe3VMIuWUh25yH1wOKiWyrYi2zPrS8e6UEgZt7dZXwyQ==
 
-"@types/json-schema@*", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.7", "@types/json-schema@^7.0.8":
+"@types/json-schema@*", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.7", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
@@ -4617,10 +4617,23 @@
     "@typescript-eslint/types" "4.31.1"
     "@typescript-eslint/visitor-keys" "4.31.1"
 
+"@typescript-eslint/scope-manager@5.11.0":
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.11.0.tgz#f5aef83ff253f457ecbee5f46f762298f0101e4b"
+  integrity sha512-z+K4LlahDFVMww20t/0zcA7gq/NgOawaLuxgqGRVKS0PiZlCTIUtX0EJbC0BK1JtR4CelmkPK67zuCgpdlF4EA==
+  dependencies:
+    "@typescript-eslint/types" "5.11.0"
+    "@typescript-eslint/visitor-keys" "5.11.0"
+
 "@typescript-eslint/types@4.31.1":
   version "4.31.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.31.1.tgz#5f255b695627a13401d2fdba5f7138bc79450d66"
   integrity sha512-kixltt51ZJGKENNW88IY5MYqTBA8FR0Md8QdGbJD2pKZ+D5IvxjTYDNtJPDxFBiXmka2aJsITdB1BtO1fsgmsQ==
+
+"@typescript-eslint/types@5.11.0":
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.11.0.tgz#ba345818a2540fdf2755c804dc2158517ab61188"
+  integrity sha512-cxgBFGSRCoBEhvSVLkKw39+kMzUKHlJGVwwMbPcTZX3qEhuXhrjwaZXWMxVfxDgyMm+b5Q5b29Llo2yow8Y7xQ==
 
 "@typescript-eslint/typescript-estree@4.31.1":
   version "4.31.1"
@@ -4635,6 +4648,31 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
+"@typescript-eslint/typescript-estree@5.11.0":
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.11.0.tgz#53f9e09b88368191e52020af77c312a4777ffa43"
+  integrity sha512-yVH9hKIv3ZN3lw8m/Jy5I4oXO4ZBMqijcXCdA4mY8ull6TPTAoQnKKrcZ0HDXg7Bsl0Unwwx7jcXMuNZc0m4lg==
+  dependencies:
+    "@typescript-eslint/types" "5.11.0"
+    "@typescript-eslint/visitor-keys" "5.11.0"
+    debug "^4.3.2"
+    globby "^11.0.4"
+    is-glob "^4.0.3"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/utils@^5.10.0":
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.11.0.tgz#d91548ef180d74c95d417950336d9260fdbe1dc5"
+  integrity sha512-g2I480tFE1iYRDyMhxPAtLQ9HAn0jjBtipgTCZmd9I9s11OV8CTsG+YfFciuNDcHqm4csbAgC2aVZCHzLxMSUw==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@typescript-eslint/scope-manager" "5.11.0"
+    "@typescript-eslint/types" "5.11.0"
+    "@typescript-eslint/typescript-estree" "5.11.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+
 "@typescript-eslint/visitor-keys@4.31.1":
   version "4.31.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.31.1.tgz#f2e7a14c7f20c4ae07d7fc3c5878c4441a1da9cc"
@@ -4642,6 +4680,14 @@
   dependencies:
     "@typescript-eslint/types" "4.31.1"
     eslint-visitor-keys "^2.0.0"
+
+"@typescript-eslint/visitor-keys@5.11.0":
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.11.0.tgz#888542381f1a2ac745b06d110c83c0b261487ebb"
+  integrity sha512-E8w/vJReMGuloGxJDkpPlGwhxocxOpSVgSvjiLO5IxZPmxZF30weOeJYyPSEACwM+X4NziYS9q+WkN/2DHYQwA==
+  dependencies:
+    "@typescript-eslint/types" "5.11.0"
+    eslint-visitor-keys "^3.0.0"
 
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
@@ -7443,7 +7489,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.1.0, debug@^4.1.1:
+debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
   integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
@@ -8390,6 +8436,13 @@ escodegen@^2.0.0:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-plugin-jest@^26.1.0:
+  version "26.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-26.1.0.tgz#9f6c33e66f3cef3f2832c3a4d2caa21a75792dee"
+  integrity sha512-vjF6RvcKm4xZSJgCmXb9fXmhzTva+I9jtj9Qv5JeZQTRocU7WT1g3Kx0cZ+00SekPe2DtSWDawHtSj4RaxFhXQ==
+  dependencies:
+    "@typescript-eslint/utils" "^5.10.0"
+
 eslint-plugin-react@^7.25.3:
   version "7.25.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.25.3.tgz#3333a974772745ddb3aecea84621019b635766bc"
@@ -8448,6 +8501,11 @@ eslint-visitor-keys@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
+
+eslint-visitor-keys@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz#6fbb166a6798ee5991358bc2daa1ba76cc1254a1"
+  integrity sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==
 
 eslint@^7.32.0:
   version "7.32.0"
@@ -9543,7 +9601,7 @@ globby@^11.0.1, globby@^11.0.3:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
-globby@^11.0.2:
+globby@^11.0.2, globby@^11.0.4:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==


### PR DESCRIPTION
## What does this change?

Adds `eslint-plugin-jest` and minor error fixes. 

I've disabled specific linting rules in a couple local files so easier to review/fix in future if desired: 
- app/client/__tests__/components/delivery/records/deliveryRecords/step1.tsx
- app/client/__tests__/components/accountoverview/contributionUpdateAmount.tsx

Turned off two rules to reduce 'warning' noise:
- "@typescript-eslint/no-explicit-any": ["off"]
- "@typescript-eslint/ban-ts-comment": ["off"] - tests only

There are still several warnings about tests that have no assertions (`jest/expect-expect`) in payment components. 


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
