### PR TITLE
Fix 'Account overview' heading hierarchy

### DIFF
--- a/client/components/accountoverview/accountOverviewCancelledCard.tsx
+++ b/client/components/accountoverview/accountOverviewCancelledCard.tsx
@@ -81,7 +81,7 @@ export const AccountOverviewCancelledCard = (
 					}
 				`}
 			>
-				<h2
+				<h3
 					css={css`
 						font-size: 17px;
 						font-weight: bold;
@@ -98,7 +98,7 @@ export const AccountOverviewCancelledCard = (
 					`}
 				>
 					{specificProductType.productTitle()}
-				</h2>
+				</h3>
 				<div
 					css={css`
 						display: flex;

--- a/client/components/accountoverview/accountOverviewCard.tsx
+++ b/client/components/accountoverview/accountOverviewCard.tsx
@@ -131,7 +131,7 @@ export const AccountOverviewCard = (props: AccountOverviewCardProps) => {
 					}
 				`}
 			>
-				<h2
+				<h3
 					css={css`
 						font-size: 17px;
 						font-weight: bold;
@@ -151,7 +151,7 @@ export const AccountOverviewCard = (props: AccountOverviewCardProps) => {
 				>
 					{specificProductType.productTitle(mainPlan)}
 					{maybePatronSuffix}
-				</h2>
+				</h3>
 				<div
 					css={css`
 						display: flex;


### PR DESCRIPTION
Change H2s to H3s to fix hierarchy

## What does this change?

The accessibility audit brought up this change to the hierarchy of headings on the Account Overview page.

## How to test

H2s under the first H2 should now be H3s.
