### PR TITLE
Add env policy comments

### DIFF
--- a/cdk/lib/manage-frontend.ts
+++ b/cdk/lib/manage-frontend.ts
@@ -144,7 +144,18 @@ systemctl start manage-frontend
 							`arn:aws:cloudformation:${this.region}:${this.account}:stack/support-CODE-*`,
 							`arn:aws:cloudformation:${this.region}:${this.account}:stack/membership-${this.stage}-*`,
 							`arn:aws:cloudformation:${this.region}:${this.account}:stack/support-${this.stage}-*`,
-						], // TODO: why does CODE depend on DEV here?
+						],
+						/*
+						 * TODO: why does CODE depend on DEV here?
+						 */
+						/*
+						 * NOTE: PROD currently requires access to CODE lambdas see here:
+						 * https://github.com/guardian/manage-frontend/wiki/test-users
+						 * and here:
+						 * https://github.com/guardian/manage-frontend/wiki/Proxying-API-Gateway-Lambdas
+						 *
+						 * TODO: Does this provide us with any real benefit (testing code resources in prod)?
+						 */
 					}),
 					new GuAllowPolicy(this, 'DiscoverApiGatewayApiKeys', {
 						actions: ['apigateway:GET'],
@@ -158,7 +169,18 @@ systemctl start manage-frontend
 							`arn:aws:execute-api:${this.region}:${this.account}:*/DEV/*`,
 							`arn:aws:execute-api:${this.region}:${this.account}:*/CODE/*`,
 							`arn:aws:execute-api:${this.region}:${this.account}:*/${this.stage}/*`,
-						], // TODO: why does CODE depend on DEV here?
+						],
+						/*
+						 * TODO: why does CODE depend on DEV here?
+						 */
+						/*
+						 * NOTE: PROD currently requires access to CODE lambdas see here:
+						 * https://github.com/guardian/manage-frontend/wiki/test-users
+						 * and here:
+						 * https://github.com/guardian/manage-frontend/wiki/Proxying-API-Gateway-Lambdas
+						 *
+						 * TODO: Does this provide us with any real benefit (testing code resources in prod)?
+						 */
 					}),
 				],
 			},

--- a/server/routes/core.ts
+++ b/server/routes/core.ts
@@ -19,6 +19,14 @@ router.get(
 	(_: Request, res: Response) => {
 		res.send('OK - signed in');
 	},
+	/*
+	 * NOTE: PROD currently requires access to CODE lambdas see here:
+	 * https://github.com/guardian/manage-frontend/wiki/test-users
+	 * and here:
+	 * https://github.com/guardian/manage-frontend/wiki/Proxying-API-Gateway-Lambdas
+	 * Without them this health check will fail on PROD
+	 * TODO: Does this provide us with any real benefit (testing code resources in prod)?
+	 */
 );
 
 router.get('/_prout', (_, res: Response) => {


### PR DESCRIPTION
## What does this change?
Explain in comments why (currently) PROD has a dependancy on CODE cloudformation policy access to the following

- DiscoverApiGatewayLambdas
- InvokeApiGateway

This is because of the test user support; being able to access code subscriptions on the production environment.

More information can be found in the following wiki pages:

- https://github.com/guardian/manage-frontend/wiki/test-users
- https://github.com/guardian/manage-frontend/wiki/Proxying-API-Gateway-Lambdas


A separate piece of work will be looked into to see if this is necessary and wether this environment dependancy can be broken.
