### PR TITLE
Ensure 'Manage subscription' shows address updates

### DIFF
--- a/app/client/components/delivery/address/deliveryAddressConfirmation.tsx
+++ b/app/client/components/delivery/address/deliveryAddressConfirmation.tsx
@@ -44,6 +44,13 @@ const AddressConfirmation = (props: ProductType) => {
 
 	const productName = props.friendlyName;
 
+	if (isAddress(addressContext.addressStateObject)) {
+		productDetail.subscription.deliveryAddress = {
+			...productDetail.subscription.deliveryAddress,
+			...addressContext.addressStateObject,
+		};
+	}
+
 	const [showTopCallCentreNumbers, setTopCallCentreNumbersVisibility] =
 		useState<boolean>(false);
 

--- a/app/client/components/delivery/address/deliveryAddressConfirmation.tsx
+++ b/app/client/components/delivery/address/deliveryAddressConfirmation.tsx
@@ -34,12 +34,8 @@ const renderConfirmation = (props: ProductType) => () =>
 	<AddressConfirmation {...props} />;
 
 const AddressConfirmation = (props: ProductType) => {
-	interface LocationState {
-		productDetail: ProductDetail;
-	}
-
 	const location = useLocation();
-	const state = location.state as LocationState;
+	const productDetail = location.state as ProductDetail;
 
 	const addressContext = useContext(NewDeliveryAddressContext);
 	const addressChangedInformationContext = useContext(
@@ -212,7 +208,7 @@ const AddressConfirmation = (props: ProductType) => {
 						<LinkButton
 							to={'/subscriptions'}
 							text={'Return to subscription'}
-							state={state}
+							state={{ productDetail }}
 							colour={palette.brand[400]}
 							textColour={palette.neutral[100]}
 							fontWeight={'bold'}

--- a/app/cypress/integration/parallel-4/deliveryAddress.spec.ts
+++ b/app/cypress/integration/parallel-4/deliveryAddress.spec.ts
@@ -51,4 +51,42 @@ describe('Delivery address', () => {
 
 		cy.get('@address_update.all').should('have.length', 1);
 	});
+
+	it('Shows updated address when returning to manage subscription page', () => {
+		cy.intercept('GET', '/api/me/mma', {
+			statusCode: 200,
+			body: [guardianWeeklyCurrentSubscription],
+		}).as('mma');
+
+		cy.intercept('PUT', '/api/delivery/address/update/**', {
+			statusCode: 200,
+			body: 'success',
+		}).as('address_update');
+
+		cy.visit('/');
+		cy.wait('@mma');
+		cy.wait('@cancelled');
+		cy.findByText('Manage subscription').click();
+		cy.findByText('Manage delivery address').click();
+
+		cy.get('input').eq(0).clear().type('Queens Place');
+		cy.get('input').eq(1).clear().type('50 York Way');
+		cy.get('input').eq(2).clear().type('Melbourne');
+		cy.get('input').eq(3).clear().type('VIC');
+		cy.get('input').eq(4).clear().type('3401');
+
+		cy.get('input[name="instructions-checkbox"]').click();
+		cy.findByText('Review details').click();
+
+		cy.findByText('Submit details').click();
+		cy.wait('@address_update');
+
+		cy.findByText('Return to subscription').click();
+
+		cy.findByText('Queens Place').should('exist');
+		cy.findByText('50 York Way').should('exist');
+		cy.findByText('Melbourne').should('exist');
+		cy.findByText('VIC').should('exist');
+		cy.findByText('3401').should('exist');
+	});
 });


### PR DESCRIPTION
## What does this change?

Fixes an issue with updating a subscription's delivery address where the _Manage subscription_ page would continue to show the old address following confirmation of update and clicking the _Return to subscription_ button.

## How to test

From the _Account overview_ page click through to the _Manage subscription_ page for a subscription with physical deliveries and select _Manage delivery address_. Go through the address update steps and on the confirmation page click _Return to subscription_ to return to the _Manage subscription_ page. The address details shown should match the updated address.

## Images

<img width="847" alt="Screenshot_2022-03-11_at_11 56 17" src="https://user-images.githubusercontent.com/1166188/186734829-4d563f41-8f8e-4003-9b08-24cea03e65a1.png">

