### PR TITLE
Use API Consents response instead of hardcoded

### DIFF
--- a/app/client/components/identity/EmailAndMarketing/OptOutSection.tsx
+++ b/app/client/components/identity/EmailAndMarketing/OptOutSection.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react';
 import { Lines } from '../Lines';
 import { WithStandardTopMargin } from '../../WithStandardTopMargin';
 import { MarketingToggle } from '../MarketingToggle';
-import { ConsentOption, ConsentOptionType } from '../models';
+import { ConsentOption } from '../models';
 import { PageSection } from '../PageSection';
 
 type ClickHandler = (id: string) => {};
@@ -63,31 +63,7 @@ const YourDataDescription: FC = () => (
 export const OptOutSection: FC<OptOutSectionProps> = (props) => {
 	const { consents, clickHandler } = props;
 
-	// TODO: Replace consentsHardcoded with props.consents once API Change released
-	const consentsHardcoded: ConsentOption[] = consents.map((consent) => {
-		const match = consentsFixture.find(
-			(hardConsent) => hardConsent.id === consent.id,
-		);
-		if (match) {
-			return {
-				id: consent.id,
-				isChannel: consent.isChannel,
-				isProduct: consent.isProduct,
-				type: consent.type,
-				subscribed: consent.subscribed,
-				name: match.name,
-				...('description' in match && {
-					description: match.description,
-				}),
-			};
-		}
-		return consent;
-	});
-
-	const addMarketingToggle = optOutFinderAndInverter(
-		consentsHardcoded,
-		clickHandler,
-	);
+	const addMarketingToggle = optOutFinderAndInverter(consents, clickHandler);
 
 	return (
 		<>
@@ -116,41 +92,3 @@ export const OptOutSection: FC<OptOutSectionProps> = (props) => {
 		</>
 	);
 };
-
-// TODO Replace with IDAPI model values once released
-const consentsFixture: ConsentOption[] = [
-	{
-		id: 'market_research_optout',
-		description:
-			'From time to time we may contact you for market research purposes inviting you to complete a survey, or take part in a group discussion. Normally, this invitation would be sent via email, but we may also contact you by phone.',
-		name: 'Allow the Guardian to contact me for market research purposes',
-		isProduct: false,
-		isChannel: false,
-		type: ConsentOptionType.OPT_OUT,
-		subscribed: false,
-	},
-	{
-		id: 'post_optout',
-		name: 'Allow the Guardian to send communications by post',
-		isProduct: false,
-		isChannel: false,
-		type: ConsentOptionType.OPT_OUT,
-		subscribed: true,
-	},
-	{
-		id: 'profiling_optout',
-		name: 'Allow the Guardian to analyse this data to improve marketing content',
-		isProduct: false,
-		isChannel: false,
-		type: ConsentOptionType.OPT_OUT,
-		subscribed: true,
-	},
-	{
-		id: 'phone_optout',
-		name: 'Allow the Guardian to send communications by telephone',
-		isProduct: false,
-		isChannel: true,
-		type: ConsentOptionType.OPT_OUT,
-		subscribed: false,
-	},
-];


### PR DESCRIPTION
RELEASING 15/3

## What does this change?

We need to hard code the new opt out consent wordings so that we could implement the toggle before updating the Consent model in the API. 

Once the[ model change PR](https://github.com/guardian/identity/pull/2079) is relased we can use that response instead. 

## How to test

- [x] tested in Code

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
