### PR TITLE
Cancellation journey for people with no products to switch to 

### DIFF
--- a/app/client/components/cancel/CancellationSwitchEligibilityCheck.tsx
+++ b/app/client/components/cancel/CancellationSwitchEligibilityCheck.tsx
@@ -70,7 +70,7 @@ const CancellationSwitchEligibilityCheck = () => {
 		);
 	}
 
-	return cancellationProductSwitchFeatureIsOn ? (
+	return cancellationProductSwitchFeatureIsOn && data.length ? (
 		<CancellationSwitchOffer availableProductsToSwitch={data} />
 	) : (
 		<CancellationReasonSelection />


### PR DESCRIPTION
## What does this change?
If the eligibility switch api response (called when the user lands on the first page of the cancellation journey) returns a blank array then direct the user to the existing cancellation journey and not the product switch one.