### PR TITLE
Manage buttons accessible names

### DIFF
--- a/client/components/accountoverview/accountOverviewCard.tsx
+++ b/client/components/accountoverview/accountOverviewCard.tsx
@@ -7,13 +7,15 @@ import {
 	space,
 	textSans,
 	until,
+	visuallyHidden,
 } from '@guardian/source-foundations';
+import { Button } from '@guardian/source-react-components';
+import { useNavigate } from 'react-router-dom';
 import { cancellationFormatDate, parseDate } from '../../../shared/dates';
 import type { ProductDetail } from '../../../shared/productResponse';
 import { getMainPlan, isGift } from '../../../shared/productResponse';
 import { GROUPED_PRODUCT_TYPES } from '../../../shared/productTypes';
 import { trackEvent } from '../../services/analytics';
-import { LinkButton } from '../buttons';
 import { CardDisplay } from '../payment/cardDisplay';
 import { DirectDebitDisplay } from '../payment/directDebitDisplay';
 import {
@@ -108,6 +110,8 @@ export const AccountOverviewCard = (props: AccountOverviewCardProps) => {
 		overflow: hidden;
 		text-overflow: ellipsis;
 	`;
+
+	const navigate = useNavigate();
 
 	return (
 		<div
@@ -337,22 +341,34 @@ export const AccountOverviewCard = (props: AccountOverviewCardProps) => {
 								margin-top: auto;
 							`}
 						>
-							<LinkButton
-								to={`/${groupedProductType.urlPart}`}
-								text={`Manage ${groupedProductType.friendlyName}`}
+							<Button
 								data-cy={`Manage ${groupedProductType.friendlyName}`}
-								state={{ productDetail: props.productDetail }}
-								colour={brand[800]}
-								textColour={brand[400]}
-								fontWeight={'bold'}
-								onClick={() =>
+								priority="secondary"
+								size="small"
+								onClick={() => {
 									trackEvent({
 										eventCategory: 'account_overview',
 										eventAction: 'click',
 										eventLabel: `manage_${groupedProductType.urlPart}`,
-									})
-								}
-							/>
+									});
+									navigate(`/${groupedProductType.urlPart}`, {
+										state: {
+											productDetail: props.productDetail,
+										},
+									});
+								}}
+							>
+								<span
+									css={css`
+										${visuallyHidden};
+									`}
+								>
+									{`${specificProductType.productTitle(
+										mainPlan,
+									)} - `}
+								</span>
+								{`Manage ${groupedProductType.friendlyName}`}
+							</Button>
 						</div>
 					)}
 				</div>
@@ -468,34 +484,53 @@ export const AccountOverviewCard = (props: AccountOverviewCardProps) => {
 										margin-top: auto;
 									`}
 								>
-									<LinkButton
-										to={`/payment/${specificProductType.urlPart}`}
-										state={{
-											productDetail: props.productDetail,
-										}}
-										text={'Manage payment method'}
-										colour={
+									<Button
+										size="small"
+										priority={
 											hasPaymentFailure
-												? brand[400]
-												: brand[800]
+												? 'primary'
+												: 'secondary'
 										}
-										textColour={
-											hasPaymentFailure
-												? neutral[100]
-												: brand[400]
+										icon={
+											hasPaymentFailure ? (
+												<ErrorIcon
+													fill={neutral[100]}
+													additionalCss={css`
+														margin-right: ${space[2]}px;
+													`}
+												/>
+											) : undefined
 										}
-										fontWeight={'bold'}
-										alert={hasPaymentFailure}
-										onClick={() =>
+										onClick={() => {
 											trackEvent({
 												eventCategory:
 													'account_overview',
 												eventAction: 'click',
 												eventLabel:
 													'manage_payment_method',
-											})
-										}
-									/>
+											});
+											navigate(
+												`/payment/${specificProductType.urlPart}`,
+												{
+													state: {
+														productDetail:
+															props.productDetail,
+													},
+												},
+											);
+										}}
+									>
+										<span
+											css={css`
+												${visuallyHidden};
+											`}
+										>
+											{`${specificProductType.productTitle(
+												mainPlan,
+											)} - `}
+										</span>
+										Manage payment method
+									</Button>
 								</div>
 							)}
 						</>

--- a/client/components/accountoverview/accountOverviewCard.tsx
+++ b/client/components/accountoverview/accountOverviewCard.tsx
@@ -7,9 +7,8 @@ import {
 	space,
 	textSans,
 	until,
-	visuallyHidden,
 } from '@guardian/source-foundations';
-import { Button } from '@guardian/source-react-components';
+import { LinkButton } from '@guardian/source-react-components';
 import { useNavigate } from 'react-router-dom';
 import { cancellationFormatDate, parseDate } from '../../../shared/dates';
 import type { ProductDetail } from '../../../shared/productResponse';
@@ -341,8 +340,13 @@ export const AccountOverviewCard = (props: AccountOverviewCardProps) => {
 								margin-top: auto;
 							`}
 						>
-							<Button
+							<LinkButton
+								aria-label={`${specificProductType.productTitle(
+									mainPlan,
+								)} : Manage ${groupedProductType.friendlyName}`}
+								tabIndex={0}
 								data-cy={`Manage ${groupedProductType.friendlyName}`}
+								role="link"
 								priority="secondary"
 								size="small"
 								onClick={() => {
@@ -358,17 +362,8 @@ export const AccountOverviewCard = (props: AccountOverviewCardProps) => {
 									});
 								}}
 							>
-								<span
-									css={css`
-										${visuallyHidden};
-									`}
-								>
-									{`${specificProductType.productTitle(
-										mainPlan,
-									)} : `}
-								</span>
 								{`Manage ${groupedProductType.friendlyName}`}
-							</Button>
+							</LinkButton>
 						</div>
 					)}
 				</div>
@@ -484,7 +479,12 @@ export const AccountOverviewCard = (props: AccountOverviewCardProps) => {
 										margin-top: auto;
 									`}
 								>
-									<Button
+									<LinkButton
+										aria-label={`${specificProductType.productTitle(
+											mainPlan,
+										)} : Manage payment method`}
+										tabIndex={0}
+										role="link"
 										size="small"
 										priority={
 											hasPaymentFailure
@@ -520,17 +520,8 @@ export const AccountOverviewCard = (props: AccountOverviewCardProps) => {
 											);
 										}}
 									>
-										<span
-											css={css`
-												${visuallyHidden};
-											`}
-										>
-											{`${specificProductType.productTitle(
-												mainPlan,
-											)} : `}
-										</span>
 										Manage payment method
-									</Button>
+									</LinkButton>
 								</div>
 							)}
 						</>

--- a/client/components/accountoverview/accountOverviewCard.tsx
+++ b/client/components/accountoverview/accountOverviewCard.tsx
@@ -365,7 +365,7 @@ export const AccountOverviewCard = (props: AccountOverviewCardProps) => {
 								>
 									{`${specificProductType.productTitle(
 										mainPlan,
-									)} - `}
+									)} : `}
 								</span>
 								{`Manage ${groupedProductType.friendlyName}`}
 							</Button>
@@ -527,7 +527,7 @@ export const AccountOverviewCard = (props: AccountOverviewCardProps) => {
 										>
 											{`${specificProductType.productTitle(
 												mainPlan,
-											)} - `}
+											)} : `}
 										</span>
 										Manage payment method
 									</Button>

--- a/client/components/billing/billing.tsx
+++ b/client/components/billing/billing.tsx
@@ -281,7 +281,7 @@ const BillingRenderer = ([mdaResponse, invoiceResponse]: [
 														text="Update payment method"
 														ariaLabelText={`${specificProductType.productTitle(
 															mainPlan,
-														)} - Update payment method`}
+														)} : Update payment method`}
 														to={`/payment/${specificProductType.urlPart}`}
 														state={{
 															productDetail,

--- a/client/components/billing/billing.tsx
+++ b/client/components/billing/billing.tsx
@@ -279,6 +279,9 @@ const BillingRenderer = ([mdaResponse, invoiceResponse]: [
 															!!productDetail.alertText
 														}
 														text="Update payment method"
+														ariaLabelText={`${specificProductType.productTitle(
+															mainPlan,
+														)} - Update payment method`}
 														to={`/payment/${specificProductType.urlPart}`}
 														state={{
 															productDetail,

--- a/client/components/buttons.tsx
+++ b/client/components/buttons.tsx
@@ -37,6 +37,7 @@ interface LinkButtonState {
 export interface LinkButtonProps extends ButtonProps {
 	to: string;
 	state?: LinkButtonState | ProductDetail;
+	ariaLabelText?: string;
 }
 
 const applyIconStyleIfApplicable = (
@@ -187,6 +188,7 @@ const styles = {
 
 export const LinkButton = (props: LinkButtonProps) => (
 	<Link
+		aria-label={props.ariaLabelText}
 		to={props.disabled ? '' : props.to}
 		onClick={props.onClick}
 		css={buttonCss(props)}

--- a/cypress/integration/parallel-3/holidayStops.spec.ts
+++ b/cypress/integration/parallel-3/holidayStops.spec.ts
@@ -218,7 +218,11 @@ describe('Holiday stops', () => {
 		cy.wait('@cancelled');
 
 		cy.findByRole('heading', { name: 'Account overview' }).should('exist');
-		cy.findAllByRole('link', { name: 'Manage subscription' }).eq(0).click();
+		cy.findAllByRole('link', {
+			name: 'Guardian Weekly : Manage subscription',
+		})
+			.eq(0)
+			.click();
 
 		cy.findByText('A-S00293857').should('exist');
 
@@ -226,7 +230,11 @@ describe('Holiday stops', () => {
 		cy.wait('@mma');
 		cy.wait('@cancelled');
 
-		cy.findAllByRole('link', { name: 'Manage subscription' }).eq(1).click();
+		cy.findAllByRole('link', {
+			name: 'Guardian Weekly : Manage subscription',
+		})
+			.eq(1)
+			.click();
 
 		cy.findByText('A-S00286635').should('exist');
 		cy.findByRole('link', { name: 'Manage suspensions' }).click();


### PR DESCRIPTION
## What does this change?

If you have multiple products you'll see multiple buttons labelled Manage subscription and Manage payment method on the Account overview page.

Screenreader users often navigate around a page by getting a list of all of the headings, links or buttons. When presented with multiple buttons with the exact same label out of context they have no way of knowing which product the button refers to.

We should add an accessible name to each of these buttons using aria-label so that screenreader users will hear something like Manage Guardian Weekly subscription instead of just Manage subscription. 

As the manage text is repeated it may make sense to put the product name first to allow users to find the product the want to manage more quickly. eg. Guardian Weekly — manage subscription and Guardian Weekly — manage payment method. Hidde de Vries has written an [excellent article on making better accessible names](https://hidde.blog/better-accessible-names/). In this PR the separator between the product name and the action is a colon - which seems to be read out better than a dash when the product name also contains a dash.

## How to test

- The buttons should be visually the same as before, except for minor differences between source and the previous buttons such as focus state
- The buttons should be functionally the same as before
- The extra information should be readable by a screen reader
- The description should be "Product : Action"

## Images

A button in focus state and a button with an alert.
Before             |  After
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/114918544/195890598-7e932138-d273-490f-b885-1a425b3bc2f4.png)  |  ![image](https://user-images.githubusercontent.com/114918544/195890338-7a5ef962-6bd8-48e6-964e-4cb2a6c902b2.png)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [x] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
