### PR TITLE
Use configure-aws-credentials instead of actions-assume-aws-role

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -19,9 +19,10 @@ jobs:
         group: [1, 2, 3, 4, 5, 6]
 
     steps:
-      - uses: guardian/actions-assume-aws-role@v1.0.0
+      - uses: aws-actions/configure-aws-credentials@v1
         with:
-          awsRoleToAssume: ${{ secrets.MANAGE_FRONTEND_IAM_ROLE }}
+          role-to-assume: ${{ secrets.MANAGE_FRONTEND_IAM_ROLE }}
+          aws-region: eu-west-1
 
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v2


### PR DESCRIPTION
We developed https://github.com/guardian/actions-assume-aws-role to support AWS IAM role assumption within GitHub Actions.

There is now an official action (maintained by AWS) which offers this functionality - https://github.com/aws-actions/configure-aws-credentials. This PR switches to using the AWS alternative instead of the (now deprecated) Guardian action. 

Related PRs:
https://github.com/guardian/actions-assume-aws-role/pull/80
https://github.com/guardian/node-riffraff-artifact/pull/33
https://github.com/guardian/sbt-riffraff-artifact/pull/69