### PR TITLE
DiscoverApiGatewayLambdas and InvokeApiGateway policy changes

### DIFF
--- a/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
@@ -1356,6 +1356,38 @@ systemctl start manage-frontend
                     ],
                   ],
                 },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:aws:cloudformation:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":stack/membership-TEST-*",
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:aws:cloudformation:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":stack/support-TEST-*",
+                    ],
+                  ],
+                },
               ],
             },
           ],
@@ -1815,6 +1847,22 @@ systemctl start manage-frontend
                         "Ref": "AWS::AccountId",
                       },
                       ":*/DEV/*",
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:aws:execute-api:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":*/CODE/*",
                     ],
                   ],
                 },

--- a/cdk/lib/manage-frontend.ts
+++ b/cdk/lib/manage-frontend.ts
@@ -137,18 +137,14 @@ systemctl start manage-frontend
 					),
 					new GuAllowPolicy(this, 'DiscoverApiGatewayLambdas', {
 						actions: ['cloudformation:ListStackResources'],
-						resources:
-							this.stage === 'PROD'
-								? [
-										`arn:aws:cloudformation:${this.region}:${this.account}:stack/membership-${this.stage}-*`,
-										`arn:aws:cloudformation:${this.region}:${this.account}:stack/support-${this.stage}-*`,
-								  ]
-								: [
-										`arn:aws:cloudformation:${this.region}:${this.account}:stack/membership-DEV-*`,
-										`arn:aws:cloudformation:${this.region}:${this.account}:stack/membership-CODE-*`,
-										`arn:aws:cloudformation:${this.region}:${this.account}:stack/support-DEV-*`,
-										`arn:aws:cloudformation:${this.region}:${this.account}:stack/support-CODE-*`,
-								  ], // TODO: why does CODE depend on DEV here?
+						resources: [
+							`arn:aws:cloudformation:${this.region}:${this.account}:stack/membership-DEV-*`,
+							`arn:aws:cloudformation:${this.region}:${this.account}:stack/membership-CODE-*`,
+							`arn:aws:cloudformation:${this.region}:${this.account}:stack/support-DEV-*`,
+							`arn:aws:cloudformation:${this.region}:${this.account}:stack/support-CODE-*`,
+							`arn:aws:cloudformation:${this.region}:${this.account}:stack/membership-${this.stage}-*`,
+							`arn:aws:cloudformation:${this.region}:${this.account}:stack/support-${this.stage}-*`,
+						], // TODO: why does CODE depend on DEV here?
 					}),
 					new GuAllowPolicy(this, 'DiscoverApiGatewayApiKeys', {
 						actions: ['apigateway:GET'],
@@ -158,15 +154,11 @@ systemctl start manage-frontend
 					}),
 					new GuAllowPolicy(this, 'InvokeApiGateway', {
 						actions: ['execute-api:Invoke'],
-						resources:
-							this.stage === 'PROD'
-								? [
-										`arn:aws:execute-api:${this.region}:${this.account}:*/${this.stage}/*`,
-								  ]
-								: [
-										`arn:aws:execute-api:${this.region}:${this.account}:*/DEV/*`,
-										`arn:aws:execute-api:${this.region}:${this.account}:*/${this.stage}/*`,
-								  ], // TODO: why does CODE depend on DEV here?
+						resources: [
+							`arn:aws:execute-api:${this.region}:${this.account}:*/DEV/*`,
+							`arn:aws:execute-api:${this.region}:${this.account}:*/CODE/*`,
+							`arn:aws:execute-api:${this.region}:${this.account}:*/${this.stage}/*`,
+						], // TODO: why does CODE depend on DEV here?
 					}),
 				],
 			},


### PR DESCRIPTION
## What does this change?

prod layer currently needs DiscoverApiGatewayLambdas and InvokeApiGateway policy access to lower envs

error message seen on prod:

Sep 28 09:37:52 ip-10-248-134-12 manage-frontend[1886]: error: ERROR loading host and api key for membership-CODE-holiday-stop-api.
Sep 28 09:37:53 ip-10-248-134-12 manage-frontend[1886]: error: ERROR loading host and api key for membership-CODE-cancellation-sf-cases-api.
Sep 28 09:37:53 ip-10-248-134-12 manage-frontend[1886]: error: ERROR loading host and api key for membership-CODE-delivery-records-api.
Sep 28 09:37:53 ip-10-248-134-12 manage-frontend[1886]: error: ERROR loading host and api key for membership-CODE-product-move-api.
Sep 28 09:37:53 ip-10-248-134-12 manage-frontend[1886]: error: ERROR loading host and api key for support-CODE-invoicing-api.

We don't understand why yet why prod needs access to the lower environments and will investigate once this pr is merged.