### PR TITLE
explode if it cannot retrieve a host or API key for ANY APIGateway (such that the healthcheck will fail)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -9,7 +9,7 @@
     "bundle": "copy-node-modules . ./dist && yarn webpack --config webpack.production.js",
     "bundle-dev": "yarn bundle-dev-server && yarn bundle-dev-client",
     "bundle-dev-server": "webpack --config webpack.dev.server.js",
-    "bundle-dev-server-cypress": "CYPRESS=SKIP_IDAPI webpack --config webpack.dev.server.js",
+    "bundle-dev-server-cypress": "CYPRESS=true webpack --config webpack.dev.server.js",
     "bundle-dev-client": "webpack --config webpack.dev.client.js",
     "bundle-check-client": "webpack --config webpack.prod.client.bundle-check.js",
     "bundle-check-client-if-changed": "((git diff --name-only --cached | grep 'yarn.lock') && yarn bundle-check-client) || true",

--- a/app/server/middleware/identityMiddleware.ts
+++ b/app/server/middleware/identityMiddleware.ts
@@ -164,7 +164,7 @@ export const withIdentity: (
 
 		const useRefererHeaderForManageUrl = !!statusCodeOverride;
 
-		if (CYPRESS === 'SKIP_IDAPI') {
+		if (CYPRESS === 'true') {
 			return next();
 		}
 

--- a/app/server/routes/core.ts
+++ b/app/server/routes/core.ts
@@ -1,23 +1,14 @@
 import { captureMessage } from '@sentry/node';
 import { Request, Response, Router } from 'express';
-import { authKeysAreFetchableMemoisedHealthcheck } from '../apiGatewayDiscovery';
 import { s3TextFilePromise } from '../awsIntegration';
 import { conf, Environments } from '../config';
 import { log } from '../log';
 
 const router = Router();
 
-/**
- * In some cases withIdentity might not call its next middleware so if you add a new healthcheck to the sequence
- * you might have to add it above withIdentity.
- */
-router.get(
-	'/_healthcheck',
-	authKeysAreFetchableMemoisedHealthcheck(),
-	(_: Request, res: Response) => {
-		res.send('OK - signed in');
-	},
-);
+router.get('/_healthcheck', (_: Request, res: Response) => {
+	res.send('OK - signed in');
+});
 
 router.get('/_prout', (_, res: Response) => {
 	res.send(`<pre>${GIT_COMMIT_HASH}</pre>`);


### PR DESCRIPTION
SECOND IDEA ([of 2](https://github.com/guardian/manage-frontend/pull/821)) to solve the slight race condition which exists now where the healthcheck's loading of the apikey and host for the holiday-stop-api succeeds but the real one used for the /api/ endpoints fails (due to AWS rate limiting, likely due Prism - see https://github.com/guardian/manage-frontend/pull/559 )