### PR TITLE
[RB] - change links around on the help centre home page

### DIFF
--- a/app/client/components/helpCentre/helpCentreConfig.ts
+++ b/app/client/components/helpCentre/helpCentreConfig.ts
@@ -87,8 +87,8 @@ export const helpCentreConfig: HelpCentreTopic[] = [
 			},
 			{
 				id: 'q2',
-				title: "I've forgotten my password",
-				link: '/help-centre/article/ive-forgotten-my-password',
+				title: 'How to stay signed in',
+				link: '/help-centre/article/how-to-stay-signed-in',
 			},
 			{
 				id: 'q3',
@@ -156,8 +156,8 @@ export const helpCentreConfig: HelpCentreTopic[] = [
 			},
 			{
 				id: 'q3',
-				title: "I'd like to offer you a contribution as a freelancer",
-				link: '/help-centre/article/i-d-like-to-offer-you-a-contribution-as-a-freelancer',
+				title: 'Using our journalism as a source',
+				link: '/help-centre/article/using-our-journalism-as-a-souce',
 			},
 			{
 				id: 'q4',


### PR DESCRIPTION
## What does this change?
Replaces 2 link in the help centre home page, one in the Accounts and Sign in section and the other in the Journalism section.

## Images
Before             |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/2510683/171430435-96b37506-af8d-494d-acce-2ae1cc9be927.png)  |  ![](https://user-images.githubusercontent.com/2510683/171431896-df11bc6e-af2a-4d1e-8317-e8da2bfa9a46.png)

