### PR TITLE
remove old wazuh security group resource

### DIFF
--- a/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
@@ -1411,41 +1411,6 @@ systemctl start manage-frontend
       },
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
     },
-    "WazuhSecurityGroup": Object {
-      "Properties": Object {
-        "GroupDescription": "Allow outbound traffic from wazuh agent to manager",
-        "SecurityGroupEgress": Array [
-          Object {
-            "CidrIp": "0.0.0.0/0",
-            "FromPort": 1514,
-            "IpProtocol": "tcp",
-            "ToPort": 1515,
-          },
-        ],
-        "Tags": Array [
-          Object {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          Object {
-            "Key": "gu:repo",
-            "Value": "guardian/manage-frontend",
-          },
-          Object {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          Object {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "VpcId": Object {
-          "Ref": "VpcId",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
-    },
     "WazuhSecurityGroupPreCDK": Object {
       "Properties": Object {
         "GroupDescription": "Allow outbound traffic from wazuh agent to manager",

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -334,18 +334,6 @@ Resources:
           ToPort: 443
           CidrIp: 0.0.0.0/0
 
-  WazuhSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: Allow outbound traffic from wazuh agent to manager
-      VpcId:
-        Ref: VpcId
-      SecurityGroupEgress:
-        - IpProtocol: tcp
-          FromPort: 1514
-          ToPort: 1515
-          CidrIp: 0.0.0.0/0
-
   WazuhSecurityGroupPreCDK:
     Type: AWS::EC2::SecurityGroup
     Properties:


### PR DESCRIPTION
## What does this change?
Part 2 of the migration of wazuh security group resource from old cloudformation yaml to CDK.

This step removes the unused security group `WazuhSecurityGroup`, which will then be recreated by CDK.

see part 1 here: #866 