### PR TITLE
Improve test suite reliability

### DIFF
--- a/app/client/__tests__/dates.test.ts
+++ b/app/client/__tests__/dates.test.ts
@@ -253,11 +253,9 @@ describe('dateRange', () => {
 		const inputStartDate = '1969-07-16';
 		const inputEndDate = '1969-08-16';
 		const dateRangeObj = dateRange(inputStartDate, inputEndDate);
-		expect(
-			dateRangeObj.start.toString() + dateRangeObj.end.toString(),
-		).toEqual(
-			'Wed Jul 16 1969 00:00:00 GMT+0100 (British Summer Time)Sat Aug 16 1969 00:00:00 GMT+0100 (British Summer Time)',
-		);
+
+		expect(localiseDate(dateRangeObj.start)).toEqual('16/07/1969');
+		expect(localiseDate(dateRangeObj.end)).toEqual('16/08/1969');
 	});
 });
 

--- a/app/server/__tests__/middleware/requestMiddleware.test.ts
+++ b/app/server/__tests__/middleware/requestMiddleware.test.ts
@@ -1,4 +1,4 @@
-import { augmentRedirectURL } from '../../middleware/identityMiddleware';
+import { augmentRedirectURL } from '../../middleware/requestMiddleware';
 
 const gulocalDomain = 'thegulocal.com';
 const codeDomain = 'code.dev-theguardian.com';

--- a/app/server/apiProxy.ts
+++ b/app/server/apiProxy.ts
@@ -7,10 +7,8 @@ import { X_GU_ID_FORWARDED_SCOPE } from '../shared/identity';
 import { MDA_TEST_USER_HEADER } from '../shared/productResponse';
 import { conf } from './config';
 import { log, putMetric } from './log';
-import {
-	augmentRedirectURL,
-	getCookiesOrEmptyString,
-} from './middleware/identityMiddleware';
+import { getCookiesOrEmptyString } from './middleware/identityMiddleware';
+import { augmentRedirectURL } from './middleware/requestMiddleware';
 
 type BodyHandler = (res: Response, body: Buffer) => void;
 type JsonString = Buffer | string | undefined;

--- a/app/server/middleware/identityMiddleware.ts
+++ b/app/server/middleware/identityMiddleware.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import fetch from 'node-fetch';
-import url, { UrlWithParsedQuery } from 'url';
+import url from 'url';
 import {
 	getScopeFromRequestPathOrEmptyString,
 	X_GU_ID_FORWARDED_SCOPE,
@@ -10,6 +10,12 @@ import { handleAwsRelatedError } from '../awsIntegration';
 import { conf } from '../config';
 import { idapiConfigPromise } from '../idapiConfig';
 import { log } from '../log';
+import {
+	augmentRedirectURL,
+	MockableExpressRequest,
+	signInTokenQueryParameterNames,
+	updateManageUrl,
+} from './requestMiddleware';
 
 interface RedirectResponseBody extends IdentityDetails {
 	signInStatus: string;
@@ -18,121 +24,12 @@ interface RedirectResponseBody extends IdentityDetails {
 	};
 }
 
-interface MockableExpressRequest {
-	baseUrl: string;
-	path: string;
-	get: (name: string) => string | undefined;
-	header: (name: string) => string | undefined;
-	query: any;
-}
-
-interface QueryParameters {
-	[name: string]: string;
-}
-
-// Filter query parameters to include only those whose name satisfies the predicate p.
-const filterQueryParametersByName = (
-	params: QueryParameters,
-	p: (name: string) => boolean,
-): QueryParameters => {
-	return Object.entries(params)
-		.filter(([name, _]) => p(name))
-		.reduce(
-			(params2, [name, value]) => ({ ...params2, [name]: value }),
-			{},
-		);
-};
-
-// Names of query parameters to that facilitate sign-in on profile.
-const signInTokenQueryParameterNames = ['encryptedEmail', 'autoSignInToken'];
-
 const containsSignInTokenQueryParameters = (
 	req: MockableExpressRequest,
 ): boolean =>
 	signInTokenQueryParameterNames.some(
 		(name) => req.query[name] !== undefined,
 	);
-
-// Adds the redirect url (if defined) as query parameter profileReferer,
-// and removes the sign-in token query parameters since they are not required by manage
-// (only used by profile if the user is redirected their to sign-in).
-const updateManageUrl = (
-	req: MockableExpressRequest,
-	useRefererHeader: boolean,
-	redirectUrl?: UrlWithParsedQuery,
-): string => {
-	// It is vital that the sign-in query parameters are removed.
-	// See the implementation of withIdentity() for more context.
-	const queryParameters = filterQueryParametersByName(
-		req.query,
-		(name) => !signInTokenQueryParameterNames.includes(name),
-	);
-
-	const profileReferrer =
-		redirectUrl && redirectUrl.path
-			? redirectUrl.path.substring(1)
-			: undefined;
-
-	const refererHeader = req.header('referer');
-
-	return useRefererHeader && refererHeader
-		? refererHeader
-		: url.format({
-				protocol: 'https',
-				host: req.get('host'),
-				pathname: req.baseUrl + req.path,
-				query: {
-					...queryParameters,
-					profileReferrer,
-				},
-		  });
-};
-
-export const augmentRedirectURL = (
-	req: MockableExpressRequest,
-	simpleRedirectURL: string,
-	currentDomain: string,
-	useRefererHeaderForReturnURL: boolean,
-) => {
-	const parsedSimpleURL = url.parse(
-		// the replace below essentially allows DEV to use CODE IDAPI but still redirect to profile.thegulocal.com
-		simpleRedirectURL.replace('code.dev-theguardian.com', currentDomain),
-		true,
-	);
-
-	const returnUrl = updateManageUrl(
-		req,
-		useRefererHeaderForReturnURL,
-		parsedSimpleURL,
-	);
-
-	// To avoid potential clashes with query parameters that have a special meaning on profile (e.g. error),
-	// only forward specific query parameters to profile.
-	const profileQueryParameterNames = [
-		'INTCMP',
-		// By passing these to profile, can measure the sign in rates across test segments.
-		'abName',
-		'abVariant',
-		'journey',
-		...signInTokenQueryParameterNames,
-	];
-
-	const profileQueryParameters = filterQueryParametersByName(
-		req.query,
-		(name) => profileQueryParameterNames.includes(name),
-	);
-
-	return url.format({
-		protocol: parsedSimpleURL.protocol,
-		host: parsedSimpleURL.host,
-		pathname: parsedSimpleURL.pathname,
-		query: {
-			...parsedSimpleURL.query,
-			...profileQueryParameters,
-			returnUrl, // this is automatically URL encoded
-		},
-	});
-};
 
 const redirectOrCustomStatusCode = (
 	res: express.Response,

--- a/app/server/middleware/requestMiddleware.ts
+++ b/app/server/middleware/requestMiddleware.ts
@@ -1,0 +1,113 @@
+import url, { UrlWithParsedQuery } from 'url';
+
+export interface MockableExpressRequest {
+	baseUrl: string;
+	path: string;
+	get: (name: string) => string | undefined;
+	header: (name: string) => string | undefined;
+	query: any;
+}
+
+interface QueryParameters {
+	[name: string]: string;
+}
+
+// Names of query parameters to that facilitate sign-in on profile.
+export const signInTokenQueryParameterNames = [
+	'encryptedEmail',
+	'autoSignInToken',
+];
+
+// Filter query parameters to include only those whose name satisfies the predicate p.
+const filterQueryParametersByName = (
+	params: QueryParameters,
+	p: (name: string) => boolean,
+): QueryParameters => {
+	return Object.entries(params)
+		.filter(([name, _]) => p(name))
+		.reduce(
+			(params2, [name, value]) => ({ ...params2, [name]: value }),
+			{},
+		);
+};
+
+// Adds the redirect url (if defined) as query parameter profileReferer,
+// and removes the sign-in token query parameters since they are not required by manage
+// (only used by profile if the user is redirected their to sign-in).
+export const updateManageUrl = (
+	req: MockableExpressRequest,
+	useRefererHeader: boolean,
+	redirectUrl?: UrlWithParsedQuery,
+): string => {
+	// It is vital that the sign-in query parameters are removed.
+	// See the implementation of withIdentity() for more context.
+	const queryParameters = filterQueryParametersByName(
+		req.query,
+		(name) => !signInTokenQueryParameterNames.includes(name),
+	);
+
+	const profileReferrer =
+		redirectUrl && redirectUrl.path
+			? redirectUrl.path.substring(1)
+			: undefined;
+
+	const refererHeader = req.header('referer');
+
+	return useRefererHeader && refererHeader
+		? refererHeader
+		: url.format({
+				protocol: 'https',
+				host: req.get('host'),
+				pathname: req.baseUrl + req.path,
+				query: {
+					...queryParameters,
+					profileReferrer,
+				},
+		  });
+};
+
+export const augmentRedirectURL = (
+	req: MockableExpressRequest,
+	simpleRedirectURL: string,
+	currentDomain: string,
+	useRefererHeaderForReturnURL: boolean,
+) => {
+	const parsedSimpleURL = url.parse(
+		// the replace below essentially allows DEV to use CODE IDAPI but still redirect to profile.thegulocal.com
+		simpleRedirectURL.replace('code.dev-theguardian.com', currentDomain),
+		true,
+	);
+
+	const returnUrl = updateManageUrl(
+		req,
+		useRefererHeaderForReturnURL,
+		parsedSimpleURL,
+	);
+
+	// To avoid potential clashes with query parameters that have a special meaning on profile (e.g. error),
+	// only forward specific query parameters to profile.
+	const profileQueryParameterNames = [
+		'INTCMP',
+		// By passing these to profile, can measure the sign in rates across test segments.
+		'abName',
+		'abVariant',
+		'journey',
+		...signInTokenQueryParameterNames,
+	];
+
+	const profileQueryParameters = filterQueryParametersByName(
+		req.query,
+		(name) => profileQueryParameterNames.includes(name),
+	);
+
+	return url.format({
+		protocol: parsedSimpleURL.protocol,
+		host: parsedSimpleURL.host,
+		pathname: parsedSimpleURL.pathname,
+		query: {
+			...parsedSimpleURL.query,
+			...profileQueryParameters,
+			returnUrl, // this is automatically URL encoded
+		},
+	});
+};


### PR DESCRIPTION
## What does this change?

Improves the reliability of the test suite by fixing issues in the `dates` and `identityMiddleware` specs. These came to light whilst migrating from TeamCity to GitHub Actions (#856).

We've previously fixed issues with tests involving dates behaving differently in dev and CI in #744, but the `dateRange` test didn't need updating. However, this does fail when run in GitHub Actions due to timezone differences so has been updated to use the existing `localiseDate` function.

The `identityMiddleware` has been generating warnings for a while, but we've never managed to get to the bottom of the issues. The warnings don't cause the test suite to fail when run locally or in TeamCity, but do when run in GitHub Actions. The source of the warnings was tracked down to the `idapiConfig` module which tries to access AWS to fetch config and also sets up a promise handler which resolves _after_ the tests have finished. This module isn't used by the code that's being tested so `identityMiddleware` has been broken out into two separate modules so we can test `augmentRedirectURL` without including this additional code.