### PR TITLE
Derive newsletter themes from API response

### DIFF
--- a/app/client/components/identity/EmailAndMarketing/NewsletterSection.tsx
+++ b/app/client/components/identity/EmailAndMarketing/NewsletterSection.tsx
@@ -21,7 +21,7 @@ const colors: { [T in Theme]: string } = {
 	[Theme.lifestyle]: palette.pink.medium,
 	[Theme.comment]: '#e05e00',
 	[Theme.work]: palette.neutral['1'],
-	[Theme.FromThePapers]: palette.neutral['1'],
+	[Theme.fromThePapers]: palette.neutral['1'],
 };
 
 const newsletterPreference = (

--- a/app/client/components/identity/EmailAndMarketing/NewsletterSection.tsx
+++ b/app/client/components/identity/EmailAndMarketing/NewsletterSection.tsx
@@ -47,11 +47,16 @@ const newsletterPreference = (
 	);
 };
 
+function notEmpty<T>(value: T | undefined): value is T {
+	return value !== undefined;
+}
+
 const newsletterPreferenceGroups = (
 	newsletters: ConsentOption[],
 	clickHandler: ClickHandler,
 ) => {
-	const groups = uniq(newsletters.map((_) => _.group));
+	const groups = uniq(newsletters.map((_) => _.group)).filter(notEmpty);
+
 	return groups.map((group) => (
 		<DropMenu key={group} color={colors[Theme.work]} title={group}>
 			{newsletters

--- a/app/client/components/identity/EmailAndMarketing/NewsletterSection.tsx
+++ b/app/client/components/identity/EmailAndMarketing/NewsletterSection.tsx
@@ -4,6 +4,7 @@ import { DropMenu } from '../DropMenu';
 import { NewsletterPreference } from '../NewsletterPreference';
 import { ConsentOption, Theme } from '../models';
 import { PageSection } from '../PageSection';
+import uniq from 'lodash/uniq';
 
 type ClickHandler = (id: string) => {};
 
@@ -50,20 +51,11 @@ const newsletterPreferenceGroups = (
 	newsletters: ConsentOption[],
 	clickHandler: ClickHandler,
 ) => {
-	const themes = [
-		Theme.news,
-		Theme.features,
-		Theme.sport,
-		Theme.culture,
-		Theme.lifestyle,
-		Theme.comment,
-		Theme.work,
-		Theme.FromThePapers,
-	];
-	return themes.map((theme) => (
-		<DropMenu key={theme} color={colors[theme]} title={theme}>
+	const groups = uniq(newsletters.map((_) => _.group));
+	return groups.map((group) => (
+		<DropMenu key={group} color={colors[Theme.work]} title={group}>
 			{newsletters
-				.filter((n) => n.theme === theme)
+				.filter((n) => n.group === group)
 				.map((n) => newsletterPreference(n, clickHandler))}
 		</DropMenu>
 	));

--- a/app/client/components/identity/EmailAndMarketing/NewsletterSection.tsx
+++ b/app/client/components/identity/EmailAndMarketing/NewsletterSection.tsx
@@ -13,17 +13,6 @@ interface NewsletterSectionProps {
 	clickHandler: ClickHandler;
 }
 
-const colors: { [T in Theme]: string } = {
-	[Theme.news]: palette.red.medium,
-	[Theme.features]: palette.neutral['1'],
-	[Theme.sport]: palette.blue.medium,
-	[Theme.culture]: '#a1845c',
-	[Theme.lifestyle]: palette.pink.medium,
-	[Theme.comment]: '#e05e00',
-	[Theme.work]: palette.neutral['1'],
-	[Theme.fromThePapers]: palette.neutral['1'],
-};
-
 const newsletterPreference = (
 	newsletter: ConsentOption,
 	clickHandler: ClickHandler,
@@ -51,16 +40,35 @@ function notEmpty<T>(value: T | undefined): value is T {
 	return value !== undefined;
 }
 
+function getColor(theme: string): string {
+	const colors: { [T in Theme]: string } = {
+		[Theme.news]: palette.red.medium,
+		[Theme.opinion]: palette.orange.medium,
+		[Theme.features]: palette.neutral['1'],
+		[Theme.sport]: palette.blue.medium,
+		[Theme.culture]: '#a1845c',
+		[Theme.lifestyle]: palette.pink.medium,
+		[Theme.comment]: '#e05e00',
+		[Theme.work]: palette.neutral['1'],
+		[Theme.fromThePapers]: palette.neutral['1'],
+	};
+
+	if (theme in Theme) {
+		return colors[theme as Theme];
+	}
+	return palette.neutral['1'];
+}
+
 const newsletterPreferenceGroups = (
 	newsletters: ConsentOption[],
 	clickHandler: ClickHandler,
 ) => {
-	const groups = uniq(newsletters.map((_) => _.group)).filter(notEmpty);
+	const themes = uniq(newsletters.map((_) => _.theme)).filter(notEmpty);
 
-	return groups.map((group) => (
-		<DropMenu key={group} color={colors[Theme.work]} title={group}>
+	return themes.map((theme) => (
+		<DropMenu key={theme} color={getColor(theme)} title={theme}>
 			{newsletters
-				.filter((n) => n.group === group)
+				.filter((n) => n.theme === theme)
 				.map((n) => newsletterPreference(n, clickHandler))}
 		</DropMenu>
 	));

--- a/app/client/components/identity/idapi/newsletters.ts
+++ b/app/client/components/identity/idapi/newsletters.ts
@@ -9,6 +9,7 @@ interface NewsletterAPIResponse {
 	frequency: string;
 	subscribed: boolean;
 	exactTargetListId: number;
+	group: string;
 }
 
 const newsletterToConsentOption = (
@@ -21,6 +22,7 @@ const newsletterToConsentOption = (
 		description,
 		frequency,
 		exactTargetListId,
+		group,
 	} = newsletter;
 	return {
 		id: exactTargetListId.toString(),
@@ -31,6 +33,7 @@ const newsletterToConsentOption = (
 		frequency,
 		subscribed: false,
 		identityName,
+		group,
 	};
 };
 

--- a/app/client/components/identity/idapi/newsletters.ts
+++ b/app/client/components/identity/idapi/newsletters.ts
@@ -9,7 +9,6 @@ interface NewsletterAPIResponse {
 	frequency: string;
 	subscribed: boolean;
 	exactTargetListId: number;
-	group: string;
 }
 
 const newsletterToConsentOption = (
@@ -22,7 +21,6 @@ const newsletterToConsentOption = (
 		description,
 		frequency,
 		exactTargetListId,
-		group,
 	} = newsletter;
 	return {
 		id: exactTargetListId.toString(),
@@ -33,7 +31,6 @@ const newsletterToConsentOption = (
 		frequency,
 		subscribed: false,
 		identityName,
-		group,
 	};
 };
 

--- a/app/client/components/identity/models.ts
+++ b/app/client/components/identity/models.ts
@@ -6,7 +6,7 @@ export enum Theme {
 	lifestyle = 'lifestyle',
 	comment = 'comment',
 	work = 'work',
-	FromThePapers = 'From the papers',
+	fromThePapers = 'From the papers',
 }
 
 export enum ErrorTypes {

--- a/app/client/components/identity/models.ts
+++ b/app/client/components/identity/models.ts
@@ -67,7 +67,6 @@ export interface ConsentOption {
 	identityName?: string;
 	isProduct?: boolean;
 	isChannel?: boolean;
-	group?: string;
 }
 
 export interface ConsentOptionCollection {

--- a/app/client/components/identity/models.ts
+++ b/app/client/components/identity/models.ts
@@ -66,7 +66,7 @@ export interface ConsentOption {
 	identityName?: string;
 	isProduct?: boolean;
 	isChannel?: boolean;
-	group: string;
+	group?: string;
 }
 
 export interface ConsentOptionCollection {

--- a/app/client/components/identity/models.ts
+++ b/app/client/components/identity/models.ts
@@ -1,5 +1,6 @@
 export enum Theme {
 	news = 'news',
+	opinion = 'opinion',
 	features = 'features',
 	sport = 'sport',
 	culture = 'culture',

--- a/app/client/components/identity/models.ts
+++ b/app/client/components/identity/models.ts
@@ -66,7 +66,7 @@ export interface ConsentOption {
 	identityName?: string;
 	isProduct?: boolean;
 	isChannel?: boolean;
-	group?: string;
+	group: string;
 }
 
 export interface ConsentOptionCollection {

--- a/app/client/components/identity/models.ts
+++ b/app/client/components/identity/models.ts
@@ -66,6 +66,7 @@ export interface ConsentOption {
 	identityName?: string;
 	isProduct?: boolean;
 	isChannel?: boolean;
+	group?: string;
 }
 
 export interface ConsentOptionCollection {


### PR DESCRIPTION
## What does this change?

* Derives the theme dropdowns from the newsletters API response, instead of a hardcoded list
* Adds the Opinion theme to the colour mappings

## Why?

* The existing hardcoded themes sometimes have 2 issues:
  * the theme could have no newsletters in the API response, so the dropdown is displayed but empty
  * new themes have been added since the hardcoded list was created. Child newsletters of the new themes are not currently displayed in MMA (e.g the "Opinion" theme)

## Considerations

* Theme => colour mapping is still hardcoded, but defaults to a neutral colour where a mapping does not exist (e.g if there is a new theme without an explicit mapping)

## Screenshots

| Before | After |
|--------|-------|
|  <img width="929" alt="Screenshot 2022-06-07 at 11 27 02" src="https://user-images.githubusercontent.com/705427/172358245-a99b9769-3845-4065-8c69-2928a9e9c17c.png"> |  <img width="924" alt="Screenshot 2022-06-07 at 11 27 30" src="https://user-images.githubusercontent.com/705427/172358314-80026d8c-f39e-4960-86aa-07e3aac1187e.png"> |