### PR TITLE
Deploy static assets to separate S3 bucket

### DIFF
--- a/app/artifact.json
+++ b/app/artifact.json
@@ -11,6 +11,11 @@
       "action": "manage-frontend",
       "path": "dist",
       "compress": "zip"
+    },
+    {
+      "action": "assets-static",
+      "path": "dist/static",
+      "compress": false
     }
   ]
 }

--- a/app/riff-raff.yaml
+++ b/app/riff-raff.yaml
@@ -3,6 +3,14 @@ regions:
 stacks:
   - support
 deployments:
+  assets-static:
+    type: aws-s3
+    parameters:
+      bucket: manage-frontend-static
+      prefixPackage: false
+      prefixStack: false
+      cacheControl: public, max-age=31536000
+      publicReadAcl: true
   manage-frontend-cloudformation:
     type: cloud-formation
     app: manage-frontend

--- a/manage-frontend-static/PROD-deploy.sh
+++ b/manage-frontend-static/PROD-deploy.sh
@@ -6,4 +6,4 @@ aws cloudformation deploy \
     --stack-name manage-PROD-frontend-static \
     --template-file cfn.yaml \
     --region eu-west-1 \
-    --tags App=frontend-static Stage=PROD Stack=support
+    --tags App=manage-frontend-static Stage=PROD Stack=support

--- a/manage-frontend-static/PROD-deploy.sh
+++ b/manage-frontend-static/PROD-deploy.sh
@@ -1,0 +1,9 @@
+# Run this file to deploy the frontend static assets bucket defined in the cfn
+# This probably won't be a common task, but see the Readme to understand more
+
+aws cloudformation deploy \
+    --profile membership \
+    --stack-name manage-PROD-frontend-static \
+    --template-file cfn.yaml \
+    --region eu-west-1 \
+    --tags App=frontend-static Stage=PROD Stack=support

--- a/manage-frontend-static/README.md
+++ b/manage-frontend-static/README.md
@@ -1,0 +1,33 @@
+# manage-frontend-static
+
+This cloudforms the assets bucket for the assets that
+is used by manage-frontend.
+
+# Deploying to PROD (manual)
+
+1. make your changes to cfn
+1. do a PR and get it approved
+1. merge to default branch
+1. check out the default branch locally
+1. get janus credentials
+1. run ./PROD-deploy.sh
+
+# More information
+
+Traditionally this would just be a manually created bucket
+but that doesn't really help us if we need to recreate the
+stack.
+
+For cloudformed assets normally riffraff uses the
+stack/stage/app tags to look up the right resource.
+However the aws-s3 task of riffraff needs
+a specific bucket name (or a key in the target account's
+SSM)
+
+This does make it a little tricky to cloudform along with
+the rest of the app, but it's simple enough to put the
+bucket in its own cloudformation.
+
+It's only possible to deploy this into PROD and once
+deployed it should not be deleted, only updated, as
+deleting it would leave open an S3 bucket on our domain.

--- a/manage-frontend-static/cfn.yaml
+++ b/manage-frontend-static/cfn.yaml
@@ -1,0 +1,10 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: manage-frontend-static
+Resources:
+  S3Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      AccessControl: Private
+      BucketName: manage-frontend-static
+      MetricsConfigurations:
+        - Id: EntireBucket


### PR DESCRIPTION
## What does this change?

Deploys static assets to a separate S3 bucket so that assets from previous deploys are retained in order to mitigate chunk loading errors following deployment due to previous assets being removed.

See the precedent at https://github.com/guardian/support-frontend/pull/2016 for more info