### PR TITLE
Remove tab role from left hand nav

### DIFF
--- a/client/components/nav/dropdownNav.tsx
+++ b/client/components/nav/dropdownNav.tsx
@@ -205,7 +205,7 @@ export const DropdownNav = () => {
 				My account
 			</button>
 
-			<ul role="tablist" css={dropdownNavCss(showMenu, isHelpCentre)}>
+			<ul css={dropdownNavCss(showMenu, isHelpCentre)}>
 				{Object.values(NAV_LINKS).map(
 					(navItem: MenuSpecificNavItem) => (
 						<li key={navItem.title}>

--- a/client/components/nav/leftSideNav.tsx
+++ b/client/components/nav/leftSideNav.tsx
@@ -92,7 +92,7 @@ export interface LeftSideNavProps {
 }
 
 export const LeftSideNav = (props: LeftSideNavProps) => (
-	<ul role="tablist" css={leftNavCss}>
+	<ul css={leftNavCss}>
 		{Object.values(NAV_LINKS)
 			.filter((navItem) => !navItem.isDropDownExclusive)
 			.map((navItem: MenuSpecificNavItem) => (
@@ -105,6 +105,11 @@ export const LeftSideNav = (props: LeftSideNavProps) => (
 							css={leftNavLinkCss(
 								props.selectedNavItem === navItem,
 							)}
+							aria-current={
+								props.selectedNavItem === navItem
+									? 'page'
+									: undefined
+							}
 							to={navItem.link}
 						>
 							{navItem.icon && (


### PR DESCRIPTION

## What does this change?

We're currently applying `role="tablist"` to the left-hand navigation although it's not actually a tab container and we're not applying any other tab related roles elsewhere.

The currently selected item is visually highlighted. We should use `aria-current` to also highlight the selected item to assistive technology.

## How to test

The `role="tablist"` attribute no longer applies to the left hand nav.
The current page that is visually highlighted has attribute `aria-current='page'`
