### PR TITLE
[RB] - add a/b test setup to manage so that tests can be run

### DIFF
--- a/app/client/experiments/abSwitches.ts
+++ b/app/client/experiments/abSwitches.ts
@@ -1,0 +1,3 @@
+export const abSwitches = {
+	abExampleTest: false,
+};

--- a/app/client/experiments/abTests.ts
+++ b/app/client/experiments/abTests.ts
@@ -1,0 +1,36 @@
+import { AB, ABTest, Participations } from '@guardian/ab-core';
+import { abSwitches } from './abSwitches';
+
+interface ABTestConfiguration {
+	abTestSwitches: Record<string, boolean>;
+	arrayOfTestObjects: ABTest[];
+	pageIsSensitive: false;
+	mvtMaxValue: 1000000;
+}
+
+// Add AB tests to run in this array
+export const tests: ABTest[] = [];
+
+const getDefaultABTestConfiguration = (): ABTestConfiguration => ({
+	abTestSwitches: abSwitches,
+	arrayOfTestObjects: tests,
+	mvtMaxValue: 1000000,
+	pageIsSensitive: false,
+});
+
+export const abTestApiForMvtId = (
+	mvtId: number,
+	forcedTestVariants?: Participations,
+) => {
+	const { abTestSwitches, arrayOfTestObjects, mvtMaxValue, pageIsSensitive } =
+		getDefaultABTestConfiguration();
+
+	return new AB({
+		abTestSwitches,
+		arrayOfTestObjects,
+		pageIsSensitive,
+		mvtMaxValue,
+		mvtId,
+		forcedTestVariants,
+	});
+};

--- a/app/client/experiments/tests/example-test.ts
+++ b/app/client/experiments/tests/example-test.ts
@@ -1,0 +1,31 @@
+import { ABTest } from '@guardian/ab-core';
+
+export const exampleTest: ABTest = {
+	id: 'ExampleTest', // This ID must match the Server Side AB Test
+	start: '2020-05-20',
+	expiry: '2020-12-01', // Remember that the server side test expiry can be different
+	author: 'anemailaddress@theguardian.com',
+	description: 'This Test',
+	audience: 0.0001, // 0.01% (1 is 100%)
+	audienceOffset: 0, // 50% (1 is 100%). Prevent overlapping with other tests.
+	successMeasure: 'It works',
+	audienceCriteria: 'Everyone',
+	idealOutcome: 'It works',
+	showForSensitive: true, // Should this A/B test run on sensitive articles?
+	canRun: () => true, // Check for things like user or page sections
+	variants: [
+		{
+			id: 'control',
+			test: (): string => {
+				// You can define what you want your variant to do in here or use the isUserInVariant API
+				return 'control';
+			},
+		},
+		{
+			id: 'variant',
+			test: (): string => {
+				return 'variant';
+			},
+		},
+	],
+};

--- a/app/client/experiments/tests/example-test.ts
+++ b/app/client/experiments/tests/example-test.ts
@@ -7,7 +7,7 @@ export const exampleTest: ABTest = {
 	author: 'anemailaddress@theguardian.com',
 	description: 'This Test',
 	audience: 0.0001, // 0.01% (1 is 100%)
-	audienceOffset: 0, // 50% (1 is 100%). Prevent overlapping with other tests.
+	audienceOffset: 0.5, // 50% (1 is 100%). Prevent overlapping with other tests.
 	successMeasure: 'It works',
 	audienceCriteria: 'Everyone',
 	idealOutcome: 'It works',

--- a/app/package.json
+++ b/app/package.json
@@ -142,6 +142,8 @@
   },
   "dependencies": {
     "@emotion/core": "^10.3.0",
+    "@guardian/ab-core": "^2.0.0",
+    "@guardian/ab-react": "^2.0.1",
     "@guardian/consent-management-platform": "^6.11.3",
     "@guardian/libs": "^1.7.1",
     "@guardian/src-button": "^2.8.2",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2407,6 +2407,16 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.2.tgz#30aa825f11d438671d585bd44e7fd564535fc210"
   integrity sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw==
 
+"@guardian/ab-core@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/ab-core/-/ab-core-2.0.0.tgz#d8a9408d5a66ff1f8c684ed458c99517bbee15b1"
+  integrity sha512-E5p6l0l37hY0GNFaZmA5/22TlVuavzlMHR3OeweD5eDcY2gB3nGgzPK/d3M67dkbDAJkGjB4a0W84Z5N2YScvQ==
+
+"@guardian/ab-react@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
+  integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
+
 "@guardian/consent-management-platform@^6.11.3":
   version "6.11.3"
   resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.11.3.tgz#92a7a6221587bcd86851e6a90198ad618f51b1e9"


### PR DESCRIPTION
## What does this change?
Integrate the Guardian a/b testing system with manage:
https://github.com/guardian/ab-testing

This pr is just the infrastructure around setting up an a/b test in manage. This doesn't create an a/b test.

The wiki has also updated with instructions on how to setup a new test:
https://github.com/guardian/manage-frontend/wiki/A-B-testing

