### PR TITLE
Remove unnecessary environment variables from CloudFormation config

### DIFF
--- a/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
@@ -34,17 +34,13 @@ Object {
     },
     "StageVariables": Object {
       "CODE": Object {
-        "ApiDomainEnvVariable": "code.dev-guardianapis.com",
         "CertificateARN": "arn:aws:acm:eu-west-1:865473395570:certificate/2c2a72a2-a0d6-4ffa-b8a1-8a7916000515",
-        "DomainEnvVariable": "code.dev-theguardian.com",
         "InstanceType": "t4g.small",
         "MaxInstances": 2,
         "MinInstances": 1,
       },
       "PROD": Object {
-        "ApiDomainEnvVariable": "guardianapis.com",
         "CertificateARN": "arn:aws:acm:eu-west-1:865473395570:certificate/d2e4911c-c78d-469b-ab53-8c507aa41576",
-        "DomainEnvVariable": "theguardian.com",
         "InstanceType": "t4g.small",
         "MaxInstances": 6,
         "MinInstances": 3,
@@ -1165,8 +1161,7 @@ Object {
         ],
         "UserData": Object {
           "Fn::Base64": Object {
-            "Fn::Sub": Array [
-              "#!/bin/bash -ev
+            "Fn::Sub": "#!/bin/bash -ev
 
 # get runnable tar from S3
 aws --region \${AWS::Region} s3 cp s3://membership-dist/\${Stack}/\${Stage}/\${App}/manage-frontend.zip /tmp
@@ -1190,10 +1185,7 @@ StandardError=syslog
 SyslogIdentifier=manage-frontend
 User=manage-frontend
 Group=manage-frontend
-Environment=NODE_ENV=production
 Environment=STAGE=\${Stage}
-Environment=DOMAIN=\${DomainEnvVariable}
-Environment=API_DOMAIN=\${ApiDomainEnvVariable}
 Environment=CLIENT_DSN=\${ClientRavenDSN}
 Environment=SERVER_DSN=\${ServerRavenDSN}
 [Install]
@@ -1205,27 +1197,6 @@ systemctl start manage-frontend
 /opt/cloudwatch-logs/configure-logs application \${Stack} \${Stage} \${App} /var/log/manage-frontend.log
 
 ",
-              Object {
-                "ApiDomainEnvVariable": Object {
-                  "Fn::FindInMap": Array [
-                    "StageVariables",
-                    Object {
-                      "Ref": "Stage",
-                    },
-                    "ApiDomainEnvVariable",
-                  ],
-                },
-                "DomainEnvVariable": Object {
-                  "Fn::FindInMap": Array [
-                    "StageVariables",
-                    Object {
-                      "Ref": "Stage",
-                    },
-                    "DomainEnvVariable",
-                  ],
-                },
-              },
-            ],
           },
         },
       },

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -36,8 +36,8 @@ Parameters:
     Description: Bastion's security group for SSH
     Type: String
 Conditions:
-  CreateProdResources: !Equals [!Ref "Stage", "PROD"]
-  CreateCodeResources: !Equals [!Ref "Stage", "CODE"]
+  CreateProdResources: !Equals [!Ref 'Stage', 'PROD']
+  CreateCodeResources: !Equals [!Ref 'Stage', 'CODE']
 Mappings:
   Constants:
     Alarm:
@@ -51,15 +51,11 @@ Mappings:
       MinInstances: 1
       InstanceType: t4g.small
       CertificateARN: arn:aws:acm:eu-west-1:865473395570:certificate/2c2a72a2-a0d6-4ffa-b8a1-8a7916000515
-      ApiDomainEnvVariable: code.dev-guardianapis.com
-      DomainEnvVariable: code.dev-theguardian.com
     PROD:
       MaxInstances: 6
       MinInstances: 3
       InstanceType: t4g.small
       CertificateARN: arn:aws:acm:eu-west-1:865473395570:certificate/d2e4911c-c78d-469b-ab53-8c507aa41576
-      ApiDomainEnvVariable: guardianapis.com
-      DomainEnvVariable: theguardian.com
 Resources:
   AutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
@@ -84,11 +80,11 @@ Resources:
           PropagateAtLaunch: true
         - Key: Name
           Value: !Join
-            - "-"
+            - '-'
             - - !Ref Stack
               - !Ref Stage
               - !Ref App
-          PropagateAtLaunch: "true"
+          PropagateAtLaunch: 'true'
   LaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
@@ -126,10 +122,7 @@ Resources:
             SyslogIdentifier=manage-frontend
             User=manage-frontend
             Group=manage-frontend
-            Environment=NODE_ENV=production
             Environment=STAGE=${Stage}
-            Environment=DOMAIN=${DomainEnvVariable}
-            Environment=API_DOMAIN=${ApiDomainEnvVariable}
             Environment=CLIENT_DSN=${ClientRavenDSN}
             Environment=SERVER_DSN=${ServerRavenDSN}
             [Install]
@@ -140,15 +133,10 @@ Resources:
             systemctl start manage-frontend
             /opt/cloudwatch-logs/configure-logs application ${Stack} ${Stage} ${App} /var/log/manage-frontend.log
 
-          - DomainEnvVariable:
-              !FindInMap [StageVariables, !Ref Stage, DomainEnvVariable]
-            ApiDomainEnvVariable:
-              !FindInMap [StageVariables, !Ref Stage, ApiDomainEnvVariable]
-
   AppRole:
     Type: AWS::IAM::Role
     Properties:
-      Path: "/"
+      Path: '/'
       ManagedPolicyArns:
         - !Sub arn:aws:iam::${AWS::AccountId}:policy/guardian-ec2-role-for-ssm
       AssumeRolePolicyDocument:
@@ -176,7 +164,7 @@ Resources:
             Statement:
               - Effect: Allow
                 Action: cloudwatch:PutMetricData
-                Resource: "*"
+                Resource: '*'
         - PolicyName: ReadPrivateCredentials
           PolicyDocument:
             Statement:
@@ -230,7 +218,7 @@ Resources:
       PolicyDocument:
         Statement:
           - Effect: Allow
-            Resource: "*"
+            Resource: '*'
             Action:
               - ec2:DescribeTags
               - ec2:DescribeInstances
@@ -255,7 +243,7 @@ Resources:
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
-      Path: "/"
+      Path: '/'
       Roles:
         - !Ref AppRole
 
@@ -359,7 +347,7 @@ Resources:
           CidrIp: 0.0.0.0/0
 
   ManageFrontendLogGroup:
-    Type: "AWS::Logs::LogGroup"
+    Type: 'AWS::Logs::LogGroup'
     Properties:
       LogGroupName: !Sub support-manage-frontend-${Stage}
       RetentionInDays: 14
@@ -394,13 +382,13 @@ Resources:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
       AlarmName: !Join
-        - " "
+        - ' '
         - - !FindInMap [Constants, Alarm, Urgent]
-          - !Ref "Stage"
+          - !Ref 'Stage'
           - !FindInMap [Constants, MetricFilters, MetricNamespace]
-          - "High 5XX rate"
+          - 'High 5XX rate'
       AlarmDescription: !Join
-        - " "
+        - ' '
         - - Impact - we're serving errors to too many people
           - !FindInMap [Constants, Alarm, Process]
       ComparisonOperator: GreaterThanOrEqualToThreshold
@@ -410,7 +398,7 @@ Resources:
       Metrics:
         - Id: total5xx
           Expression: backend5XX + elb5XX
-          Label: "Count of Backend AND ELB 5XX"
+          Label: 'Count of Backend AND ELB 5XX'
         - Id: backend5XX
           MetricStat:
             Metric:
@@ -445,7 +433,7 @@ Resources:
     Type: AWS::CloudWatch::Dashboard
     Condition: CreateProdResources
     Properties:
-      DashboardName: "manage-frontend"
+      DashboardName: 'manage-frontend'
       DashboardBody: >-
         {
           "widgets": [

--- a/server/config.ts
+++ b/server/config.ts
@@ -3,7 +3,6 @@ interface Config {
 	readonly DOMAIN: string;
 	readonly API_DOMAIN: string;
 	readonly ENVIRONMENT: Environments;
-	readonly BUILD: string;
 	readonly CLIENT_DSN: string | null;
 	readonly SERVER_DSN: string | null;
 }
@@ -21,18 +20,31 @@ const getConfig: (name: string) => string | null = (name) => {
 };
 
 export enum Environments {
-	PRODUCTION,
+	AWS,
 	DEVELOPMENT,
 }
 
+const stage = getConfig('STAGE');
+
+const getDomain = () => {
+	switch (stage) {
+		case 'PROD':
+			return 'theguardian.com';
+		case 'CODE':
+			return 'code.dev-theguardian.com';
+		default:
+			return 'thegulocal.com';
+	}
+};
+
 export const conf: Config = {
-	STAGE: getConfig('STAGE') || 'DEV',
-	DOMAIN: getConfig('DOMAIN') || 'thegulocal.com',
-	API_DOMAIN: getConfig('API_DOMAIN') || 'code.dev-guardianapis.com',
-	BUILD: getConfig('BUILD') || 'DEV',
+	STAGE: stage || 'DEV',
+	DOMAIN: getDomain(),
+	API_DOMAIN:
+		stage === 'PROD' ? 'guardianapis.com' : 'code.dev-guardianapis.com',
 	ENVIRONMENT:
-		getConfig('NODE_ENV') === 'production'
-			? Environments.PRODUCTION
+		stage === 'PROD' || stage === 'CODE'
+			? Environments.AWS
 			: Environments.DEVELOPMENT,
 	CLIENT_DSN: getConfig('CLIENT_DSN'),
 	SERVER_DSN: getConfig('SERVER_DSN'),

--- a/server/log.ts
+++ b/server/log.ts
@@ -2,8 +2,7 @@ import winston from 'winston';
 import { putMetricDataPromise } from './awsIntegration';
 import { conf, Environments } from './config';
 
-const location =
-	conf.ENVIRONMENT === Environments.PRODUCTION ? '/var/log/' : './';
+const location = conf.ENVIRONMENT === Environments.AWS ? '/var/log/' : './';
 
 export const log = winston.createLogger({
 	level: 'info',

--- a/server/routes/core.ts
+++ b/server/routes/core.ts
@@ -45,7 +45,7 @@ router.get('/robots.txt', (_, res: Response) => {
 		allowHelpCentre + disallowGoogleAdsBots + helpCentreSitemap;
 	const preProdAccessList = disallowAll;
 	const accessList =
-		conf.ENVIRONMENT === Environments.PRODUCTION
+		conf.ENVIRONMENT === Environments.AWS
 			? prodAccessList
 			: preProdAccessList;
 	res.contentType('text/plain').send(accessList);

--- a/server/routes/frontendCommon.ts
+++ b/server/routes/frontendCommon.ts
@@ -5,10 +5,10 @@ import { recaptchaConfigPromise } from '../recaptchaConfig';
 import { stripePublicKeysPromise } from '../stripeSetupIntentConfig';
 
 export const clientDSN =
-	conf.ENVIRONMENT === Environments.PRODUCTION && conf.CLIENT_DSN
+	conf.ENVIRONMENT === Environments.AWS && conf.CLIENT_DSN
 		? conf.CLIENT_DSN
 		: null;
-if (conf.ENVIRONMENT === Environments.PRODUCTION && !conf.CLIENT_DSN) {
+if (conf.ENVIRONMENT === Environments.AWS && !conf.CLIENT_DSN) {
 	log.error('NO SENTRY IN CLIENT PROD!');
 }
 


### PR DESCRIPTION
## What does this change?

Removes environment variables defining application and API domains as these don't need to be part of the CloudFormation config and can be defined directly in the application code. (Fallbacks for dev environment domains are already defined in the code so this also cleans up some duplication.) `NODE_ENV` has also been removed from CloudFormation as this is always set to the same value, and `BUILD` has been removed from the app config as it's unused.

