### PR TITLE
[RB] - update cancellation page title on offer review page

### DIFF
--- a/app/client/components/cancel/CancellationContainer.tsx
+++ b/app/client/components/cancel/CancellationContainer.tsx
@@ -1,4 +1,10 @@
-import { Context, createContext } from 'react';
+import {
+	Context,
+	createContext,
+	Dispatch,
+	SetStateAction,
+	useState,
+} from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
 import {
 	isProduct,
@@ -66,41 +72,55 @@ export interface CancellationRouterState {
 	dontShowOffer?: boolean;
 }
 
+export interface CancellationPageTitleInterface {
+	setPageTitle: Dispatch<SetStateAction<string>>;
+}
+
+export const CancellationPageTitleContext: Context<
+	CancellationPageTitleInterface | {}
+> = createContext({});
+
 const CancellationContainer = (props: WithProductType<ProductType>) => {
 	const location = useLocation();
 	const routerState = location.state as CancellationRouterState;
 	const productDetail = routerState?.productDetail;
 
+	const [pageTitle, setPageTitle] = useState<string>(
+		`Cancel ${
+			props.productType.shortFriendlyName ||
+			props.productType.friendlyName
+		}`,
+	);
+
 	return (
-		<PageContainer
-			selectedNavItem={NAV_LINKS.accountOverview}
-			pageTitle={`Cancel ${
-				props.productType.shortFriendlyName ||
-				props.productType.friendlyName
-			}`}
-			breadcrumbs={[
-				{
-					title: NAV_LINKS.accountOverview.title,
-					link: NAV_LINKS.accountOverview.link,
-				},
-				{
-					title: `Cancel ${props.productType.friendlyName}`,
-					currentPage: true,
-				},
-			]}
-		>
-			{productDetail ? (
-				contextAndOutletContainer(productDetail, props.productType)
-			) : (
-				<MembersDataApiAsyncLoader
-					fetch={createProductDetailFetcher(props.productType)}
-					render={renderSingleProductOrReturnToAccountOverview(
-						props.productType,
-					)}
-					loadingMessage={`Checking the status of your ${props.productType.friendlyName}...`}
-				/>
-			)}
-		</PageContainer>
+		<CancellationPageTitleContext.Provider value={{ setPageTitle }}>
+			<PageContainer
+				selectedNavItem={NAV_LINKS.accountOverview}
+				pageTitle={pageTitle}
+				breadcrumbs={[
+					{
+						title: NAV_LINKS.accountOverview.title,
+						link: NAV_LINKS.accountOverview.link,
+					},
+					{
+						title: `Cancel ${props.productType.friendlyName}`,
+						currentPage: true,
+					},
+				]}
+			>
+				{productDetail ? (
+					contextAndOutletContainer(productDetail, props.productType)
+				) : (
+					<MembersDataApiAsyncLoader
+						fetch={createProductDetailFetcher(props.productType)}
+						render={renderSingleProductOrReturnToAccountOverview(
+							props.productType,
+						)}
+						loadingMessage={`Checking the status of your ${props.productType.friendlyName}...`}
+					/>
+				)}
+			</PageContainer>
+		</CancellationPageTitleContext.Provider>
 	);
 };
 

--- a/app/client/components/cancel/CancellationSwitchEligibilityCheck.tsx
+++ b/app/client/components/cancel/CancellationSwitchEligibilityCheck.tsx
@@ -1,18 +1,38 @@
 import CancellationReasonSelection from './CancellationReasonSelection';
 import CancellationSwitchOffer from './CancellationSwitchOffer';
 import { useLocation } from 'react-router-dom';
-import { CancellationRouterState } from './CancellationContainer';
+import {
+	CancellationPageTitleContext,
+	CancellationPageTitleInterface,
+	CancellationRouterState,
+	CancellationContext,
+	CancellationContextInterface,
+} from './CancellationContainer';
+import { useContext } from 'react';
 
 const CancellationSwitchEligibilityCheck = () => {
 	const location = useLocation();
 	const routerState = location.state as CancellationRouterState;
+	const cancellationContext = useContext(
+		CancellationContext,
+	) as CancellationContextInterface;
+	const pageTitleContext = useContext(
+		CancellationPageTitleContext,
+	) as CancellationPageTitleInterface;
 
 	if (routerState.dontShowOffer) {
+		pageTitleContext.setPageTitle(
+			`Cancel ${
+				cancellationContext.productType.shortFriendlyName ||
+				cancellationContext.productType.friendlyName
+			}`,
+		);
 		return <CancellationReasonSelection />;
 	}
 
 	const isEligibleToSwitch: boolean = false;
 	const inABTest: boolean = false;
+
 	return inABTest && isEligibleToSwitch ? (
 		<CancellationSwitchOffer />
 	) : (

--- a/app/client/components/cancel/CancellationSwitchOffer.tsx
+++ b/app/client/components/cancel/CancellationSwitchOffer.tsx
@@ -210,7 +210,9 @@ const CancellationSwitchOffer = () => {
 								iconSide="right"
 								priority="secondary"
 								nudgeIcon
-								onClick={() => navigate('./switch')}
+								onClick={() =>
+									navigate('./switch', { state: routerState })
+								}
 							>
 								{'Explore a digital subscription'}
 							</Button>

--- a/app/client/components/cancel/CancellationSwitchReview.tsx
+++ b/app/client/components/cancel/CancellationSwitchReview.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { css, ThemeProvider } from '@emotion/react';
 import {
@@ -17,6 +17,10 @@ import { minWidth } from '../../styles/breakpoints';
 import { cardTypeToSVG } from '../payment/cardDisplay';
 import { ExpanderButton } from '../expanderButton';
 import { ArrowInCircle } from '../svgs/arrowInCircle';
+import {
+	CancellationPageTitleContext,
+	CancellationPageTitleInterface,
+} from './CancellationContainer';
 
 /**
  * Generic Card container component
@@ -140,6 +144,10 @@ const KeyValueTable = (props: KeyValueTableProps) => {
 
 const CancellationSwitchReview = () => {
 	const navigate = useNavigate();
+	const pageTitleContext = useContext(
+		CancellationPageTitleContext,
+	) as CancellationPageTitleInterface;
+	pageTitleContext.setPageTitle('Manage your support type');
 
 	const subHeadingCss = css`
 		border-top: 1px solid ${palette.neutral[86]};


### PR DESCRIPTION
## What does this change?
The page title needs to change when on the review page of the cancellation switch journey.

Also passed the current router state through when navigating from the offer page to the review page to avoid an additional unnecessary members data api http request.

## Images
Before             |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/2510683/173384497-c32456f6-0030-49bc-b706-7b3ebd8b6db6.png)  |  ![](https://user-images.githubusercontent.com/2510683/173384509-b14b7fe1-9133-44f7-8e89-5768d4ba1bf0.png)