### PR TITLE
Remove holidays signup

### DIFF
--- a/client/components/identity/EmailAndMarketing/ConsentSection.tsx
+++ b/client/components/identity/EmailAndMarketing/ConsentSection.tsx
@@ -18,7 +18,7 @@ const supportReminderConsent = (consents: ConsentOption[]): ConsentOption[] =>
 	ConsentOptions.findByIds(consents, ['support_reminder']);
 
 const marketingEmailConsents = (consents: ConsentOption[]): ConsentOption[] => {
-	const ids = ['supporter', 'jobs', 'holidays', 'events', 'offers'];
+	const ids = ['supporter', 'jobs', 'events', 'offers'];
 	return ConsentOptions.findByIds(consents, ids);
 };
 

--- a/client/fixtures/consents.ts
+++ b/client/fixtures/consents.ts
@@ -68,15 +68,6 @@ export const consents = [
 			'Information on similar products and further ways to support our independent journalism.',
 	},
 	{
-		id: 'holidays',
-		isOptOut: false,
-		isChannel: false,
-		isProduct: false,
-		name: 'Holidays & Vacations',
-		description:
-			'Ideas and inspiration for your next trip away, as well as the latest offers from Guardian Holidays in the UK and Guardian Vacations in the US.',
-	},
-	{
 		id: 'market_research_optout',
 		isOptOut: true,
 		isChannel: false,


### PR DESCRIPTION
## What does this change?

Removes "Guardian Holidays" from the list of marketing emails on the /email-prefs page.

The marketing emails for "Guardian Holidays" are being replaced with a new editorial newsletter "Guardian Traveller" see
https://github.com/guardian/identity/pull/2148 for details.

When the replacement is complete, users will use the checkbox in the "your newsletters" section to unsubscribe from "Guardian Traveller"

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Open the /email-prefs page in dev - the "Guardian Holidays" checkbox is removed.

## How can we measure success?

Users will be able to unsubscribe using the "Guardian Traveller" checkbox. The "Guardian Holidays" checkbox will not be rendered.

## Have we considered potential risks?

Merging this PR will needs to be merged so the checkbox is removed after the audience migration that will subscribe the "Guardian Holidays" audience to "Guardian Traveller".

We are planning to check the user data in identity to address any users who unsubscribe from "Holidays" during a cross-over period after they have been subscribed to "Guardian Traveller".

## Images

| Before      | After      |
|-------------|------------|
| <img width="1253" alt="Screenshot 2022-10-05 at 14 51 34" src="https://user-images.githubusercontent.com/30567854/194080453-b81805aa-d94a-473f-be50-c483497e7ea2.png">| <img width="1253" alt="Screenshot 2022-10-05 at 14 51 09" src="https://user-images.githubusercontent.com/30567854/194080562-5b6aaa4a-e322-4a2b-95b2-03e26b643961.png"> |




## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
