### PR TITLE
Visual components for product-movement journey page 3

### DIFF
--- a/app/client/components/cancel/CancellationSwitchConfirmed.tsx
+++ b/app/client/components/cancel/CancellationSwitchConfirmed.tsx
@@ -289,9 +289,7 @@ const CancellationSwitchConfirmed = () => {
 					<p
 						css={css`
 							${textSans.medium()};
-							${minWidth.tablet} {
-								max-width: 70%;
-							}
+							max-width: 45ch;
 							margin-bottom: 0;
 						`}
 					>

--- a/app/client/components/cancel/CancellationSwitchConfirmed.tsx
+++ b/app/client/components/cancel/CancellationSwitchConfirmed.tsx
@@ -197,7 +197,7 @@ const CancellationSwitchConfirmed = () => {
 			<div
 				css={css`
 					border: 1px solid ${neutral[86]};
-					margin: ${space[6]}px 0;
+					margin: ${space[6]}px 0 ${space[9]}px;
 				`}
 			>
 				<div

--- a/app/client/components/cancel/CancellationSwitchConfirmed.tsx
+++ b/app/client/components/cancel/CancellationSwitchConfirmed.tsx
@@ -197,7 +197,11 @@ const CancellationSwitchConfirmed = () => {
 			<div
 				css={css`
 					border: 1px solid ${neutral[86]};
-					margin: ${space[6]}px 0 ${space[9]}px;
+					margin: ${space[6]}px 0;
+
+					${minWidth.tablet} {
+						margin: ${space[6]}px 0 ${space[9]}px;
+					}
 				`}
 			>
 				<div

--- a/app/client/components/cancel/CancellationSwitchConfirmed.tsx
+++ b/app/client/components/cancel/CancellationSwitchConfirmed.tsx
@@ -253,6 +253,7 @@ const CancellationSwitchConfirmed = () => {
 							href={
 								'https://apps.apple.com/us/app/the-guardian/id409128287'
 							}
+							aria-label="Click to download the Guardian Daily app on the Apple App Store"
 						>
 							{/* had to add max-width in the cssOverrides as well as the sizes attribute as the attribute only doesn't work in IE11 */}
 							<GridImage
@@ -271,6 +272,7 @@ const CancellationSwitchConfirmed = () => {
 							target="_blank"
 							href="https://play.google.com/store/apps/details?id=com.guardian"
 							rel="noreferrer"
+							aria-label="Click to download the Guardian Live app on Google Play"
 						>
 							<GridImage
 								cssOverrides={css`

--- a/app/client/components/cancel/CancellationSwitchConfirmed.tsx
+++ b/app/client/components/cancel/CancellationSwitchConfirmed.tsx
@@ -243,8 +243,10 @@ const CancellationSwitchConfirmed = () => {
 							margin-bottom: ${space[4]}px;
 						`}
 					>
-						<Link
-							to={
+						<a
+							target="_blank"
+							rel="noreferrer"
+							href={
 								'https://apps.apple.com/us/app/the-guardian/id409128287'
 							}
 						>
@@ -260,11 +262,11 @@ const CancellationSwitchConfirmed = () => {
 								gridId="appleAppStore"
 								srcSizes={[140, 500]}
 							/>
-						</Link>
-						<Link
-							to={
-								'https://play.google.com/store/apps/details?id=com.guardian'
-							}
+						</a>
+						<a
+							target="_blank"
+							href="https://play.google.com/store/apps/details?id=com.guardian"
+							rel="noreferrer"
 						>
 							<GridImage
 								cssOverrides={css`
@@ -276,7 +278,7 @@ const CancellationSwitchConfirmed = () => {
 								gridId="googlePlay"
 								srcSizes={[140, 500]}
 							/>
-						</Link>
+						</a>
 					</div>
 					<p
 						css={css`

--- a/app/client/components/cancel/CancellationSwitchConfirmed.tsx
+++ b/app/client/components/cancel/CancellationSwitchConfirmed.tsx
@@ -4,42 +4,38 @@ import {
 	neutral,
 	headline,
 	textSans,
+	brand,
+	brandAlt,
 } from '@guardian/source-foundations';
 import {
 	Button,
 	SvgArrowRightStraight,
 } from '@guardian/source-react-components';
-import { useNavigate } from 'react-router-dom';
-import { maxWidth } from '../../styles/breakpoints';
+import { useNavigate, Link } from 'react-router-dom';
+import { maxWidth, minWidth } from '../../styles/breakpoints';
+import GridPicture from '../images/GridPicture';
+import GridImage from '../images/GridImage';
 
 const CancellationSwitchConfirmed = () => {
 	const navigate = useNavigate();
 
-	const subHeadingTitleCss = `
-    ${headline.small({ fontWeight: 'bold' })};
-    ${maxWidth.tablet} {
-      font-size: 1.25rem;
-      line-height: 1.6;
-    };
-  `;
-	const subHeadingBorderTopCss = `
-    border-top: 1px solid ${neutral['86']};
-    margin: 50px 0 ${space[5]}px;
-  `;
+	const subHeadingCss = css`
+		margin: ${space[9]}px 0 ${space[3]}px;
+		border-top: 1px solid ${neutral['86']};
+		${headline.small({ fontWeight: 'bold' })};
+		${maxWidth.tablet} {
+			font-size: 1.25rem;
+			line-height: 1.6;
+		}
+	`;
 
 	return (
 		<>
-			<h2
-				css={css`
-					${subHeadingTitleCss}
-					${subHeadingBorderTopCss}
-				`}
-			>
-				You’re now a digital subscritber
-			</h2>
+			<h2 css={subHeadingCss}>You’re now a digital subscriber</h2>
 			<p
 				css={css`
 					${textSans.medium()}
+					margin-bottom: ${space[9]}px;
 				`}
 			>
 				Your monthly contribution has successfully been changed to a
@@ -48,6 +44,257 @@ const CancellationSwitchConfirmed = () => {
 				email containing all your details and information on how to
 				access your benefits.
 			</p>
+			<div
+				css={css`
+					border: 1px solid ${neutral[86]};
+				`}
+			>
+				<div
+					css={css`
+						background-color: #e3edfe;
+
+						padding: ${space[4]}px ${space[4]}px 0 ${space[4]}px;
+
+						${minWidth.tablet} {
+							display: flex;
+							justify-content: space-between;
+							padding: ${space[4]}px ${space[5]}px 0 ${space[5]}px;
+						}
+					`}
+				>
+					<p
+						css={css`
+							${headline.xsmall({ fontWeight: 'bold' })};
+						`}
+					>
+						What happens now?
+					</p>
+					<GridPicture
+						cssOverrides={css`
+							display: flex;
+							margin: auto;
+
+							${minWidth.tablet} {
+								display: block;
+								margin-right: 42px;
+							}
+
+							max-width: 220px;
+						`}
+						sources={[
+							{
+								gridId: 'digitalSubPackshot',
+								srcSizes: [497, 285],
+								imgType: 'png',
+								sizes: '100vw',
+								media: '(max-width: 220px)',
+							},
+						]}
+						fallback="digitalSubPackshot"
+						fallbackSize={497}
+						altText=""
+						fallbackImgType="png"
+					/>
+				</div>
+
+				<ul
+					css={css`
+						padding: ${space[6]}px ${space[9]}px;
+						margin: 0;
+					`}
+				>
+					<li
+						css={css`
+							${textSans.medium()};
+							margin-bottom: ${space[3]}px;
+							line-height: 20px;
+						`}
+					>
+						<span
+							css={css`
+								margin-left: ${space[1]}px;
+							`}
+						>
+							Check your inbox for an email containing all your
+							important information, plus details on how to access
+							your benefits.
+						</span>
+					</li>
+					<li
+						css={css`
+							${textSans.medium()};
+							margin-bottom: ${space[3]}px;
+							line-height: 20px;
+						`}
+					>
+						<span
+							css={css`
+								margin-left: ${space[1]}px;
+							`}
+						>
+							We'll stop your monthly contribution payments.
+						</span>
+					</li>
+					<li
+						css={css`
+							${textSans.medium()};
+							margin-bottom: ${space[3]}px;
+							line-height: 20px;
+						`}
+					>
+						<span
+							css={css`
+								margin-left: ${space[1]}px;
+							`}
+						>
+							Your new digital subscription starts today.
+						</span>
+					</li>
+					<li
+						css={css`
+							${textSans.medium()};
+							margin-bottom: ${space[3]}px;
+							line-height: 20px;
+						`}
+					>
+						<span
+							css={css`
+								margin-left: ${space[1]}px;
+							`}
+						>
+							Your first payment of £12 will be taken on 26 May
+							2022.
+						</span>
+					</li>
+					<li
+						css={css`
+							${textSans.medium()};
+							margin-bottom: ${space[4]}px;
+							line-height: 20px;
+						`}
+					>
+						<span
+							css={css`
+								margin-left: ${space[1]}px;
+							`}
+						>
+							You can manage your subscription online from your{' '}
+							<Link to="/">
+								<span
+									css={css`
+										color: ${brand[500]};
+										text-decoration: underline;
+									`}
+								>
+									Account overview.
+								</span>
+							</Link>
+						</span>
+					</li>
+				</ul>
+			</div>
+
+			<div
+				css={css`
+					border: 1px solid ${neutral[86]};
+					margin: ${space[6]}px 0;
+				`}
+			>
+				<div
+					css={css`
+						display: flex;
+						justify-content: space-between;
+						align-items: start;
+						background-color: ${brand[400]};
+
+						${minWidth.mobileLandscape} {
+							align-items: center;
+						}
+					`}
+				>
+					<h2
+						css={css`
+							${headline.xsmall({ fontWeight: 'bold' })};
+							margin: 0;
+							padding: ${space[3]}px;
+							color: ${brandAlt[400]};
+							${maxWidth.mobileLandscape} {
+								padding: ${space[3]}px;
+							}
+							${minWidth.tablet} {
+								font-size: 20px;
+								padding: ${space[3]}px ${space[5]}px;
+							}
+						`}
+					>
+						Download the Live app now!
+					</h2>
+				</div>
+
+				<div
+					css={css`
+						background-color: ${neutral[97]};
+						padding: ${space[6]}px ${space[5]}px;
+					`}
+				>
+					<div
+						css={css`
+							display: flex;
+							margin-bottom: ${space[4]}px;
+						`}
+					>
+						<Link
+							to={
+								'https://apps.apple.com/us/app/the-guardian/id409128287'
+							}
+						>
+							{/* had to add max-width in the cssOverrides as well as the sizes attribute as the attribute only doesn't work in IE11 */}
+							<GridImage
+								cssOverrides={css`
+									max-width: 119px;
+									margin-right: ${space[4]}px;
+								`}
+								imgType="png"
+								altText="googlePlay"
+								sizes="119px"
+								gridId="appleAppStore"
+								srcSizes={[140, 500]}
+							/>
+						</Link>
+						<Link
+							to={
+								'https://play.google.com/store/apps/details?id=com.guardian'
+							}
+						>
+							<GridImage
+								cssOverrides={css`
+									max-width: 119px;
+								`}
+								imgType="png"
+								altText="googlePlay"
+								sizes="119px"
+								gridId="googlePlay"
+								srcSizes={[140, 500]}
+							/>
+						</Link>
+					</div>
+					<p
+						css={css`
+							${textSans.medium()};
+							${minWidth.tablet} {
+								max-width: 70%;
+							}
+							margin-bottom: 0;
+						`}
+					>
+						This app comes with a variety of features including Live
+						news, Discover - a tailored feed, and the ability to
+						read offline. Don’t forget to sign in using your
+						subscriber details to access ad-free.
+					</p>
+				</div>
+			</div>
+
 			<Button
 				icon={<SvgArrowRightStraight />}
 				iconSide="right"

--- a/app/client/components/cancel/CancellationSwitchEligibilityCheck.tsx
+++ b/app/client/components/cancel/CancellationSwitchEligibilityCheck.tsx
@@ -30,8 +30,8 @@ const CancellationSwitchEligibilityCheck = () => {
 		return <CancellationReasonSelection />;
 	}
 
-	const isEligibleToSwitch: boolean = true;
-	const inABTest: boolean = true;
+	const isEligibleToSwitch: boolean = false;
+	const inABTest: boolean = false;
 
 	return inABTest && isEligibleToSwitch ? (
 		<CancellationSwitchOffer />

--- a/app/client/components/cancel/CancellationSwitchEligibilityCheck.tsx
+++ b/app/client/components/cancel/CancellationSwitchEligibilityCheck.tsx
@@ -30,8 +30,8 @@ const CancellationSwitchEligibilityCheck = () => {
 		return <CancellationReasonSelection />;
 	}
 
-	const isEligibleToSwitch: boolean = false;
-	const inABTest: boolean = false;
+	const isEligibleToSwitch: boolean = true;
+	const inABTest: boolean = true;
 
 	return inABTest && isEligibleToSwitch ? (
 		<CancellationSwitchOffer />

--- a/app/client/components/images/GridImage.tsx
+++ b/app/client/components/images/GridImage.tsx
@@ -2,14 +2,8 @@
 // This code is designed to work with a single image at one or more crops
 // If you want to work with multiple (different) images, maybe try gridPicture instead
 // ----- Imports ----- //
-import {
-	gridSrcset,
-	gridUrl,
-	ImageId,
-	ImageType,
-	ascending,
-	classNameWithModifiers,
-} from './theGrid';
+import { gridSrcset, gridUrl, ImageId, ImageType, ascending } from './theGrid';
+import { SerializedStyles } from '@emotion/react';
 // ----- Constants ----- //
 const MIN_IMG_WIDTH = 300;
 // ----- Types ----- //
@@ -19,7 +13,7 @@ export type GridImg = {
 	sizes: string;
 	altText: string;
 	imgType?: ImageType;
-	classModifiers?: Array<string | null | undefined>;
+	cssOverrides?: SerializedStyles | SerializedStyles[];
 };
 type PropTypes = GridImg; // ----- Component ----- //
 
@@ -34,10 +28,7 @@ export default function GridImage(props: PropTypes): JSX.Element | null {
 	const fallbackSrc = gridUrl(props.gridId, fallbackSize, props.imgType);
 	return (
 		<img
-			className={classNameWithModifiers(
-				'component-grid-image',
-				props.classModifiers ?? [],
-			)}
+			css={props.cssOverrides}
 			sizes={props.sizes}
 			srcSet={srcSet}
 			src={fallbackSrc}

--- a/app/client/components/images/theGrid.ts
+++ b/app/client/components/images/theGrid.ts
@@ -1,6 +1,8 @@
 // ----- Setup ----- //
 const catalogue = {
 	digitalSubPackshot: '71ff2a443acb92047e428782ed0239075fd2007a/0_0_497_285',
+	googlePlay: '0a3eda7d719ad8ebe3a13a9bab8fd2b3348d1f20/0_0_554_160',
+	appleAppStore: 'a0787d3b313f03ed87a16ced224ab4022f794bc5/0_0_554_160',
 };
 
 export const GRID_DOMAIN = 'https://media.guim.co.uk';
@@ -59,17 +61,4 @@ export function gridSrcset(
 // Ascending comparison function for use with Array.prototype.sort.
 export function ascending(a: number, b: number): number {
 	return a - b;
-}
-// Generates the "class class-modifier" string for HTML elements.
-// Does not add null, undefined and empty string.
-export function classNameWithModifiers(
-	className: string,
-	modifiers: Array<string | null | undefined>,
-): string {
-	const validModifiers = modifiers.filter(Boolean) as string[];
-
-	return validModifiers.reduce(
-		(acc, modifier) => `${acc} ${className}--${modifier}`,
-		className,
-	);
 }


### PR DESCRIPTION
<img width="1053" alt="Screenshot 2022-06-17 at 09 24 56" src="https://user-images.githubusercontent.com/91546670/174258571-2479ee7e-8dc0-40ac-af96-685f637eb2f7.png">

Note: the Apple appstore does not seem to have geolocation implemented so we have to direct users to the correct site respective of their country, e.g.: UK, US, etc. [Support-frontend](https://github.com/guardian/support-frontend/blob/97da18b6d681754bb57eae3e578210b7887426b1/support-frontend/assets/helpers/urls/externalLinks.ts#L97)  take the users country code and match it with the correct appstore site. We can implement this behaviour in a subsequent PR.
