### PR TITLE
Clean up Cypress specs

### DIFF
--- a/app/cypress/integration/parallel-1/updatePaymentDetails.spec.ts
+++ b/app/cypress/integration/parallel-1/updatePaymentDetails.spec.ts
@@ -1,4 +1,3 @@
-import { setLocalBaseUrl } from '../../lib/setLocalBaseUrl';
 import {
 	guardianWeeklyCurrentSubscription,
 	digitalDD,
@@ -9,49 +8,14 @@ import {
 	ddPaymentMethod,
 } from '../../../client/fixtures/payment';
 import { paymentMethods } from '../../../client/fixtures/stripe';
+import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
 
-// 'No IAB consent management framework' exception is thrown from here: https://github.com/guardian/consent-management-platform/blob/405a4fee4c54c2bdabea3df0fd1bf187ae6d7927/src/onConsentChange.ts#L34
-Cypress.on('uncaught:exception', () => {
-	return false;
-});
-
-const iframeMessage = `[id^="sp_message_iframe_"]`;
-const acceptCookiesButtonText = 'Yes, I’m happy';
-
-describe('E2E Page rendering', function () {
-	beforeEach(function () {
-		cy.session('auth', () => {
-			setLocalBaseUrl();
-
-			cy.intercept('GET', '/api/me/mma', {
-				statusCode: 200,
-				body: [guardianWeeklyCurrentSubscription],
-			}).as('mma');
-
-			cy.intercept('GET', '/api/cancelled/', {
-				statusCode: 200,
-				body: [],
-			}).as('cancelled');
-
-			cy.wait(1000);
-			cy.visit('/');
-
-			cy.wait('@mma');
-			cy.wait('@cancelled');
-
-			// accept cookies
-			cy.getIframeBody(iframeMessage)
-				.find(`button[title="${acceptCookiesButtonText}"]`, {
-					timeout: 10000,
-				})
-				.click();
-
-			// wait for cookies to be set
-			cy.wait(1000);
-		});
+describe('Update payment details', () => {
+	beforeEach(() => {
+		signInAndAcceptCookies();
 	});
 
-	it('Complete card payment update', function () {
+	it('Complete card payment update', () => {
 		cy.intercept('GET', '/api/me/mma?productType=*', {
 			statusCode: 200,
 			body: [guardianWeeklyCurrentSubscription],
@@ -118,7 +82,7 @@ describe('E2E Page rendering', function () {
 		cy.get('@scala_backend.all').should('have.length', 1);
 	});
 
-	it('Shows correct error messages for direct debit form', function () {
+	it('Shows correct error messages for direct debit form', () => {
 		cy.intercept('GET', '/api/me/mma?productType=*', {
 			statusCode: 200,
 			body: [digitalDD],
@@ -154,7 +118,7 @@ describe('E2E Page rendering', function () {
 		);
 	});
 
-	it('Complete direct debit payment update', function () {
+	it('Complete direct debit payment update', () => {
 		cy.intercept('GET', '/api/me/mma?productType=*', {
 			statusCode: 200,
 			body: [digitalDD],
@@ -194,7 +158,7 @@ describe('E2E Page rendering', function () {
 		cy.get('@scala_backend.all').should('have.length', 1);
 	});
 
-	it('Show recaptcha error', function () {
+	it('Show recaptcha error', () => {
 		cy.intercept('GET', '/api/me/mma?productType=*', {
 			statusCode: 200,
 			body: [guardianWeeklyCurrentSubscription],

--- a/app/cypress/integration/parallel-2/cancelContribution.spec.ts
+++ b/app/cypress/integration/parallel-2/cancelContribution.spec.ts
@@ -1,48 +1,12 @@
-import { setLocalBaseUrl } from '../../lib/setLocalBaseUrl';
 import { contribution } from '../../../client/fixtures/productDetail';
+import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
 
-// 'No IAB consent management framework' exception is thrown from here: https://github.com/guardian/consent-management-platform/blob/405a4fee4c54c2bdabea3df0fd1bf187ae6d7927/src/onConsentChange.ts#L34
-Cypress.on('uncaught:exception', () => {
-	return false;
-});
-
-const iframeMessage = `[id^="sp_message_iframe_"]`;
-const acceptCookiesButtonText = 'Yes, I’m happy';
-
-describe('E2E Page rendering', function () {
-	beforeEach(function () {
-		cy.session('auth', () => {
-			setLocalBaseUrl();
-
-			cy.intercept('GET', '/api/me/mma', {
-				statusCode: 200,
-				body: [contribution],
-			}).as('mma');
-
-			cy.intercept('GET', '/api/cancelled/', {
-				statusCode: 200,
-				body: [],
-			}).as('cancelled');
-
-			cy.wait(1000);
-			cy.visit('/');
-
-			cy.wait('@mma');
-			cy.wait('@cancelled');
-
-			// accept cookies
-			cy.getIframeBody(iframeMessage)
-				.find(`button[title="${acceptCookiesButtonText}"]`, {
-					timeout: 10000,
-				})
-				.click();
-
-			// wait for cookies to be set
-			cy.wait(1000);
-		});
+describe('Cancel contribution', () => {
+	beforeEach(() => {
+		signInAndAcceptCookies();
 	});
 
-	it('cancels contribution', function () {
+	it('cancels contribution', () => {
 		cy.intercept('GET', '/api/me/mma?productType=Contribution', {
 			statusCode: 200,
 			body: [contribution],

--- a/app/cypress/integration/parallel-3/holidayStops.spec.ts
+++ b/app/cypress/integration/parallel-3/holidayStops.spec.ts
@@ -1,4 +1,3 @@
-import { setLocalBaseUrl } from '../../lib/setLocalBaseUrl';
 import { guardianWeeklyCurrentSubscription } from '../../../client/fixtures/productDetail';
 import {
 	potentialDeliveries,
@@ -6,46 +5,11 @@ import {
 	existingHolidays,
 	existingHolidaysWithDeletion,
 } from '../../../client/fixtures/holidays';
+import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
 
-// 'No IAB consent management framework' exception is thrown from here: https://github.com/guardian/consent-management-platform/blob/405a4fee4c54c2bdabea3df0fd1bf187ae6d7927/src/onConsentChange.ts#L34
-Cypress.on('uncaught:exception', () => {
-	return false;
-});
-
-const iframeMessage = `[id^="sp_message_iframe_"]`;
-const acceptCookiesButtonText = 'Yes, I’m happy';
-
-describe('Holiday stops', function () {
-	beforeEach(function () {
-		cy.session('auth', () => {
-			setLocalBaseUrl();
-
-			cy.intercept('GET', '/api/me/mma', {
-				statusCode: 200,
-				body: [guardianWeeklyCurrentSubscription],
-			}).as('mma');
-
-			cy.intercept('GET', '/api/cancelled/', {
-				statusCode: 200,
-				body: [],
-			}).as('cancelled');
-
-			cy.wait(1000);
-			cy.visit('/');
-
-			cy.wait('@mma');
-			cy.wait('@cancelled');
-
-			// accept cookies
-			cy.getIframeBody(iframeMessage)
-				.find(`button[title="${acceptCookiesButtonText}"]`, {
-					timeout: 10000,
-				})
-				.click();
-
-			// wait for cookies to be set
-			cy.wait(1000);
-		});
+describe('Holiday stops', () => {
+	beforeEach(() => {
+		signInAndAcceptCookies();
 
 		cy.intercept('GET', '/api/me/mma?productType=Weekly', {
 			statusCode: 200,
@@ -70,7 +34,7 @@ describe('Holiday stops', function () {
 		}).as('create_holiday_stop');
 	});
 
-	it('can add a new holiday stop', function () {
+	it('can add a new holiday stop', () => {
 		cy.visit('/suspend/guardianweekly');
 		cy.wait('@fetch_existing_holidays');
 		cy.wait('@product_detail');
@@ -96,7 +60,7 @@ describe('Holiday stops', function () {
 		cy.findByText('Your schedule has been set').should('exist');
 	});
 
-	it('can amend a non-confirmed holiday stop', function () {
+	it('can amend a non-confirmed holiday stop', () => {
 		cy.visit('/suspend/guardianweekly');
 		cy.wait('@fetch_existing_holidays');
 		cy.wait('@product_detail');
@@ -124,7 +88,7 @@ describe('Holiday stops', function () {
 		cy.get('[aria-label="day"]').eq(1).should('have.value', '18');
 	});
 
-	it('can not create a holiday stop for date range when there are no deliveries', function () {
+	it('can not create a holiday stop for date range when there are no deliveries', () => {
 		cy.intercept('GET', '/api/holidays/A-S00293857/potential?*', {
 			statusCode: 200,
 			body: noPotentialDeliveries,
@@ -142,7 +106,7 @@ describe('Holiday stops', function () {
 		cy.findByText('No issues occur during selected period').should('exist');
 	});
 
-	it('shows existing holidays stops on landing page', function () {
+	it('shows existing holidays stops on landing page', () => {
 		cy.visit('/suspend/guardianweekly');
 		cy.wait('@fetch_existing_holidays');
 		cy.wait('@product_detail');
@@ -150,7 +114,7 @@ describe('Holiday stops', function () {
 		cy.get('table').contains('11 March - 12 March 2022');
 	});
 
-	it('can amend an existing holiday stop', function () {
+	it('can amend an existing holiday stop', () => {
 		cy.visit('/suspend/guardianweekly');
 		cy.wait('@fetch_existing_holidays');
 		cy.wait('@product_detail');
@@ -166,7 +130,7 @@ describe('Holiday stops', function () {
 		cy.get('table').contains('9 February - 11 February 2022');
 	});
 
-	it('can delete an existing holiday stop', function () {
+	it('can delete an existing holiday stop', () => {
 		cy.intercept('DELETE', '/api/holidays/*/*', {
 			statusCode: 200,
 			body: {

--- a/app/cypress/lib/setLocalBaseUrl.ts
+++ b/app/cypress/lib/setLocalBaseUrl.ts
@@ -1,2 +1,0 @@
-export const setLocalBaseUrl = () =>
-	Cypress.config('baseUrl', 'http://localhost:9234');

--- a/app/cypress/lib/signInAndAcceptCookies.ts
+++ b/app/cypress/lib/signInAndAcceptCookies.ts
@@ -1,0 +1,32 @@
+const iframeMessage = `[id^="sp_message_iframe_"]`;
+const acceptCookiesButtonText = 'Yes, I’m happy';
+
+export const signInAndAcceptCookies = () => {
+	cy.session('auth', () => {
+		cy.intercept('GET', '/api/me/mma', {
+			statusCode: 200,
+			body: [],
+		}).as('mma');
+
+		cy.intercept('GET', '/api/cancelled/', {
+			statusCode: 200,
+			body: [],
+		}).as('cancelled');
+
+		cy.wait(1000);
+		cy.visit('/');
+
+		cy.wait('@mma');
+		cy.wait('@cancelled');
+
+		// accept cookies
+		cy.getIframeBody(iframeMessage)
+			.find(`button[title="${acceptCookiesButtonText}"]`, {
+				timeout: 10000,
+			})
+			.click();
+
+		// wait for cookies to be set
+		cy.wait(1000);
+	});
+};

--- a/app/cypress/support/index.ts
+++ b/app/cypress/support/index.ts
@@ -30,3 +30,8 @@ declare global {
 		}
 	}
 }
+
+// 'No IAB consent management framework' exception is thrown from here: https://github.com/guardian/consent-management-platform/blob/405a4fee4c54c2bdabea3df0fd1bf187ae6d7927/src/onConsentChange.ts#L34
+Cypress.on('uncaught:exception', () => {
+	return false;
+});


### PR DESCRIPTION
## What does this change?

- Moves authentication and cookie banner set up to separate module to avoid duplication in specs
- Removes unnecessary `setLocalBaseUrl` method (this is already defined in `cypress.json`)
- Moves IAB consent management framework exception handling to global test set up in `index.ts` to avoid duplicating in specs