### PR TITLE
Introduce route53

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -6,8 +6,10 @@ const app = new App();
 new ManageFrontend(app, 'ManageFrontend-CODE', {
 	stack: 'support',
 	stage: 'CODE',
+	domain: 'manage.code.dev-theguardian.com.origin.membership.guardianapis.com',
 });
 new ManageFrontend(app, 'ManageFrontend-PROD', {
 	stack: 'support',
 	stage: 'PROD',
+	domain: 'manage.theguardian.com.origin.membership.guardianapis.com',
 });

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -6,10 +6,12 @@ const app = new App();
 new ManageFrontend(app, 'ManageFrontend-CODE', {
 	stack: 'support',
 	stage: 'CODE',
-	domain: 'manage.code.dev-theguardian.com.origin.membership.guardianapis.com',
+	domain: 'manage.code.theguardian.com.origin.membership.guardianapis.com',
+	cloudFormationStackName: 'support-CODE-manage-frontend',
 });
 new ManageFrontend(app, 'ManageFrontend-PROD', {
 	stack: 'support',
 	stage: 'PROD',
 	domain: 'manage.theguardian.com.origin.membership.guardianapis.com',
+	cloudFormationStackName: 'support-PROD-manage-frontend',
 });

--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -1,5 +1,6 @@
 {
   "app": "npx ts-node bin/cdk.ts",
+  "profile": "membership",
   "context": {
     "aws-cdk:enableDiffNoFail": "true",
     "@aws-cdk/core:stackRelativeExports": "true"

--- a/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
@@ -116,7 +116,10 @@ Object {
             ],
           },
           "HostedZoneId": Object {
-            "Ref": "hostedZoneId",
+            "Fn::GetAtt": Array [
+              "ElasticLoadBalancer",
+              "CanonicalHostedZoneID",
+            ],
           },
         },
         "HostedZoneId": Object {

--- a/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
@@ -125,7 +125,7 @@ Object {
         "HostedZoneId": Object {
           "Ref": "hostedZoneId",
         },
-        "Name": "manage.code.dev-theguardian.com.origin.membership.guardianapis.com",
+        "Name": "manage.code.theguardian.com.origin.membership.guardianapis.com",
         "Type": "A",
       },
       "Type": "AWS::Route53::RecordSet",

--- a/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
@@ -48,7 +48,9 @@ Object {
     },
   },
   "Metadata": Object {
-    "gu:cdk:constructs": Array [],
+    "gu:cdk:constructs": Array [
+      "GuStringParameter",
+    ],
     "gu:cdk:version": "47.3.1",
   },
   "Parameters": Object {
@@ -98,8 +100,33 @@ Object {
       "Description": "VpcId of your existing Virtual Private Cloud (VPC)",
       "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
     },
+    "hostedZoneId": Object {
+      "Default": "/account/route53/membership/hostedZoneId",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
   },
   "Resources": Object {
+    "AliasRecord": Object {
+      "Properties": Object {
+        "AliasTarget": Object {
+          "DNSName": Object {
+            "Fn::GetAtt": Array [
+              "ElasticLoadBalancer",
+              "DNSName",
+            ],
+          },
+          "HostedZoneId": Object {
+            "Ref": "hostedZoneId",
+          },
+        },
+        "HostedZoneId": Object {
+          "Ref": "hostedZoneId",
+        },
+        "Name": "manage.code.dev-theguardian.com.origin.membership.guardianapis.com",
+        "Type": "A",
+      },
+      "Type": "AWS::Route53::RecordSet",
+    },
     "AppRole": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {

--- a/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
@@ -296,6 +296,10 @@ Object {
         ],
         "Tags": Array [
           Object {
+            "Key": "App",
+            "Value": "manage-frontend",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -344,9 +348,7 @@ Object {
           Object {
             "Key": "App",
             "PropagateAtLaunch": true,
-            "Value": Object {
-              "Ref": "App",
-            },
+            "Value": "manage-frontend",
           },
           Object {
             "Key": "gu:cdk:version",
@@ -963,9 +965,7 @@ Object {
         "Tags": Array [
           Object {
             "Key": "App",
-            "Value": Object {
-              "Ref": "App",
-            },
+            "Value": "manage-frontend",
           },
           Object {
             "Key": "gu:cdk:version",
@@ -1143,6 +1143,10 @@ Object {
         ],
         "Tags": Array [
           Object {
+            "Key": "App",
+            "Value": "manage-frontend",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -1286,6 +1290,10 @@ systemctl start manage-frontend
         ],
         "Tags": Array [
           Object {
+            "Key": "App",
+            "Value": "manage-frontend",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -1315,6 +1323,10 @@ systemctl start manage-frontend
         },
         "RetentionInDays": 14,
         "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "manage-frontend",
+          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -1414,6 +1426,10 @@ systemctl start manage-frontend
         "Protocol": "HTTP",
         "Tags": Array [
           Object {
+            "Key": "App",
+            "Value": "manage-frontend",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -1455,6 +1471,10 @@ systemctl start manage-frontend
           },
         ],
         "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "manage-frontend",
+          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",

--- a/cdk/lib/manage-frontend.test.ts
+++ b/cdk/lib/manage-frontend.test.ts
@@ -8,7 +8,7 @@ describe('The ManageFrontend stack', () => {
 		const stack = new ManageFrontend(app, 'ManageFrontend', {
 			stack: 'support',
 			stage: 'TEST',
-			domain: 'manage.code.dev-theguardian.com.origin.membership.guardianapis.com',
+			domain: 'manage.code.theguardian.com.origin.membership.guardianapis.com',
 		});
 		const template = Template.fromStack(stack);
 		expect(template.toJSON()).toMatchSnapshot();

--- a/cdk/lib/manage-frontend.test.ts
+++ b/cdk/lib/manage-frontend.test.ts
@@ -8,6 +8,7 @@ describe('The ManageFrontend stack', () => {
 		const stack = new ManageFrontend(app, 'ManageFrontend', {
 			stack: 'support',
 			stage: 'TEST',
+			domain: 'manage.code.dev-theguardian.com.origin.membership.guardianapis.com',
 		});
 		const template = Template.fromStack(stack);
 		expect(template.toJSON()).toMatchSnapshot();

--- a/cdk/lib/manage-frontend.ts
+++ b/cdk/lib/manage-frontend.ts
@@ -32,7 +32,7 @@ export class ManageFrontend extends GuStack {
 			hostedZoneId,
 			aliasTarget: {
 				dnsName: loadBalancer.attrDnsName,
-				hostedZoneId,
+				hostedZoneId: loadBalancer.attrCanonicalHostedZoneId,
 			},
 		});
 	}

--- a/cdk/lib/manage-frontend.ts
+++ b/cdk/lib/manage-frontend.ts
@@ -1,15 +1,39 @@
 import { join } from 'path';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
-import { GuStack } from '@guardian/cdk/lib/constructs/core';
+import { GuStack, GuStringParameter } from '@guardian/cdk/lib/constructs/core';
 import type { App } from 'aws-cdk-lib';
+import type { CfnLoadBalancer } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import { CfnRecordSet } from 'aws-cdk-lib/aws-route53';
 import { CfnInclude } from 'aws-cdk-lib/cloudformation-include';
 
+interface ManageGuStackProps extends GuStackProps {
+	domain: string;
+}
 export class ManageFrontend extends GuStack {
-	constructor(scope: App, id: string, props: GuStackProps) {
+	constructor(scope: App, id: string, props: ManageGuStackProps) {
 		super(scope, id, props);
 		const yamlTemplateFilePath = join(__dirname, '../..', 'cfn.yaml');
-		new CfnInclude(this, 'YamlTemplate', {
+		const existingYaml = new CfnInclude(this, 'YamlTemplate', {
 			templateFile: yamlTemplateFilePath,
+		});
+
+		const loadBalancer = existingYaml.getResource(
+			'ElasticLoadBalancer',
+		) as CfnLoadBalancer;
+
+		const hostedZoneId = new GuStringParameter(this, 'hostedZoneId', {
+			fromSSM: true,
+			default: '/account/route53/membership/hostedZoneId',
+		}).valueAsString;
+
+		new CfnRecordSet(this, 'AliasRecord', {
+			name: props.domain,
+			type: 'A',
+			hostedZoneId,
+			aliasTarget: {
+				dnsName: loadBalancer.attrDnsName,
+				hostedZoneId,
+			},
 		});
 	}
 }

--- a/cdk/lib/manage-frontend.ts
+++ b/cdk/lib/manage-frontend.ts
@@ -12,6 +12,7 @@ interface ManageGuStackProps extends GuStackProps {
 export class ManageFrontend extends GuStack {
 	constructor(scope: App, id: string, props: ManageGuStackProps) {
 		super(scope, id, props);
+		this.addTag('App', 'manage-frontend');
 		const yamlTemplateFilePath = join(__dirname, '../..', 'cfn.yaml');
 		const existingYaml = new CfnInclude(this, 'YamlTemplate', {
 			templateFile: yamlTemplateFilePath,

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -8,7 +8,8 @@
     "format": "prettier --write \"{lib,bin}/**/*.ts\"",
     "lint": "eslint lib/** bin/** --ext .ts --no-error-on-unmatched-pattern",
     "synth": "cdk synth --path-metadata false --version-reporting false",
-    "diff": "cdk diff --path-metadata false --version-reporting false"
+    "diff": "cdk diff --path-metadata false --version-reporting false",
+    "deploy-code": "cdk deploy --path-metadata false --version-reporting false ManageFrontend-CODE"
   },
   "devDependencies": {
     "@guardian/cdk": "47.3.1",


### PR DESCRIPTION
## What does this change?
Introduce the route53 DNS layer in between fastly and the load balancers. 

This helps us manage the migration to cdk, as part of the dual stack deployment (before we tear down the old stack) we can make routing changes at the DNS (route53) level instead of messing around in fastly.

Added a new deploy-code script in package.json and explicitly set the `App` tag via cdk hence why the snapshot is larger than just the route53 changes.
