### PR TITLE
[RB] - update to marketing consent copy

### DIFF
--- a/app/client/__tests__/components/identity/OptOutSection.test.tsx
+++ b/app/client/__tests__/components/identity/OptOutSection.test.tsx
@@ -26,7 +26,7 @@ describe('OptOutSection component', () => {
 		).toBeChecked();
 		expect(
 			screen.getByLabelText(
-				'Allow the Guardian to send communications by telephone',
+				'Allow the Guardian to send communications by telephone and SMS',
 			),
 		).not.toBeChecked();
 		expect(screen.getByLabelText('Allow optin consent')).toBeChecked();
@@ -45,7 +45,7 @@ const idapiConsentsFixture: ConsentOption[] = [
 	},
 	{
 		id: 'phone_optout',
-		name: 'Allow the Guardian to send communications by telephone',
+		name: 'Allow the Guardian to send communications by telephone and SMS',
 		isProduct: false,
 		isChannel: false,
 		type: ConsentOptionType.OPT_OUT,

--- a/app/client/fixtures/consents.ts
+++ b/app/client/fixtures/consents.ts
@@ -104,7 +104,7 @@ export const consents = [
 		isOptOut: true,
 		isChannel: true,
 		isProduct: false,
-		name: 'Allow the Guardian to send communications by telephone',
+		name: 'Allow the Guardian to send communications by telephone and SMS',
 	},
 	{
 		id: 'personalised_advertising',


### PR DESCRIPTION
## What does this change?
Update the consent fixture copy used in the tests for the marketing consent copy to reflect SMS messages as well as phone calls.