### PR TITLE
[RB] - show missing helpcenter article in the more topics section on homepage

### DIFF
--- a/app/client/components/helpCentre/helpCentreConfig.ts
+++ b/app/client/components/helpCentre/helpCentreConfig.ts
@@ -264,6 +264,11 @@ export const helpCentreMoreQuestionsConfig: HelpCentreMoreQuestionsTopic[] = [
 				title: 'Subscribe to our newsletters',
 				link: '/help-centre/article/subscribe-to-our-newsletters-and-emails',
 			},
+			{
+				id: 'q4',
+				title: 'How to identify legitimate emails from the Guardian',
+				link: '/help-centre/article/how-to-identify-legitimate-emails-from-the-guardian',
+			},
 		],
 	},
 	{


### PR DESCRIPTION
## What does this change?
How to identify legitimate emails from the Guardian needs to show up in the more topics section (inside the newsletters section) on the homepage of the help center.

## Images
![Screenshot 2022-07-25 at 10 42 43](https://user-images.githubusercontent.com/2510683/180748164-cb4c8106-1f18-4a54-8833-9b07cce6f673.png)
