### PR TITLE
Switch cancellation API for Supporter Plus

### DIFF
--- a/client/components/cancel/stages/executeCancellation.tsx
+++ b/client/components/cancel/stages/executeCancellation.tsx
@@ -37,7 +37,7 @@ const getCancelFunc =
 		const isSupporterPlus =
 			productType.allProductsProductTypeFilterString === 'SupporterPlus';
 		const cancellationApi = isSupporterPlus
-			? '/supporter-plus-cancel/'
+			? '/api/supporter-plus-cancel/'
 			: '/api/cancel/';
 		await fetchWithDefaultParameters(
 			`${cancellationApi}${subscriptionName}`,

--- a/cypress/integration/parallel-2/cancelSupporterPlus.spec.ts
+++ b/cypress/integration/parallel-2/cancelSupporterPlus.spec.ts
@@ -46,7 +46,7 @@ describe('Cancel Supporter Plus', () => {
 			body: { cancellationEffectiveDate: '2022-02-05' },
 		});
 
-		cy.intercept('POST', 'api/cancel/**', {
+		cy.intercept('POST', '/supporter-plus-cancel/**', {
 			statusCode: 200,
 		}).as('cancel_supporter_plus');
 	});

--- a/cypress/integration/parallel-2/cancelSupporterPlus.spec.ts
+++ b/cypress/integration/parallel-2/cancelSupporterPlus.spec.ts
@@ -46,7 +46,7 @@ describe('Cancel Supporter Plus', () => {
 			body: { cancellationEffectiveDate: '2022-02-05' },
 		});
 
-		cy.intercept('POST', '/supporter-plus-cancel/**', {
+		cy.intercept('POST', '/api/supporter-plus-cancel/**', {
 			statusCode: 200,
 		}).as('cancel_supporter_plus');
 	});

--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -14,7 +14,7 @@ import {
 	deliveryRecordsAPI,
 	holidayStopAPI,
 	invoicingAPI,
-	// productMoveAPI,
+	productMoveAPI,
 } from '../apiGatewayDiscovery';
 import {
 	customMembersDataApiHandler,
@@ -99,6 +99,14 @@ router.post(
 		'/user-attributes/me/cancel/:subscriptionName',
 		'MDA_CANCEL',
 		['subscriptionName'],
+	),
+);
+
+router.get(
+	'/supporter-plus-cancel/:subscriptionName',
+	productMoveAPI(
+		'supporter-plus-cancel/:subscriptionName',
+		'CANCEL_SUPPORTER_PLUS',
 	),
 );
 

--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -102,7 +102,7 @@ router.post(
 	),
 );
 
-router.get(
+router.post(
 	'/supporter-plus-cancel/:subscriptionName',
 	productMoveAPI(
 		'supporter-plus-cancel/:subscriptionName',

--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -107,6 +107,7 @@ router.post(
 	productMoveAPI(
 		'supporter-plus-cancel/:subscriptionName',
 		'CANCEL_SUPPORTER_PLUS',
+		['subscriptionName'],
 	),
 );
 


### PR DESCRIPTION
## What does this change?

Updates the product cancellation flow to use the product movement API if the product being cancelled is Supporter Plus. All other products continue to use the existing cancellation API.

## Have we considered potential risks?

Supporter Plus is not currently available in production so this change should have no impact. We're explicitly checking if the product being cancelled is Supporter Plus when switching API. The existing cancellation API is the default and therefore used for all other products.