### PR TITLE
fix: Use correct type for CFN Parameters sourced from SSM

### DIFF
--- a/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
@@ -73,12 +73,12 @@ Object {
     "PrivateVpcSubnetsPreCDK": Object {
       "Default": "/account/vpc/primary/subnets/private",
       "Description": "Private subnets to use for EC2 instances",
-      "Type": "List<AWS::EC2::Subnet::Id>",
+      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
     },
     "PublicVpcSubnetsPreCDK": Object {
       "Default": "/account/vpc/primary/subnets/public",
       "Description": "Public subnets to use for the ELB",
-      "Type": "List<AWS::EC2::Subnet::Id>",
+      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
     },
     "ServerRavenDSN": Object {
       "Description": "the DSN to use with sentry on the server",
@@ -96,7 +96,7 @@ Object {
     "VpcIdPreCDK": Object {
       "Default": "/account/vpc/primary/id",
       "Description": "VpcId of your existing Virtual Private Cloud (VPC)",
-      "Type": "String",
+      "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
     },
   },
   "Resources": Object {

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -2,16 +2,16 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: manage-frontend
 Parameters:
   VpcIdPreCDK:
-    Type: String
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>
     Description: VpcId of your existing Virtual Private Cloud (VPC)
     Default: /account/vpc/primary/id
   PrivateVpcSubnetsPreCDK:
     Description: Private subnets to use for EC2 instances
-    Type: List<AWS::EC2::Subnet::Id>
+    Type: AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>
     Default: /account/vpc/primary/subnets/private
   PublicVpcSubnetsPreCDK:
     Description: Public subnets to use for the ELB
-    Type: List<AWS::EC2::Subnet::Id>
+    Type: AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>
     Default: /account/vpc/primary/subnets/public
   Stack:
     Description: Applied directly as a tag


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

In #869 we moved to loading the VPC parameters from SSM Parameter Store, however we forgot to update the `Type` which tells CloudFormation where to source the value from.

In this change, we set the `Type` to [`AWS::SSM::Parameter::Value`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html#aws-ssm-parameter-types) so that it reads from SSM rather than use the raw string value.