### PR TITLE
Disable holidays consent signups

### DIFF
--- a/client/components/checkbox.tsx
+++ b/client/components/checkbox.tsx
@@ -8,6 +8,7 @@ export interface CheckboxProps {
 	label?: string;
 	checkboxFill?: string;
 	maxWidth?: string;
+	disabled?: boolean;
 }
 
 export const Checkbox = (props: CheckboxProps) => (
@@ -15,79 +16,81 @@ export const Checkbox = (props: CheckboxProps) => (
 		css={{
 			display: 'flex',
 			maxWidth: props.maxWidth,
-			cursor: 'pointer',
+			cursor: props.disabled ? 'default' : 'pointer',
 			userSelect: 'none',
 			':hover .checkbox': {
 				boxShadow: `0 0 0 3px ${palette.neutral[93]}`,
 			},
 		}}
 	>
-		<div
-			className="checkbox"
-			css={{
-				transition: 'all .2s ease-in-out',
-				border: props.checked
-					? undefined
-					: `1px solid ${palette.neutral[60]}`,
-				minWidth: '18px',
-				height: '18px',
-				display: 'inline-block',
-				margin: '3px',
-				marginRight: '10px',
-				background: props.checked
-					? props.checkboxFill || palette.success[400]
-					: palette.neutral[100],
-				position: 'relative',
-				outline: 0,
-				':focus': {
-					boxShadow: `0 0 0 3px ${palette.brandAlt[400]}`,
-				},
-			}}
-			// accessibility props below
-			role="checkbox"
-			aria-checked={props.checked}
-			tabIndex={0}
-			onKeyPress={() => props.onChange(!props.checked)}
-		>
-			<input
-				type="checkbox"
-				css={{
-					position: 'absolute',
-					zIndex: -999999,
-					overflow: 'hidden',
-					opacity: 0,
-				}}
-				onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-					props.onChange(event.target.checked)
-				}
-				checked={props.checked}
-				required={props.required}
-				tabIndex={-1}
-			/>
+		{!props.disabled && (
 			<div
+				className="checkbox"
 				css={{
-					position: 'absolute',
-					left: '3px',
-					top: '5px',
-					width: '12px',
-					height: '6px',
-					transform: 'rotate(-45deg)',
-					textAlign: 'right',
+					transition: 'all .2s ease-in-out',
+					border: props.checked
+						? undefined
+						: `1px solid ${palette.neutral[60]}`,
+					minWidth: '18px',
+					height: '18px',
+					display: 'inline-block',
+					margin: '3px',
+					marginRight: '10px',
+					background: props.checked
+						? props.checkboxFill || palette.success[400]
+						: palette.neutral[100],
+					position: 'relative',
+					outline: 0,
+					':focus': {
+						boxShadow: `0 0 0 3px ${palette.brandAlt[400]}`,
+					},
 				}}
+				// accessibility props below
+				role="checkbox"
+				aria-checked={props.checked}
+				tabIndex={0}
+				onKeyPress={() => props.onChange(!props.checked)}
 			>
+				<input
+					type="checkbox"
+					css={{
+						position: 'absolute',
+						zIndex: -999999,
+						overflow: 'hidden',
+						opacity: 0,
+					}}
+					onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+						props.onChange(event.target.checked)
+					}
+					checked={props.checked}
+					required={props.required}
+					tabIndex={-1}
+				/>
 				<div
 					css={{
-						width: props.checked ? '12px' : '2px',
+						position: 'absolute',
+						left: '3px',
+						top: '5px',
+						width: '12px',
 						height: '6px',
-						borderColor: palette.neutral[100],
-						borderWidth: '0 0 2px 2px',
-						borderStyle: 'solid',
-						transition: 'all .2s ease-in-out',
-						transitionDelay: '.1s',
+						transform: 'rotate(-45deg)',
+						textAlign: 'right',
 					}}
-				/>
+				>
+					<div
+						css={{
+							width: props.checked ? '12px' : '2px',
+							height: '6px',
+							borderColor: palette.neutral[100],
+							borderWidth: '0 0 2px 2px',
+							borderStyle: 'solid',
+							transition: 'all .2s ease-in-out',
+							transitionDelay: '.1s',
+						}}
+					/>
+				</div>
 			</div>
-		</div>
+		)}
 		<span>{props.label}</span>
 	</label>
 );

--- a/client/components/identity/EmailAndMarketing/ConsentSection.tsx
+++ b/client/components/identity/EmailAndMarketing/ConsentSection.tsx
@@ -45,6 +45,7 @@ const consentPreference = (
 		title: name,
 		description,
 		selected: subscribed,
+		canOnlyUnsubscribe: id === 'holidays',
 	};
 	switch (uxType) {
 		case 'checkbox': {

--- a/client/components/identity/MarketingCheckbox.tsx
+++ b/client/components/identity/MarketingCheckbox.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import { Checkbox } from '../checkbox';
 import { standardSansText } from './sharedStyles';
 
@@ -8,6 +8,7 @@ interface MarketingCheckboxProps {
 	title?: string;
 	selected?: boolean;
 	onClick: (id: string) => {};
+	canOnlyUnsubscribe?: boolean;
 }
 
 const getTitle = (title: MarketingCheckboxProps['title']) => (
@@ -37,7 +38,21 @@ const getDescription = (description: MarketingCheckboxProps['description']) => (
 );
 
 export const MarketingCheckbox: FC<MarketingCheckboxProps> = (props) => {
-	const { id, description, selected, title, onClick } = props;
+	const {
+		id,
+		description,
+		selected,
+		title,
+		onClick,
+		canOnlyUnsubscribe = false,
+	} = props;
+
+	const [wasInitiallySelected] = useState(selected);
+
+	if (canOnlyUnsubscribe && !wasInitiallySelected) {
+		return null;
+	}
+
 	return (
 		<div
 			onClick={(e) => {
@@ -49,6 +64,11 @@ export const MarketingCheckbox: FC<MarketingCheckboxProps> = (props) => {
 				) {
 					return;
 				}
+
+				if (canOnlyUnsubscribe && !selected) {
+					return;
+				}
+
 				onClick(id);
 			}}
 			css={[

--- a/client/components/identity/MarketingCheckbox.tsx
+++ b/client/components/identity/MarketingCheckbox.tsx
@@ -11,12 +11,15 @@ interface MarketingCheckboxProps {
 	canOnlyUnsubscribe?: boolean;
 }
 
-const getTitle = (title: MarketingCheckboxProps['title']) => (
+const getTitle = (
+	title: MarketingCheckboxProps['title'],
+	disabledInput: boolean,
+) => (
 	<p
 		css={[
 			standardSansText,
 			{
-				cursor: 'pointer',
+				cursor: disabledInput ? 'default' : 'pointer',
 				lineHeight: '22px',
 				fontWeight: 'bold',
 				margin: '0',
@@ -83,12 +86,13 @@ export const MarketingCheckbox: FC<MarketingCheckboxProps> = (props) => {
 			<div css={{ position: 'absolute', left: 0 }}>
 				<Checkbox
 					checked={!!selected}
+					disabled={canOnlyUnsubscribe && !selected}
 					onChange={(_) => {
 						return;
 					}}
 				/>
 			</div>
-			{title && getTitle(title)}
+			{title && getTitle(title, canOnlyUnsubscribe && !selected)}
 			{description && getDescription(description)}
 		</div>
 	);

--- a/client/components/identity/MarketingToggle.tsx
+++ b/client/components/identity/MarketingToggle.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import { css } from '@emotion/react';
 import { ToggleSwitch } from './ToggleSwitch';
 import { standardSansText, toggleDescriptionPadding } from './sharedStyles';
@@ -9,6 +9,7 @@ interface MarketingToggleProps {
 	title?: string;
 	selected?: boolean;
 	onClick: (id: string) => {};
+	canOnlyUnsubscribe?: boolean;
 }
 
 const getDescription = (description: MarketingToggleProps['description']) => (
@@ -16,7 +17,19 @@ const getDescription = (description: MarketingToggleProps['description']) => (
 );
 
 export const MarketingToggle: FC<MarketingToggleProps> = (props) => {
-	const { id, description, selected, title, onClick } = props;
+	const {
+		id,
+		description,
+		selected,
+		title,
+		onClick,
+		canOnlyUnsubscribe = false,
+	} = props;
+
+	const [wasInitiallySelected] = useState(selected);
+	if (canOnlyUnsubscribe && !wasInitiallySelected) {
+		return null;
+	}
 	return (
 		<div
 			css={[
@@ -44,6 +57,9 @@ export const MarketingToggle: FC<MarketingToggleProps> = (props) => {
 					id={id}
 					checked={!!selected}
 					onClick={() => {
+						if (canOnlyUnsubscribe && !selected) {
+							return;
+						}
 						onClick(id);
 					}}
 				/>

--- a/client/components/identity/MarketingToggle.tsx
+++ b/client/components/identity/MarketingToggle.tsx
@@ -27,6 +27,7 @@ export const MarketingToggle: FC<MarketingToggleProps> = (props) => {
 	} = props;
 
 	const [wasInitiallySelected] = useState(selected);
+	const disabled = canOnlyUnsubscribe && !selected;
 	if (canOnlyUnsubscribe && !wasInitiallySelected) {
 		return null;
 	}
@@ -62,6 +63,7 @@ export const MarketingToggle: FC<MarketingToggleProps> = (props) => {
 						}
 						onClick(id);
 					}}
+					disabled={disabled}
 				/>
 			</div>
 			{description && getDescription(description)}

--- a/client/components/identity/ToggleSwitch.tsx
+++ b/client/components/identity/ToggleSwitch.tsx
@@ -65,6 +65,11 @@ interface ToggleSwitchProps extends Props {
 	 * Receives the click event as an argument.
 	 */
 	onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+
+	/**
+	 * Whether interaction with the toggle should be disabled.
+	 */
+	disabled?: boolean;
 }
 
 /**
@@ -112,14 +117,19 @@ export const ToggleSwitch = ({
 	return (
 		<label id={labelId} css={[labelStyles, cssOverrides]} {...props}>
 			{labelPosition === 'left' && label}
-			<button
-				id={id}
-				css={[buttonStyles(labelPosition), getPlatformStyles(platform)]}
-				role="switch"
-				aria-checked={isChecked()}
-				aria-labelledby={labelId}
-				onClick={onClick}
-			></button>
+			{!props.disabled && (
+				<button
+					id={id}
+					css={[
+						buttonStyles(labelPosition),
+						getPlatformStyles(platform),
+					]}
+					role="switch"
+					aria-checked={isChecked()}
+					aria-labelledby={labelId}
+					onClick={onClick}
+				></button>
+			)}
 			{labelPosition === 'right' && label}
 		</label>
 	);


### PR DESCRIPTION
## What does this change?

Prevents users for subscribing to the 'holidays' marketting email on the "/email-prefs" page, but still allow existing subscribers to unsubscribe: 
 - if the user was no subscribed when the page is populated, the whole `consentPreference` for 'holidays' is not rendered.
 - If the user was subscribed, but then unsubscribes, the description & title remain in place, but the button or checkbox is removed.
 
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
