### PR TITLE
Exclude `node_modules` from server bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "webpack-cli": "^4.9.1",
     "webpack-dev-server": "^4.4.0",
     "webpack-merge": "^5.8.0",
+    "webpack-node-externals": "^3.0.0",
     "whatwg-fetch": "^2.0.4"
   },
   "dependencies": {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -6,6 +6,7 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 const GitRevisionPlugin = require('git-revision-webpack-plugin');
 const NodePolyfillPlugin = require('node-polyfill-webpack-plugin');
 const babelLoaderExcludeNodeModulesExcept = require('babel-loader-exclude-node-modules-except');
+const nodeExternals = require('webpack-node-externals');
 
 const assetsPluginInstance = new AssetsPlugin({
 	path: path.resolve(__dirname, './dist/'),
@@ -70,6 +71,7 @@ const server = merge(common, {
 		__dirname: false,
 		__filename: false,
 	},
+	externals: [nodeExternals()],
 	module: {
 		rules: [
 			{

--- a/yarn.lock
+++ b/yarn.lock
@@ -16891,6 +16891,11 @@ webpack-merge@^5.7.3, webpack-merge@^5.8.0:
     clone-deep "^4.0.1"
     wildcard "^2.0.0"
 
+webpack-node-externals@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/webpack-node-externals/-/webpack-node-externals-3.0.0.tgz#1a3407c158d547a9feb4229a9e3385b7b60c9917"
+  integrity sha512-LnL6Z3GGDPht/AigwRh2dvL9PQPFQ8skEpVrWZXLWBYmqcaojHNN0onvHzie6rq7EWKrrBfPYqNEzTJgiwEQDQ==
+
 webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"


### PR DESCRIPTION
## What does this change?

Exclude `node_modules` from server bundle. These modules are already available on the server and generate warnings when bundled:

```
WARNING in ./node_modules/express/lib/view.js 81:13-25
Critical dependency: the request of a dependency is an expression
 @ ./node_modules/express/lib/application.js 22:11-28
 @ ./node_modules/express/lib/express.js 18:12-36
 @ ./node_modules/express/index.js 11:0-41
 @ ./server/server.ts 4:0-45 11:15-22 35:22-36

1 warning has detailed information that is not shown.
Use 'stats.errorDetails: true' resp. '--stats-error-details' to show it.
```

The [`webpack-node-externals`](https://github.com/liady/webpack-node-externals) package is used to scan `node_modules` to generate a list of modules to exclude from the bundle.