### PR TITLE
Transpile React Router for IE11

### DIFF
--- a/app/webpack.common.js
+++ b/app/webpack.common.js
@@ -116,7 +116,11 @@ const client = merge(common, {
 		rules: [
 			{
 				test: /\.(tsx?)|(js)$/,
-				exclude: babelLoaderExcludeNodeModulesExcept(['@guardian/*']),
+				exclude: babelLoaderExcludeNodeModulesExcept([
+					'@guardian/*',
+					'react-router',
+					'react-router-dom',
+				]),
 				use: {
 					loader: 'babel-loader',
 					options: {


### PR DESCRIPTION
## What does this change?

This adds React Router to the list of packages that are _not_ excluded from babel-loader.

Previously we excluded everything in `node_modules` from babel-loader with the exception of internal `@guardian/*` packages. As React Router uses modern ES6 features it causes a JS error in IE11 and users see a blank page. To prevent this the React Router packages are now transpiled via babel-loader.

<img width="509" alt="Screenshot 2022-06-08 at 15 38 39" src="https://user-images.githubusercontent.com/1166188/172665094-35acf4d0-ba23-4dc1-91a2-89867233dcfd.png">

## How to test

Open the application in BrowserStack and check that it now renders in IE11. It would also be worthwhile testing some key journeys in modern browsers to ensure there are no regressions.