### PR TITLE
Exclude Dependabot PRs from Chromatic and Cypress actions

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,5 +1,8 @@
 name: Chromatic
-on: push
+on:
+  push:
+    branches-ignore:
+      - "dependabot/**"
 
 jobs:
   chromatic:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,5 +1,8 @@
 name: manage-frontend cypress
-on: push
+on:
+  push:
+    branches-ignore:
+      - "dependabot/**"
 
 jobs:
   cypress:


### PR DESCRIPTION
## What does this change?

The Chromatic and Cypress checks fail on PRs raised by Dependabot. This is due to [the actions not having access to GitHub secrets](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions#accessing-secrets) so they can't be run. As Dependabot PRs are raised relatively infrequently, tend not to cause UI regressions, and the checks are still run when merging to `main` we felt that it was safe to exclude Dependabot PRs from these actions for now rather than duplicating the secrets for Dependabot. (We may revisit this at a later date.)