### PR TITLE
Decouple payment update spec from GoCardless

### DIFF
--- a/cypress/integration/parallel-1/updatePaymentDetails.spec.ts
+++ b/cypress/integration/parallel-1/updatePaymentDetails.spec.ts
@@ -88,6 +88,11 @@ describe('Update payment details', () => {
 			body: [digitalDD],
 		}).as('product_detail');
 
+		cy.intercept('POST', '/api/validate/payment/**', {
+			statusCode: 200,
+			body: { data: { accountValid: false } },
+		}).as('validate_dd');
+
 		cy.visit('/payment/digital');
 
 		cy.wait('@product_detail');
@@ -113,6 +118,9 @@ describe('Update payment details', () => {
 
 		cy.get('input[name="accountHolderConfirmation"').click();
 		cy.findByText('Update payment method').click();
+
+		cy.wait('@validate_dd');
+
 		cy.findByText(
 			'Your bank details are invalid. Please check them and try again.',
 		);
@@ -128,6 +136,11 @@ describe('Update payment details', () => {
 			statusCode: 200,
 			body: [digitalDD],
 		}).as('refetch_subscription');
+
+		cy.intercept('POST', '/api/validate/payment/**', {
+			statusCode: 200,
+			body: { data: { accountValid: true } },
+		}).as('validate_dd');
 
 		cy.intercept('POST', '/api/payment/dd/**', {
 			statusCode: 200,
@@ -150,6 +163,7 @@ describe('Update payment details', () => {
 		cy.get('input[name="accountHolderConfirmation"').click();
 		cy.findByText('Update payment method').click();
 
+		cy.wait('@validate_dd');
 		cy.wait('@scala_backend');
 		cy.wait('@refetch_subscription');
 
@@ -168,6 +182,11 @@ describe('Update payment details', () => {
 			statusCode: 200,
 			body: [digitalDD],
 		}).as('refetch_subscription');
+
+		cy.intercept('POST', '/api/validate/payment/**', {
+			statusCode: 200,
+			body: { data: { accountValid: true } },
+		}).as('validate_dd');
 
 		cy.intercept('POST', '/api/payment/dd/**', {
 			statusCode: 500,
@@ -189,6 +208,7 @@ describe('Update payment details', () => {
 		cy.get('input[name="accountHolderConfirmation"').click();
 		cy.findByText('Update payment method').click();
 
+		cy.wait('@validate_dd');
 		cy.wait('@scala_backend');
 
 		cy.findByText('Try again');


### PR DESCRIPTION
## What does this change?

The payment update spec was calling the real `/api/validate/payment/dd?mode=live` endpoint which in turn was calling out to GoCardless. This intercepts the API call and mocks the response in the relevant payment update tests so there is no reliance on real APIs.

## Have we considered potential risks?

It's not entirely clear why this was previously working, so it's possible that it may fail again.