### PR TITLE
Migrate cfn yaml to cdk

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -6,12 +6,19 @@ const app = new App();
 new ManageFrontend(app, 'ManageFrontend-CODE', {
 	stack: 'support',
 	stage: 'CODE',
+	scaling: {
+		minimumInstances: 1,
+	},
 	domain: 'manage.code.theguardian.com.origin.membership.guardianapis.com',
 	cloudFormationStackName: 'support-CODE-manage-frontend',
 });
+
 new ManageFrontend(app, 'ManageFrontend-PROD', {
 	stack: 'support',
 	stage: 'PROD',
+	scaling: {
+		minimumInstances: 3,
+	},
 	domain: 'manage.theguardian.com.origin.membership.guardianapis.com',
 	cloudFormationStackName: 'support-PROD-manage-frontend',
 });

--- a/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
@@ -2405,7 +2405,10 @@ systemctl start manage-frontend
       "Properties": Object {
         "HealthCheckIntervalSeconds": 10,
         "HealthCheckPath": "/_healthcheck",
+        "HealthCheckPort": "9233",
         "HealthCheckProtocol": "HTTP",
+        "HealthCheckTimeoutSeconds": 5,
+        "HealthyThresholdCount": 2,
         "Name": Object {
           "Fn::Sub": "\${Stack}-\${Stage}-\${App}",
         },
@@ -2435,6 +2438,7 @@ systemctl start manage-frontend
             "Value": "45",
           },
         ],
+        "UnhealthyThresholdCount": 2,
         "VpcId": Object {
           "Ref": "VpcIdPreCDK",
         },

--- a/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
@@ -2100,33 +2100,6 @@ systemctl start manage-frontend
       },
       "Type": "AWS::Logs::LogGroup",
     },
-    "ManageFrontendLogGroup7414E8CD": Object {
-      "DeletionPolicy": "Retain",
-      "Properties": Object {
-        "LogGroupName": "support-manage-frontend-TEST",
-        "RetentionInDays": 14,
-        "Tags": Array [
-          Object {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          Object {
-            "Key": "gu:repo",
-            "Value": "guardian/manage-frontend",
-          },
-          Object {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          Object {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-      },
-      "Type": "AWS::Logs::LogGroup",
-      "UpdateReplacePolicy": "Retain",
-    },
     "NoHealthyInstancesAlarm": Object {
       "Condition": "CreateProdResources",
       "DependsOn": Array [
@@ -2238,7 +2211,7 @@ systemctl start manage-frontend
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "ManageFrontendLogGroup7414E8CD",
+                  "ManageFrontendLogGroup",
                   "Arn",
                 ],
               },

--- a/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
@@ -50,14 +50,59 @@ Object {
   "Metadata": Object {
     "gu:cdk:constructs": Array [
       "GuStringParameter",
+      "GuStringParameter",
+      "GuStringParameter",
+      "GuAllowPolicy",
+      "GuPutCloudwatchMetricsPolicy",
+      "GuGetS3ObjectsPolicy",
+      "GuGetS3ObjectsPolicy",
+      "GuGetS3ObjectsPolicy",
+      "GuAllowPolicy",
+      "GuAllowPolicy",
+      "GuAllowPolicy",
+      "GuGetS3ObjectsPolicy",
+      "GuVpcParameter",
+      "GuSubnetListParameter",
+      "GuCertificate",
+      "GuInstanceRole",
+      "GuSSMRunCommandPolicy",
+      "GuDescribeEC2Policy",
+      "GuLoggingStreamNameParameter",
+      "GuLogShippingPolicy",
+      "GuDistributionBucketParameter",
+      "GuGetDistributablePolicy",
+      "GuParameterStoreReadPolicy",
+      "GuAmiParameter",
+      "GuHttpsEgressSecurityGroup",
+      "GuAutoScalingGroup",
+      "GuWazuhAccess",
+      "GuSubnetListParameter",
+      "GuApplicationLoadBalancer",
+      "GuApplicationTargetGroup",
+      "GuHttpsApplicationListener",
     ],
     "gu:cdk:version": "47.3.1",
+  },
+  "Outputs": Object {
+    "LoadBalancerManagefrontendDnsName": Object {
+      "Description": "DNS entry for LoadBalancerManagefrontend",
+      "Value": Object {
+        "Fn::GetAtt": Array [
+          "LoadBalancerManagefrontend184BCE6C",
+          "DNSName",
+        ],
+      },
+    },
   },
   "Parameters": Object {
     "AMI": Object {
       "Default": "ami-88a6af62",
       "Description": "AMI ID",
       "Type": "String",
+    },
+    "AMIManagefrontend": Object {
+      "Description": "Amazon Machine Image ID for the app manage-frontend. Use this in conjunction with AMIgo to keep AMIs up to date.",
+      "Type": "AWS::EC2::Image::Id",
     },
     "App": Object {
       "Default": "manage-frontend",
@@ -71,6 +116,16 @@ Object {
     "ClientRavenDSN": Object {
       "Description": "the DSN to use with sentry on the client",
       "Type": "String",
+    },
+    "DistributionBucketName": Object {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "LoggingStreamName": Object {
+      "Default": "/account/services/logging.stream.name",
+      "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
+      "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "PrivateVpcSubnetsPreCDK": Object {
       "Default": "/account/vpc/primary/subnets/private",
@@ -95,13 +150,38 @@ Object {
       "Description": "Applied directly as a tag",
       "Type": "String",
     },
+    "VpcId": Object {
+      "Default": "/account/vpc/primary/id",
+      "Description": "Virtual Private Cloud to run EC2 instances within. Should NOT be the account default VPC.",
+      "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
+    },
     "VpcIdPreCDK": Object {
       "Default": "/account/vpc/primary/id",
       "Description": "VpcId of your existing Virtual Private Cloud (VPC)",
       "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
     },
+    "clientRavenDSN": Object {
+      "Default": "/TEST/support/manage-frontend/clientRavenDSN",
+      "Description": "the DSN to use with Sentry on the client",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "hostedZoneId": Object {
       "Default": "/account/route53/membership/hostedZoneId",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "managefrontendPrivateSubnets": Object {
+      "Default": "/account/vpc/primary/subnets/private",
+      "Description": "A list of private subnets",
+      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
+    },
+    "managefrontendPublicSubnets": Object {
+      "Default": "/account/vpc/primary/subnets/public",
+      "Description": "A list of public subnets",
+      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
+    },
+    "serverRavenDSN": Object {
+      "Default": "/TEST/support/manage-frontend/serverRavenDSN",
+      "Description": "the DSN to use with Sentry on the server",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
   },
@@ -296,10 +376,6 @@ Object {
         ],
         "Tags": Array [
           Object {
-            "Key": "App",
-            "Value": "manage-frontend",
-          },
-          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -348,7 +424,9 @@ Object {
           Object {
             "Key": "App",
             "PropagateAtLaunch": true,
-            "Value": "manage-frontend",
+            "Value": Object {
+              "Ref": "App",
+            },
           },
           Object {
             "Key": "gu:cdk:version",
@@ -401,6 +479,206 @@ Object {
         },
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
+    },
+    "AutoScalingGroupManagefrontendASGD7F4CC81": Object {
+      "Properties": Object {
+        "HealthCheckGracePeriod": 120,
+        "HealthCheckType": "ELB",
+        "LaunchConfigurationName": Object {
+          "Ref": "AutoScalingGroupManagefrontendLaunchConfig1BB2A57B",
+        },
+        "MaxSize": "2",
+        "MinSize": "1",
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "PropagateAtLaunch": true,
+            "Value": "manage-frontend",
+          },
+          Object {
+            "Key": "gu:cdk:pattern-name",
+            "PropagateAtLaunch": true,
+            "Value": "GuNodeApp",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "PropagateAtLaunch": true,
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "PropagateAtLaunch": true,
+            "Value": "guardian/manage-frontend",
+          },
+          Object {
+            "Key": "gu:riffraff:new-asg",
+            "PropagateAtLaunch": true,
+            "Value": "true",
+          },
+          Object {
+            "Key": "LogKinesisStreamName",
+            "PropagateAtLaunch": true,
+            "Value": Object {
+              "Ref": "LoggingStreamName",
+            },
+          },
+          Object {
+            "Key": "Name",
+            "PropagateAtLaunch": true,
+            "Value": "ManageFrontend/AutoScalingGroupManagefrontend",
+          },
+          Object {
+            "Key": "Stack",
+            "PropagateAtLaunch": true,
+            "Value": "support",
+          },
+          Object {
+            "Key": "Stage",
+            "PropagateAtLaunch": true,
+            "Value": "TEST",
+          },
+        ],
+        "TargetGroupARNs": Array [
+          Object {
+            "Ref": "TargetGroupManagefrontend7AE2B787",
+          },
+        ],
+        "VPCZoneIdentifier": Object {
+          "Ref": "managefrontendPrivateSubnets",
+        },
+      },
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+    },
+    "AutoScalingGroupManagefrontendInstanceProfileB8F58630": Object {
+      "Properties": Object {
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleManagefrontendC8EBF20D",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
+    },
+    "AutoScalingGroupManagefrontendLaunchConfig1BB2A57B": Object {
+      "DependsOn": Array [
+        "InstanceRoleManagefrontendC8EBF20D",
+      ],
+      "Properties": Object {
+        "IamInstanceProfile": Object {
+          "Ref": "AutoScalingGroupManagefrontendInstanceProfileB8F58630",
+        },
+        "ImageId": Object {
+          "Ref": "AMIManagefrontend",
+        },
+        "InstanceType": "t4g.small",
+        "MetadataOptions": Object {
+          "HttpTokens": "required",
+        },
+        "SecurityGroups": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "GuHttpsEgressSecurityGroupManagefrontend8E53A220",
+              "GroupId",
+            ],
+          },
+          Object {
+            "Fn::GetAtt": Array [
+              "WazuhSecurityGroup",
+              "GroupId",
+            ],
+          },
+        ],
+        "UserData": Object {
+          "Fn::Base64": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "#!/bin/bash -ev
+            # get runnable tar from S3
+            aws --region ",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                " s3 cp s3://membership-dist/support/TEST/manage-frontend/manage-frontend.zip /tmp
+            mkdir /etc/gu
+            unzip /tmp/manage-frontend.zip -d /etc/gu/dist/
+            # add user
+            groupadd manage-frontend
+            useradd -r -s /usr/bin/nologin -g manage-frontend manage-frontend
+            touch /var/log/manage-frontend.log
+            chown -R manage-frontend:manage-frontend /etc/gu
+            chown manage-frontend:manage-frontend /var/log/manage-frontend.log
+            # write out systemd file
+            cat >/etc/systemd/system/manage-frontend.service <<EOL
+            [Service]
+            ExecStart=/usr/bin/node /etc/gu/dist/server.js
+            Restart=always
+            StandardOutput=syslog
+            StandardError=syslog
+            SyslogIdentifier=manage-frontend
+            User=manage-frontend
+            Group=manage-frontend
+            Environment=STAGE=TEST
+            Environment=CLIENT_DSN=",
+                Object {
+                  "Ref": "clientRavenDSN",
+                },
+                "
+            Environment=SERVER_DSN=",
+                Object {
+                  "Ref": "serverRavenDSN",
+                },
+                "
+            [Install]
+            WantedBy=multi-user.target
+            EOL
+            # RUN
+            systemctl enable manage-frontend
+            systemctl start manage-frontend
+            /opt/cloudwatch-logs/configure-logs application support TEST manage-frontend /var/log/manage-frontend.log",
+              ],
+            ],
+          },
+        },
+      },
+      "Type": "AWS::AutoScaling::LaunchConfiguration",
+    },
+    "CertificateManagefrontend6C431D69": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "DomainName": "manage.code.theguardian.com.origin.membership.guardianapis.com",
+        "DomainValidationOptions": Array [
+          Object {
+            "DomainName": "manage.code.theguardian.com.origin.membership.guardianapis.com",
+            "HostedZoneId": "Z1E4V12LQGXFEC",
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "manage-frontend",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/manage-frontend",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "ValidationMethod": "DNS",
+      },
+      "Type": "AWS::CertificateManager::Certificate",
+      "UpdateReplacePolicy": "Retain",
     },
     "CriticalPathsCloudWatchDashboard": Object {
       "Condition": "CreateProdResources",
@@ -949,6 +1227,118 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
+    "DescribeEC2PolicyFF5F9295": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "autoscaling:DescribeAutoScalingInstances",
+                "autoscaling:DescribeAutoScalingGroups",
+                "ec2:DescribeTags",
+                "ec2:DescribeInstances",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "describe-ec2-policy",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleManagefrontendC8EBF20D",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "DiscoverApiGatewayApiKeys089E4788": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "apigateway:GET",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:apigateway:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    "::/apikeys/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DiscoverApiGatewayApiKeys089E4788",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleManagefrontendC8EBF20D",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "DiscoverApiGatewayLambdas813153A8": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "cloudformation:ListStackResources",
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:aws:cloudformation:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":stack/membership-TEST-*",
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:aws:cloudformation:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":stack/support-TEST-*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DiscoverApiGatewayLambdas813153A8",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleManagefrontendC8EBF20D",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "ElasticLoadBalancer": Object {
       "Properties": Object {
         "Name": Object {
@@ -962,6 +1352,77 @@ Object {
         "Subnets": Object {
           "Ref": "PublicVpcSubnetsPreCDK",
         },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": Object {
+              "Ref": "App",
+            },
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/manage-frontend",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    },
+    "GetDistributablePolicyManagefrontendF60D9EB4": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:s3:::",
+                    Object {
+                      "Ref": "DistributionBucketName",
+                    },
+                    "/support/TEST/manage-frontend/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GetDistributablePolicyManagefrontendF60D9EB4",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleManagefrontendC8EBF20D",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GuHttpsEgressSecurityGroupManagefrontend8E53A220": Object {
+      "Properties": Object {
+        "GroupDescription": "Allow all outbound HTTPS traffic",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound HTTPS traffic",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
         "Tags": Array [
           Object {
             "Key": "App",
@@ -984,8 +1445,95 @@ Object {
             "Value": "TEST",
           },
         ],
+        "VpcId": Object {
+          "Ref": "VpcId",
+        },
       },
-      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "GuHttpsEgressSecurityGroupManagefrontendfromManageFrontendLoadBalancerManagefrontendSecurityGroup4DBBACB9300072467277": Object {
+      "Properties": Object {
+        "Description": "Load balancer to target",
+        "FromPort": 3000,
+        "GroupId": Object {
+          "Fn::GetAtt": Array [
+            "GuHttpsEgressSecurityGroupManagefrontend8E53A220",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": Object {
+          "Fn::GetAtt": Array [
+            "LoadBalancerManagefrontendSecurityGroupED621ABF",
+            "GroupId",
+          ],
+        },
+        "ToPort": 3000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "GuLogShippingPolicy981BFE5A": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "kinesis:Describe*",
+                "kinesis:Put*",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:kinesis:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":stream/",
+                    Object {
+                      "Ref": "LoggingStreamName",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GuLogShippingPolicy981BFE5A",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleManagefrontendC8EBF20D",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GuPutCloudwatchMetricsPolicyC5BCE402": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "cloudwatch:PutMetricData",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GuPutCloudwatchMetricsPolicyC5BCE402",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleManagefrontendC8EBF20D",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "High5XXRateAlarm": Object {
       "Condition": "CreateProdResources",
@@ -1112,6 +1660,56 @@ Object {
       },
       "Type": "AWS::IAM::InstanceProfile",
     },
+    "InstanceRoleManagefrontendC8EBF20D": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "ec2.",
+                      Object {
+                        "Ref": "AWS::URLSuffix",
+                      },
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Path": "/",
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "manage-frontend",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/manage-frontend",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
     "InstanceSecurityGroup": Object {
       "Properties": Object {
         "GroupDescription": "Open up SSH access and enable HTTP access on the configured port",
@@ -1143,10 +1741,6 @@ Object {
         ],
         "Tags": Array [
           Object {
-            "Key": "App",
-            "Value": "manage-frontend",
-          },
-          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -1168,6 +1762,42 @@ Object {
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
+    },
+    "InvokeApiGatewayD4DDF95A": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "execute-api:Invoke",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:execute-api:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":*/TEST/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "InvokeApiGatewayD4DDF95A",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleManagefrontendC8EBF20D",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "LaunchConfig": Object {
       "Properties": Object {
@@ -1238,6 +1868,31 @@ systemctl start manage-frontend
       },
       "Type": "AWS::AutoScaling::LaunchConfiguration",
     },
+    "ListenerManagefrontendF0B970A7": Object {
+      "Properties": Object {
+        "Certificates": Array [
+          Object {
+            "CertificateArn": Object {
+              "Ref": "CertificateManagefrontend6C431D69",
+            },
+          },
+        ],
+        "DefaultActions": Array [
+          Object {
+            "TargetGroupArn": Object {
+              "Ref": "TargetGroupManagefrontend7AE2B787",
+            },
+            "Type": "forward",
+          },
+        ],
+        "LoadBalancerArn": Object {
+          "Ref": "LoadBalancerManagefrontend184BCE6C",
+        },
+        "Port": 443,
+        "Protocol": "HTTPS",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+    },
     "LoadBalancerListener": Object {
       "Properties": Object {
         "Certificates": Array [
@@ -1269,6 +1924,113 @@ systemctl start manage-frontend
       },
       "Type": "AWS::ElasticLoadBalancingV2::Listener",
     },
+    "LoadBalancerManagefrontend184BCE6C": Object {
+      "Properties": Object {
+        "LoadBalancerAttributes": Array [
+          Object {
+            "Key": "deletion_protection.enabled",
+            "Value": "true",
+          },
+        ],
+        "Scheme": "internet-facing",
+        "SecurityGroups": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "LoadBalancerManagefrontendSecurityGroupED621ABF",
+              "GroupId",
+            ],
+          },
+        ],
+        "Subnets": Object {
+          "Ref": "managefrontendPublicSubnets",
+        },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "manage-frontend",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/manage-frontend",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Type": "application",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    },
+    "LoadBalancerManagefrontendSecurityGroupED621ABF": Object {
+      "Properties": Object {
+        "GroupDescription": "Automatically created Security Group for ELB ManageFrontendLoadBalancerManagefrontend0170C9E2",
+        "SecurityGroupIngress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow from anyone on port 443",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "manage-frontend",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/manage-frontend",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "LoadBalancerManagefrontendSecurityGrouptoManageFrontendGuHttpsEgressSecurityGroupManagefrontendD45FBEBD3000A633E9D8": Object {
+      "Properties": Object {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": Object {
+          "Fn::GetAtt": Array [
+            "GuHttpsEgressSecurityGroupManagefrontend8E53A220",
+            "GroupId",
+          ],
+        },
+        "FromPort": 3000,
+        "GroupId": Object {
+          "Fn::GetAtt": Array [
+            "LoadBalancerManagefrontendSecurityGroupED621ABF",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 3000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
     "LoadBalancerSecurityGroup": Object {
       "Properties": Object {
         "GroupDescription": "Permit incoming HTTPS access on port 443, egress to port 9233",
@@ -1289,10 +2051,6 @@ systemctl start manage-frontend
           },
         ],
         "Tags": Array [
-          Object {
-            "Key": "App",
-            "Value": "manage-frontend",
-          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -1324,9 +2082,31 @@ systemctl start manage-frontend
         "RetentionInDays": 14,
         "Tags": Array [
           Object {
-            "Key": "App",
-            "Value": "manage-frontend",
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
           },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/manage-frontend",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+    },
+    "ManageFrontendLogGroup7414E8CD": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "LogGroupName": "support-manage-frontend-TEST",
+        "RetentionInDays": 14,
+        "Tags": Array [
           Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -1346,6 +2126,7 @@ systemctl start manage-frontend
         ],
       },
       "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
     },
     "NoHealthyInstancesAlarm": Object {
       "Condition": "CreateProdResources",
@@ -1386,6 +2167,95 @@ systemctl start manage-frontend
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
+    "ParameterStoreReadManagefrontendB2A65B47": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/support/manage-frontend",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/support/manage-frontend/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "parameter-store-read-policy",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleManagefrontendC8EBF20D",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "PushLogs4B59405A": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "ManageFrontendLogGroup7414E8CD",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "PushLogs4B59405A",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleManagefrontendC8EBF20D",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "ReadFromDistBucketPolicy": Object {
       "Properties": Object {
         "PolicyDocument": Object {
@@ -1408,6 +2278,126 @@ systemctl start manage-frontend
       },
       "Type": "AWS::IAM::Policy",
     },
+    "ReadFromDistBucketPolicy7F95061E": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": "arn:aws:s3:::membership-dist/*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ReadFromDistBucketPolicy7F95061E",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleManagefrontendC8EBF20D",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ReadFulfilmentDateCalculatorOutputB22863A2": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": "arn:aws:s3:::fulfilment-date-calculator-TEST/*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ReadFulfilmentDateCalculatorOutputB22863A2",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleManagefrontendC8EBF20D",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ReadManageHelpContent49917399": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": "arn:aws:s3:::manage-help-content/TEST/*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ReadManageHelpContent49917399",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleManagefrontendC8EBF20D",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ReadPrivateCredentialsB593C891": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": "arn:aws:s3:::gu-reader-revenue-private/manage-frontend/TEST/*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ReadPrivateCredentialsB593C891",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleManagefrontendC8EBF20D",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "SSMRunCommandPolicy244E1613": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "ec2messages:AcknowledgeMessage",
+                "ec2messages:DeleteMessage",
+                "ec2messages:FailMessage",
+                "ec2messages:GetEndpoint",
+                "ec2messages:GetMessages",
+                "ec2messages:SendReply",
+                "ssm:UpdateInstanceInformation",
+                "ssm:ListInstanceAssociations",
+                "ssm:DescribeInstanceProperties",
+                "ssm:DescribeDocumentParameters",
+                "ssmmessages:CreateControlChannel",
+                "ssmmessages:CreateDataChannel",
+                "ssmmessages:OpenControlChannel",
+                "ssmmessages:OpenDataChannel",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ssm-run-command-policy",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleManagefrontendC8EBF20D",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "TargetGroup": Object {
       "DependsOn": Array [
         "ElasticLoadBalancer",
@@ -1425,10 +2415,6 @@ systemctl start manage-frontend
         "Port": 9233,
         "Protocol": "HTTP",
         "Tags": Array [
-          Object {
-            "Key": "App",
-            "Value": "manage-frontend",
-          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -1459,6 +2445,98 @@ systemctl start manage-frontend
       },
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
     },
+    "TargetGroupManagefrontend7AE2B787": Object {
+      "Properties": Object {
+        "HealthCheckIntervalSeconds": 10,
+        "HealthCheckPath": "/healthcheck",
+        "HealthCheckProtocol": "HTTP",
+        "HealthCheckTimeoutSeconds": 5,
+        "HealthyThresholdCount": 5,
+        "Port": 3000,
+        "Protocol": "HTTP",
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "manage-frontend",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/manage-frontend",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "TargetGroupAttributes": Array [
+          Object {
+            "Key": "deregistration_delay.timeout_seconds",
+            "Value": "30",
+          },
+          Object {
+            "Key": "stickiness.enabled",
+            "Value": "false",
+          },
+        ],
+        "TargetType": "instance",
+        "UnhealthyThresholdCount": 2,
+        "VpcId": Object {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    },
+    "WazuhSecurityGroup": Object {
+      "Properties": Object {
+        "GroupDescription": "Allow outbound traffic from wazuh agent to manager",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Wazuh event logging",
+            "FromPort": 1514,
+            "IpProtocol": "tcp",
+            "ToPort": 1514,
+          },
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Wazuh agent registration",
+            "FromPort": 1515,
+            "IpProtocol": "tcp",
+            "ToPort": 1515,
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/manage-frontend",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
     "WazuhSecurityGroupPreCDK": Object {
       "Properties": Object {
         "GroupDescription": "Allow outbound traffic from wazuh agent to manager",
@@ -1471,10 +2549,6 @@ systemctl start manage-frontend
           },
         ],
         "Tags": Array [
-          Object {
-            "Key": "App",
-            "Value": "manage-frontend",
-          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",

--- a/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
@@ -593,48 +593,48 @@ Object {
               "",
               Array [
                 "#!/bin/bash -ev
-            # get runnable tar from S3
-            aws --region ",
+# get runnable tar from S3
+aws --region ",
                 Object {
                   "Ref": "AWS::Region",
                 },
                 " s3 cp s3://membership-dist/support/TEST/manage-frontend/manage-frontend.zip /tmp
-            mkdir /etc/gu
-            unzip /tmp/manage-frontend.zip -d /etc/gu/dist/
-            # add user
-            groupadd manage-frontend
-            useradd -r -s /usr/bin/nologin -g manage-frontend manage-frontend
-            touch /var/log/manage-frontend.log
-            chown -R manage-frontend:manage-frontend /etc/gu
-            chown manage-frontend:manage-frontend /var/log/manage-frontend.log
-            # write out systemd file
-            cat >/etc/systemd/system/manage-frontend.service <<EOL
-            [Service]
-            ExecStart=/usr/bin/node /etc/gu/dist/server.js
-            Restart=always
-            StandardOutput=syslog
-            StandardError=syslog
-            SyslogIdentifier=manage-frontend
-            User=manage-frontend
-            Group=manage-frontend
-            Environment=STAGE=TEST
-            Environment=CLIENT_DSN=",
+mkdir /etc/gu
+unzip /tmp/manage-frontend.zip -d /etc/gu/dist/
+# add user
+groupadd manage-frontend
+useradd -r -s /usr/bin/nologin -g manage-frontend manage-frontend
+touch /var/log/manage-frontend.log
+chown -R manage-frontend:manage-frontend /etc/gu
+chown manage-frontend:manage-frontend /var/log/manage-frontend.log
+# write out systemd file
+cat >/etc/systemd/system/manage-frontend.service <<EOL
+[Service]
+ExecStart=/usr/bin/node /etc/gu/dist/server.js
+Restart=always
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=manage-frontend
+User=manage-frontend
+Group=manage-frontend
+Environment=STAGE=TEST
+Environment=CLIENT_DSN=",
                 Object {
                   "Ref": "clientRavenDSN",
                 },
                 "
-            Environment=SERVER_DSN=",
+Environment=SERVER_DSN=",
                 Object {
                   "Ref": "serverRavenDSN",
                 },
                 "
-            [Install]
-            WantedBy=multi-user.target
-            EOL
-            # RUN
-            systemctl enable manage-frontend
-            systemctl start manage-frontend
-            /opt/cloudwatch-logs/configure-logs application support TEST manage-frontend /var/log/manage-frontend.log",
+[Install]
+WantedBy=multi-user.target
+EOL
+# RUN
+systemctl enable manage-frontend
+systemctl start manage-frontend
+/opt/cloudwatch-logs/configure-logs application support TEST manage-frontend /var/log/manage-frontend.log",
               ],
             ],
           },

--- a/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
@@ -1304,7 +1304,7 @@ systemctl start manage-frontend
                       Object {
                         "Ref": "AWS::AccountId",
                       },
-                      ":stack/membership-TEST-*",
+                      ":stack/membership-DEV-*",
                     ],
                   ],
                 },
@@ -1320,7 +1320,39 @@ systemctl start manage-frontend
                       Object {
                         "Ref": "AWS::AccountId",
                       },
-                      ":stack/support-TEST-*",
+                      ":stack/membership-CODE-*",
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:aws:cloudformation:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":stack/support-DEV-*",
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:aws:cloudformation:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":stack/support-CODE-*",
                     ],
                   ],
                 },
@@ -1769,22 +1801,40 @@ systemctl start manage-frontend
             Object {
               "Action": "execute-api:Invoke",
               "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    "arn:aws:execute-api:",
-                    Object {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    Object {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":*/TEST/*",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:aws:execute-api:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":*/DEV/*",
+                    ],
                   ],
-                ],
-              },
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:aws:execute-api:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":*/TEST/*",
+                    ],
+                  ],
+                },
+              ],
             },
           ],
           "Version": "2012-10-17",

--- a/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
@@ -2405,10 +2405,7 @@ systemctl start manage-frontend
       "Properties": Object {
         "HealthCheckIntervalSeconds": 10,
         "HealthCheckPath": "/_healthcheck",
-        "HealthCheckPort": "9233",
         "HealthCheckProtocol": "HTTP",
-        "HealthCheckTimeoutSeconds": 5,
-        "HealthyThresholdCount": 2,
         "Name": Object {
           "Fn::Sub": "\${Stack}-\${Stage}-\${App}",
         },
@@ -2438,7 +2435,6 @@ systemctl start manage-frontend
             "Value": "45",
           },
         ],
-        "UnhealthyThresholdCount": 2,
         "VpcId": Object {
           "Ref": "VpcIdPreCDK",
         },

--- a/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
@@ -2449,7 +2449,7 @@ systemctl start manage-frontend
     "TargetGroupManagefrontend7AE2B787": Object {
       "Properties": Object {
         "HealthCheckIntervalSeconds": 10,
-        "HealthCheckPath": "/healthcheck",
+        "HealthCheckPath": "/_healthcheck",
         "HealthCheckProtocol": "HTTP",
         "HealthCheckTimeoutSeconds": 5,
         "HealthyThresholdCount": 5,

--- a/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
@@ -60,7 +60,6 @@ Object {
       "GuAllowPolicy",
       "GuAllowPolicy",
       "GuAllowPolicy",
-      "GuGetS3ObjectsPolicy",
       "GuVpcParameter",
       "GuSubnetListParameter",
       "GuCertificate",
@@ -2273,27 +2272,6 @@ systemctl start manage-frontend
         "Roles": Array [
           Object {
             "Ref": "AppRole",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "ReadFromDistBucketPolicy7F95061E": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "s3:GetObject",
-              "Effect": "Allow",
-              "Resource": "arn:aws:s3:::membership-dist/*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "ReadFromDistBucketPolicy7F95061E",
-        "Roles": Array [
-          Object {
-            "Ref": "InstanceRoleManagefrontendC8EBF20D",
           },
         ],
       },

--- a/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
@@ -497,7 +497,7 @@ Object {
           Object {
             "Key": "gu:cdk:pattern-name",
             "PropagateAtLaunch": true,
-            "Value": "GuNodeApp",
+            "Value": "GuEc2App",
           },
           Object {
             "Key": "gu:cdk:version",
@@ -1482,10 +1482,10 @@ systemctl start manage-frontend
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "GuHttpsEgressSecurityGroupManagefrontendfromManageFrontendLoadBalancerManagefrontendSecurityGroup4DBBACB9300072467277": Object {
+    "GuHttpsEgressSecurityGroupManagefrontendfromManageFrontendLoadBalancerManagefrontendSecurityGroup4DBBACB992338D8ADC65": Object {
       "Properties": Object {
         "Description": "Load balancer to target",
-        "FromPort": 3000,
+        "FromPort": 9233,
         "GroupId": Object {
           "Fn::GetAtt": Array [
             "GuHttpsEgressSecurityGroupManagefrontend8E53A220",
@@ -1499,7 +1499,7 @@ systemctl start manage-frontend
             "GroupId",
           ],
         },
-        "ToPort": 3000,
+        "ToPort": 9233,
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
     },
@@ -2059,7 +2059,7 @@ systemctl start manage-frontend
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "LoadBalancerManagefrontendSecurityGrouptoManageFrontendGuHttpsEgressSecurityGroupManagefrontendD45FBEBD3000A633E9D8": Object {
+    "LoadBalancerManagefrontendSecurityGrouptoManageFrontendGuHttpsEgressSecurityGroupManagefrontendD45FBEBD9233E0609005": Object {
       "Properties": Object {
         "Description": "Load balancer to target",
         "DestinationSecurityGroupId": Object {
@@ -2068,7 +2068,7 @@ systemctl start manage-frontend
             "GroupId",
           ],
         },
-        "FromPort": 3000,
+        "FromPort": 9233,
         "GroupId": Object {
           "Fn::GetAtt": Array [
             "LoadBalancerManagefrontendSecurityGroupED621ABF",
@@ -2076,7 +2076,7 @@ systemctl start manage-frontend
           ],
         },
         "IpProtocol": "tcp",
-        "ToPort": 3000,
+        "ToPort": 9233,
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
@@ -2453,7 +2453,7 @@ systemctl start manage-frontend
         "HealthCheckProtocol": "HTTP",
         "HealthCheckTimeoutSeconds": 5,
         "HealthyThresholdCount": 5,
-        "Port": 3000,
+        "Port": 9233,
         "Protocol": "HTTP",
         "Tags": Array [
           Object {

--- a/cdk/lib/manage-frontend.test.ts
+++ b/cdk/lib/manage-frontend.test.ts
@@ -8,6 +8,7 @@ describe('The ManageFrontend stack', () => {
 		const stack = new ManageFrontend(app, 'ManageFrontend', {
 			stack: 'support',
 			stage: 'TEST',
+			scaling: { minimumInstances: 1 },
 			domain: 'manage.code.theguardian.com.origin.membership.guardianapis.com',
 		});
 		const template = Template.fromStack(stack);

--- a/cdk/lib/manage-frontend.ts
+++ b/cdk/lib/manage-frontend.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import { GuNodeApp } from '@guardian/cdk';
+import { GuEc2App } from '@guardian/cdk';
 import { AccessScope } from '@guardian/cdk/lib/constants';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack, GuStringParameter } from '@guardian/cdk/lib/constructs/core';
@@ -102,8 +102,9 @@ systemctl start manage-frontend
 		) as CfnLogGroup;
 
 		// docs https://guardian.github.io/cdk/classes/patterns.GuEc2App.html
-		const nodeApp = new GuNodeApp(this, {
+		const nodeApp = new GuEc2App(this, {
 			access: { scope: AccessScope.PUBLIC },
+			applicationPort: 9233, // TODO: why has this number been choosen?
 			app,
 			certificateProps: {
 				domainName: props.domain,

--- a/cdk/lib/manage-frontend.ts
+++ b/cdk/lib/manage-frontend.ts
@@ -150,10 +150,18 @@ systemctl start manage-frontend
 					),
 					new GuAllowPolicy(this, 'DiscoverApiGatewayLambdas', {
 						actions: ['cloudformation:ListStackResources'],
-						resources: [
-							`arn:aws:cloudformation:${this.region}:${this.account}:stack/membership-${this.stage}-*`,
-							`arn:aws:cloudformation:${this.region}:${this.account}:stack/support-${this.stage}-*`,
-						],
+						resources:
+							this.stage === 'PROD'
+								? [
+										`arn:aws:cloudformation:${this.region}:${this.account}:stack/membership-${this.stage}-*`,
+										`arn:aws:cloudformation:${this.region}:${this.account}:stack/support-${this.stage}-*`,
+								  ]
+								: [
+										`arn:aws:cloudformation:${this.region}:${this.account}:stack/membership-DEV-*`,
+										`arn:aws:cloudformation:${this.region}:${this.account}:stack/membership-CODE-*`,
+										`arn:aws:cloudformation:${this.region}:${this.account}:stack/support-DEV-*`,
+										`arn:aws:cloudformation:${this.region}:${this.account}:stack/support-CODE-*`,
+								  ],
 					}),
 					new GuAllowPolicy(this, 'DiscoverApiGatewayApiKeys', {
 						actions: ['apigateway:GET'],
@@ -163,9 +171,15 @@ systemctl start manage-frontend
 					}),
 					new GuAllowPolicy(this, 'InvokeApiGateway', {
 						actions: ['execute-api:Invoke'],
-						resources: [
-							`arn:aws:execute-api:${this.region}:${this.account}:*/${this.stage}/*`,
-						],
+						resources:
+							this.stage === 'PROD'
+								? [
+										`arn:aws:execute-api:${this.region}:${this.account}:*/${this.stage}/*`,
+								  ]
+								: [
+										`arn:aws:execute-api:${this.region}:${this.account}:*/DEV/*`,
+										`arn:aws:execute-api:${this.region}:${this.account}:*/${this.stage}/*`,
+								  ],
 					}),
 				],
 			},

--- a/cdk/lib/manage-frontend.ts
+++ b/cdk/lib/manage-frontend.ts
@@ -1,19 +1,34 @@
 import { join } from 'path';
+import { GuNodeApp } from '@guardian/cdk';
+import { AccessScope } from '@guardian/cdk/lib/constants';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack, GuStringParameter } from '@guardian/cdk/lib/constructs/core';
+import {
+	GuAllowPolicy,
+	GuGetS3ObjectsPolicy,
+	GuPutCloudwatchMetricsPolicy,
+} from '@guardian/cdk/lib/constructs/iam';
+import type { GuAsgCapacity } from '@guardian/cdk/lib/types';
 import type { App } from 'aws-cdk-lib';
+import { Tags } from 'aws-cdk-lib';
+import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
 import type { CfnLoadBalancer } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { CfnRecordSet } from 'aws-cdk-lib/aws-route53';
 import { CfnInclude } from 'aws-cdk-lib/cloudformation-include';
 
 interface ManageGuStackProps extends GuStackProps {
+	scaling: GuAsgCapacity;
 	domain: string;
 }
+
 export class ManageFrontend extends GuStack {
 	constructor(scope: App, id: string, props: ManageGuStackProps) {
 		super(scope, id, props);
-		this.addTag('App', 'manage-frontend');
 		const yamlTemplateFilePath = join(__dirname, '../..', 'cfn.yaml');
+
+		const app = 'manage-frontend';
+
 		const existingYaml = new CfnInclude(this, 'YamlTemplate', {
 			templateFile: yamlTemplateFilePath,
 		});
@@ -36,5 +51,136 @@ export class ManageFrontend extends GuStack {
 				hostedZoneId: loadBalancer.attrCanonicalHostedZoneId,
 			},
 		});
+
+		const clientRavenDSN = new GuStringParameter(this, 'clientRavenDSN', {
+			description: 'the DSN to use with Sentry on the client',
+			fromSSM: true,
+			default: `/${this.stage}/${this.stack}/${app}/clientRavenDSN`,
+		});
+
+		const serverRavenDSN = new GuStringParameter(this, 'serverRavenDSN', {
+			description: 'the DSN to use with Sentry on the server',
+			fromSSM: true,
+			default: `/${this.stage}/${this.stack}/${app}/serverRavenDSN`,
+		});
+
+		const userData = `#!/bin/bash -ev
+            # get runnable tar from S3
+            aws --region ${this.region} s3 cp s3://membership-dist/${this.stack}/${this.stage}/${app}/manage-frontend.zip /tmp
+            mkdir /etc/gu
+            unzip /tmp/manage-frontend.zip -d /etc/gu/dist/
+            # add user
+            groupadd manage-frontend
+            useradd -r -s /usr/bin/nologin -g manage-frontend manage-frontend
+            touch /var/log/manage-frontend.log
+            chown -R manage-frontend:manage-frontend /etc/gu
+            chown manage-frontend:manage-frontend /var/log/manage-frontend.log
+            # write out systemd file
+            cat >/etc/systemd/system/manage-frontend.service <<EOL
+            [Service]
+            ExecStart=/usr/bin/node /etc/gu/dist/server.js
+            Restart=always
+            StandardOutput=syslog
+            StandardError=syslog
+            SyslogIdentifier=manage-frontend
+            User=manage-frontend
+            Group=manage-frontend
+            Environment=STAGE=${this.stage}
+            Environment=CLIENT_DSN=${clientRavenDSN.valueAsString}
+            Environment=SERVER_DSN=${serverRavenDSN.valueAsString}
+            [Install]
+            WantedBy=multi-user.target
+            EOL
+            # RUN
+            systemctl enable manage-frontend
+            systemctl start manage-frontend
+            /opt/cloudwatch-logs/configure-logs application ${this.stack} ${this.stage} ${app} /var/log/manage-frontend.log`;
+
+		const logGroup = new LogGroup(this, 'ManageFrontendLogGroup', {
+			logGroupName: `support-manage-frontend-${this.stage}`,
+			retention: RetentionDays.TWO_WEEKS,
+		});
+
+		// docs https://guardian.github.io/cdk/classes/patterns.GuEc2App.html
+		const nodeApp = new GuNodeApp(this, {
+			access: { scope: AccessScope.PUBLIC },
+			app,
+			certificateProps: {
+				domainName: props.domain,
+				// `dig NS manage.theguardian.com.origin.membership.guardianapis.com` shows the nameserver as `ns-1529.awsdns-63.org`, which is Route53
+				// https://prism.gutools.co.uk/route53-zones tells us the zone id for 'membership.guardianapis.com'
+				hostedZoneId: 'Z1E4V12LQGXFEC',
+			},
+			instanceType: InstanceType.of(
+				InstanceClass.T4G,
+				InstanceSize.SMALL,
+			),
+			monitoringConfiguration: {
+				noMonitoring: true,
+			},
+			scaling: props.scaling,
+			userData,
+			roleConfiguration: {
+				additionalPolicies: [
+					new GuAllowPolicy(this, 'PushLogs', {
+						actions: [
+							'logs:CreateLogGroup',
+							'logs:CreateLogStream',
+							'logs:PutLogEvents',
+						],
+						resources: [logGroup.logGroupArn],
+					}),
+					new GuPutCloudwatchMetricsPolicy(this),
+					// TODO: whats this bucket used for and are we doing the right thing?
+					new GuGetS3ObjectsPolicy(this, 'ReadPrivateCredentials', {
+						bucketName: 'gu-reader-revenue-private',
+						paths: [`${app}/${this.stage}/*`],
+					}),
+					// we're using a wild card for the help center content as the bucket only contains public json files needed to display the help center pages
+					new GuGetS3ObjectsPolicy(this, 'ReadManageHelpContent', {
+						bucketName: 'manage-help-content',
+						paths: [`${this.stage}/*`],
+					}),
+					new GuGetS3ObjectsPolicy(
+						this,
+						'ReadFulfilmentDateCalculatorOutput',
+						{
+							bucketName: `fulfilment-date-calculator-${this.stage}`,
+							paths: ['*'],
+						},
+					),
+					new GuAllowPolicy(this, 'DiscoverApiGatewayLambdas', {
+						actions: ['cloudformation:ListStackResources'],
+						resources: [
+							`arn:aws:cloudformation:${this.region}:${this.account}:stack/membership-${this.stage}-*`,
+							`arn:aws:cloudformation:${this.region}:${this.account}:stack/support-${this.stage}-*`,
+						],
+					}),
+					new GuAllowPolicy(this, 'DiscoverApiGatewayApiKeys', {
+						actions: ['apigateway:GET'],
+						resources: [
+							`arn:aws:apigateway:${this.region}::/apikeys/*`,
+						],
+					}),
+					new GuAllowPolicy(this, 'InvokeApiGateway', {
+						actions: ['execute-api:Invoke'],
+						resources: [
+							`arn:aws:execute-api:${this.region}:${this.account}:*/${this.stage}/*`,
+						],
+					}),
+
+					// TODO tighten this and read the bucket name from SSM Parameter Store
+					// https://github.com/guardian/recommendations/blob/main/github.md#repository-contents
+					// https://github.com/guardian/cdk/blob/main/src/constructs/iam/policies/s3-get-object.ts#L22-L60
+					new GuGetS3ObjectsPolicy(this, 'ReadFromDistBucketPolicy', {
+						bucketName: 'membership-dist',
+						paths: ['*'],
+					}),
+				],
+			},
+		});
+
+		const nodeAppAsg = nodeApp.autoScalingGroup;
+		Tags.of(nodeAppAsg).add('gu:riffraff:new-asg', 'true');
 	}
 }

--- a/cdk/lib/manage-frontend.ts
+++ b/cdk/lib/manage-frontend.ts
@@ -21,7 +21,6 @@ interface ManageGuStackProps extends GuStackProps {
 	scaling: GuAsgCapacity;
 	domain: string;
 }
-
 export class ManageFrontend extends GuStack {
 	constructor(scope: App, id: string, props: ManageGuStackProps) {
 		super(scope, id, props);
@@ -64,37 +63,38 @@ export class ManageFrontend extends GuStack {
 			default: `/${this.stage}/${this.stack}/${app}/serverRavenDSN`,
 		});
 
+		// intentionally removed tabs from the following string for bash's sake!
 		const userData = `#!/bin/bash -ev
-            # get runnable tar from S3
-            aws --region ${this.region} s3 cp s3://membership-dist/${this.stack}/${this.stage}/${app}/manage-frontend.zip /tmp
-            mkdir /etc/gu
-            unzip /tmp/manage-frontend.zip -d /etc/gu/dist/
-            # add user
-            groupadd manage-frontend
-            useradd -r -s /usr/bin/nologin -g manage-frontend manage-frontend
-            touch /var/log/manage-frontend.log
-            chown -R manage-frontend:manage-frontend /etc/gu
-            chown manage-frontend:manage-frontend /var/log/manage-frontend.log
-            # write out systemd file
-            cat >/etc/systemd/system/manage-frontend.service <<EOL
-            [Service]
-            ExecStart=/usr/bin/node /etc/gu/dist/server.js
-            Restart=always
-            StandardOutput=syslog
-            StandardError=syslog
-            SyslogIdentifier=manage-frontend
-            User=manage-frontend
-            Group=manage-frontend
-            Environment=STAGE=${this.stage}
-            Environment=CLIENT_DSN=${clientRavenDSN.valueAsString}
-            Environment=SERVER_DSN=${serverRavenDSN.valueAsString}
-            [Install]
-            WantedBy=multi-user.target
-            EOL
-            # RUN
-            systemctl enable manage-frontend
-            systemctl start manage-frontend
-            /opt/cloudwatch-logs/configure-logs application ${this.stack} ${this.stage} ${app} /var/log/manage-frontend.log`;
+# get runnable tar from S3
+aws --region ${this.region} s3 cp s3://membership-dist/${this.stack}/${this.stage}/${app}/manage-frontend.zip /tmp
+mkdir /etc/gu
+unzip /tmp/manage-frontend.zip -d /etc/gu/dist/
+# add user
+groupadd manage-frontend
+useradd -r -s /usr/bin/nologin -g manage-frontend manage-frontend
+touch /var/log/manage-frontend.log
+chown -R manage-frontend:manage-frontend /etc/gu
+chown manage-frontend:manage-frontend /var/log/manage-frontend.log
+# write out systemd file
+cat >/etc/systemd/system/manage-frontend.service <<EOL
+[Service]
+ExecStart=/usr/bin/node /etc/gu/dist/server.js
+Restart=always
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=manage-frontend
+User=manage-frontend
+Group=manage-frontend
+Environment=STAGE=${this.stage}
+Environment=CLIENT_DSN=${clientRavenDSN.valueAsString}
+Environment=SERVER_DSN=${serverRavenDSN.valueAsString}
+[Install]
+WantedBy=multi-user.target
+EOL
+# RUN
+systemctl enable manage-frontend
+systemctl start manage-frontend
+/opt/cloudwatch-logs/configure-logs application ${this.stack} ${this.stage} ${app} /var/log/manage-frontend.log`;
 
 		const logGroup = existingYaml.getResource(
 			'ManageFrontendLogGroup',

--- a/cdk/lib/manage-frontend.ts
+++ b/cdk/lib/manage-frontend.ts
@@ -168,14 +168,6 @@ export class ManageFrontend extends GuStack {
 							`arn:aws:execute-api:${this.region}:${this.account}:*/${this.stage}/*`,
 						],
 					}),
-
-					// TODO tighten this and read the bucket name from SSM Parameter Store
-					// https://github.com/guardian/recommendations/blob/main/github.md#repository-contents
-					// https://github.com/guardian/cdk/blob/main/src/constructs/iam/policies/s3-get-object.ts#L22-L60
-					new GuGetS3ObjectsPolicy(this, 'ReadFromDistBucketPolicy', {
-						bucketName: 'membership-dist',
-						paths: ['*'],
-					}),
 				],
 			},
 		});

--- a/cdk/lib/manage-frontend.ts
+++ b/cdk/lib/manage-frontend.ts
@@ -10,9 +10,10 @@ import {
 } from '@guardian/cdk/lib/constructs/iam';
 import type { GuAsgCapacity } from '@guardian/cdk/lib/types';
 import type { App } from 'aws-cdk-lib';
-import { Tags } from 'aws-cdk-lib';
+import { Duration, Tags } from 'aws-cdk-lib';
 import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
 import type { CfnLoadBalancer } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import { Protocol } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import type { CfnLogGroup } from 'aws-cdk-lib/aws-logs';
 import { CfnRecordSet } from 'aws-cdk-lib/aws-route53';
 import { CfnInclude } from 'aws-cdk-lib/cloudformation-include';
@@ -183,6 +184,15 @@ systemctl start manage-frontend
 					}),
 				],
 			},
+		});
+
+		nodeApp.targetGroup.configureHealthCheck({
+			path: '/_healthcheck',
+			healthyThresholdCount: 5,
+			unhealthyThresholdCount: 2,
+			interval: Duration.seconds(10),
+			timeout: Duration.seconds(5),
+			protocol: Protocol.HTTP,
 		});
 
 		const nodeAppAsg = nodeApp.autoScalingGroup;

--- a/cdk/lib/manage-frontend.ts
+++ b/cdk/lib/manage-frontend.ts
@@ -13,7 +13,7 @@ import type { App } from 'aws-cdk-lib';
 import { Tags } from 'aws-cdk-lib';
 import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
 import type { CfnLoadBalancer } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
-import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
+import type { CfnLogGroup } from 'aws-cdk-lib/aws-logs';
 import { CfnRecordSet } from 'aws-cdk-lib/aws-route53';
 import { CfnInclude } from 'aws-cdk-lib/cloudformation-include';
 
@@ -96,10 +96,9 @@ export class ManageFrontend extends GuStack {
             systemctl start manage-frontend
             /opt/cloudwatch-logs/configure-logs application ${this.stack} ${this.stage} ${app} /var/log/manage-frontend.log`;
 
-		const logGroup = new LogGroup(this, 'ManageFrontendLogGroup', {
-			logGroupName: `support-manage-frontend-${this.stage}`,
-			retention: RetentionDays.TWO_WEEKS,
-		});
+		const logGroup = existingYaml.getResource(
+			'ManageFrontendLogGroup',
+		) as CfnLogGroup;
 
 		// docs https://guardian.github.io/cdk/classes/patterns.GuEc2App.html
 		const nodeApp = new GuNodeApp(this, {
@@ -128,7 +127,7 @@ export class ManageFrontend extends GuStack {
 							'logs:CreateLogStream',
 							'logs:PutLogEvents',
 						],
-						resources: [logGroup.logGroupArn],
+						resources: [logGroup.attrArn],
 					}),
 					new GuPutCloudwatchMetricsPolicy(this),
 					// TODO: whats this bucket used for and are we doing the right thing?

--- a/cdk/lib/manage-frontend.ts
+++ b/cdk/lib/manage-frontend.ts
@@ -163,7 +163,7 @@ systemctl start manage-frontend
 										`arn:aws:cloudformation:${this.region}:${this.account}:stack/membership-CODE-*`,
 										`arn:aws:cloudformation:${this.region}:${this.account}:stack/support-DEV-*`,
 										`arn:aws:cloudformation:${this.region}:${this.account}:stack/support-CODE-*`,
-								  ],
+								  ], // TODO: why does CODE depend on DEV here?
 					}),
 					new GuAllowPolicy(this, 'DiscoverApiGatewayApiKeys', {
 						actions: ['apigateway:GET'],
@@ -181,7 +181,7 @@ systemctl start manage-frontend
 								: [
 										`arn:aws:execute-api:${this.region}:${this.account}:*/DEV/*`,
 										`arn:aws:execute-api:${this.region}:${this.account}:*/${this.stage}/*`,
-								  ],
+								  ], // TODO: why does CODE depend on DEV here?
 					}),
 				],
 			},

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -289,7 +289,11 @@ Resources:
         Ref: VpcIdPreCDK
       HealthCheckIntervalSeconds: 10
       HealthCheckPath: /_healthcheck
+      HealthCheckPort: 9233
       HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 2
       TargetGroupAttributes:
         - Key: deregistration_delay.timeout_seconds
           Value: 45 # only connection drains for 45 seconds (rather than default of 300)

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -289,11 +289,7 @@ Resources:
         Ref: VpcIdPreCDK
       HealthCheckIntervalSeconds: 10
       HealthCheckPath: /_healthcheck
-      HealthCheckPort: 9233
       HealthCheckProtocol: HTTP
-      HealthCheckTimeoutSeconds: 5
-      HealthyThresholdCount: 2
-      UnhealthyThresholdCount: 2
       TargetGroupAttributes:
         - Key: deregistration_delay.timeout_seconds
           Value: 45 # only connection drains for 45 seconds (rather than default of 300)

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -22,6 +22,7 @@ deployments:
         Recipe: manage-frontend-arm-node16
         AmigoStage: PROD
       amiEncrypted: true
+      amiParameter: AMIManagefrontend
   manage-frontend:
     type: autoscaling
     dependencies: [manage-frontend-cloudformation]


### PR DESCRIPTION
## What does this change?
Define manage-frontend infrastructure in guCDK.

This setup should allow us to dual run the application via the old cfn.yaml file as well the new guCDK setup.

This represents the entirety of step 1 in the following migration guide: https://github.com/guardian/cdk/blob/main/docs/migration-guide-ec2.md