### PR TITLE
[RB] - add withoutImdsv2 to EC2 class to re-enable cloudwatch logs

### DIFF
--- a/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
@@ -225,9 +225,6 @@ Object {
           "Ref": "AMIManagefrontend",
         },
         "InstanceType": "t4g.small",
-        "MetadataOptions": Object {
-          "HttpTokens": "required",
-        },
         "SecurityGroups": Array [
           Object {
             "Fn::GetAtt": Array [

--- a/cdk/lib/manage-frontend.ts
+++ b/cdk/lib/manage-frontend.ts
@@ -101,6 +101,7 @@ systemctl start manage-frontend
 				InstanceClass.T4G,
 				InstanceSize.SMALL,
 			),
+			withoutImdsv2: true,
 			monitoringConfiguration: {
 				noMonitoring: true,
 			},


### PR DESCRIPTION
## What does this change?

In reference to this pr: https://github.com/guardian/support-frontend/pull/3647

We need to add the `withoutImdsv2 ` property to the GuEc2App class in order to make the instance compatible with the  cloudwatch agent. Without doing this the logs disappear.