### PR TITLE
create secondary wazuh security group and update snapshot

### DIFF
--- a/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
@@ -1156,7 +1156,7 @@ Object {
             "Ref": "InstanceSecurityGroup",
           },
           Object {
-            "Ref": "WazuhSecurityGroup",
+            "Ref": "WazuhSecurityGroupPreCDK",
           },
         ],
         "UserData": Object {
@@ -1412,6 +1412,41 @@ systemctl start manage-frontend
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
     },
     "WazuhSecurityGroup": Object {
+      "Properties": Object {
+        "GroupDescription": "Allow outbound traffic from wazuh agent to manager",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 1514,
+            "IpProtocol": "tcp",
+            "ToPort": 1515,
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/manage-frontend",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "WazuhSecurityGroupPreCDK": Object {
       "Properties": Object {
         "GroupDescription": "Allow outbound traffic from wazuh agent to manager",
         "SecurityGroupEgress": Array [

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -91,7 +91,7 @@ Resources:
       ImageId: !Ref AMI
       SecurityGroups:
         - !Ref InstanceSecurityGroup
-        - !Ref WazuhSecurityGroup
+        - !Ref WazuhSecurityGroupPreCDK
       InstanceType: !FindInMap [StageVariables, !Ref Stage, InstanceType]
       IamInstanceProfile: !Ref InstanceProfile
       AssociatePublicIpAddress: false
@@ -335,6 +335,18 @@ Resources:
           CidrIp: 0.0.0.0/0
 
   WazuhSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow outbound traffic from wazuh agent to manager
+      VpcId:
+        Ref: VpcId
+      SecurityGroupEgress:
+        - IpProtocol: tcp
+          FromPort: 1514
+          ToPort: 1515
+          CidrIp: 0.0.0.0/0
+
+  WazuhSecurityGroupPreCDK:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: Allow outbound traffic from wazuh agent to manager


### PR DESCRIPTION
## What does this change?
Part one of handing over the wazuh security group param from the cloudformation yaml file over to the cdk process. 

During the process of migrating over to CDK manage will run off of the old cloudformation file as well as the CDK this requires to duplicate the wazuh security group resource inside the cloudformation yaml file in order to prevent us from deleting the resource that the CDK also wants to use.

The first step is to duplicate the security group, and the subsequent step will be to remove the old duplicate.
