### PR TITLE
Check routerstate not null in cancellation/product movement journey.

### DIFF
--- a/app/client/components/cancel/CancellationSwitchEligibilityCheck.tsx
+++ b/app/client/components/cancel/CancellationSwitchEligibilityCheck.tsx
@@ -20,7 +20,7 @@ const CancellationSwitchEligibilityCheck = () => {
 		CancellationPageTitleContext,
 	) as CancellationPageTitleInterface;
 
-	if (routerState.dontShowOffer) {
+	if (routerState?.dontShowOffer) {
 		pageTitleContext.setPageTitle(
 			`Cancel ${
 				cancellationContext.productType.shortFriendlyName ||


### PR DESCRIPTION
https://sentry.io/organizations/the-guardian/issues/?project=1208603&query=is%3Aunresolved+message%3AdontShowOffer&statsPeriod=14d

Router state is null if person directly navigates to the URL so we are checking it here.