### PR TITLE
Disable cmp via cookie in Cypress tests

### DIFF
--- a/app/cypress/lib/signInAndAcceptCookies.ts
+++ b/app/cypress/lib/signInAndAcceptCookies.ts
@@ -1,9 +1,9 @@
-const iframeMessage = `[id^="sp_message_iframe_"]`;
-const acceptCookiesButtonText = 'Yes, I’m happy';
 import { guardianWeeklyCurrentSubscription } from '../../client/fixtures/productDetail';
 
 export const signInAndAcceptCookies = () => {
 	cy.session('auth', () => {
+		cy.setCookie('gu-cmp-disabled', 'true');
+
 		cy.intercept('GET', '/api/me/mma', {
 			statusCode: 200,
 			body: [guardianWeeklyCurrentSubscription],
@@ -19,15 +19,5 @@ export const signInAndAcceptCookies = () => {
 
 		cy.wait('@mma');
 		cy.wait('@cancelled');
-
-		// accept cookies
-		cy.getIframeBody(iframeMessage)
-			.find(`button[title="${acceptCookiesButtonText}"]`, {
-				timeout: 10000,
-			})
-			.click();
-
-		// wait for cookies to be set
-		cy.wait(1000);
 	});
 };


### PR DESCRIPTION
## What does this change?

The cmp banner can be disabled via a cookie. This is convenient for integration testing with Cypress. 


## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
