### PR TITLE
SPIKE: Account Overview updates for new prop

### DIFF
--- a/client/components/accountoverview/accountOverview.tsx
+++ b/client/components/accountoverview/accountOverview.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { headline, neutral, space, until } from '@guardian/source-foundations';
 import { Stack } from '@guardian/source-react-components';
+import { capitalize } from 'lodash';
 import { Fragment } from 'react';
 import {
 	CancelledProductDetail,
@@ -86,7 +87,7 @@ const AccountOverviewRenderer = ([mdaResponse, cancelledProductsResponse]: [
 				return (
 					<Fragment key={category}>
 						<h2 css={subHeadingCss}>
-							My {groupedProductType.groupFriendlyName}
+							{capitalize(groupedProductType.groupFriendlyName)}
 						</h2>
 						<Stack space={6}>
 							{activeProductsInCategory.map((productDetail) => (
@@ -112,7 +113,7 @@ const AccountOverviewRenderer = ([mdaResponse, cancelledProductsResponse]: [
 							{(groupedProductType.groupFriendlyName ===
 								'membership' ||
 								groupedProductType.groupFriendlyName ===
-									'contribution') &&
+									'contributions') &&
 								(cancelledProductsInCategory.length > 0 ||
 									activeProductsInCategory.some(
 										(productDetail) =>

--- a/client/components/accountoverview/accountOverviewCancelledCard.tsx
+++ b/client/components/accountoverview/accountOverviewCancelledCard.tsx
@@ -171,14 +171,16 @@ export const AccountOverviewCancelledCard = (
 						}
 					`}
 				>
-					{groupedProductType.shouldRevealSubscriptionId && (
-						<ul css={keyValuePairCss}>
-							<li css={keyCss}>Subscription ID</li>
-							<li css={valueCss}>
-								{props.product.subscription.subscriptionId}
-							</li>
-						</ul>
-					)}
+					<ul css={keyValuePairCss}>
+						<li css={keyCss}>
+							{groupedProductType.showSupporterId
+								? 'Supporter ID'
+								: 'Subscription ID'}
+						</li>
+						<li css={valueCss}>
+							{props.product.subscription.subscriptionId}
+						</li>
+					</ul>
 					{groupedProductType.tierLabel && (
 						<ul css={keyValuePairCss}>
 							<li css={keyCss}>{groupedProductType.tierLabel}</li>

--- a/client/components/accountoverview/accountOverviewCard.tsx
+++ b/client/components/accountoverview/accountOverviewCard.tsx
@@ -263,17 +263,16 @@ export const AccountOverviewCard = (props: AccountOverviewCardProps) => {
 						}
 					`}
 				>
-					{groupedProductType.shouldRevealSubscriptionId && (
-						<ul css={keyValuePairCss}>
-							<li css={keyCss}>Subscription ID</li>
-							<li css={valueCss}>
-								{
-									props.productDetail.subscription
-										.subscriptionId
-								}
-							</li>
-						</ul>
-					)}
+					<ul css={keyValuePairCss}>
+						<li css={keyCss}>
+							{groupedProductType.showSupporterId
+								? 'Supporter ID'
+								: 'Subscription ID'}
+						</li>
+						<li css={valueCss}>
+							{props.productDetail.subscription.subscriptionId}
+						</li>
+					</ul>
 					{groupedProductType.tierLabel && (
 						<ul css={keyValuePairCss}>
 							<li css={keyCss}>{groupedProductType.tierLabel}</li>

--- a/client/components/accountoverview/accountOverviewCard.tsx
+++ b/client/components/accountoverview/accountOverviewCard.tsx
@@ -8,10 +8,12 @@ import {
 	textSans,
 	until,
 } from '@guardian/source-foundations';
+import { capitalize } from 'lodash';
 import { cancellationFormatDate, parseDate } from '../../../shared/dates';
 import {
 	getMainPlan,
 	isGift,
+	PaidSubscriptionPlan,
 	ProductDetail,
 } from '../../../shared/productResponse';
 import { GROUPED_PRODUCT_TYPES } from '../../../shared/productTypes';
@@ -34,7 +36,9 @@ interface AccountOverviewCardProps {
 }
 
 export const AccountOverviewCard = (props: AccountOverviewCardProps) => {
-	const mainPlan = getMainPlan(props.productDetail.subscription);
+	const mainPlan = getMainPlan(
+		props.productDetail.subscription,
+	) as PaidSubscriptionPlan;
 	if (!mainPlan) {
 		throw new Error('mainPlan does not exist in accountOverviewCard');
 	}
@@ -85,6 +89,16 @@ export const AccountOverviewCard = (props: AccountOverviewCardProps) => {
 	const shouldShowStartDate = !(
 		shouldShowJoinDateNotStartDate || userIsGifter
 	);
+
+	const productName = () => {
+		if (props.productDetail.mmaCategory === 'contributions') {
+			return capitalize(`${mainPlan.interval}ly`);
+		}
+
+		return `${specificProductType.productTitle(
+			mainPlan,
+		)}${maybePatronSuffix}`;
+	};
 
 	const keyValuePairCss = css`
 		list-style: none;
@@ -149,8 +163,7 @@ export const AccountOverviewCard = (props: AccountOverviewCardProps) => {
 						}
 					`}
 				>
-					{specificProductType.productTitle(mainPlan)}
-					{maybePatronSuffix}
+					{productName()}
 				</h2>
 				<div
 					css={css`

--- a/client/components/accountoverview/accountOverviewCard.tsx
+++ b/client/components/accountoverview/accountOverviewCard.tsx
@@ -354,7 +354,7 @@ export const AccountOverviewCard = (props: AccountOverviewCardProps) => {
 						>
 							<LinkButton
 								to={`/${groupedProductType.urlPart}`}
-								text={`Manage ${groupedProductType.friendlyName}`}
+								text="Manage"
 								data-cy={`Manage ${groupedProductType.friendlyName}`}
 								state={{ productDetail: props.productDetail }}
 								colour={brand[800]}
@@ -488,7 +488,7 @@ export const AccountOverviewCard = (props: AccountOverviewCardProps) => {
 										state={{
 											productDetail: props.productDetail,
 										}}
-										text={'Manage payment method'}
+										text="Adjust payment method"
 										colour={
 											hasPaymentFailure
 												? brand[400]

--- a/client/components/accountoverview/contributionUpdateAmount.tsx
+++ b/client/components/accountoverview/contributionUpdateAmount.tsx
@@ -68,6 +68,10 @@ export const ContributionUpdateAmount = (
 				borderColour={neutral[86]}
 				content={[
 					{
+						title: 'Supporter ID',
+						value: props.subscriptionId,
+					},
+					{
 						title: `${capitalize(
 							augmentInterval(props.mainPlan.interval),
 						)} amount`,

--- a/client/components/basicProductInfoTable.tsx
+++ b/client/components/basicProductInfoTable.tsx
@@ -12,15 +12,12 @@ export const BasicProductInfoTable = (props: BasicProductInfoTableProps) => {
 	return (
 		<ProductDescriptionListTable
 			content={[
-				...(props.groupedProductType.shouldRevealSubscriptionId
-					? [
-							{
-								title: 'Subscription ID',
-								value: props.productDetail.subscription
-									.subscriptionId,
-							},
-					  ]
-					: []),
+				{
+					title: props.groupedProductType.showSupporterId
+						? 'Supporter ID'
+						: 'Subscription ID',
+					value: props.productDetail.subscription.subscriptionId,
+				},
 				...(props.groupedProductType.tierLabel
 					? [
 							{

--- a/shared/productTypes.tsx
+++ b/shared/productTypes.tsx
@@ -160,7 +160,7 @@ export interface ProductType {
 	getOphanProductType?: (
 		productDetail: ProductDetail,
 	) => OphanProduct | undefined;
-	shouldRevealSubscriptionId?: boolean;
+	showSupporterId?: boolean;
 	tierLabel?: string;
 	renewalMetadata?: SupportTheGuardianButtonProps;
 	noProductSupportUrlSuffix?: string;
@@ -644,6 +644,7 @@ export const GROUPED_PRODUCT_TYPES: {
 		...PRODUCT_TYPES.contributions,
 		mapGroupedToSpecific: () => PRODUCT_TYPES.contributions,
 		groupFriendlyName: 'recurring support',
+		showSupporterId: true,
 		supportTheGuardianSectionProps: {
 			alternateButtonText: 'Contribute again',
 			supportReferer: 'account_overview_contributions_section',
@@ -686,7 +687,6 @@ export const GROUPED_PRODUCT_TYPES: {
 		},
 		cancelledCopy:
 			'Your subscription has been cancelled. You are able to access your subscription until',
-		shouldRevealSubscriptionId: true,
 		supportTheGuardianSectionProps: {
 			alternateButtonText: 'Subscribe again',
 			supportReferer: 'account_overview_subscriptions_section',

--- a/shared/productTypes.tsx
+++ b/shared/productTypes.tsx
@@ -643,7 +643,7 @@ export const GROUPED_PRODUCT_TYPES: {
 	contributions: {
 		...PRODUCT_TYPES.contributions,
 		mapGroupedToSpecific: () => PRODUCT_TYPES.contributions,
-		groupFriendlyName: 'contributions',
+		groupFriendlyName: 'recurring support',
 		supportTheGuardianSectionProps: {
 			alternateButtonText: 'Contribute again',
 			supportReferer: 'account_overview_contributions_section',


### PR DESCRIPTION
## What does this change?

Spikes changes to Account Overview page to support new product prop:

- Products are grouped as _Recurring support_ and _Subscriptions_.
- For _Recurring support_ products the billing interval is shown instead of the product name. eg. _Monthly_ instead of _Recurring contribution_. (This hasn't been done for Supporter Plus as this still comes through as a subscription.)
- Subscription ID can be exposed for contributions, but is displayed as _Supporter ID_.

These changes only affect contributions at the moment and need to be replicated for Supporter Plus. (This also needs to be recategorised in the API response.) There may be other instances of _Subscription ID_ that need to be changed to _Supporter ID_ for recurring support products.

## Images

<img width="850" alt="Screenshot 2022-10-14 at 16 45 57" src="https://user-images.githubusercontent.com/1166188/195888757-b361dff3-cb9d-4807-b1a4-54e1f92fcea0.png">
