### PR TITLE
Remove gu domain

### DIFF
--- a/app/client/__tests__/components/payment/paypalDisplay.test.ts
+++ b/app/client/__tests__/components/payment/paypalDisplay.test.ts
@@ -7,10 +7,14 @@ test('obfuscate email id', () => {
 	expect(getObfuscatedPayPalId('last.first@guardian.com')).toEqual(
 		'l********t@guardian.com',
 	);
-	expect(getObfuscatedPayPalId('j@gu.com')).toEqual('j@gu.com');
-	expect(getObfuscatedPayPalId('jm@gu.com')).toEqual('jm@gu.com');
-	expect(getObfuscatedPayPalId('jim@gu.com')).toEqual('j*m@gu.com');
-	expect(getObfuscatedPayPalId('james@gu.com')).toEqual('j***s@gu.com');
+	expect(getObfuscatedPayPalId('j@guardian.com')).toEqual('j@guardian.com');
+	expect(getObfuscatedPayPalId('jm@guardian.com')).toEqual('jm@guardian.com');
+	expect(getObfuscatedPayPalId('jim@guardian.com')).toEqual(
+		'j*m@guardian.com',
+	);
+	expect(getObfuscatedPayPalId('james@guardian.com')).toEqual(
+		'j***s@guardian.com',
+	);
 });
 
 test('obfuscate string id', () => {

--- a/app/client/components/payment/paypalDisplay.tsx
+++ b/app/client/components/payment/paypalDisplay.tsx
@@ -18,13 +18,13 @@ interface PayPalProps {
 //
 // Examples:
 //
-// ID           | 1 | 2   | 3
-// -------------|---|-----|---------
-// james        | j | ame | s
-// james@gu.com | j | ame | s@gu.com
-// jim@gu.com   | j | i   | m@gu.com
-// jm@gu.com    | j |     | m@gu.com
-// j@gu.com     | j |     | @gu.com
+// ID                    | 1 | 2   | 3
+// ----------------------|---|-----|---------
+// james                 | j | ame | s
+// james@theguardian.com | j | ame | s@theguardian.com
+// jim@theguardian.com   | j | i   | m@theguardian.com
+// jm@theguardian.com    | j |     | m@theguardian.com
+// j@theguardian.com     | j |     | @theguardian.com
 
 const SPLIT_PAYPAL_ID_REGEX = /^(.)(.*?)(.?|.?@.+)$/;
 


### PR DESCRIPTION
## What does this change?
This is part of our work to remove the gu domain from our codebases. 

This PR removes references to the domain from our test files.

[Trello Card](https://trello.com/c/nuIYTPrH/484-change-all-uses-of-gucom-to-thegulocalcom)