### PR TITLE
[RB] - subscription.plan object still exists

### DIFF
--- a/app/shared/productResponse.ts
+++ b/app/shared/productResponse.ts
@@ -160,6 +160,7 @@ export interface Subscription {
 	autoRenew: boolean;
 	currentPlans: (SubscriptionPlan | PaidSubscriptionPlan)[];
 	futurePlans: (SubscriptionPlan | PaidSubscriptionPlan)[];
+	plan?: PaidSubscriptionPlan;
 	trialLength: number;
 	readerType: ReaderType;
 	deliveryAddress?: DeliveryAddress;
@@ -202,7 +203,15 @@ export const getMainPlan: (subscription: Subscription) => SubscriptionPlan = (
 			);
 		}
 		return subscription.currentPlans[0];
+	} else if (subscription.futurePlans.length > 0) {
+		// fallback to use the first future plan (contributions for example are always future plans)
+		return subscription.futurePlans[0];
 	}
-	// fallback to use the first future plan (contributions for example are always future plans)
-	return subscription.futurePlans?.[0];
+	return {
+		name: null,
+		start: subscription.start,
+		shouldBeVisible: true,
+		currency: subscription.plan?.currency,
+		currencyISO: subscription.plan?.currencyISO,
+	};
 };


### PR DESCRIPTION
## What does this change?
Subscription.plan object has not been fully removed from the members-data-api response, specifically contributions still seem to make use of this property. Therefore we need to add the plan object back in to the product response interface and add the object as a fallback in the getMainPlan function. This fixes a bug where the .plan object exists and both currentPlans and futurePlans properties (both arrays) are blank, which would result in the generic error message being shown in the account overview and throughout manage frontend.