### PR TITLE
[RB] - add optional chaining operator

### DIFF
--- a/app/client/components/cancel/CancellationReasonReview.tsx
+++ b/app/client/components/cancel/CancellationReasonReview.tsx
@@ -309,7 +309,7 @@ const CancellationReasonReview = () => {
 		cancellationPolicy: string;
 	};
 
-	if (!routerState.selectedReasonId) {
+	if (!routerState?.selectedReasonId) {
 		return <Navigate to=".." />;
 	}
 


### PR DESCRIPTION
## What does this change?
Add optional chaining operator to the router state selected reason check in the cancellation review stage. In order to catch the possibility that the router state itself is null and throwing an error trying to access a property of null