### PR TITLE
livechat start button position

### DIFF
--- a/app/client/components/liveChat/liveChatCssOverrides.ts
+++ b/app/client/components/liveChat/liveChatCssOverrides.ts
@@ -13,7 +13,7 @@ export const liveChatCss = css`
 			top: 0;
 			width: 100%;
 			max-width: 100%;
-			min-height: 100vh;
+			min-height: 100%;
 			margin-top: 0;
 		}
 		.embeddedServiceLiveAgentSidebarFeature


### PR DESCRIPTION
## What does this change?
Fix issue on mobile browsers where 100vh used in conjunction with position: fixed calculated the window inner size and the url bar meaning the start live chat button was being pushed below the fold of the screen without the option to scroll down and view/click it :s

## Images

Before             |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/2510683/160885692-29b43c02-ad63-4c02-9a0e-261ab13434f5.png)  |  ![](https://user-images.githubusercontent.com/2510683/160885775-be8c852d-8e48-46c6-b3e8-b79aebf30f5a.png)

