### PR TITLE
Lint rules fixes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,7 +28,6 @@ module.exports = {
 		// Overrides for rules from `@guardian/eslint-config-typescript`.
 		// There are a number of these due to applying the config to an existing
 		// codebase. We should progressively fix these and remove the overrides.
-		'@typescript-eslint/array-type': ['off'],
 		'@typescript-eslint/consistent-indexed-object-style': ['off'],
 		'@typescript-eslint/consistent-type-imports': ['off'],
 		'@typescript-eslint/naming-convention': ['off'],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,7 +28,6 @@ module.exports = {
 		// Overrides for rules from `@guardian/eslint-config-typescript`.
 		// There are a number of these due to applying the config to an existing
 		// codebase. We should progressively fix these and remove the overrides.
-		'@typescript-eslint/consistent-indexed-object-style': ['off'],
 		'@typescript-eslint/consistent-type-imports': ['off'],
 		'@typescript-eslint/naming-convention': ['off'],
 		'@typescript-eslint/no-floating-promises': ['off'],

--- a/client/components/accountoverview/contributionUpdateAmountForm.tsx
+++ b/client/components/accountoverview/contributionUpdateAmountForm.tsx
@@ -45,12 +45,13 @@ interface ContributionAmountOptions {
 	maxAmount: number;
 }
 
-interface ContributionAmountsLookup {
-	[currencyISO: string]: {
+type ContributionAmountsLookup = Record<
+	string,
+	{
 		month: ContributionAmountOptions;
 		year: ContributionAmountOptions;
-	};
-}
+	}
+>;
 
 class UpdateAmountLoader extends AsyncLoader<string> {}
 

--- a/client/components/delivery/records/deliveryRecordsApi.ts
+++ b/client/components/delivery/records/deliveryRecordsApi.ts
@@ -11,9 +11,8 @@ interface DeliveryProblem {
 	id: string;
 	ref: string;
 }
-export interface DeliveryProblemMap {
-	[problemCaseId: string]: DeliveryProblem;
-}
+
+export type DeliveryProblemMap = Record<string, DeliveryProblem>;
 
 export interface ContactPhoneNumbers {
 	id: string;

--- a/client/components/holiday/collatedCredits.tsx
+++ b/client/components/holiday/collatedCredits.tsx
@@ -1,9 +1,7 @@
 import { DATE_FNS_LONG_OUTPUT_FORMAT } from '../../../shared/dates';
 import { HolidayStopDetail } from './holidayStopApi';
 
-interface CollatedCreditByInvoiceDate {
-	[invoiceDateString: string]: number;
-}
+type CollatedCreditByInvoiceDate = Record<string, number>;
 
 const reduceCreditCallback = (
 	accumulator: CollatedCreditByInvoiceDate | null,

--- a/client/components/productSwitch/ProductBenefits.tsx
+++ b/client/components/productSwitch/ProductBenefits.tsx
@@ -1,11 +1,7 @@
 import { ReactNode } from 'react';
 
-interface ProductBenefits {
-	/**
-	 * `key` represents product id returned from `available-products-move` API
-	 */
-	[key: string]: ReactNode[];
-}
+// Record `key` represents product id returned from `available-products-move` API
+type ProductBenefits = Record<string, ReactNode[]>;
 
 export const productBenefits: ProductBenefits = {
 	'123': [

--- a/client/services/deliveryAddress.ts
+++ b/client/services/deliveryAddress.ts
@@ -10,9 +10,10 @@ interface ProductDetailAndProductType {
 	productType: ProductType;
 }
 
-export interface ContactIdToArrayOfProductDetailAndProductType {
-	[contactId: string]: ProductDetailAndProductType[];
-}
+export type ContactIdToArrayOfProductDetailAndProductType = Record<
+	string,
+	ProductDetailAndProductType[]
+>;
 
 interface ProductDetailWithContactId extends ProductDetail {
 	subscription: Subscription & {

--- a/client/services/useFetch.ts
+++ b/client/services/useFetch.ts
@@ -5,7 +5,7 @@ interface State<T> {
 	error?: Error;
 }
 
-type Cache<T> = { [url: string]: T };
+type Cache<T> = Record<string, T>;
 
 // discriminated union type
 type Action<T> =

--- a/server/apiProxy.ts
+++ b/server/apiProxy.ts
@@ -26,9 +26,7 @@ function safeJsonParse(jsonStr: JsonString): object | JsonString {
 		return jsonStr;
 	}
 }
-export interface Headers {
-	[headerName: string]: string;
-}
+export type Headers = Record<string, string>;
 export type AdditionalHeaderGenerator = (
 	method: string,
 	host: string,

--- a/server/awsIntegration.ts
+++ b/server/awsIntegration.ts
@@ -124,12 +124,9 @@ export const s3TextFilePromise = (
 		);
 	})();
 
-interface MetricDimensions {
-	[name: string]: string;
-}
 export const putMetricDataPromise = (
 	metricName: string,
-	dimensions: MetricDimensions,
+	dimensions: Record<string, string>,
 ) =>
 	CloudWatch.putMetricData({
 		Namespace: 'manage-frontend',

--- a/server/config.ts
+++ b/server/config.ts
@@ -8,9 +8,7 @@ interface Config {
 }
 
 declare let process: {
-	env: {
-		[key: string]: string | undefined;
-	};
+	env: Record<string, string | undefined>;
 };
 
 const getConfig: (name: string) => string | null = (name) => {

--- a/server/fulfilmentDateCalculatorReader.ts
+++ b/server/fulfilmentDateCalculatorReader.ts
@@ -5,12 +5,10 @@ import { s3FilePromise } from './awsIntegration';
 import { conf } from './config';
 import { log } from './log';
 
-interface RawFulfilmentDateCalculatorDates {
-	[dayOfWeek: string]: {
-		deliveryAddressChangeEffectiveDate?: string;
-		// there are a number of other fields, but we don't need them
-	};
-}
+type RawFulfilmentDateCalculatorDates = Record<
+	string,
+	{ deliveryAddressChangeEffectiveDate?: string }
+>;
 
 const getDeliveryAddressChangeEffectiveDateForToday = async (
 	filenameProductPart: string,

--- a/server/middleware/requestMiddleware.ts
+++ b/server/middleware/requestMiddleware.ts
@@ -8,9 +8,7 @@ export interface MockableExpressRequest {
 	query: any;
 }
 
-interface QueryParameters {
-	[name: string]: string;
-}
+type QueryParameters = Record<string, string>;
 
 // Names of query parameters to that facilitate sign-in on profile.
 export const signInTokenQueryParameterNames = [

--- a/server/stripeSetupIntentConfig.ts
+++ b/server/stripeSetupIntentConfig.ts
@@ -1,7 +1,7 @@
 import { s3ConfigPromise } from './awsIntegration';
-interface StripePublicToSecretKeyMapping {
-	[publicKey: string]: string;
-}
+
+type StripePublicToSecretKeyMapping = Record<string, string>;
+
 export interface StripePublicKeySet {
 	uat: string;
 	default: string;

--- a/shared/featureSwitches.ts
+++ b/shared/featureSwitches.ts
@@ -1,7 +1,3 @@
-interface FeatureSwitches {
-	[x: string]: boolean;
-}
-
 export const initFeatureSwitchUrlParamOverride = () => {
 	const searchParams = new URLSearchParams(window?.location.search);
 	const param = searchParams.get('withFeature');
@@ -26,7 +22,7 @@ export const initFeatureSwitchUrlParamOverride = () => {
  * name provided then the function will return false and the feature switch
  * will be set to off.
  */
-export const featureSwitches: FeatureSwitches = {
+export const featureSwitches: Record<string, boolean> = {
 	exampleFeature: false,
 	cancellationProductSwitch: false,
 };

--- a/shared/productResponse.ts
+++ b/shared/productResponse.ts
@@ -159,8 +159,8 @@ export interface Subscription {
 	mandate?: DirectDebitDetails;
 	sepaMandate?: SepaDetails;
 	autoRenew: boolean;
-	currentPlans: (SubscriptionPlan | PaidSubscriptionPlan)[];
-	futurePlans: (SubscriptionPlan | PaidSubscriptionPlan)[];
+	currentPlans: Array<SubscriptionPlan | PaidSubscriptionPlan>;
+	futurePlans: Array<SubscriptionPlan | PaidSubscriptionPlan>;
 	plan?: PaidSubscriptionPlan;
 	trialLength: number;
 	readerType: ReaderType;


### PR DESCRIPTION
## What does this change?

This follows on from #878 which introduced `@guardian/eslint-config-typescript`.

Overrides for the following linting rules have been removed and any errors / warnings in the code fixed:

| Rule |
| --- |
|array-type|
|consistent-indexed-object-style|