### PR TITLE
[RB] - Remove subscription.plan object

### DIFF
--- a/app/client/components/accountoverview/accountOverviewCard.tsx
+++ b/app/client/components/accountoverview/accountOverviewCard.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/browser';
 import { css } from '@emotion/react';
 import {
 	space,
@@ -34,6 +35,10 @@ interface AccountOverviewCardProps {
 
 export const AccountOverviewCard = (props: AccountOverviewCardProps) => {
 	const mainPlan = getMainPlan(props.productDetail.subscription);
+	if (!mainPlan) {
+		Sentry.captureMessage('mainPlan does not exist in accountOverviewCard');
+		return null;
+	}
 
 	const hasCancellationPending: boolean =
 		props.productDetail.subscription.cancelledAt;

--- a/app/client/components/accountoverview/manageProduct.tsx
+++ b/app/client/components/accountoverview/manageProduct.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/browser';
 import { css } from '@emotion/react';
 import {
 	space,
@@ -38,6 +39,7 @@ import { PaymentFailureAlertIfApplicable } from '../payment/paymentFailureAlertI
 import { ProductDescriptionListTable } from '../productDescriptionListTable';
 import { SupportTheGuardianButton } from '../supportTheGuardianButton';
 import { ErrorIcon } from '../svgs/errorIcon';
+import { GenericErrorMessage } from '../identity/GenericErrorMessage';
 import { GiftIcon } from '../svgs/giftIcon';
 import { ContributionUpdateAmount } from './contributionUpdateAmount';
 import { NewsletterOptinSection } from './newsletterOptinSection';
@@ -70,6 +72,10 @@ const InnerContent = ({
 	productDetail,
 }: InnerContentProps) => {
 	const mainPlan = getMainPlan(productDetail.subscription);
+	if (!mainPlan) {
+		Sentry.captureMessage('mainPlan does not exist in manageProduct page');
+		return <GenericErrorMessage />;
+	}
 
 	const groupedProductType = manageProductProps.groupedProductType;
 

--- a/app/client/components/billing/billing.tsx
+++ b/app/client/components/billing/billing.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/browser';
 import { css } from '@emotion/react';
 import {
 	space,
@@ -104,6 +105,12 @@ const BillingRenderer = ([mdaResponse, invoiceResponse]: [
 									const mainPlan = getMainPlan(
 										productDetail.subscription,
 									);
+									if (!mainPlan) {
+										Sentry.captureMessage(
+											'mainPlan does not exist for product in billing page',
+										);
+										return null;
+									}
 									const groupedProductType =
 										GROUPED_PRODUCT_TYPES[
 											productDetail.mmaCategory

--- a/app/client/components/cancel/voucher/voucherCancellationFlowStart.tsx
+++ b/app/client/components/cancel/voucher/voucherCancellationFlowStart.tsx
@@ -1,6 +1,8 @@
+import * as Sentry from '@sentry/browser';
 import { getMainPlan, ProductDetail } from '../../../../shared/productResponse';
 import { trackEvent } from '../../../services/analytics';
 import { WithStandardTopMargin } from '../../WithStandardTopMargin';
+import { GenericErrorMessage } from '../../identity/GenericErrorMessage';
 import { hrefStyle } from '../cancellationConstants';
 
 const trackCancellationClickEvent = (eventLabel: string) => () =>
@@ -15,8 +17,15 @@ export const voucherCancellationFlowStart = ({
 }: ProductDetail) => {
 	const mainPlan = getMainPlan(subscription);
 
+	if (!mainPlan) {
+		Sentry.captureMessage(
+			'mainPlan does not exist in voucherCancellationFlowStart',
+		);
+		return <GenericErrorMessage />;
+	}
+
 	const isEligibleForFreeDigipackAccess =
-		mainPlan?.name?.indexOf('plus Digi') === -1;
+		mainPlan.name?.indexOf('plus Digi') === -1;
 
 	return (
 		<WithStandardTopMargin>

--- a/app/client/components/delivery/records/deliveryRecords.tsx
+++ b/app/client/components/delivery/records/deliveryRecords.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/browser';
 import { css } from '@emotion/react';
 import { Button } from '@guardian/source-react-components';
 import {
@@ -17,11 +18,13 @@ import {
 	isGift,
 	PaidSubscriptionPlan,
 	getMainPlan,
+	isPaidSubscriptionPlan,
 } from '../../../../shared/productResponse';
 import {
 	DeliveryProblemType,
 	holidaySuspensionDeliveryProblem,
 } from '../../../../shared/productTypes';
+import { GenericErrorMessage } from '../../identity/GenericErrorMessage';
 import { maxWidth, minWidth } from '../../../styles/breakpoints';
 import { trackEvent } from '../../../services/analytics';
 import { CallCentreEmailAndNumbers } from '../../callCenterEmailAndNumbers';
@@ -116,6 +119,13 @@ const DeliveryRecords = () => {
 	const mainPlan = getMainPlan(
 		productDetail.subscription,
 	) as PaidSubscriptionPlan;
+
+	if (!isPaidSubscriptionPlan(mainPlan)) {
+		Sentry.captureMessage(
+			'mainPlan is not a PaidSubscriptionPlan in deliveryRecords',
+		);
+		return <GenericErrorMessage />;
+	}
 
 	const subscriptionCurrency = mainPlan.currency;
 	const hasExistingDeliveryProblem = checkForExistingDeliveryProblem(

--- a/app/client/components/delivery/records/deliveryRecordsProblemConfirmation.tsx
+++ b/app/client/components/delivery/records/deliveryRecordsProblemConfirmation.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/browser';
 import { css } from '@emotion/react';
 import { LinkButton } from '@guardian/source-react-components';
 import {
@@ -19,6 +20,7 @@ import {
 	Subscription,
 	getMainPlan,
 } from '../../../../shared/productResponse';
+import { GenericErrorMessage } from '../../identity/GenericErrorMessage';
 import { maxWidth, minWidth } from '../../../styles/breakpoints';
 import { NAV_LINKS } from '../../nav/navConfig';
 import { ProductDescriptionListTable } from '../../productDescriptionListTable';
@@ -47,6 +49,13 @@ import { ReadOnlyAddressDisplay } from './readOnlyAddressDisplay';
 const renderDeliveryRecordsConfirmation =
 	(subscription: Subscription) => (data: DeliveryRecordsResponse) => {
 		const mainPlan = getMainPlan(subscription) as PaidSubscriptionPlan;
+
+		if (!mainPlan) {
+			Sentry.captureMessage(
+				'mainPlan does not exist in deliveryRecordsProblemReview',
+			);
+			return <GenericErrorMessage />;
+		}
 
 		return (
 			<DeliveryRecordsProblemConfirmationFC

--- a/app/client/components/delivery/records/deliveryRecordsProblemReview.tsx
+++ b/app/client/components/delivery/records/deliveryRecordsProblemReview.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/browser';
 import { css } from '@emotion/react';
 import { Button } from '@guardian/source-react-components';
 import {
@@ -14,8 +15,10 @@ import { parseDate } from '../../../../shared/dates';
 import {
 	DeliveryRecordApiItem,
 	getMainPlan,
+	isPaidSubscriptionPlan,
 	PaidSubscriptionPlan,
 } from '../../../../shared/productResponse';
+import { GenericErrorMessage } from '../../identity/GenericErrorMessage';
 import { maxWidth, minWidth } from '../../../styles/breakpoints';
 import { CallCentreEmailAndNumbers } from '../../callCenterEmailAndNumbers';
 import {
@@ -123,6 +126,13 @@ const DeliveryRecordsProblemReviewFC = (
 	const mainPlan = getMainPlan(
 		productDetail.subscription,
 	) as PaidSubscriptionPlan;
+
+	if (!isPaidSubscriptionPlan(mainPlan)) {
+		Sentry.captureMessage(
+			'mainPlan is not a PaidSubscriptionPlan in deliveryRecordsProblemReview',
+		);
+		return <GenericErrorMessage />;
+	}
 
 	const contactPhoneNumbers = data.contactPhoneNumbers;
 	const apiProductName =

--- a/app/client/components/payment/update/PaymentDetailUpdateConfirmation.tsx
+++ b/app/client/components/payment/update/PaymentDetailUpdateConfirmation.tsx
@@ -277,9 +277,7 @@ export const ConfirmedNewPaymentDetailsRenderer = ({
 											100.0
 										).toFixed(2)}{' '}
 										/{' '}
-										{getPaymentInterval(
-											subscription.plan?.interval,
-										)}
+										{getPaymentInterval(mainPlan.interval)}
 										{subscription.stripePublicKeyForCardAddition && (
 											<span>No Payment Method</span>
 										)}

--- a/app/client/fixtures/productDetail.ts
+++ b/app/client/fixtures/productDetail.ts
@@ -53,13 +53,6 @@ export const guardianWeeklyCard: ProductDetail = {
 		subscriptionId: 'A-S00286635',
 		trialLength: 9,
 		autoRenew: true,
-		plan: {
-			name: 'Guardian Weekly - Domestic',
-			amount: 15000,
-			currency: '£',
-			currencyISO: 'GBP',
-			interval: 'year',
-		},
 		currentPlans: [],
 		futurePlans: [
 			{
@@ -228,13 +221,6 @@ export const newspaperVoucherPaypal: ProductDetail = {
 		subscriptionId: 'A-S00285104',
 		trialLength: -7,
 		autoRenew: true,
-		plan: {
-			name: 'Newspaper Digital Voucher',
-			amount: 5299,
-			currency: '£',
-			currencyISO: 'GBP',
-			interval: 'month',
-		},
 		currentPlans: [
 			{
 				name: 'Everyday',
@@ -308,13 +294,6 @@ export const guardianWeeklyCurrentSubscription: ProductDetail = {
 		subscriptionId: 'A-S00293857',
 		trialLength: -37,
 		autoRenew: true,
-		plan: {
-			name: 'Guardian Weekly - Domestic',
-			amount: 3250,
-			currency: '$',
-			currencyISO: 'AUD',
-			interval: 'month',
-		},
 		currentPlans: [
 			{
 				name: null,
@@ -379,13 +358,6 @@ export const homeDeliverySubscription: ProductDetail = {
 		subscriptionId: 'A-S00293857',
 		trialLength: -37,
 		autoRenew: true,
-		plan: {
-			name: 'Newspaper Delivery',
-			amount: 3250,
-			currency: '$',
-			currencyISO: 'AUD',
-			interval: 'month',
-		},
 		currentPlans: [
 			{
 				name: 'Everyday',
@@ -453,13 +425,6 @@ export const contribution: ProductDetail = {
 		subscriptionId: 'A-S00303370',
 		trialLength: -24,
 		autoRenew: true,
-		plan: {
-			name: 'Contributor',
-			amount: 10000,
-			currency: '£',
-			currencyISO: 'GBP',
-			interval: 'month',
-		},
 		currentPlans: [
 			{
 				name: null,

--- a/app/client/fixtures/subscription.ts
+++ b/app/client/fixtures/subscription.ts
@@ -42,13 +42,6 @@ export const guardianWeeklySubscriptionCard: Subscription = {
 	subscriberId: 'A-S00286635',
 	trialLength: 9,
 	autoRenew: true,
-	plan: {
-		name: 'Guardian Weekly - Domestic',
-		amount: 15000,
-		currency: '£',
-		currencyISO: 'GBP',
-		interval: 'year',
-	},
 	currentPlans: [],
 	futurePlans: [
 		{
@@ -103,13 +96,6 @@ export const guardianWeeklySubscriptionAustralia: Subscription = {
 	subscriptionId: 'A-S00293857',
 	trialLength: 9,
 	autoRenew: true,
-	plan: {
-		name: 'Guardian Weekly - Domestic',
-		amount: 3250,
-		currency: '$',
-		currencyISO: 'AUD',
-		interval: 'month',
-	},
 	currentPlans: [],
 	futurePlans: [
 		{
@@ -161,13 +147,6 @@ export const digitalSubscriptionDD: Subscription = {
 	subscriptionId: 'A-S00287957',
 	trialLength: 16,
 	autoRenew: true,
-	plan: {
-		name: 'Digital Pack',
-		amount: 11900,
-		currency: '£',
-		currencyISO: 'GBP',
-		interval: 'year',
-	},
 	currentPlans: [],
 	futurePlans: [
 		{

--- a/app/server/fulfilmentDateCalculatorReader.ts
+++ b/app/server/fulfilmentDateCalculatorReader.ts
@@ -44,6 +44,13 @@ const getDeliveryAddressChangeEffectiveDateForToday = async (
 
 export const augmentProductDetailWithDeliveryAddressChangeEffectiveDateForToday =
 	async (productDetail: ProductDetail) => {
+		const mainPlan = getMainPlan(productDetail.subscription);
+		if (!mainPlan) {
+			const missingMainPlanErrorMsg =
+				'mainPlan does not exist in augmentProductDetailWithDeliveryAddressChangeEffectiveDateForToday function (fulfilmentDateCalculatorReader)';
+			log.error(missingMainPlanErrorMsg);
+			Sentry.captureMessage(missingMainPlanErrorMsg);
+		}
 		const productType =
 			GROUPED_PRODUCT_TYPES.subscriptions.mapGroupedToSpecific(
 				productDetail,
@@ -54,7 +61,7 @@ export const augmentProductDetailWithDeliveryAddressChangeEffectiveDateForToday 
 			productType.fulfilmentDateCalculator?.explicitSingleDayOfWeek;
 		const maybeDaysOfWeek = maybeExplicitSingleDayOfWeek
 			? [maybeExplicitSingleDayOfWeek]
-			: getMainPlan(productDetail.subscription).daysOfWeek;
+			: mainPlan.daysOfWeek;
 		const maybeDeliveryAddressChangeEffectiveDate =
 			maybeFulfilmentDateCalculatorProductFilenamePart &&
 			maybeDaysOfWeek &&

--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -158,7 +158,6 @@ export interface Subscription {
 	mandate?: DirectDebitDetails;
 	sepaMandate?: SepaDetails;
 	autoRenew: boolean;
-	plan?: any;
 	currentPlans: (SubscriptionPlan | PaidSubscriptionPlan)[];
 	futurePlans: (SubscriptionPlan | PaidSubscriptionPlan)[];
 	trialLength: number;
@@ -203,15 +202,7 @@ export const getMainPlan: (subscription: Subscription) => SubscriptionPlan = (
 			);
 		}
 		return subscription.currentPlans[0];
-	} else if (subscription.futurePlans.length > 0) {
-		// fallback to use the first future plan (contributions for example are always future plans)
-		return subscription.futurePlans[0];
 	}
-	return {
-		name: null,
-		start: subscription.start,
-		shouldBeVisible: true,
-		currency: subscription.plan?.currency,
-		currencyISO: subscription.plan?.currencyISO,
-	};
+	// fallback to use the first future plan (contributions for example are always future plans)
+	return subscription.futurePlans?.[0];
 };


### PR DESCRIPTION
## What does this change?
Use the currentPlans and futurePlans objects instead of the plan object as part of the product detail member data api response. 

Wrap usage of these (currentPlans and futurePlans) with a sentry alert if the response from the api doesn't include them for some reason and add early return of fallback error message component where applicable to stop potential run time error.

#### Relevant members data api pr:
https://github.com/guardian/members-data-api/pull/371