### PR TITLE
Do not render theme dropdown if there are no newsletters

### DIFF
--- a/app/client/components/identity/EmailAndMarketing/NewsletterSection.tsx
+++ b/app/client/components/identity/EmailAndMarketing/NewsletterSection.tsx
@@ -60,13 +60,18 @@ const newsletterPreferenceGroups = (
 		Theme.work,
 		Theme.FromThePapers,
 	];
-	return themes.map((theme) => (
-		<DropMenu key={theme} color={colors[theme]} title={theme}>
-			{newsletters
-				.filter((n) => n.theme === theme)
-				.map((n) => newsletterPreference(n, clickHandler))}
-		</DropMenu>
-	));
+	return themes.map((theme) => {
+		const newslettersForTheme = newsletters.filter(
+			(n) => n.theme === theme,
+		);
+		return newslettersForTheme.length ? (
+			<DropMenu key={theme} color={colors[theme]} title={theme}>
+				{newslettersForTheme.map((n) =>
+					newsletterPreference(n, clickHandler),
+				)}
+			</DropMenu>
+		) : null;
+	});
 };
 
 export const NewsletterSection: FC<NewsletterSectionProps> = (props) => {


### PR DESCRIPTION
## What does this change?

It is possible for newsletters to be marked as inactive, and therefore hidden from MMA. If there are no newsletters visible for a given newsletter category, we should no longer display that theme dropdown as it can be confusing for users.

* Do not render theme dropdown if there are no newsletters for that theme

An alternative approach would be to render a message within the theme dropdown instead of hiding the dropdown

## How to test

* Verify that there all categories have newsletters, so that there are no empty categories

## Images

### Before

* Both the Comment and From the Papers sections are empty yet still appear

![Screenshot 2022-03-18 at 16 10 19](https://user-images.githubusercontent.com/705427/159040336-18f8c998-10a5-48a0-b517-e3ff30476a37.png)

### After

* The empty sections no longer appear

![Screenshot 2022-03-18 at 16 07 40](https://user-images.githubusercontent.com/705427/159039852-8086e545-bc07-4cbe-a626-548654d51c1c.png)


