### PR TITLE
[JD RB] - change s3 asset max cache age

### DIFF
--- a/app/riff-raff.yaml
+++ b/app/riff-raff.yaml
@@ -9,7 +9,7 @@ deployments:
       bucket: manage-frontend-static
       prefixPackage: false
       prefixStack: false
-      cacheControl: public, max-age=31536000
+      cacheControl: public, max-age=30
       publicReadAcl: true
   manage-frontend-cloudformation:
     type: cloud-formation


### PR DESCRIPTION
## What does this change?

Some of the assets have fixed names therefore we need to fetch a fresh copy soon after a deploy. The simplest way around that is to set a short max cache age time.
