### PR TITLE
Ophan tracking for the product switching cancellation journey

### DIFF
--- a/app/client/components/cancel/CancellationSwitchEligibilityCheck.tsx
+++ b/app/client/components/cancel/CancellationSwitchEligibilityCheck.tsx
@@ -16,6 +16,7 @@ import { WithStandardTopMargin } from '../WithStandardTopMargin';
 import { AvailableProductsResponse } from '../productSwitch/productSwitchApi';
 import { useAB } from '@guardian/ab-react';
 import { ProductMovementTest } from '../../experiments/tests/product-movement-test';
+import { trackEventInOphanOnly } from '../../services/analytics';
 
 const CancellationSwitchEligibilityCheck = () => {
 	const ABTestAPI = useAB();
@@ -74,6 +75,12 @@ const CancellationSwitchEligibilityCheck = () => {
 			</WithStandardTopMargin>
 		);
 	}
+
+	trackEventInOphanOnly({
+		eventCategory: 'pageView',
+		eventAction: 'cancellation_page_1',
+		eventLabel: inABTest ? 'with_product_switch' : 'without_product_switch',
+	});
 
 	return inABTest ? (
 		<CancellationSwitchOffer availableProductsToSwitch={data} />

--- a/app/client/components/productSwitch/CancellationSwitchConfirmed.tsx
+++ b/app/client/components/productSwitch/CancellationSwitchConfirmed.tsx
@@ -30,6 +30,7 @@ import {
 } from './productSwitchHelpers';
 import { CancellationRouterState } from '../cancel/CancellationContainer';
 import { headingCss, listCss, standfirstCss } from './productSwitchStyles';
+import { trackEventInOphanOnly } from '../../services/analytics';
 
 const CancellationSwitchConfirmed = () => {
 	const navigate = useNavigate();
@@ -47,6 +48,11 @@ const CancellationSwitchConfirmed = () => {
 	}
 
 	const newProduct = productSwitchConfirmationInfo.newProduct;
+
+	trackEventInOphanOnly({
+		eventCategory: 'pageView',
+		eventAction: 'product_switch_confirmation',
+	});
 
 	return (
 		<>


### PR DESCRIPTION
## What does this change?
Add Ophan tracking for the product switching cancellation journey.

The tracking has been put in 3 places
- The `CancellationSwitchEligibilityCheck` component which serves as the first page in the cancellation journey, whether or not they are in the product switch variant or the old cancel journey.
- The `ExecuteCancellation` component which is the page that does the cancelling eg posts to the cancel api.
- The `CancellationSwitchConfirmed` component which is the confirmation page that the user lands on when they have successfully switched from a contribution to a digital subscription.

The events are all fired manually as a pageView so that where applicable the ab variant or control version can be passed through additionally with the eventLabel property.