### PR TITLE
Add The Guardian Apps to Help Centre navigation

### DIFF
--- a/app/client/components/helpCentre/helpCentreConfig.ts
+++ b/app/client/components/helpCentre/helpCentreConfig.ts
@@ -235,7 +235,7 @@ export const helpCentreMoreQuestionsConfig: HelpCentreMoreQuestionsTopic[] = [
 			},
 			{
 				id: 'q4',
-				title: 'Device compatability',
+				title: 'Device compatibility',
 				link: '/help-centre/article/what-devices-are-compatible-with-your-apps',
 			},
 			{
@@ -359,5 +359,6 @@ export const helpCentreNavConfig: HelpCentreNavConfig[] = [
 	{ id: 'website', title: 'The Guardian Website' },
 	{ id: 'journalism', title: 'Journalism' },
 	{ id: 'subscriptions', title: 'Print Subscriptions' },
+	{ id: 'apps', title: 'The Guardian Apps' },
 	{ id: 'more-topics', title: 'More Topics' },
 ];


### PR DESCRIPTION
## What does this change?

Adds The Guardian Apps to the Help Centre navigation. This links to the existing apps topic at `/topic/apps`.

## Images

<img width="1097" alt="Screenshot 2022-08-18 at 17 04 51" src="https://user-images.githubusercontent.com/1166188/185442324-a95d9dde-72d8-4ffa-91c9-e5f80b2def6e.png">
