### PR TITLE
Enable Direct Debit payment method update widget to show in more cases

### DIFF
--- a/app/client/__tests__/components/payment/updatePaymentFlow.test.tsx
+++ b/app/client/__tests__/components/payment/updatePaymentFlow.test.tsx
@@ -53,7 +53,7 @@ describe('updatePaymentFlow.tsx', () => {
 				value={PaymentMethod.payPal}
 				currentPaymentMethod={PaymentMethod.payPal}
 				updatePaymentMethod={() => null}
-				directDebitIsAllowed={true}
+				directDebitIsAllowed={false}
 			/>,
 		);
 

--- a/app/client/__tests__/components/payment/updatePaymentFlow.test.tsx
+++ b/app/client/__tests__/components/payment/updatePaymentFlow.test.tsx
@@ -5,25 +5,27 @@ import {
 } from '../../../components/payment/update/PaymentDetailUpdate';
 
 describe('updatePaymentFlow.tsx', () => {
-	it('Shows only card when sub/crontrib is already using card', () => {
+	it('Shows only card when sub/contrib is already using card, and dd is not allowed', () => {
 		const { getByText, queryByText } = render(
 			<SelectPaymentMethod
 				value={PaymentMethod.card}
 				currentPaymentMethod={PaymentMethod.card}
 				updatePaymentMethod={() => null}
+				directDebitIsAllowed={false}
 			/>,
 		);
 
-		getByText(PaymentMethod.card);
+		expect(getByText(PaymentMethod.card)).toBeDefined();
 		expect(queryByText(PaymentMethod.dd)).toBeNull();
 	});
 
-	it('Shows both card and direct debit when sub/crontrib is using direct debit', () => {
+	it('Shows both card and direct debit when sub/contrib is using card and direct debit is allowed', () => {
 		const { getByText } = render(
 			<SelectPaymentMethod
-				value={PaymentMethod.dd}
-				currentPaymentMethod={PaymentMethod.dd}
+				value={PaymentMethod.card}
+				currentPaymentMethod={PaymentMethod.card}
 				updatePaymentMethod={() => null}
+				directDebitIsAllowed={true}
 			/>,
 		);
 
@@ -31,16 +33,45 @@ describe('updatePaymentFlow.tsx', () => {
 		expect(getByText(PaymentMethod.dd)).toBeDefined();
 	});
 
-	it('Shows only card when sub/crontrib is using Paypal', () => {
+	it('Shows both card and direct debit when sub/contrib is already using direct debit', () => {
+		const { getByText } = render(
+			<SelectPaymentMethod
+				value={PaymentMethod.dd}
+				currentPaymentMethod={PaymentMethod.dd}
+				updatePaymentMethod={() => null}
+				directDebitIsAllowed={true}
+			/>,
+		);
+
+		expect(getByText(PaymentMethod.card)).toBeDefined();
+		expect(getByText(PaymentMethod.dd)).toBeDefined();
+	});
+
+	it('Shows only card when sub/contrib is using Paypal and direct debit is not allowed', () => {
 		const { getByText, queryByText } = render(
 			<SelectPaymentMethod
 				value={PaymentMethod.payPal}
 				currentPaymentMethod={PaymentMethod.payPal}
 				updatePaymentMethod={() => null}
+				directDebitIsAllowed={true}
 			/>,
 		);
 
-		getByText(PaymentMethod.card);
+		expect(getByText(PaymentMethod.card)).toBeDefined();
 		expect(queryByText(PaymentMethod.dd)).toBeNull();
+	});
+
+	it('Shows card and dd when sub/contrib is using Paypal and direct debit is allowed', () => {
+		const { getByText } = render(
+			<SelectPaymentMethod
+				value={PaymentMethod.payPal}
+				currentPaymentMethod={PaymentMethod.payPal}
+				updatePaymentMethod={() => null}
+				directDebitIsAllowed={true}
+			/>,
+		);
+
+		expect(getByText(PaymentMethod.card)).toBeDefined();
+		expect(getByText(PaymentMethod.dd)).toBeDefined();
 	});
 });

--- a/app/client/components/payment/update/PaymentDetailUpdate.tsx
+++ b/app/client/components/payment/update/PaymentDetailUpdate.tsx
@@ -224,9 +224,9 @@ const PaymentDetailUpdate = (props: WithProductType<ProductType>) => {
 		(isPaidSubscriptionPlan(mainPlan) &&
 			mainPlan &&
 			mainPlan.currencyISO === 'GBP' &&
-			productDetail.subscription.deliveryAddress !== undefined &&
-			productDetail.subscription.deliveryAddress.country ===
-				'United Kingdom');
+			(productDetail.subscription.deliveryAddress === undefined ||
+				productDetail.subscription.deliveryAddress.country ===
+					'United Kingdom'));
 
 	const [paymentUpdateState, setPaymentUpdateState] =
 		useState<PaymentUpdaterStepState>({

--- a/app/client/components/payment/update/PaymentDetailUpdate.tsx
+++ b/app/client/components/payment/update/PaymentDetailUpdate.tsx
@@ -19,6 +19,8 @@ import {
 import * as Sentry from '@sentry/browser';
 import * as React from 'react';
 import {
+	getMainPlan,
+	isPaidSubscriptionPlan,
 	ProductDetail,
 	Subscription,
 	WithSubscription,
@@ -215,11 +217,15 @@ const PaymentDetailUpdate = (props: WithProductType<ProductType>) => {
 
 	const currentPaymentMethod = subscriptionToPaymentMethod(productDetail);
 
+	const mainPlan = getMainPlan(productDetail.subscription);
+
 	const directDebitIsAllowed =
-		currentPaymentMethod == PaymentMethod.dd || (
-			productDetail.subscription.plan !== undefined &&
+		currentPaymentMethod === PaymentMethod.dd ||
+		(
+			isPaidSubscriptionPlan(mainPlan) &&
+			mainPlan &&
+			mainPlan.currencyISO === "GBP" &&
 			productDetail.subscription.deliveryAddress !== undefined &&
-			productDetail.subscription.plan.currency === "GBP" &&
 			productDetail.subscription.deliveryAddress.country === "United Kingdom"
 		);
 

--- a/app/client/components/payment/update/PaymentDetailUpdate.tsx
+++ b/app/client/components/payment/update/PaymentDetailUpdate.tsx
@@ -70,7 +70,7 @@ const subHeadingCss = css`
 interface PaymentMethodProps {
 	value: PaymentMethod;
 	updatePaymentMethod: (newPaymentMethod: PaymentMethod) => void;
-	directDebitIsAllowed: Boolean
+	directDebitIsAllowed: Boolean;
 }
 
 interface PaymentMethodRadioButtonProps extends PaymentMethodProps {
@@ -220,14 +220,13 @@ const PaymentDetailUpdate = (props: WithProductType<ProductType>) => {
 	const mainPlan = getMainPlan(productDetail.subscription);
 
 	const directDebitIsAllowed =
-		(currentPaymentMethod === PaymentMethod.dd) ||
-		(
-			isPaidSubscriptionPlan(mainPlan) &&
+		currentPaymentMethod === PaymentMethod.dd ||
+		(isPaidSubscriptionPlan(mainPlan) &&
 			mainPlan &&
-			mainPlan.currencyISO === "GBP" &&
+			mainPlan.currencyISO === 'GBP' &&
 			productDetail.subscription.deliveryAddress !== undefined &&
-			productDetail.subscription.deliveryAddress.country === "United Kingdom"
-		);
+			productDetail.subscription.deliveryAddress.country ===
+				'United Kingdom');
 
 	const [paymentUpdateState, setPaymentUpdateState] =
 		useState<PaymentUpdaterStepState>({

--- a/app/client/components/payment/update/PaymentDetailUpdate.tsx
+++ b/app/client/components/payment/update/PaymentDetailUpdate.tsx
@@ -222,9 +222,9 @@ const PaymentDetailUpdate = (props: WithProductType<ProductType>) => {
 	const directDebitIsAllowed =
 		currentPaymentMethod === PaymentMethod.dd ||
 		(isPaidSubscriptionPlan(mainPlan) &&
-			mainPlan &&
 			mainPlan.currencyISO === 'GBP' &&
-			(productDetail.subscription.deliveryAddress === undefined ||
+			(!productDetail.subscription.deliveryAddress ||
+				!productDetail.subscription.deliveryAddress?.country ||
 				productDetail.subscription.deliveryAddress.country ===
 					'United Kingdom'));
 

--- a/app/client/components/payment/update/PaymentDetailUpdate.tsx
+++ b/app/client/components/payment/update/PaymentDetailUpdate.tsx
@@ -220,7 +220,7 @@ const PaymentDetailUpdate = (props: WithProductType<ProductType>) => {
 	const mainPlan = getMainPlan(productDetail.subscription);
 
 	const directDebitIsAllowed =
-		currentPaymentMethod === PaymentMethod.dd ||
+		(currentPaymentMethod === PaymentMethod.dd) ||
 		(
 			isPaidSubscriptionPlan(mainPlan) &&
 			mainPlan &&

--- a/app/client/components/payment/update/PaymentDetailUpdate.tsx
+++ b/app/client/components/payment/update/PaymentDetailUpdate.tsx
@@ -68,6 +68,7 @@ const subHeadingCss = css`
 interface PaymentMethodProps {
 	value: PaymentMethod;
 	updatePaymentMethod: (newPaymentMethod: PaymentMethod) => void;
+	directDebitIsAllowed: Boolean
 }
 
 interface PaymentMethodRadioButtonProps extends PaymentMethodProps {
@@ -164,7 +165,7 @@ export const SelectPaymentMethod = (
 				paymentMethod={PaymentMethod.card}
 				{...props}
 			/>
-			{props.currentPaymentMethod === PaymentMethod.dd ? (
+			{props.directDebitIsAllowed ? (
 				<PaymentMethodRadioButton
 					paymentMethod={PaymentMethod.dd}
 					{...props}
@@ -213,6 +214,14 @@ const PaymentDetailUpdate = (props: WithProductType<ProductType>) => {
 	) as ProductDetail;
 
 	const currentPaymentMethod = subscriptionToPaymentMethod(productDetail);
+
+	const directDebitIsAllowed =
+		currentPaymentMethod == PaymentMethod.dd || (
+			productDetail.subscription.plan !== undefined &&
+			productDetail.subscription.deliveryAddress !== undefined &&
+			productDetail.subscription.plan.currency === "GBP" &&
+			productDetail.subscription.deliveryAddress.country === "United Kingdom"
+		);
 
 	const [paymentUpdateState, setPaymentUpdateState] =
 		useState<PaymentUpdaterStepState>({
@@ -457,6 +466,7 @@ const PaymentDetailUpdate = (props: WithProductType<ProductType>) => {
 				updatePaymentMethod={updatePaymentMethod}
 				value={selectedPaymentMethod}
 				currentPaymentMethod={currentPaymentMethod}
+				directDebitIsAllowed={directDebitIsAllowed}
 			/>
 
 			{getInputForm(productDetail.subscription, productDetail.isTestUser)}


### PR DESCRIPTION
## What does this change?
It enables Direct Debit payment method update widget to show whenever the currency is GBP and the delivery country is, or is implied to be, United Kingdom.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Ensure https://github.com/guardian/members-data-api/pull/770 has been deployed.

1. Create a recurring contribution or digital subscription using Card or PayPal.
2. Log into manage and check that you can change the payment method to DD.
3. Once you've changed, check that you can change/update the DD details successfully, as well as go on to select card again as an alternative.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Increase in number of payment failure recovery switches to DD.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
Delivery address is determining it rather than billing address, which isn't available to manage. This should be very very rare that the currency being GBP does not mean that the billing country is not UK. Plus the DD bank details won't validate if the user is not using a UK bank.

## Trello
https://trello.com/c/vqFqYqIU

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
Before:

![Screen Shot 2022-07-14 at 15 28 35](https://user-images.githubusercontent.com/1515970/179183429-b718d2c1-04d1-442f-ab17-93c238cf7cec.png)

After:

![Screen Shot 2022-07-15 at 09 20 17](https://user-images.githubusercontent.com/1515970/179183486-6d92a035-9d7f-4739-8911-00130232eda9.png)

![Screen Shot 2022-07-15 at 09 20 25](https://user-images.githubusercontent.com/1515970/179183505-bcfb7e17-73d4-4bf3-836c-8cbd67c049a2.png)

![Screen Shot 2022-07-15 at 09 23 55](https://user-images.githubusercontent.com/1515970/179184075-bb0097c9-def0-49ec-a934-8b8ced0ff50d.png)

![Screen Shot 2022-07-15 at 09 24 01](https://user-images.githubusercontent.com/1515970/179184096-42004501-4576-493e-8702-146e4698d742.png)

![Screen Shot 2022-07-15 at 14 09 20](https://user-images.githubusercontent.com/1515970/179229603-02bdad6f-a5b8-4c7a-b44e-ebb88a0c0b06.png)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
