### PR TITLE
[RB] - live chat pre chat form css overrides.

### DIFF
--- a/app/client/components/liveChat/liveChat.tsx
+++ b/app/client/components/liveChat/liveChat.tsx
@@ -180,8 +180,8 @@ const initESW = (
 		} else {
 			// Initialise live chat API for DEV1 test sandbox
 			liveChatAPI.init(
-				'https://gnmtouchpoint--dev1.my.salesforce.com',
-				'https://dev1-guardiansurveys.cs88.force.com/liveagent',
+				'https://gnmtouchpoint--dev1.sandbox.my.salesforce.com',
+				'https://gnmtouchpoint--dev1.sandbox.my.salesforce-sites.com/liveagent',
 				gslbBaseUrl,
 				'00D9E0000004jvh',
 				'Chat_Team',

--- a/app/client/components/liveChat/liveChatCssOverrides.ts
+++ b/app/client/components/liveChat/liveChatCssOverrides.ts
@@ -8,6 +8,10 @@ import {
 } from '@guardian/source-foundations';
 
 export const liveChatCss = css`
+	.embeddedServiceSidebar.layout-docked .dockableContainer,
+	.embeddedServiceSidebar.layout-float .dockableContainer {
+		max-height: 524px;
+	}
 	${until.desktop} {
 		.embeddedServiceSidebar.layout-docked .dockableContainer,
 		.embeddedServiceSidebar.layout-float .dockableContainer {
@@ -27,15 +31,25 @@ export const liveChatCss = css`
 			flex-direction: column;
 			min-height: 100%;
 		}
-		.prechat--button-holder[c-prechatForm_prechatForm] {
-			margin-top: auto;
-		}
 		.stateBody {
 			overflow-y: scroll;
 		}
 	}
+	.prechat--container {
+		height: 100%;
+		display: flex;
+		flex-direction: column;
+	}
+	.prechat--button-holder[c-prechatForm_prechatForm] {
+		margin-top: auto;
+	}
+	.prechat--fieldset[c-prechatForm_prechatForm] {
+		padding-top: 8px;
+		padding-bottom: 0;
+	}
 	.embeddedServiceSidebar.layout-docked .dockableContainer {
 		border-radius: 0;
+		margin-top: auto;
 	}
 	.waitingStateButtonContainer .waitingCancelChat {
 		border-radius: 0;


### PR DESCRIPTION
## What does this change?
Fix issue where start chatting button is obscured from view when the form validation errors show above the prechat form 
input fields

## Images
Before             |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/2510683/187945715-d46fe899-7cfa-4511-bbc3-36f24c636da8.png)  |  ![](https://user-images.githubusercontent.com/2510683/187945809-bd2f140b-29f0-4cf7-b3a6-2cbf43a06175.png)


