### PR TITLE
Add `<Heading>` component and update cancellation heading styles

### DIFF
--- a/app/client/components/Heading.tsx
+++ b/app/client/components/Heading.tsx
@@ -1,0 +1,32 @@
+import { css, SerializedStyles } from '@emotion/react';
+import { from, headline, palette } from '@guardian/source-foundations';
+import { ReactNode } from 'react';
+import { measure } from '../styles/typography';
+
+interface HeadingProps {
+	children: ReactNode;
+	measure?: 'regular' | 'medium';
+	cssOverrides?: SerializedStyles;
+}
+
+export const Heading = (props: HeadingProps) => {
+	const containerStyles = css`
+		border-top: 1px solid ${palette.neutral[86]};
+	`;
+
+	const headingStyles = css`
+		${headline.xsmall({ fontWeight: 'bold' })};
+		margin-top: 0;
+		margin-bottom: 0;
+		${props.measure && measure[props.measure]}
+		${from.tablet} {
+			${headline.small({ fontWeight: 'bold' })};
+		} ;
+	`;
+
+	return (
+		<div css={[containerStyles, props.cssOverrides]}>
+			<h2 css={headingStyles}>{props.children}</h2>
+		</div>
+	);
+};

--- a/app/client/components/Heading.tsx
+++ b/app/client/components/Heading.tsx
@@ -1,12 +1,10 @@
 import { css, SerializedStyles } from '@emotion/react';
 import { from, headline, palette } from '@guardian/source-foundations';
 import { ReactNode } from 'react';
-import { measure } from '../styles/typography';
 
 interface HeadingProps {
 	children: ReactNode;
-	measure?: 'regular' | 'medium';
-	cssOverrides?: SerializedStyles;
+	cssOverrides?: SerializedStyles | SerializedStyles[];
 }
 
 export const Heading = (props: HeadingProps) => {
@@ -18,15 +16,14 @@ export const Heading = (props: HeadingProps) => {
 		${headline.xsmall({ fontWeight: 'bold' })};
 		margin-top: 0;
 		margin-bottom: 0;
-		${props.measure && measure[props.measure]}
 		${from.tablet} {
 			${headline.small({ fontWeight: 'bold' })};
 		} ;
 	`;
 
 	return (
-		<div css={[containerStyles, props.cssOverrides]}>
-			<h2 css={headingStyles}>{props.children}</h2>
+		<div css={containerStyles}>
+			<h2 css={[headingStyles, props.cssOverrides]}>{props.children}</h2>
 		</div>
 	);
 };

--- a/app/client/components/Heading.tsx
+++ b/app/client/components/Heading.tsx
@@ -5,10 +5,11 @@ import { ReactNode } from 'react';
 interface HeadingProps {
 	children: ReactNode;
 	cssOverrides?: SerializedStyles | SerializedStyles[];
+	level?: '1' | '2' | '3' | '4';
 }
 
 export const Heading = (props: HeadingProps) => {
-	const containerStyles = css`
+	const dividerStyles = css`
 		border-top: 1px solid ${palette.neutral[86]};
 	`;
 
@@ -21,9 +22,13 @@ export const Heading = (props: HeadingProps) => {
 		} ;
 	`;
 
+	const HeadingElement: keyof JSX.IntrinsicElements = `h${props.level ?? 2}`;
+
 	return (
-		<div css={containerStyles}>
-			<h2 css={[headingStyles, props.cssOverrides]}>{props.children}</h2>
+		<div css={dividerStyles}>
+			<HeadingElement css={[headingStyles, props.cssOverrides]}>
+				{props.children}
+			</HeadingElement>
 		</div>
 	);
 };

--- a/app/client/components/cancel/CancellationReasonReview.tsx
+++ b/app/client/components/cancel/CancellationReasonReview.tsx
@@ -45,6 +45,7 @@ import {
 import { Spinner } from '../spinner';
 import { GenericErrorScreen } from '../genericErrorScreen';
 import { Heading } from '../Heading';
+import { measure } from '../../styles/typography';
 
 const getPatchUpdateCaseFunc =
 	(isTestUser: boolean, caseId: string, feedback: string) => async () =>
@@ -434,10 +435,12 @@ const CancellationReasonReview = () => {
 				) : (
 					<>
 						<Heading
-							measure="medium"
-							cssOverrides={css`
-								margin-bottom: ${space[6]}px;
-							`}
+							cssOverrides={[
+								measure.heading,
+								css`
+									margin-bottom: ${space[6]}px;
+								`,
+							]}
 						>
 							{productType.cancellation.hideReasonTitlePrefix
 								? ''

--- a/app/client/components/cancel/CancellationReasonReview.tsx
+++ b/app/client/components/cancel/CancellationReasonReview.tsx
@@ -44,7 +44,7 @@ import {
 } from '../delivery/records/deliveryRecordsApi';
 import { Spinner } from '../spinner';
 import { GenericErrorScreen } from '../genericErrorScreen';
-import { heading, measure } from '../../styles/typography';
+import { Heading } from '../Heading';
 
 const getPatchUpdateCaseFunc =
 	(isTestUser: boolean, caseId: string, feedback: string) => async () =>
@@ -433,29 +433,17 @@ const CancellationReasonReview = () => {
 					)
 				) : (
 					<>
-						<h2
-							css={[
-								heading,
-								css`
-									margin-bottom: ${space[6]}px;
-								`,
-							]}
-							id="save_title"
+						<Heading
+							measure="medium"
+							cssOverrides={css`
+								margin-bottom: ${space[6]}px;
+							`}
 						>
-							<span
-								css={[
-									css`
-										display: inline-block;
-									`,
-									measure.medium,
-								]}
-							>
-								{productType.cancellation.hideReasonTitlePrefix
-									? ''
-									: 'Reason: '}
-								{reason.saveTitle || reason.linkLabel}
-							</span>
-						</h2>
+							{productType.cancellation.hideReasonTitlePrefix
+								? ''
+								: 'Reason: '}
+							{reason.saveTitle || reason.linkLabel}
+						</Heading>
 						{needsCancellationEscalation && (
 							<p>
 								Once you submit your cancellation request our

--- a/app/client/components/cancel/CancellationReasonReview.tsx
+++ b/app/client/components/cancel/CancellationReasonReview.tsx
@@ -44,6 +44,7 @@ import {
 } from '../delivery/records/deliveryRecordsApi';
 import { Spinner } from '../spinner';
 import { GenericErrorScreen } from '../genericErrorScreen';
+import { heading, measure } from '../../styles/typography';
 
 const getPatchUpdateCaseFunc =
 	(isTestUser: boolean, caseId: string, feedback: string) => async () =>
@@ -432,12 +433,29 @@ const CancellationReasonReview = () => {
 					)
 				) : (
 					<>
-						<h3 id="save_title">
-							{productType.cancellation.hideReasonTitlePrefix
-								? ''
-								: 'Reason: '}
-							{reason.saveTitle || reason.linkLabel}
-						</h3>
+						<h2
+							css={[
+								heading,
+								css`
+									margin-bottom: ${space[6]}px;
+								`,
+							]}
+							id="save_title"
+						>
+							<span
+								css={[
+									css`
+										display: inline-block;
+									`,
+									measure.medium,
+								]}
+							>
+								{productType.cancellation.hideReasonTitlePrefix
+									? ''
+									: 'Reason: '}
+								{reason.saveTitle || reason.linkLabel}
+							</span>
+						</h2>
 						{needsCancellationEscalation && (
 							<p>
 								Once you submit your cancellation request our

--- a/app/client/components/cancel/cancellationSummary.tsx
+++ b/app/client/components/cancel/cancellationSummary.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { brand } from '@guardian/source-foundations';
+import { brand, space } from '@guardian/source-foundations';
 import { cancellationFormatDate } from '../../../shared/dates';
 import { ProductDetail, Subscription } from '../../../shared/productResponse';
 import { ProductType } from '../../../shared/productTypes';
@@ -12,6 +12,7 @@ import { hrefStyle } from './cancellationConstants';
 import { CancellationReasonContext } from './cancellationContexts';
 import { CancellationContributionReminder } from './cancellationContributionReminder';
 import { Link } from 'react-router-dom';
+import { heading, measure } from '../../styles/typography';
 
 const actuallyCancelled = (
 	productType: ProductType,
@@ -23,7 +24,25 @@ const actuallyCancelled = (
 	return (
 		<>
 			<WithStandardTopMargin>
-				<h3>Your {productType.friendlyName} is cancelled.</h3>
+				<h2
+					css={[
+						heading,
+						css`
+							margin-bottom: ${space[6]}px;
+						`,
+					]}
+				>
+					<span
+						css={[
+							css`
+								display: inline-block;
+							`,
+							measure.medium,
+						]}
+					>
+						Your {productType.friendlyName} is cancelled.
+					</span>
+				</h2>
 				{productType.cancellation &&
 					!productType.cancellation.shouldHideSummaryMainPara && (
 						<p>

--- a/app/client/components/cancel/cancellationSummary.tsx
+++ b/app/client/components/cancel/cancellationSummary.tsx
@@ -12,7 +12,7 @@ import { hrefStyle } from './cancellationConstants';
 import { CancellationReasonContext } from './cancellationContexts';
 import { CancellationContributionReminder } from './cancellationContributionReminder';
 import { Link } from 'react-router-dom';
-import { heading, measure } from '../../styles/typography';
+import { Heading } from '../Heading';
 
 const actuallyCancelled = (
 	productType: ProductType,
@@ -24,25 +24,14 @@ const actuallyCancelled = (
 	return (
 		<>
 			<WithStandardTopMargin>
-				<h2
-					css={[
-						heading,
-						css`
-							margin-bottom: ${space[6]}px;
-						`,
-					]}
+				<Heading
+					measure="medium"
+					cssOverrides={css`
+						margin-bottom: ${space[6]}px;
+					`}
 				>
-					<span
-						css={[
-							css`
-								display: inline-block;
-							`,
-							measure.medium,
-						]}
-					>
-						Your {productType.friendlyName} is cancelled.
-					</span>
-				</h2>
+					Your {productType.friendlyName} is cancelled.
+				</Heading>
 				{productType.cancellation &&
 					!productType.cancellation.shouldHideSummaryMainPara && (
 						<p>

--- a/app/client/components/cancel/cancellationSummary.tsx
+++ b/app/client/components/cancel/cancellationSummary.tsx
@@ -13,6 +13,7 @@ import { CancellationReasonContext } from './cancellationContexts';
 import { CancellationContributionReminder } from './cancellationContributionReminder';
 import { Link } from 'react-router-dom';
 import { Heading } from '../Heading';
+import { measure } from '../../styles/typography';
 
 const actuallyCancelled = (
 	productType: ProductType,
@@ -25,10 +26,12 @@ const actuallyCancelled = (
 		<>
 			<WithStandardTopMargin>
 				<Heading
-					measure="medium"
-					cssOverrides={css`
-						margin-bottom: ${space[6]}px;
-					`}
+					cssOverrides={[
+						measure.heading,
+						css`
+							margin-bottom: ${space[6]}px;
+						`,
+					]}
 				>
 					Your {productType.friendlyName} is cancelled.
 				</Heading>

--- a/app/client/components/cancel/contributions/contributionsCancellationFlowStart.tsx
+++ b/app/client/components/cancel/contributions/contributionsCancellationFlowStart.tsx
@@ -1,38 +1,18 @@
-import { css } from '@emotion/react';
 import { Stack } from '@guardian/source-react-components';
 import { featureSwitches } from '../../../../shared/featureSwitches';
-import { heading, measure } from '../../../styles/typography';
+import { Heading } from '../../Heading';
 
 export const contributionsCancellationFlowStart = () =>
 	featureSwitches.cancellationProductSwitch ? (
-		<h2 css={heading}>
-			<span
-				css={[
-					css`
-						display: inline-block;
-					`,
-					measure.medium,
-				]}
-			>
-				Please could you take a moment to tell us why you want to
-				cancel?
-			</span>
-		</h2>
+		<Heading measure="medium">
+			Please could you take a moment to tell us why you want to cancel?
+		</Heading>
 	) : (
 		<Stack space={4}>
-			<h2 css={heading}>
-				<span
-					css={[
-						css`
-							display: inline-block;
-						`,
-						measure.medium,
-					]}
-				>
-					We’re sorry to hear you’re thinking of cancelling your
-					recurring contribution.
-				</span>
-			</h2>
+			<Heading measure="medium">
+				We’re sorry to hear you’re thinking of cancelling your recurring
+				contribution.
+			</Heading>
 			<p>
 				Your support means The Guardian can remain editorially
 				independent, free from the influence of billionaire owners and

--- a/app/client/components/cancel/contributions/contributionsCancellationFlowStart.tsx
+++ b/app/client/components/cancel/contributions/contributionsCancellationFlowStart.tsx
@@ -1,15 +1,16 @@
 import { Stack } from '@guardian/source-react-components';
 import { featureSwitches } from '../../../../shared/featureSwitches';
+import { measure } from '../../../styles/typography';
 import { Heading } from '../../Heading';
 
 export const contributionsCancellationFlowStart = () =>
 	featureSwitches.cancellationProductSwitch ? (
-		<Heading measure="medium">
+		<Heading cssOverrides={measure.heading}>
 			Please could you take a moment to tell us why you want to cancel?
 		</Heading>
 	) : (
 		<Stack space={4}>
-			<Heading measure="medium">
+			<Heading cssOverrides={measure.heading}>
 				We’re sorry to hear you’re thinking of cancelling your recurring
 				contribution.
 			</Heading>

--- a/app/client/components/cancel/contributions/contributionsCancellationFlowStart.tsx
+++ b/app/client/components/cancel/contributions/contributionsCancellationFlowStart.tsx
@@ -1,20 +1,49 @@
-import { WithStandardTopMargin } from '../../WithStandardTopMargin';
+import { css } from '@emotion/react';
+import { Stack } from '@guardian/source-react-components';
+import { featureSwitches } from '../../../../shared/featureSwitches';
+import { heading, measure } from '../../../styles/typography';
 
-export const contributionsCancellationFlowStart = () => (
-	<WithStandardTopMargin>
-		<h3>
-			We’re sorry to hear you’re thinking of cancelling your recurring
-			contribution.
-		</h3>
-		<p>
-			Your support means The Guardian can remain editorially independent,
-			free from the influence of billionaire owners and politicians. This
-			enables us to give a voice to the voiceless, challenge the powerful
-			and hold them to account. The support from our readers helps us to
-			keep our journalism free of a paywall, so it’s open and accessible
-			to all.
-		</p>
-
-		<p>Please could you take a moment to tell us why you want to cancel?</p>
-	</WithStandardTopMargin>
-);
+export const contributionsCancellationFlowStart = () =>
+	featureSwitches.cancellationProductSwitch ? (
+		<h2 css={heading}>
+			<span
+				css={[
+					css`
+						display: inline-block;
+					`,
+					measure.medium,
+				]}
+			>
+				Please could you take a moment to tell us why you want to
+				cancel?
+			</span>
+		</h2>
+	) : (
+		<Stack space={4}>
+			<h2 css={heading}>
+				<span
+					css={[
+						css`
+							display: inline-block;
+						`,
+						measure.medium,
+					]}
+				>
+					We’re sorry to hear you’re thinking of cancelling your
+					recurring contribution.
+				</span>
+			</h2>
+			<p>
+				Your support means The Guardian can remain editorially
+				independent, free from the influence of billionaire owners and
+				politicians. This enables us to give a voice to the voiceless,
+				challenge the powerful and hold them to account. The support
+				from our readers helps us to keep our journalism free of a
+				paywall, so it’s open and accessible to all.
+			</p>
+			<p>
+				Please could you take a moment to tell us why you want to
+				cancel?
+			</p>
+		</Stack>
+	);

--- a/app/client/components/cancel/digipack/digipackCancellationFlowStart.tsx
+++ b/app/client/components/cancel/digipack/digipackCancellationFlowStart.tsx
@@ -1,11 +1,13 @@
-import { WithStandardTopMargin } from '../../WithStandardTopMargin';
+import { Stack } from '@guardian/source-react-components';
+import { measure } from '../../../styles/typography';
+import { Heading } from '../../Heading';
 
 export const digipackCancellationFlowStart = () => (
-	<WithStandardTopMargin>
-		<h3>
+	<Stack space={4}>
+		<Heading cssOverrides={measure.heading}>
 			We’re sorry to hear you’re thinking of cancelling your digital
 			subscription.
-		</h3>
+		</Heading>
 		<p>
 			Your support means The Guardian can remain editorially independent,
 			free from the influence of billionaire owners and politicians. This
@@ -16,5 +18,5 @@ export const digipackCancellationFlowStart = () => (
 		</p>
 
 		<p>Please could you take a moment to tell us why you want to cancel?</p>
-	</WithStandardTopMargin>
+	</Stack>
 );

--- a/app/client/components/cancel/gw/gwCancellationFlowStart.tsx
+++ b/app/client/components/cancel/gw/gwCancellationFlowStart.tsx
@@ -1,5 +1,7 @@
+import { Stack } from '@guardian/source-react-components';
 import { trackEvent } from '../../../services/analytics';
-import { WithStandardTopMargin } from '../../WithStandardTopMargin';
+import { measure } from '../../../styles/typography';
+import { Heading } from '../../Heading';
 import { hrefStyle } from '../cancellationConstants';
 
 const trackCancellationClickEvent = (eventLabel: string) => () =>
@@ -10,11 +12,11 @@ const trackCancellationClickEvent = (eventLabel: string) => () =>
 	});
 
 export const gwCancellationFlowStart = () => (
-	<WithStandardTopMargin>
-		<h3>
+	<Stack space={4}>
+		<Heading cssOverrides={measure.heading}>
 			We’re sorry to hear you’re thinking of cancelling your Guardian
 			Weekly subscription.
-		</h3>
+		</Heading>
 
 		<p>
 			Your support means The Guardian can remain editorially independent,
@@ -41,5 +43,5 @@ export const gwCancellationFlowStart = () => (
 		</p>
 
 		<p>Please could you take a moment to tell us why you want to cancel?</p>
-	</WithStandardTopMargin>
+	</Stack>
 );

--- a/app/client/components/cancel/stages/executeCancellation.tsx
+++ b/app/client/components/cancel/stages/executeCancellation.tsx
@@ -75,6 +75,7 @@ const ReturnToAccountButton = () => {
 			cssOverrides={css`
 				margin-top: ${space[5]}px;
 			`}
+			priority="tertiary"
 			onClick={() => navigate('/')}
 		>
 			Return to your account

--- a/app/client/components/cancel/voucher/voucherCancellationFlowStart.tsx
+++ b/app/client/components/cancel/voucher/voucherCancellationFlowStart.tsx
@@ -1,6 +1,8 @@
+import { Stack } from '@guardian/source-react-components';
 import { getMainPlan, ProductDetail } from '../../../../shared/productResponse';
 import { trackEvent } from '../../../services/analytics';
-import { WithStandardTopMargin } from '../../WithStandardTopMargin';
+import { measure } from '../../../styles/typography';
+import { Heading } from '../../Heading';
 import { hrefStyle } from '../cancellationConstants';
 
 const trackCancellationClickEvent = (eventLabel: string) => () =>
@@ -25,11 +27,11 @@ export const voucherCancellationFlowStart = ({
 		mainPlan.name?.indexOf('plus Digi') === -1;
 
 	return (
-		<WithStandardTopMargin>
-			<h3>
+		<Stack space={4}>
+			<Heading cssOverrides={measure.heading}>
 				We’re sorry to hear you’re thinking of cancelling your voucher
 				subscription.
-			</h3>
+			</Heading>
 
 			<p>
 				We understand that some of you may have concerns about claiming
@@ -100,6 +102,6 @@ export const voucherCancellationFlowStart = ({
 				Please could you take a moment to tell us why you want to
 				cancel?
 			</p>
-		</WithStandardTopMargin>
+		</Stack>
 	);
 };

--- a/app/client/components/productSwitch/CancellationSwitchConfirmed.tsx
+++ b/app/client/components/productSwitch/CancellationSwitchConfirmed.tsx
@@ -32,10 +32,10 @@ import { CancellationRouterState } from '../cancel/CancellationContainer';
 import {
 	buttonFullWidthOnMobileCss,
 	colour,
-	headingCss,
 	listCss,
-	standfirstCss,
+	pageTopCss,
 } from './productSwitchStyles';
+import { heading, measure } from '../../styles/typography';
 
 const CancellationSwitchConfirmed = () => {
 	const navigate = useNavigate();
@@ -55,10 +55,10 @@ const CancellationSwitchConfirmed = () => {
 	const newProduct = productSwitchConfirmationInfo.newProduct;
 
 	return (
-		<>
-			<h2 css={headingCss}>Your {newProduct.name} is now active</h2>
-			<Stack space={9}>
-				<p css={standfirstCss}>
+		<Stack space={9} cssOverrides={pageTopCss}>
+			<Stack space={3}>
+				<h2 css={heading}>Your {newProduct.name} is now active</h2>
+				<p css={[textSans.medium(), measure.regular]}>
 					Your {newProduct.billing.frequency.name}ly{' '}
 					{productSwitchContext.productType.friendlyName} has
 					successfully been changed to a {newProduct.name}. We’ve
@@ -66,215 +66,213 @@ const CancellationSwitchConfirmed = () => {
 					plan. Please check your inbox for an email containing all
 					your details and information on how to access your benefits.
 				</p>
+			</Stack>
+			<div
+				css={css`
+					border: 1px solid ${neutral[86]};
+				`}
+			>
 				<div
 					css={css`
-						border: 1px solid ${neutral[86]};
+						background-color: ${colour.background.hero};
+
+						padding: ${space[4]}px ${space[4]}px 0 ${space[4]}px;
+
+						${from.tablet} {
+							display: flex;
+							justify-content: space-between;
+							padding: ${space[4]}px ${space[5]}px 0 ${space[5]}px;
+						}
 					`}
 				>
-					<div
+					<p
 						css={css`
-							background-color: ${colour.background.hero};
-
-							padding: ${space[4]}px ${space[4]}px 0 ${space[4]}px;
+							${headline.xsmall({ fontWeight: 'bold' })};
+						`}
+					>
+						What happens now?
+					</p>
+					<GridPicture
+						cssOverrides={css`
+							display: flex;
+							margin: auto;
 
 							${from.tablet} {
-								display: flex;
-								justify-content: space-between;
-								padding: ${space[4]}px ${space[5]}px 0
-									${space[5]}px;
+								display: block;
+								margin-right: 42px;
 							}
+
+							max-width: 220px;
 						`}
-					>
-						<p
-							css={css`
-								${headline.xsmall({ fontWeight: 'bold' })};
-							`}
-						>
-							What happens now?
-						</p>
-						<GridPicture
-							cssOverrides={css`
-								display: flex;
-								margin: auto;
-
-								${from.tablet} {
-									display: block;
-									margin-right: 42px;
-								}
-
-								max-width: 220px;
-							`}
-							sources={[
-								{
-									gridId: 'digitalSubPackshot',
-									srcSizes: [497, 285],
-									imgType: 'png',
-									sizes: '100vw',
-									media: '(max-width: 220px)',
-								},
-							]}
-							fallback="digitalSubPackshot"
-							fallbackSize={497}
-							altText=""
-							fallbackImgType="png"
-						/>
-					</div>
-
-					<div
-						css={css`
-							padding: ${space[6]}px ${space[5]}px;
-							max-width: 60ch;
-						`}
-					>
-						<ul css={listCss}>
-							<li>
-								Check your inbox for an email containing all
-								your important information, plus details on how
-								to access your benefits.
-							</li>
-							<li>
-								We'll stop your{' '}
-								{newProduct.billing.frequency.name}ly{' '}
-								{productSwitchContext.productType.friendlyName}{' '}
-								payments.
-							</li>
-							{newProduct && (
-								<>
-									<li>
-										Your new {newProduct.name} starts today.
-									</li>
-									<li>
-										Your first payment of{' '}
-										{productFirstPaymentAmount(newProduct)}{' '}
-										will be taken on{' '}
-										{productStartDate(newProduct)}.
-									</li>
-								</>
-							)}
-							<li>
-								You can manage your subscription online from
-								your{' '}
-								<Link
-									to="/"
-									css={css`
-										color: ${brand[500]};
-										text-decoration: underline;
-									`}
-								>
-									Account overview.
-								</Link>
-							</li>
-						</ul>
-					</div>
+						sources={[
+							{
+								gridId: 'digitalSubPackshot',
+								srcSizes: [497, 285],
+								imgType: 'png',
+								sizes: '100vw',
+								media: '(max-width: 220px)',
+							},
+						]}
+						fallback="digitalSubPackshot"
+						fallbackSize={497}
+						altText=""
+						fallbackImgType="png"
+					/>
 				</div>
 
 				<div
 					css={css`
-						border: 1px solid ${neutral[86]};
+						padding: ${space[6]}px ${space[5]}px;
+						max-width: 60ch;
+					`}
+				>
+					<ul css={listCss}>
+						<li>
+							Check your inbox for an email containing all your
+							important information, plus details on how to access
+							your benefits.
+						</li>
+						<li>
+							We'll stop your {newProduct.billing.frequency.name}
+							ly {
+								productSwitchContext.productType.friendlyName
+							}{' '}
+							payments.
+						</li>
+						{newProduct && (
+							<>
+								<li>
+									Your new {newProduct.name} starts today.
+								</li>
+								<li>
+									Your first payment of{' '}
+									{productFirstPaymentAmount(newProduct)} will
+									be taken on {productStartDate(newProduct)}.
+								</li>
+							</>
+						)}
+						<li>
+							You can manage your subscription online from your{' '}
+							<Link
+								to="/"
+								css={css`
+									color: ${brand[500]};
+									text-decoration: underline;
+								`}
+							>
+								Account overview.
+							</Link>
+						</li>
+					</ul>
+				</div>
+			</div>
+
+			<div
+				css={css`
+					border: 1px solid ${neutral[86]};
+				`}
+			>
+				<div
+					css={css`
+						display: flex;
+						justify-content: space-between;
+						align-items: start;
+						background-color: ${brand[400]};
+
+						${from.mobileLandscape} {
+							align-items: center;
+						}
+					`}
+				>
+					<h2
+						css={css`
+							${headline.xsmall({ fontWeight: 'bold' })};
+							margin: 0;
+							padding: ${space[3]}px ${space[5]}px;
+							color: ${brandAlt[400]};
+						`}
+					>
+						Download the Live app
+					</h2>
+				</div>
+
+				<div
+					css={css`
+						background-color: ${neutral[97]};
+						padding: ${space[6]}px ${space[5]}px;
 					`}
 				>
 					<div
 						css={css`
 							display: flex;
-							justify-content: space-between;
-							align-items: start;
-							background-color: ${brand[400]};
-
-							${from.mobileLandscape} {
-								align-items: center;
-							}
+							margin-bottom: ${space[4]}px;
 						`}
 					>
-						<h2
-							css={css`
-								${headline.xsmall({ fontWeight: 'bold' })};
-								margin: 0;
-								padding: ${space[3]}px ${space[5]}px;
-								color: ${brandAlt[400]};
-							`}
+						<a
+							target="_blank"
+							rel="noreferrer"
+							href={getIosAppUrl(getGeoLocation())}
+							aria-label="Click to download the Guardian Daily app on the Apple App Store"
 						>
-							Download the Live app
-						</h2>
+							{/* had to add max-width in the cssOverrides as well as the sizes attribute as the attribute only doesn't work in IE11 */}
+							<GridImage
+								cssOverrides={css`
+									max-width: 119px;
+									margin-right: ${space[4]}px;
+								`}
+								imgType="png"
+								altText="googlePlay"
+								sizes="119px"
+								gridId="appleAppStore"
+								srcSizes={[140, 500]}
+							/>
+						</a>
+						<a
+							target="_blank"
+							href="https://play.google.com/store/apps/details?id=com.guardian"
+							rel="noreferrer"
+							aria-label="Click to download the Guardian Live app on Google Play"
+						>
+							<GridImage
+								cssOverrides={css`
+									max-width: 119px;
+								`}
+								imgType="png"
+								altText="googlePlay"
+								sizes="119px"
+								gridId="googlePlay"
+								srcSizes={[140, 500]}
+							/>
+						</a>
 					</div>
-
-					<div
+					<p
 						css={css`
-							background-color: ${neutral[97]};
-							padding: ${space[6]}px ${space[5]}px;
+							${textSans.medium()};
+							max-width: 45ch;
+							margin-bottom: 0;
 						`}
 					>
-						<div
-							css={css`
-								display: flex;
-								margin-bottom: ${space[4]}px;
-							`}
-						>
-							<a
-								target="_blank"
-								rel="noreferrer"
-								href={getIosAppUrl(getGeoLocation())}
-								aria-label="Click to download the Guardian Daily app on the Apple App Store"
-							>
-								{/* had to add max-width in the cssOverrides as well as the sizes attribute as the attribute only doesn't work in IE11 */}
-								<GridImage
-									cssOverrides={css`
-										max-width: 119px;
-										margin-right: ${space[4]}px;
-									`}
-									imgType="png"
-									altText="googlePlay"
-									sizes="119px"
-									gridId="appleAppStore"
-									srcSizes={[140, 500]}
-								/>
-							</a>
-							<a
-								target="_blank"
-								href="https://play.google.com/store/apps/details?id=com.guardian"
-								rel="noreferrer"
-								aria-label="Click to download the Guardian Live app on Google Play"
-							>
-								<GridImage
-									cssOverrides={css`
-										max-width: 119px;
-									`}
-									imgType="png"
-									altText="googlePlay"
-									sizes="119px"
-									gridId="googlePlay"
-									srcSizes={[140, 500]}
-								/>
-							</a>
-						</div>
-						<p
-							css={css`
-								${textSans.medium()};
-								max-width: 45ch;
-								margin-bottom: 0;
-							`}
-						>
-							This app comes with a variety of features including
-							Live news, Discover &mdash; a tailored feed, and the
-							ability to read offline. Don’t forget to sign in
-							using your subscriber details to access ad-free.
-						</p>
-					</div>
+						This app comes with a variety of features including Live
+						news, Discover &mdash; a tailored feed, and the ability
+						to read offline. Don’t forget to sign in using your
+						subscriber details to access ad-free.
+					</p>
 				</div>
+			</div>
 
-				<div>
-					<Button
-						icon={<SvgArrowRightStraight />}
-						iconSide="right"
-						cssOverrides={buttonFullWidthOnMobileCss}
-						onClick={() => {
-							navigate('/');
-						}}
-					>
-						Return to Account overview
-					</Button>
-				</div>
-			</Stack>
-		</>
+			<div>
+				<Button
+					icon={<SvgArrowRightStraight />}
+					iconSide="right"
+					cssOverrides={buttonFullWidthOnMobileCss}
+					onClick={() => {
+						navigate('/');
+					}}
+				>
+					Return to Account overview
+				</Button>
+			</div>
+		</Stack>
 	);
 };
 

--- a/app/client/components/productSwitch/CancellationSwitchConfirmed.tsx
+++ b/app/client/components/productSwitch/CancellationSwitchConfirmed.tsx
@@ -35,7 +35,8 @@ import {
 	listCss,
 	pageTopCss,
 } from './productSwitchStyles';
-import { heading, measure } from '../../styles/typography';
+import { measure } from '../../styles/typography';
+import { Heading } from '../Heading';
 
 const CancellationSwitchConfirmed = () => {
 	const navigate = useNavigate();
@@ -57,7 +58,7 @@ const CancellationSwitchConfirmed = () => {
 	return (
 		<Stack space={9} cssOverrides={pageTopCss}>
 			<Stack space={3}>
-				<h2 css={heading}>Your {newProduct.name} is now active</h2>
+				<Heading>Your {newProduct.name} is now active</Heading>
 				<p css={[textSans.medium(), measure.regular]}>
 					Your {newProduct.billing.frequency.name}ly{' '}
 					{productSwitchContext.productType.friendlyName} has

--- a/app/client/components/productSwitch/CancellationSwitchConfirmed.tsx
+++ b/app/client/components/productSwitch/CancellationSwitchConfirmed.tsx
@@ -59,7 +59,7 @@ const CancellationSwitchConfirmed = () => {
 		<Stack space={9} cssOverrides={pageTopCss}>
 			<Stack space={3}>
 				<Heading>Your {newProduct.name} is now active</Heading>
-				<p css={[textSans.medium(), measure.regular]}>
+				<p css={[textSans.medium(), measure.copy]}>
 					Your {newProduct.billing.frequency.name}ly{' '}
 					{productSwitchContext.productType.friendlyName} has
 					successfully been changed to a {newProduct.name}. We’ve

--- a/app/client/components/productSwitch/CancellationSwitchOffer.tsx
+++ b/app/client/components/productSwitch/CancellationSwitchOffer.tsx
@@ -56,7 +56,7 @@ const CancellationSwitchOffer = (props: CancellationSwitchOfferProps) => {
 				<Heading>
 					We're sorry to hear you're thinking of cancelling
 				</Heading>
-				<p css={[textSans.medium(), measure.regular]}>
+				<p css={[textSans.medium(), measure.copy]}>
 					Your support means the Guardian can remain editorially
 					independent, free from the influence of billionaire owners
 					and politicians. This enables us to give a voice to the

--- a/app/client/components/productSwitch/CancellationSwitchOffer.tsx
+++ b/app/client/components/productSwitch/CancellationSwitchOffer.tsx
@@ -38,7 +38,8 @@ import {
 	pageTopCss,
 	tickListCss,
 } from './productSwitchStyles';
-import { heading, measure } from '../../styles/typography';
+import { measure } from '../../styles/typography';
+import { Heading } from '../Heading';
 
 interface CancellationSwitchOfferProps {
 	availableProductsToSwitch: AvailableProductsResponse[];
@@ -52,9 +53,9 @@ const CancellationSwitchOffer = (props: CancellationSwitchOfferProps) => {
 	return (
 		<Stack space={9} cssOverrides={pageTopCss}>
 			<Stack space={3}>
-				<h2 css={heading}>
+				<Heading>
 					We're sorry to hear you're thinking of cancelling
-				</h2>
+				</Heading>
 				<p css={[textSans.medium(), measure.regular]}>
 					Your support means the Guardian can remain editorially
 					independent, free from the influence of billionaire owners

--- a/app/client/components/productSwitch/CancellationSwitchOffer.tsx
+++ b/app/client/components/productSwitch/CancellationSwitchOffer.tsx
@@ -34,11 +34,11 @@ import {
 	buttonFullWidthOnMobileCss,
 	buttonHideChevronOnMobileCss,
 	colour,
-	headingCss,
 	listCss,
-	standfirstCss,
+	pageTopCss,
 	tickListCss,
 } from './productSwitchStyles';
+import { heading, measure } from '../../styles/typography';
 
 interface CancellationSwitchOfferProps {
 	availableProductsToSwitch: AvailableProductsResponse[];
@@ -50,13 +50,12 @@ const CancellationSwitchOffer = (props: CancellationSwitchOfferProps) => {
 	const routerState = location.state as CancellationRouterState;
 
 	return (
-		<>
-			<h2 css={headingCss}>
-				We're sorry to hear you're thinking of cancelling
-			</h2>
-
-			<Stack space={9}>
-				<p css={standfirstCss}>
+		<Stack space={9} cssOverrides={pageTopCss}>
+			<Stack space={3}>
+				<h2 css={heading}>
+					We're sorry to hear you're thinking of cancelling
+				</h2>
+				<p css={[textSans.medium(), measure.regular]}>
 					Your support means the Guardian can remain editorially
 					independent, free from the influence of billionaire owners
 					and politicians. This enables us to give a voice to the
@@ -64,306 +63,299 @@ const CancellationSwitchOffer = (props: CancellationSwitchOfferProps) => {
 					The support from our readers helps us to keep our journalism
 					free of a paywall, so it’s open and accessible to all.
 				</p>
-				{props.availableProductsToSwitch.map(
-					(availableProduct, availableProductIndex) => (
+			</Stack>
+			{props.availableProductsToSwitch.map(
+				(availableProduct, availableProductIndex) => (
+					<div
+						key={`available-product-${availableProduct.id}`}
+						css={css`
+							border: 1px solid ${neutral[86]};
+						`}
+					>
 						<div
-							key={`available-product-${availableProduct.id}`}
 							css={css`
-								border: 1px solid ${neutral[86]};
+								display: flex;
+								justify-content: space-between;
+								align-items: flex-end;
+								background-color: ${colour.background.hero};
+
+								padding: ${space[4]}px ${space[3]}px;
+
+								${from.tablet} {
+									padding: ${space[3]}px ${space[5]}px 0
+										${space[5]}px;
+								}
 							`}
 						>
 							<div
 								css={css`
-									display: flex;
-									justify-content: space-between;
-									align-items: flex-end;
-									background-color: ${colour.background.hero};
+									${headline.xsmall({
+										fontWeight: 'bold',
+									})};
 
-									padding: ${space[4]}px ${space[3]}px;
+									margin: 0;
 
 									${from.tablet} {
-										padding: ${space[3]}px ${space[5]}px 0
-											${space[5]}px;
+										padding-bottom: ${space[5]}px;
+										max-width: 67%;
 									}
 								`}
 							>
-								<div
+								<p
 									css={css`
-										${headline.xsmall({
-											fontWeight: 'bold',
-										})};
-
-										margin: 0;
-
-										${from.tablet} {
-											padding-bottom: ${space[5]}px;
-											max-width: 67%;
-										}
+										margin: 0 0 ${space[3]}px 0;
 									`}
 								>
-									<p
+									Before you go, would you consider supporting
+									us another way{' '}
+									<span
 										css={css`
-											margin: 0 0 ${space[3]}px 0;
+											color: ${brand[500]};
+
+											${from.tablet} {
+												display: block;
+											}
 										`}
 									>
-										Before you go, would you consider
-										supporting us another way{' '}
-										<span
-											css={css`
-												color: ${brand[500]};
+										with a {availableProduct.name}?
+									</span>
+								</p>
+								<p
+									css={css`
+										${textSans.medium({
+											fontWeight: 'bold',
+										})};
+										line-height: 28px;
+										display: inline;
+										background-color: ${brand[400]};
+										box-shadow: 0 5px 0 ${brand[400]},
+											0 -5px 0 ${brand[400]};
+										box-decoration-break: clone;
+										color: ${brandAlt[400]};
+										padding: 0px ${space[2]}px 1px
+											${space[2]}px;
+									`}
+								>
+									{trialCopy(availableProduct)}{' '}
+									<span
+										css={css`
+											display: inline-block;
+										`}
+									>
+										{introOfferCopy(availableProduct)}
+									</span>
+								</p>
+							</div>
+							<GridPicture
+								cssOverrides={css`
+									margin-right: 42px;
+									max-width: 220px;
 
-												${from.tablet} {
-													display: block;
-												}
-											`}
-										>
-											with a {availableProduct.name}?
-										</span>
-									</p>
+									${until.tablet} {
+										display: none;
+									}
+								`}
+								sources={[
+									{
+										gridId: 'digitalSubPackshot',
+										srcSizes: [497, 285],
+										imgType: 'png',
+										sizes: '100vw',
+										media: '(max-width: 220px)',
+									},
+								]}
+								fallback="digitalSubPackshot"
+								fallbackSize={497}
+								altText=""
+								fallbackImgType="png"
+							/>
+						</div>
+
+						<div
+							css={css`
+								padding: ${space[4]}px ${space[3]}px 0
+									${space[3]}px;
+								border-top: 1px solid ${neutral[86]};
+
+								${from.tablet} {
+									padding: ${space[4]}px ${space[5]}px;
+									display: flex;
+									align-items: center;
+									justify-content: space-between;
+								}
+							`}
+						>
+							{availableProduct.introOffer && (
+								<div
+									css={css`
+										flex: 1;
+									`}
+								>
 									<p
 										css={css`
 											${textSans.medium({
 												fontWeight: 'bold',
+												lineHeight: 'regular',
 											})};
-											line-height: 28px;
-											display: inline;
-											background-color: ${brand[400]};
-											box-shadow: 0 5px 0 ${brand[400]},
-												0 -5px 0 ${brand[400]};
-											box-decoration-break: clone;
-											color: ${brandAlt[400]};
-											padding: 0px ${space[2]}px 1px
-												${space[2]}px;
+											margin: 0;
 										`}
 									>
-										{trialCopy(availableProduct)}{' '}
 										<span
 											css={css`
-												display: inline-block;
+												font-size: 20px;
 											`}
 										>
-											{introOfferCopy(availableProduct)}
-										</span>
+											{introOfferPrice(availableProduct)}
+										</span>{' '}
+										for{' '}
+										{introOfferDuration(availableProduct)}
 									</p>
-								</div>
-								<GridPicture
-									cssOverrides={css`
-										margin-right: 42px;
-										max-width: 220px;
-
-										${until.tablet} {
-											display: none;
-										}
-									`}
-									sources={[
-										{
-											gridId: 'digitalSubPackshot',
-											srcSizes: [497, 285],
-											imgType: 'png',
-											sizes: '100vw',
-											media: '(max-width: 220px)',
-										},
-									]}
-									fallback="digitalSubPackshot"
-									fallbackSize={497}
-									altText=""
-									fallbackImgType="png"
-								/>
-							</div>
-
-							<div
-								css={css`
-									padding: ${space[4]}px ${space[3]}px 0
-										${space[3]}px;
-									border-top: 1px solid ${neutral[86]};
-
-									${from.tablet} {
-										padding: ${space[4]}px ${space[5]}px;
-										display: flex;
-										align-items: center;
-										justify-content: space-between;
-									}
-								`}
-							>
-								{availableProduct.introOffer && (
-									<div
-										css={css`
-											flex: 1;
-										`}
-									>
-										<p
+									<div>
+										<div
 											css={css`
-												${textSans.medium({
-													fontWeight: 'bold',
+												${textSans.small({
 													lineHeight: 'regular',
 												})};
-												margin: 0;
+												color: ${neutral[46]};
 											`}
 										>
-											<span
-												css={css`
-													font-size: 20px;
-												`}
-											>
-												{introOfferPrice(
-													availableProduct,
-												)}
-											</span>{' '}
-											for{' '}
-											{introOfferDuration(
+											{`Then ${regularPrice(
 												availableProduct,
-											)}
-										</p>
-										<div>
-											<div
-												css={css`
-													${textSans.small({
-														lineHeight: 'regular',
-													})};
-													color: ${neutral[46]};
-												`}
-											>
-												{`Then ${regularPrice(
-													availableProduct,
-												)} ${regularBillingFrequency(
-													availableProduct,
-												)}. `}
-												<strong>Cancel anytime</strong>.
-											</div>
+											)} ${regularBillingFrequency(
+												availableProduct,
+											)}. `}
+											<strong>Cancel anytime</strong>.
 										</div>
 									</div>
-								)}
-								<div
-									css={css`
-										margin: ${space[4]}px 0 ${space[5]}px 0;
-										${from.tablet} {
-											margin: 0;
-										}
-									`}
-								>
-									<ThemeProvider
-										theme={buttonThemeReaderRevenueBrand}
-									>
-										<Button
-											icon={<SvgArrowRightStraight />}
-											iconSide="right"
-											nudgeIcon
-											cssOverrides={[
-												buttonFullWidthOnMobileCss,
-												buttonHideChevronOnMobileCss,
-											]}
-											onClick={() => {
-												navigate('./switch', {
-													state: {
-														...routerState,
-														chosenProductToSwitchTo:
-															props
-																.availableProductsToSwitch[
-																availableProductIndex
-															],
-													},
-												});
-											}}
-										>
-											{`Explore a ${availableProduct.name}`}
-										</Button>
-									</ThemeProvider>
 								</div>
-							</div>
-
+							)}
 							<div
 								css={css`
-									padding: 0 ${space[3]}px ${space[6]}px
-										${space[3]}px;
+									margin: ${space[4]}px 0 ${space[5]}px 0;
 									${from.tablet} {
-										padding: 0 ${space[5]}px;
+										margin: 0;
 									}
 								`}
 							>
+								<ThemeProvider
+									theme={buttonThemeReaderRevenueBrand}
+								>
+									<Button
+										icon={<SvgArrowRightStraight />}
+										iconSide="right"
+										nudgeIcon
+										cssOverrides={[
+											buttonFullWidthOnMobileCss,
+											buttonHideChevronOnMobileCss,
+										]}
+										onClick={() => {
+											navigate('./switch', {
+												state: {
+													...routerState,
+													chosenProductToSwitchTo:
+														props
+															.availableProductsToSwitch[
+															availableProductIndex
+														],
+												},
+											});
+										}}
+									>
+										{`Explore a ${availableProduct.name}`}
+									</Button>
+								</ThemeProvider>
+							</div>
+						</div>
+
+						<div
+							css={css`
+								padding: 0 ${space[3]}px ${space[6]}px
+									${space[3]}px;
+								${from.tablet} {
+									padding: 0 ${space[5]}px;
+								}
+							`}
+						>
+							<div
+								css={css`
+									${from.tablet} {
+										border-top: 1px solid ${neutral[86]};
+										padding: ${space[3]}px 0 ${space[9]}px 0;
+									}
+								`}
+							>
+								<p
+									css={css`
+										${textSans.medium()};
+										margin-bottom: ${space[6]}px;
+									`}
+								>
+									Unlock additional features and benefits.
+								</p>
+
 								<div
 									css={css`
+										padding-top: ${space[6]}px;
+										border-top: 1px solid ${neutral[86]};
 										${from.tablet} {
-											border-top: 1px solid ${neutral[86]};
-											padding: ${space[3]}px 0
-												${space[9]}px 0;
+											display: flex;
+											justify-content: space-between;
+											padding-top: 0;
+											border-top: 0;
 										}
 									`}
 								>
-									<p
-										css={css`
-											${textSans.medium()};
-											margin-bottom: ${space[6]}px;
-										`}
-									>
-										Unlock additional features and benefits.
-									</p>
-
-									<div
-										css={css`
-											padding-top: ${space[6]}px;
-											border-top: 1px solid ${neutral[86]};
-											${from.tablet} {
-												display: flex;
-												justify-content: space-between;
-												padding-top: 0;
-												border-top: 0;
-											}
-										`}
-									>
-										{productBenefits[
-											availableProduct.id
-										] && (
-											<ul
-												css={[
-													listCss,
-													tickListCss,
-													css`
-														${from.tablet} {
-															columns: 2;
-															column-gap: ${space[4]}px;
-														}
-													`,
-												]}
-											>
-												{productBenefits[
-													availableProduct.id
-												].map((benefit, index) => (
-													<li key={index}>
-														<SvgTickRound size="small" />
-														<span>{benefit}</span>
-													</li>
-												))}
-											</ul>
-										)}
-									</div>
+									{productBenefits[availableProduct.id] && (
+										<ul
+											css={[
+												listCss,
+												tickListCss,
+												css`
+													${from.tablet} {
+														columns: 2;
+														column-gap: ${space[4]}px;
+													}
+												`,
+											]}
+										>
+											{productBenefits[
+												availableProduct.id
+											].map((benefit, index) => (
+												<li key={index}>
+													<SvgTickRound size="small" />
+													<span>{benefit}</span>
+												</li>
+											))}
+										</ul>
+									)}
 								</div>
 							</div>
 						</div>
-					),
-				)}
-				<div
-					css={css`
-						${from.tablet} {
-							display: flex;
-							justify-content: flex-end;
-						}
-					`}
+					</div>
+				),
+			)}
+			<div
+				css={css`
+					${from.tablet} {
+						display: flex;
+						justify-content: flex-end;
+					}
+				`}
+			>
+				<Button
+					icon={<SvgArrowRightStraight />}
+					iconSide="right"
+					cssOverrides={buttonFullWidthOnMobileCss}
+					onClick={() =>
+						navigate('./', {
+							state: { ...routerState, dontShowOffer: true },
+						})
+					}
 				>
-					<Button
-						icon={<SvgArrowRightStraight />}
-						iconSide="right"
-						cssOverrides={buttonFullWidthOnMobileCss}
-						onClick={() =>
-							navigate('./', {
-								state: { ...routerState, dontShowOffer: true },
-							})
-						}
-					>
-						Continue to cancellation
-					</Button>
-				</div>
-			</Stack>
-		</>
+					Continue to cancellation
+				</Button>
+			</div>
+		</Stack>
 	);
 };
 

--- a/app/client/components/productSwitch/CancellationSwitchReview.tsx
+++ b/app/client/components/productSwitch/CancellationSwitchReview.tsx
@@ -342,7 +342,7 @@ const CancellationSwitchReview = () => {
 
 	const smallPrintCss = css`
 		${textSans.xsmall()};
-		${measure.regular};
+		${measure.copy};
 		margin-top: 0;
 		margin-bottom: 0;
 
@@ -458,7 +458,7 @@ const CancellationSwitchReview = () => {
 		<Stack space={9} cssOverrides={pageTopCss}>
 			<Stack space={3}>
 				<Heading>Change your support to a {chosenProduct.name}</Heading>
-				<p css={[textSans.medium(), measure.regular]}>
+				<p css={[textSans.medium(), measure.copy]}>
 					If you decide to change your support to a{' '}
 					{chosenProduct.name} we’ll stop your{' '}
 					{chosenProduct.billing.frequency.name}ly{' '}

--- a/app/client/components/productSwitch/CancellationSwitchReview.tsx
+++ b/app/client/components/productSwitch/CancellationSwitchReview.tsx
@@ -53,7 +53,8 @@ import {
 	tickListCss,
 } from './productSwitchStyles';
 import { productBenefits } from './ProductBenefits';
-import { heading, measure } from '../../styles/typography';
+import { measure } from '../../styles/typography';
+import { Heading } from '../Heading';
 
 /**
  * Generic Card container component
@@ -62,7 +63,7 @@ import { heading, measure } from '../../styles/typography';
 
 interface CardProps {
 	heading: string;
-	theme?: 'brand' | undefined;
+	theme?: 'brand';
 	children: ReactNode;
 }
 
@@ -342,6 +343,7 @@ const CancellationSwitchReview = () => {
 	const smallPrintCss = css`
 		${textSans.xsmall()};
 		${measure.regular};
+		margin-top: 0;
 		margin-bottom: 0;
 
 		> a {
@@ -455,9 +457,7 @@ const CancellationSwitchReview = () => {
 	return (
 		<Stack space={9} cssOverrides={pageTopCss}>
 			<Stack space={3}>
-				<h2 css={heading}>
-					Change your support to a {chosenProduct.name}
-				</h2>
+				<Heading>Change your support to a {chosenProduct.name}</Heading>
 				<p css={[textSans.medium(), measure.regular]}>
 					If you decide to change your support to a{' '}
 					{chosenProduct.name} we’ll stop your{' '}
@@ -736,18 +736,20 @@ const CancellationSwitchReview = () => {
 					</Card>
 				</Stack>
 
-				<p css={smallPrintCss}>
-					By proceeding, you are agreeing to our{' '}
-					<a href="https://www.theguardian.com/info/2014/aug/06/guardian-observer-digital-subscriptions-terms-conditions">
-						Terms and Conditions
-					</a>
-					. To find out what personal data we collect and how we use
-					it, please visit our{' '}
-					<a href="https://www.theguardian.com/help/privacy-policy">
-						Privacy Policy
-					</a>
-					.
-				</p>
+				<div>
+					<p css={smallPrintCss}>
+						By proceeding, you are agreeing to our{' '}
+						<a href="https://www.theguardian.com/info/2014/aug/06/guardian-observer-digital-subscriptions-terms-conditions">
+							Terms and Conditions
+						</a>
+						. To find out what personal data we collect and how we
+						use it, please visit our{' '}
+						<a href="https://www.theguardian.com/help/privacy-policy">
+							Privacy Policy
+						</a>
+						.
+					</p>
+				</div>
 			</Stack>
 		</Stack>
 	);

--- a/app/client/components/productSwitch/CancellationSwitchReview.tsx
+++ b/app/client/components/productSwitch/CancellationSwitchReview.tsx
@@ -48,12 +48,12 @@ import { SepaDisplay } from '../payment/sepaDisplay';
 import { DirectDebitDisplay } from '../payment/directDebitDisplay';
 import {
 	colour,
-	headingCss,
 	listCss,
-	standfirstCss,
+	pageTopCss,
 	tickListCss,
 } from './productSwitchStyles';
 import { productBenefits } from './ProductBenefits';
+import { heading, measure } from '../../styles/typography';
 
 /**
  * Generic Card container component
@@ -340,10 +340,9 @@ const CancellationSwitchReview = () => {
 	`;
 
 	const smallPrintCss = css`
-		margin-top: ${space[4]}px;
-		margin-bottom: 0;
 		${textSans.xsmall()};
-		max-width: 60ch;
+		${measure.regular};
+		margin-bottom: 0;
 
 		> a {
 			color: inherit;
@@ -454,13 +453,12 @@ const CancellationSwitchReview = () => {
 	};
 
 	return (
-		<>
-			<h2 css={headingCss}>
-				Change your support to a {chosenProduct.name}
-			</h2>
-
-			<Stack space={9}>
-				<p css={standfirstCss}>
+		<Stack space={9} cssOverrides={pageTopCss}>
+			<Stack space={3}>
+				<h2 css={heading}>
+					Change your support to a {chosenProduct.name}
+				</h2>
+				<p css={[textSans.medium(), measure.regular]}>
 					If you decide to change your support to a{' '}
 					{chosenProduct.name} we’ll stop your{' '}
 					{chosenProduct.billing.frequency.name}ly{' '}
@@ -468,210 +466,198 @@ const CancellationSwitchReview = () => {
 					straight away and you’ll have immediate access to the
 					benefits of a {chosenProduct.name}.
 				</p>
-
-				<div css={cardLayoutCss}>
-					<Card
-						heading={`Your ${productSwitchContext.productType.friendlyName}`}
-					>
-						{chosenProduct.introOffer && (
-							<hr
-								css={css`
-									display: none;
-									height: 42px;
-									margin: 0;
-									border: none;
-									border-bottom: 1px solid
-										${palette.neutral[86]};
-									${between.tablet.and.desktop} {
-										display: block;
-									}
-									${from.leftCol} {
-										display: block;
-									}
-								`}
-							/>
-						)}
-						<div
+			</Stack>
+			<div css={cardLayoutCss}>
+				<Card
+					heading={`Your ${productSwitchContext.productType.friendlyName}`}
+				>
+					{chosenProduct.introOffer && (
+						<hr
 							css={css`
-								${textSans.medium()};
-								padding: ${space[4]}px;
+								display: none;
+								height: 42px;
+								margin: 0;
+								border: none;
+								border-bottom: 1px solid ${palette.neutral[86]};
+								${between.tablet.and.desktop} {
+									display: block;
+								}
+								${from.leftCol} {
+									display: block;
+								}
+							`}
+						/>
+					)}
+					<div
+						css={css`
+							${textSans.medium()};
+							padding: ${space[4]}px;
+						`}
+					>
+						<PaymentDetails paymentAmount={currentProductPrice()} />
+						<ul css={[listCss, tickListCss]}>
+							<li>
+								<SvgTickRound size="small" />
+								Support independent journalism
+							</li>
+						</ul>
+					</div>
+				</Card>
+
+				<div css={arrowIconCss}>
+					<span>
+						<SvgArrowRightStraight size="small" />
+					</span>
+				</div>
+
+				<Card theme="brand" heading={`Your new ${chosenProduct.name}`}>
+					{chosenProduct.introOffer && (
+						<h4
+							css={css`
+								margin: 0;
+								padding: ${space[2]}px ${space[4]}px;
+								${textSans.medium({ fontWeight: 'bold' })};
+								color: ${palette.brandAlt[400]};
+								background-color: ${palette.brand[400]};
 							`}
 						>
-							<PaymentDetails
-								paymentAmount={currentProductPrice()}
-							/>
-							<ul css={[listCss, tickListCss]}>
-								<li>
-									<SvgTickRound size="small" />
-									Support independent journalism
-								</li>
-							</ul>
-						</div>
-					</Card>
-
-					<div css={arrowIconCss}>
-						<span>
-							<SvgArrowRightStraight size="small" />
-						</span>
-					</div>
-
-					<Card
-						theme="brand"
-						heading={`Your new ${chosenProduct.name}`}
-					>
-						{chosenProduct.introOffer && (
-							<h4
+							{trialCopy(chosenProduct)}{' '}
+							<span
 								css={css`
-									margin: 0;
-									padding: ${space[2]}px ${space[4]}px;
-									${textSans.medium({ fontWeight: 'bold' })};
-									color: ${palette.brandAlt[400]};
-									background-color: ${palette.brand[400]};
+									display: inline-block;
 								`}
 							>
-								{trialCopy(chosenProduct)}{' '}
-								<span
-									css={css`
-										display: inline-block;
-									`}
-								>
-									{introOfferCopy(chosenProduct)}
-								</span>
-							</h4>
-						)}
-						<div
-							css={css`
-								${textSans.medium()};
-								padding: ${space[4]}px;
-								background-color: ${colour.background.hero};
-							`}
-						>
-							{chosenProduct.introOffer ? (
-								<PaymentDetails
-									paymentAmount={`
+								{introOfferCopy(chosenProduct)}
+							</span>
+						</h4>
+					)}
+					<div
+						css={css`
+							${textSans.medium()};
+							padding: ${space[4]}px;
+							background-color: ${colour.background.hero};
+						`}
+					>
+						{chosenProduct.introOffer ? (
+							<PaymentDetails
+								paymentAmount={`
 										${introOfferPrice(chosenProduct)} for
 										${introOfferDuration(chosenProduct)}
 									`}
-									paymentFollowOnAmount={
-										<span
+								paymentFollowOnAmount={
+									<span
+										css={css`
+											padding-left: 8ch;
+										`}
+									>
+										{`Then  ${regularPrice(
+											chosenProduct,
+										)} ${regularBillingFrequency(
+											chosenProduct,
+										)}. `}
+										<strong
 											css={css`
-												padding-left: 8ch;
+												display: inline-block;
 											`}
 										>
-											{`Then  ${regularPrice(
-												chosenProduct,
-											)} ${regularBillingFrequency(
-												chosenProduct,
-											)}. `}
-											<strong
-												css={css`
-													display: inline-block;
-												`}
-											>
-												Cancel anytime.
-											</strong>
-										</span>
-									}
-									theme="brand"
-								/>
-							) : (
-								<PaymentDetails
-									paymentAmount={`${regularPrice(
-										chosenProduct,
-									)} ${regularBillingFrequency(
-										chosenProduct,
-									)}`}
-									theme="brand"
-								/>
-							)}
+											Cancel anytime.
+										</strong>
+									</span>
+								}
+								theme="brand"
+							/>
+						) : (
+							<PaymentDetails
+								paymentAmount={`${regularPrice(
+									chosenProduct,
+								)} ${regularBillingFrequency(chosenProduct)}`}
+								theme="brand"
+							/>
+						)}
 
-							{primaryBenefits && (
-								<ul css={[listCss, tickListCss]}>
-									{primaryBenefits.map((benefit, index) => (
-										<li key={index}>
-											<SvgTickRound size="small" />
-											<span>{benefit}</span>
-										</li>
-									))}
+						{primaryBenefits && (
+							<ul css={[listCss, tickListCss]}>
+								{primaryBenefits.map((benefit, index) => (
+									<li key={index}>
+										<SvgTickRound size="small" />
+										<span>{benefit}</span>
+									</li>
+								))}
+							</ul>
+						)}
+
+						{additionalBenefits && (
+							<>
+								<ul
+									id="additional-benefits"
+									css={[
+										listCss,
+										tickListCss,
+										css`
+											margin-top: ${space[2]}px;
+										`,
+									]}
+									hidden={!benefitsExpanded}
+								>
+									{additionalBenefits.map(
+										(benefit, index) => (
+											<li key={index}>
+												<SvgTickRound size="small" />
+												<span>{benefit}</span>
+											</li>
+										),
+									)}
 								</ul>
-							)}
+								<button
+									css={[
+										expanderButtonCss()(benefitsExpanded),
+										css`
+											padding: 0;
+											margin-top: ${space[4]}px;
+											margin-bottom: ${space[1]}px;
+											margin-left: 34px;
+											border-bottom: 1px solid
+												${palette.neutral[7]};
+										`,
+									]}
+									type="button"
+									aria-expanded={benefitsExpanded}
+									aria-controls="additional-benefits"
+									onClick={() =>
+										setBenefitsExpanded(!benefitsExpanded)
+									}
+								>
+									View {benefitsExpanded ? 'less' : 'more'}
+								</button>
+							</>
+						)}
+					</div>
+				</Card>
+			</div>
 
-							{additionalBenefits && (
-								<>
-									<ul
-										id="additional-benefits"
-										css={[
-											listCss,
-											tickListCss,
-											css`
-												margin-top: ${space[2]}px;
-											`,
-										]}
-										hidden={!benefitsExpanded}
-									>
-										{additionalBenefits.map(
-											(benefit, index) => (
-												<li key={index}>
-													<SvgTickRound size="small" />
-													<span>{benefit}</span>
-												</li>
-											),
-										)}
-									</ul>
-									<button
-										css={[
-											expanderButtonCss()(
-												benefitsExpanded,
-											),
-											css`
-												padding: 0;
-												margin-top: ${space[4]}px;
-												margin-bottom: ${space[1]}px;
-												margin-left: 34px;
-												border-bottom: 1px solid
-													${palette.neutral[7]};
-											`,
-										]}
-										type="button"
-										aria-expanded={benefitsExpanded}
-										aria-controls="additional-benefits"
-										onClick={() =>
-											setBenefitsExpanded(
-												!benefitsExpanded,
-											)
-										}
-									>
-										View{' '}
-										{benefitsExpanded ? 'less' : 'more'}
-									</button>
-								</>
-							)}
-						</div>
-					</Card>
-				</div>
-
-				<div css={buttonLayoutCss}>
+			<div css={buttonLayoutCss}>
+				<Button
+					priority="tertiary"
+					cssOverrides={css`
+						justify-content: center;
+					`}
+				>
+					Return to cancellation
+				</Button>
+				<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
 					<Button
-						priority="tertiary"
 						cssOverrides={css`
 							justify-content: center;
 						`}
+						isLoading={confirmingChange}
+						onClick={confirmChange}
 					>
-						Return to cancellation
+						Confirm change
 					</Button>
-					<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
-						<Button
-							cssOverrides={css`
-								justify-content: center;
-							`}
-							isLoading={confirmingChange}
-							onClick={confirmChange}
-						>
-							Confirm change
-						</Button>
-					</ThemeProvider>
-				</div>
+				</ThemeProvider>
+			</div>
 
+			<Stack space={4}>
 				<Stack space={6}>
 					<Card heading="Payment details">
 						<KeyValueTable
@@ -749,21 +735,21 @@ const CancellationSwitchReview = () => {
 						</div>
 					</Card>
 				</Stack>
-			</Stack>
 
-			<p css={smallPrintCss}>
-				By proceeding, you are agreeing to our{' '}
-				<a href="https://www.theguardian.com/info/2014/aug/06/guardian-observer-digital-subscriptions-terms-conditions">
-					Terms and Conditions
-				</a>
-				. To find out what personal data we collect and how we use it,
-				please visit our{' '}
-				<a href="https://www.theguardian.com/help/privacy-policy">
-					Privacy Policy
-				</a>
-				.
-			</p>
-		</>
+				<p css={smallPrintCss}>
+					By proceeding, you are agreeing to our{' '}
+					<a href="https://www.theguardian.com/info/2014/aug/06/guardian-observer-digital-subscriptions-terms-conditions">
+						Terms and Conditions
+					</a>
+					. To find out what personal data we collect and how we use
+					it, please visit our{' '}
+					<a href="https://www.theguardian.com/help/privacy-policy">
+						Privacy Policy
+					</a>
+					.
+				</p>
+			</Stack>
+		</Stack>
 	);
 };
 

--- a/app/client/components/productSwitch/productSwitchStyles.ts
+++ b/app/client/components/productSwitch/productSwitchStyles.ts
@@ -1,12 +1,11 @@
 import { css } from '@emotion/react';
 import {
-	headline,
+	from,
 	palette,
 	space,
 	textSans,
 	until,
 } from '@guardian/source-foundations';
-import { minWidth } from '../../styles/breakpoints';
 
 export const colour = {
 	background: {
@@ -14,21 +13,11 @@ export const colour = {
 	},
 };
 
-export const headingCss = css`
-	border-top: 1px solid ${palette.neutral[86]};
-	${headline.xsmall({ fontWeight: 'bold' })};
+export const pageTopCss = css`
 	margin-top: ${space[6]}px;
-	margin-bottom: ${space[3]}px;
-	${minWidth.tablet} {
-		${headline.small({ fontWeight: 'bold' })};
+	${from.tablet} {
 		margin-top: ${space[9]}px;
-	} ;
-`;
-
-export const standfirstCss = css`
-	${textSans.medium()};
-	margin: 0;
-	max-width: 60ch;
+	}
 `;
 
 export const listCss = css`

--- a/app/client/styles/typography.ts
+++ b/app/client/styles/typography.ts
@@ -1,15 +1,4 @@
 import { css } from '@emotion/react';
-import { from, headline, palette } from '@guardian/source-foundations';
-
-export const heading = css`
-	${headline.xsmall({ fontWeight: 'bold' })};
-	margin-top: 0;
-	margin-bottom: 0;
-	border-top: 1px solid ${palette.neutral[86]};
-	${from.tablet} {
-		${headline.small({ fontWeight: 'bold' })};
-	} ;
-`;
 
 export const measure = {
 	regular: css`

--- a/app/client/styles/typography.ts
+++ b/app/client/styles/typography.ts
@@ -15,4 +15,7 @@ export const measure = {
 	regular: css`
 		max-width: 60ch;
 	`,
+	medium: css`
+		max-width: 30ch;
+	`,
 };

--- a/app/client/styles/typography.ts
+++ b/app/client/styles/typography.ts
@@ -1,10 +1,10 @@
 import { css } from '@emotion/react';
 
 export const measure = {
-	regular: css`
+	copy: css`
 		max-width: 60ch;
 	`,
-	medium: css`
+	heading: css`
 		max-width: 30ch;
 	`,
 };

--- a/app/client/styles/typography.ts
+++ b/app/client/styles/typography.ts
@@ -1,0 +1,18 @@
+import { css } from '@emotion/react';
+import { from, headline, palette } from '@guardian/source-foundations';
+
+export const heading = css`
+	${headline.xsmall({ fontWeight: 'bold' })};
+	margin-top: 0;
+	margin-bottom: 0;
+	border-top: 1px solid ${palette.neutral[86]};
+	${from.tablet} {
+		${headline.small({ fontWeight: 'bold' })};
+	} ;
+`;
+
+export const measure = {
+	regular: css`
+		max-width: 60ch;
+	`,
+};


### PR DESCRIPTION
## What does this change?

We use the same heading style across `manage-frontend`, but the CSS is duplicated in multiple places and implementations vary so there are subtle variations across the site. (Particularly with regards to responsive behaviour.)

This PR introduces a new `<Heading>` component in an attempt to standardise headings across the site and avoid duplication. It's fairly barebones for now so will likely be expanded to add additional options as it is used more widely.

The component includes two props: `level` and `cssOverrides`. `level` can be used to set the desired heading level. (If not specified it defaults to a `<h2>` element.) `cssOverrides` follows the Source convention and allows styling overrides to be applied to the heading element directly.

Headings do not include any external spacing. Instead, layout components such as `<Stack>` should be used to space out headings and adjacent elements. As this isn't always straightforward when using the component within existing layouts the `cssOverrides` prop can be used to apply spacing where needed. `cssOverrides` is also used to restrict the maximum width of headings on the cancellation pages by applying the `measure.heading` style.

The contribution cancellation flow has been updated to use the `<Heading>` component so that the styling matches the new product switch pages. (As well as other pages on the site.)

The diff is best viewed with _Hide whitespace_ enabled due to indentation changes in the existing product switch pages which makes it look like there are more changes than there really are.

<img width="650" alt="Screenshot 2022-07-20 at 18 02 32" src="https://user-images.githubusercontent.com/1166188/180040967-8ed1c20a-ad00-40bf-8a6e-4bc18fb8d830.png">

## Images

### Existing style

<img width="840" alt="Screenshot 2022-07-28 at 10 22 16" src="https://user-images.githubusercontent.com/1166188/181475340-578ac94e-1407-4949-9b1c-54760004d8eb.png">

### Updated style with feature switch off

<img width="850" alt="Screenshot 2022-07-20 at 17 36 46" src="https://user-images.githubusercontent.com/1166188/180040158-e9c103e2-ddbd-45aa-90b3-8b3e2c9f71fa.png">

### Updated style with feature switch on

If coming from the product switch offer page different content is shown to avoid repetition.

<img width="848" alt="Screenshot 2022-07-20 at 17 37 26" src="https://user-images.githubusercontent.com/1166188/180040185-78fcf293-794e-40c0-968a-6b75c72ae4e9.png">

### Updated, but not dependent on feature switch

For subsequent steps in the flow only the heading style has changed. Content remains the same.

<img width="845" alt="Screenshot 2022-07-20 at 17 37 45" src="https://user-images.githubusercontent.com/1166188/180040629-fe7b478c-1644-4076-a10e-f7d7753024b4.png">

<img width="849" alt="Screenshot 2022-07-20 at 17 38 11" src="https://user-images.githubusercontent.com/1166188/180040651-d4d5a468-1927-4fef-9b8f-998d1578fc02.png">

### Other product types

<img width="841" alt="Screenshot 2022-07-29 at 10 40 26" src="https://user-images.githubusercontent.com/1166188/181731970-4a8562dc-90e3-4c06-932e-d8b5b8216ee3.png">
