### PR TITLE
Product switching routes

### DIFF
--- a/app/client/components/MMAPage.tsx
+++ b/app/client/components/MMAPage.tsx
@@ -59,10 +59,10 @@ const CancellationContainer = lazy(
 		),
 );
 
-const CancellationReasonSelection = lazy(
+const CancellationSwitchEligibilityCheck = lazy(
 	() =>
 		import(
-			/* webpackChunkName: "Cancellation" */ './cancel/CancellationReasonSelection'
+			/* webpackChunkName: "Cancellation" */ './cancel/CancellationSwitchEligibilityCheck'
 		),
 );
 
@@ -410,7 +410,7 @@ const MMARouter = () => {
 									<Route
 										index
 										element={
-											<CancellationReasonSelection />
+											<CancellationSwitchEligibilityCheck />
 										}
 									/>
 									<Route

--- a/app/client/components/MMAPage.tsx
+++ b/app/client/components/MMAPage.tsx
@@ -62,7 +62,21 @@ const CancellationContainer = lazy(
 const CancellationSwitchEligibilityCheck = lazy(
 	() =>
 		import(
-			/* webpackChunkName: "Cancellation" */ './cancel/CancellationSwitchEligibilityCheck'
+			/* webpackChunkName: "Cancellation" */ './cancel/cancellationSwitchEligibilityCheck'
+		),
+);
+
+const CancellationSwitchReview = lazy(
+	() =>
+		import(
+			/* webpackChunkName: "Cancellation" */ './cancel/cancellationSwitchReview'
+		),
+);
+
+const CancellationSwitchConfirmed = lazy(
+	() =>
+		import(
+			/* webpackChunkName: "Cancellation" */ './cancel/cancellationSwitchConfirmed'
 		),
 );
 
@@ -411,6 +425,16 @@ const MMARouter = () => {
 										index
 										element={
 											<CancellationSwitchEligibilityCheck />
+										}
+									/>
+									<Route
+										path="switch"
+										element={<CancellationSwitchReview />}
+									/>
+									<Route
+										path="switch/confirmed"
+										element={
+											<CancellationSwitchConfirmed />
 										}
 									/>
 									<Route

--- a/app/client/components/cancel/CancellationSwitchConfirmed.tsx
+++ b/app/client/components/cancel/CancellationSwitchConfirmed.tsx
@@ -7,7 +7,7 @@ import { Button } from '@guardian/src-button';
 import { useNavigate } from 'react-router-dom';
 import { maxWidth } from '../../styles/breakpoints';
 
-const CancellationSwitchOffer = () => {
+const CancellationSwitchConfirmed = () => {
 	const navigate = useNavigate();
 
 	const subHeadingTitleCss = `
@@ -30,31 +30,30 @@ const CancellationSwitchOffer = () => {
 					${subHeadingBorderTopCss}
 				`}
 			>
-				We’re sorry to hear you’re thinking of cancelling.
+				You’re now a digital subscritber
 			</h2>
 			<p
 				css={css`
 					${textSans.medium()}
 				`}
 			>
-				Your support means the Guardian can remain editorially
-				independent, free from the influence of billionaire owners and
-				politicians. This enables us to give a voice to the voiceless,
-				challenge the powerful and hold them to account. The support
-				from our readers helps us to keep our journalism free of a
-				paywall, so it’s open and accessible to all.
+				Your monthly contribution has successfully been changed to a
+				Digital Subscription. We’ve stopped your previous payments and
+				started you on your new plan. Please check your inbox for an
+				email containing all your details and information on how to
+				access your benefits.
 			</p>
 			<Button
 				icon={<SvgArrowRightStraight />}
 				iconSide="right"
 				onClick={() => {
-					navigate('./switch');
+					navigate('/');
 				}}
 			>
-				Explore a digital subscription
+				Return to Account overview
 			</Button>
 		</>
 	);
 };
 
-export default CancellationSwitchOffer;
+export default CancellationSwitchConfirmed;

--- a/app/client/components/cancel/CancellationSwitchConfirmed.tsx
+++ b/app/client/components/cancel/CancellationSwitchConfirmed.tsx
@@ -1,9 +1,14 @@
-import { css } from '@emotion/core';
-import { headline, textSans } from '@guardian/src-foundations/typography';
-import { neutral } from '@guardian/src-foundations/palette';
-import { space } from '@guardian/src-foundations';
-import { SvgArrowRightStraight } from '@guardian/src-icons';
-import { Button } from '@guardian/src-button';
+import { css } from '@emotion/react';
+import {
+	space,
+	neutral,
+	headline,
+	textSans,
+} from '@guardian/source-foundations';
+import {
+	Button,
+	SvgArrowRightStraight,
+} from '@guardian/source-react-components';
 import { useNavigate } from 'react-router-dom';
 import { maxWidth } from '../../styles/breakpoints';
 

--- a/app/client/components/cancel/CancellationSwitchEligibilityCheck.tsx
+++ b/app/client/components/cancel/CancellationSwitchEligibilityCheck.tsx
@@ -2,8 +2,8 @@ import CancellationReasonSelection from './CancellationReasonSelection';
 import CancellationSwitchOffer from './CancellationSwitchOffer';
 
 const CancellationSwitchEligibilityCheck = () => {
-	const inABTest: boolean = false;
 	const isEligibleToSwitch: boolean = false;
+	const inABTest: boolean = false;
 	return inABTest && isEligibleToSwitch ? (
 		<CancellationSwitchOffer />
 	) : (

--- a/app/client/components/cancel/CancellationSwitchEligibilityCheck.tsx
+++ b/app/client/components/cancel/CancellationSwitchEligibilityCheck.tsx
@@ -1,0 +1,14 @@
+import CancellationReasonSelection from './CancellationReasonSelection';
+import CancellationSwitchOffer from './CancellationSwitchOffer';
+
+const CancellationSwitchEligibilityCheck = () => {
+	const inABTest: boolean = false;
+	const isEligibleToSwitch: boolean = false;
+	return inABTest && isEligibleToSwitch ? (
+		<CancellationSwitchOffer />
+	) : (
+		<CancellationReasonSelection />
+	);
+};
+
+export default CancellationSwitchEligibilityCheck;

--- a/app/client/components/cancel/CancellationSwitchOffer.tsx
+++ b/app/client/components/cancel/CancellationSwitchOffer.tsx
@@ -1,0 +1,3 @@
+const CancellationSwitchOffer = () => <></>;
+
+export default CancellationSwitchOffer;

--- a/app/client/components/cancel/CancellationSwitchOffer.tsx
+++ b/app/client/components/cancel/CancellationSwitchOffer.tsx
@@ -1,9 +1,15 @@
-import { css } from '@emotion/core';
-import { headline, textSans } from '@guardian/src-foundations/typography';
-import { neutral } from '@guardian/src-foundations/palette';
-import { space } from '@guardian/src-foundations';
-import { SvgArrowRightStraight } from '@guardian/src-icons';
-import { Button } from '@guardian/src-button';
+import { css } from '@emotion/react';
+import {
+	space,
+	neutral,
+	headline,
+	textSans,
+} from '@guardian/source-foundations';
+import {
+	Button,
+	SvgArrowRightStraight,
+} from '@guardian/source-react-components';
+
 import { useNavigate } from 'react-router-dom';
 import { maxWidth } from '../../styles/breakpoints';
 

--- a/app/client/components/cancel/CancellationSwitchReview.tsx
+++ b/app/client/components/cancel/CancellationSwitchReview.tsx
@@ -1,9 +1,15 @@
-import { css } from '@emotion/core';
-import { headline, textSans } from '@guardian/src-foundations/typography';
-import { neutral } from '@guardian/src-foundations/palette';
-import { space } from '@guardian/src-foundations';
-import { SvgArrowRightStraight } from '@guardian/src-icons';
-import { Button } from '@guardian/src-button';
+import { css } from '@emotion/react';
+import {
+	space,
+	neutral,
+	headline,
+	textSans,
+} from '@guardian/source-foundations';
+import {
+	Button,
+	SvgArrowRightStraight,
+} from '@guardian/source-react-components';
+
 import { useNavigate } from 'react-router-dom';
 import { maxWidth } from '../../styles/breakpoints';
 

--- a/app/client/components/cancel/CancellationSwitchReview.tsx
+++ b/app/client/components/cancel/CancellationSwitchReview.tsx
@@ -7,7 +7,7 @@ import { Button } from '@guardian/src-button';
 import { useNavigate } from 'react-router-dom';
 import { maxWidth } from '../../styles/breakpoints';
 
-const CancellationSwitchOffer = () => {
+const CancellationSwitchReview = () => {
 	const navigate = useNavigate();
 
 	const subHeadingTitleCss = `
@@ -30,31 +30,29 @@ const CancellationSwitchOffer = () => {
 					${subHeadingBorderTopCss}
 				`}
 			>
-				We’re sorry to hear you’re thinking of cancelling.
+				Change your support to a digital subscription
 			</h2>
 			<p
 				css={css`
 					${textSans.medium()}
 				`}
 			>
-				Your support means the Guardian can remain editorially
-				independent, free from the influence of billionaire owners and
-				politicians. This enables us to give a voice to the voiceless,
-				challenge the powerful and hold them to account. The support
-				from our readers helps us to keep our journalism free of a
-				paywall, so it’s open and accessible to all.
+				If you decide to change the way you support us by becoming a
+				digital subscriber we’ll stop your monthly contribution payments
+				straight away and you’ll have immediate access to the benefits
+				of a digital subscription.
 			</p>
 			<Button
 				icon={<SvgArrowRightStraight />}
 				iconSide="right"
 				onClick={() => {
-					navigate('./switch');
+					navigate('./confirmed');
 				}}
 			>
-				Explore a digital subscription
+				Confirm change
 			</Button>
 		</>
 	);
 };
 
-export default CancellationSwitchOffer;
+export default CancellationSwitchReview;


### PR DESCRIPTION
## What does this change?

Add client side routes for the new cancellation switch journey

- /cancel/contributions `<CancellationSwitchEligibilityCheck />`
- /cancel/contributions/switch `<CancellationSwitchReview />`
- /cancel/contributions/switch/confirmed `<CancellationSwitchConfirmed />`

The `<CancellationSwitchEligibilityCheck />` component contains the placeholder logic for deciding whether to send the user down the usual cancellation route or through the fancy new switch journey.