### PR TITLE
Add 'skip to content' link

### DIFF
--- a/client/__tests__/__snapshots__/main.test.tsx.snap
+++ b/client/__tests__/__snapshots__/main.test.tsx.snap
@@ -19,6 +19,17 @@ exports[`Main renders something 1`] = `
 }
 
 .emotion-1 {
+  color: #052962;
+  position: absolute;
+  text-align: center;
+  font-size: 12px;
+}
+
+.emotion-1:focus {
+  position: static;
+}
+
+.emotion-2 {
   background-color: #052962;
   min-height: 50px;
   overflow: visible;
@@ -28,12 +39,12 @@ exports[`Main renders something 1`] = `
 }
 
 @media (min-width: 980px) {
-  .emotion-1 {
+  .emotion-2 {
     min-height: 82px;
   }
 }
 
-.emotion-2 {
+.emotion-3 {
   padding-left: 12px;
   padding-right: 12px;
   display: -ms-grid;
@@ -52,13 +63,13 @@ exports[`Main renders something 1`] = `
 }
 
 @supports (display: grid) {
-  .emotion-2 {
+  .emotion-3 {
     display: grid;
   }
 }
 
 @media (min-width: 740px) {
-  .emotion-2 {
+  .emotion-3 {
     padding-left: 20px;
     padding-right: 20px;
     -ms-grid-columns: (minmax(0, 1fr))[12];
@@ -67,13 +78,13 @@ exports[`Main renders something 1`] = `
 }
 
 @media (min-width: 1300px) {
-  .emotion-2 {
+  .emotion-3 {
     -ms-grid-columns: (minmax(0, 1fr))[16];
     grid-template-columns: repeat(16, minmax(0, 1fr));
   }
 }
 
-.emotion-3 {
+.emotion-4 {
   grid-column-start: -2;
   grid-column-end: span 1;
   -ms-grid-column: 4;
@@ -83,7 +94,7 @@ exports[`Main renders something 1`] = `
 }
 
 @media (min-width: 740px) {
-  .emotion-3 {
+  .emotion-4 {
     margin: auto;
     max-height: 51px;
     grid-column-start: -2;
@@ -95,7 +106,7 @@ exports[`Main renders something 1`] = `
 }
 
 @media (min-width: 1300px) {
-  .emotion-3 {
+  .emotion-4 {
     grid-column-start: -2;
     grid-column-end: span 1;
     -ms-grid-column: 16;
@@ -104,23 +115,11 @@ exports[`Main renders something 1`] = `
   }
 }
 
-.emotion-4 {
+.emotion-5 {
   display: block;
   margin: auto 0 auto auto;
   height: 39px;
   text-align: right;
-}
-
-@media (min-width: 980px) {
-  .emotion-4 {
-    width: 51px;
-    height: 51px;
-  }
-}
-
-.emotion-5 {
-  width: 39px;
-  height: 39px;
 }
 
 @media (min-width: 980px) {
@@ -131,6 +130,18 @@ exports[`Main renders something 1`] = `
 }
 
 .emotion-6 {
+  width: 39px;
+  height: 39px;
+}
+
+@media (min-width: 980px) {
+  .emotion-6 {
+    width: 51px;
+    height: 51px;
+  }
+}
+
+.emotion-7 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -147,7 +158,7 @@ exports[`Main renders something 1`] = `
   flex-direction: column;
 }
 
-.emotion-7 {
+.emotion-8 {
   font-family: "GuardianTextEgyptian",Georgia,serif;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -158,30 +169,30 @@ exports[`Main renders something 1`] = `
   flex-shrink: 0;
 }
 
-.emotion-8 {
+.emotion-9 {
   background-color: #052962;
   color: #FFFFFF;
 }
 
-.emotion-9 {
+.emotion-10 {
   max-width: 1300px;
   margin: auto;
 }
 
-.emotion-10 {
+.emotion-11 {
   padding: 10px;
   border: 1px solid rgba(255, 255, 255, 0.3);
   border-top: 0;
 }
 
 @media (min-width: 980px) {
-  .emotion-10 {
+  .emotion-11 {
     padding: 0 20px;
   }
 }
 
 @media (min-width: 1140px) {
-  .emotion-10 {
+  .emotion-11 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -189,7 +200,7 @@ exports[`Main renders something 1`] = `
   }
 }
 
-.emotion-11 {
+.emotion-12 {
   padding: 0;
   border: 0;
   width: 100%;
@@ -197,22 +208,22 @@ exports[`Main renders something 1`] = `
 }
 
 @media (min-width: 1140px) {
-  .emotion-11 {
+  .emotion-12 {
     width: 340px;
   }
 }
 
 @media (min-width: 1300px) {
-  .emotion-11 {
+  .emotion-12 {
     width: 460px;
   }
 }
 
-.emotion-12 {
+.emotion-13 {
   min-height: 150px;
 }
 
-.emotion-13 {
+.emotion-14 {
   font-feature-settings: kern;
   font-size: 16px;
   line-height: 16px;
@@ -232,12 +243,12 @@ exports[`Main renders something 1`] = `
 }
 
 @media (min-width: 1300px) {
-  .emotion-13 {
+  .emotion-14 {
     border-top: 0;
   }
 }
 
-.emotion-14 {
+.emotion-15 {
   line-height: 19.2px;
   width: calc(50% - 1.25rem - 1px);
   list-style: none;
@@ -246,45 +257,45 @@ exports[`Main renders something 1`] = `
   margin: 0;
 }
 
-.emotion-14:nth-of-type(even) {
+.emotion-15:nth-of-type(even) {
   border-left: 1px solid rgba(255, 255, 255, 0.3);
 }
 
 @media (min-width: 740px) {
-  .emotion-14 {
+  .emotion-15 {
     width: 161px;
     -webkit-flex: 1 0 0;
     -ms-flex: 1 0 0;
     flex: 1 0 0;
   }
 
-  .emotion-14:not(:first-of-type) {
+  .emotion-15:not(:first-of-type) {
     border-left: 1px solid rgba(255, 255, 255, 0.3);
   }
 }
 
 @media (min-width: 980px) {
-  .emotion-14 {
+  .emotion-15 {
     border-left: 1px solid rgba(255, 255, 255, 0.3);
   }
 }
 
-.emotion-15 {
+.emotion-16 {
   list-style: none;
 }
 
-.emotion-16 {
+.emotion-17 {
   display: inline-block;
   padding: 6px 0;
   color: #FFFFFF;
 }
 
-.emotion-16:hover {
+.emotion-17:hover {
   color: #FFE500;
   cursor: pointer;
 }
 
-.emotion-57 {
+.emotion-58 {
   width: 50%;
   border-left: 1px solid rgba(255, 255, 255, 0.3);
   padding-left: 10px;
@@ -292,18 +303,18 @@ exports[`Main renders something 1`] = `
 }
 
 @media (min-width: 660px) {
-  .emotion-57 {
+  .emotion-58 {
     width: 312px;
   }
 }
 
 @media (min-width: 740px) {
-  .emotion-57 {
+  .emotion-58 {
     border-top: 0;
   }
 }
 
-.emotion-58 {
+.emotion-59 {
   color: #FFE500;
   font-family: GH Guardian Headline,"GuardianTextEgyptian",Georgia,serif;
   font-size: 24px;
@@ -314,19 +325,19 @@ exports[`Main renders something 1`] = `
 }
 
 @media (min-width: 660px) {
-  .emotion-58 {
+  .emotion-59 {
     font-size: 32px;
     line-height: 32px;
   }
 }
 
-.emotion-59 {
+.emotion-60 {
   display: inline-block;
   margin-right: 10px;
   margin-bottom: 6px;
 }
 
-.emotion-60 {
+.emotion-61 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -360,24 +371,24 @@ exports[`Main renders something 1`] = `
   color: #052962;
 }
 
-.emotion-60:disabled {
+.emotion-61:disabled {
   cursor: not-allowed;
 }
 
-.emotion-60:focus {
+.emotion-61:focus {
   outline: 0;
 }
 
-html:not(.src-focus-disabled) .emotion-60:focus {
+html:not(.src-focus-disabled) .emotion-61:focus {
   outline: 5px solid #0077B6;
   outline-offset: 3px;
 }
 
-.emotion-60:hover {
+.emotion-61:hover {
   background-color: #FFD213;
 }
 
-.emotion-60 svg {
+.emotion-61 svg {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -388,15 +399,15 @@ html:not(.src-focus-disabled) .emotion-60:focus {
   height: auto;
 }
 
-.emotion-60 .src-button-space {
+.emotion-61 .src-button-space {
   width: 8px;
 }
 
-.emotion-60 svg {
+.emotion-61 svg {
   margin-right: -4px;
 }
 
-.emotion-60 svg {
+.emotion-61 svg {
   -webkit-transform: translate(0, 0);
   -moz-transform: translate(0, 0);
   -ms-transform: translate(0, 0);
@@ -405,22 +416,22 @@ html:not(.src-focus-disabled) .emotion-60:focus {
   transition: .2s cubic-bezier(.64, .57, .67, 1.53);
 }
 
-.emotion-60:hover svg,
-.emotion-60:focus svg {
+.emotion-61:hover svg,
+.emotion-61:focus svg {
   -webkit-transform: translate(2px, 0);
   -moz-transform: translate(2px, 0);
   -ms-transform: translate(2px, 0);
   transform: translate(2px, 0);
 }
 
-.emotion-62 {
+.emotion-63 {
   padding-bottom: 24px;
   padding-left: 20px;
   padding-right: 20px;
   position: relative;
 }
 
-.emotion-63 {
+.emotion-64 {
   font-size: 16px;
   color: #FFFFFF;
   font-weight: bold;
@@ -434,17 +445,17 @@ html:not(.src-focus-disabled) .emotion-60:focus {
   transform: translateY(-50%);
 }
 
-.emotion-63:hover {
+.emotion-64:hover {
   color: #FFE500;
 }
 
-.emotion-64 {
+.emotion-65 {
   display: inline-block;
   padding-right: 5px;
   padding-top: 9px;
 }
 
-.emotion-65 {
+.emotion-66 {
   position: relative;
   float: right;
   background-color: currentColor;
@@ -453,20 +464,20 @@ html:not(.src-focus-disabled) .emotion-60:focus {
   width: 42px;
 }
 
-.emotion-66 {
+.emotion-67 {
   position: absolute;
   fill: #052962;
   top: 9px;
   left: 9px;
 }
 
-.emotion-67 {
+.emotion-68 {
   padding-top: 26px;
   font-size: 12px;
 }
 
 @media (min-width: 740px) {
-  .emotion-67 {
+  .emotion-68 {
     padding-top: 6px;
   }
 }
@@ -474,22 +485,28 @@ html:not(.src-focus-disabled) .emotion-60:focus {
 <div
   className="emotion-0"
 >
-  <header
+  <a
     className="emotion-1"
+    href="#maincontent"
+  >
+    Skip to main content
+  </a>
+  <header
+    className="emotion-2"
   >
     <div
-      className="emotion-2"
+      className="emotion-3"
     >
       <div
-        className="emotion-3"
+        className="emotion-4"
       >
         <a
-          className="emotion-4"
+          className="emotion-5"
           href="https://www.theguardian.com"
           title="The Guardian - Back to home"
         >
           <svg
-            className="emotion-5"
+            className="emotion-6"
             viewBox="0 0 56 56"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -507,10 +524,10 @@ html:not(.src-focus-disabled) .emotion-60:focus {
     </div>
   </header>
   <div
-    className="emotion-6"
+    className="emotion-7"
   >
     <main
-      className="emotion-7"
+      className="emotion-8"
     >
       <p>
         hi
@@ -520,19 +537,19 @@ html:not(.src-focus-disabled) .emotion-60:focus {
   <footer>
     <div>
       <div
-        className="emotion-8"
+        className="emotion-9"
       >
         <div
-          className="emotion-9"
+          className="emotion-10"
         >
           <div
-            className="emotion-10"
+            className="emotion-11"
           >
             <div
-              className="emotion-11"
+              className="emotion-12"
             >
               <iframe
-                className="emotion-12"
+                className="emotion-13"
                 data-form-success-desc="We will send you our picks of the most important headlines tomorrow morning."
                 data-node-uid="2"
                 frameBorder="0"
@@ -545,66 +562,66 @@ html:not(.src-focus-disabled) .emotion-60:focus {
               />
             </div>
             <div
-              className="emotion-13"
+              className="emotion-14"
             >
               <ul
-                className="emotion-14"
+                className="emotion-15"
               >
                 <li
-                  className="emotion-15"
+                  className="emotion-16"
                 >
                   <a
-                    className="emotion-16"
+                    className="emotion-17"
                     href="https://thegulocal.com/about"
                   >
                     About us
                   </a>
                 </li>
                 <li
-                  className="emotion-15"
+                  className="emotion-16"
                 >
                   <a
-                    className="emotion-16"
+                    className="emotion-17"
                     href="https://thegulocal.com/help/contact-us"
                   >
                     Contact us
                   </a>
                 </li>
                 <li
-                  className="emotion-15"
+                  className="emotion-16"
                 >
                   <a
-                    className="emotion-16"
+                    className="emotion-17"
                     href="https://thegulocal.com/info/complaints-and-corrections"
                   >
                     Complaints & corrections
                   </a>
                 </li>
                 <li
-                  className="emotion-15"
+                  className="emotion-16"
                 >
                   <a
-                    className="emotion-16"
+                    className="emotion-17"
                     href="https://thegulocal.com/securedrop"
                   >
                     Secure Drop
                   </a>
                 </li>
                 <li
-                  className="emotion-15"
+                  className="emotion-16"
                 >
                   <a
-                    className="emotion-16"
+                    className="emotion-17"
                     href="https://workforus.thegulocal.com"
                   >
                     Work for us
                   </a>
                 </li>
                 <li
-                  className="emotion-15"
+                  className="emotion-16"
                 >
                   <a
-                    className="emotion-16"
+                    className="emotion-17"
                     href="#"
                     onClick={[Function]}
                   >
@@ -612,40 +629,40 @@ html:not(.src-focus-disabled) .emotion-60:focus {
                   </a>
                 </li>
                 <li
-                  className="emotion-15"
+                  className="emotion-16"
                 >
                   <a
-                    className="emotion-16"
+                    className="emotion-17"
                     href="https://thegulocal.com/info/privacy"
                   >
                     Privacy policy
                   </a>
                 </li>
                 <li
-                  className="emotion-15"
+                  className="emotion-16"
                 >
                   <a
-                    className="emotion-16"
+                    className="emotion-17"
                     href="https://thegulocal.com/info/cookies"
                   >
                     Cookie policy
                   </a>
                 </li>
                 <li
-                  className="emotion-15"
+                  className="emotion-16"
                 >
                   <a
-                    className="emotion-16"
+                    className="emotion-17"
                     href="https://www.thegulocal.com/help/terms-of-service"
                   >
                     Terms & conditions
                   </a>
                 </li>
                 <li
-                  className="emotion-15"
+                  className="emotion-16"
                 >
                   <a
-                    className="emotion-16"
+                    className="emotion-17"
                     href="https://www.thegulocal.com/help"
                   >
                     Help
@@ -653,63 +670,63 @@ html:not(.src-focus-disabled) .emotion-60:focus {
                 </li>
               </ul>
               <ul
-                className="emotion-14"
+                className="emotion-15"
               >
                 <li
-                  className="emotion-15"
+                  className="emotion-16"
                 >
                   <a
-                    className="emotion-16"
+                    className="emotion-17"
                     href="https://thegulocal.com/index/subjects/a"
                   >
                     All topics
                   </a>
                 </li>
                 <li
-                  className="emotion-15"
+                  className="emotion-16"
                 >
                   <a
-                    className="emotion-16"
+                    className="emotion-17"
                     href="https://thegulocal.com/index/contributors"
                   >
                     All writers
                   </a>
                 </li>
                 <li
-                  className="emotion-15"
+                  className="emotion-16"
                 >
                   <a
-                    className="emotion-16"
+                    className="emotion-17"
                     href="https://uploads.guim.co.uk/2021/07/27/STL_&_GMG_Modern_Slavery_Act_Statement_2021.pdf"
                   >
                     Modern Slavery Act
                   </a>
                 </li>
                 <li
-                  className="emotion-15"
+                  className="emotion-16"
                 >
                   <a
-                    className="emotion-16"
+                    className="emotion-17"
                     href="https://theguardian.newspapers.com/"
                   >
                     Digital newspaper archive
                   </a>
                 </li>
                 <li
-                  className="emotion-15"
+                  className="emotion-16"
                 >
                   <a
-                    className="emotion-16"
+                    className="emotion-17"
                     href="https://www.facebook.com/theguardian"
                   >
                     Facebook
                   </a>
                 </li>
                 <li
-                  className="emotion-15"
+                  className="emotion-16"
                 >
                   <a
-                    className="emotion-16"
+                    className="emotion-17"
                     href="https://twitter.com/guardian"
                   >
                     Twitter
@@ -717,43 +734,43 @@ html:not(.src-focus-disabled) .emotion-60:focus {
                 </li>
               </ul>
               <ul
-                className="emotion-14"
+                className="emotion-15"
               >
                 <li
-                  className="emotion-15"
+                  className="emotion-16"
                 >
                   <a
-                    className="emotion-16"
+                    className="emotion-17"
                     href="https://advertising.thegulocal.com"
                   >
                     Advertise with us
                   </a>
                 </li>
                 <li
-                  className="emotion-15"
+                  className="emotion-16"
                 >
                   <a
-                    className="emotion-16"
+                    className="emotion-17"
                     href="https://thegulocal.com/guardian-labs"
                   >
                     Guardian Labs
                   </a>
                 </li>
                 <li
-                  className="emotion-15"
+                  className="emotion-16"
                 >
                   <a
-                    className="emotion-16"
+                    className="emotion-17"
                     href="https://jobs.thegulocal.com/?INTCMP=NGW_FOOTER_UK_GU_JOBS"
                   >
                     Search jobs
                   </a>
                 </li>
                 <li
-                  className="emotion-15"
+                  className="emotion-16"
                 >
                   <a
-                    className="emotion-16"
+                    className="emotion-17"
                     href="https://patrons.thegulocal.com/?INTCMP=footer_patrons"
                   >
                     Patrons
@@ -761,18 +778,18 @@ html:not(.src-focus-disabled) .emotion-60:focus {
                 </li>
               </ul>
               <div
-                className="emotion-57"
+                className="emotion-58"
               >
                 <div
-                  className="emotion-58"
+                  className="emotion-59"
                 >
                   Support The Guardian
                 </div>
                 <div
-                  className="emotion-59"
+                  className="emotion-60"
                 >
                   <a
-                    className="emotion-60"
+                    className="emotion-61"
                     href="https://support.thegulocal.com/contribute?INTCMP=mma_footer_support_contribute&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_MANAGE_MY_ACCOUNT%22%2C%22componentId%22%3A%22mma_footer_support_contribute%22%7D&displayExistingPaymentOptions=true"
                     onClick={[Function]}
                   >
@@ -796,7 +813,7 @@ html:not(.src-focus-disabled) .emotion-60:focus {
                   </a>
                 </div>
                 <a
-                  className="emotion-60"
+                  className="emotion-61"
                   href="https://support.thegulocal.com/subscribe?INTCMP=mma_footer_support_subscribe&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_MANAGE_MY_ACCOUNT%22%2C%22componentId%22%3A%22mma_footer_support_subscribe%22%7D&displayExistingPaymentOptions=true"
                   onClick={[Function]}
                 >
@@ -822,22 +839,22 @@ html:not(.src-focus-disabled) .emotion-60:focus {
             </div>
           </div>
           <div
-            className="emotion-62"
+            className="emotion-63"
           >
             <a
-              className="emotion-63"
+              className="emotion-64"
               href="#top"
             >
               <span
-                className="emotion-64"
+                className="emotion-65"
               >
                 Back to top
               </span>
               <span
-                className="emotion-65"
+                className="emotion-66"
               >
                 <span
-                  className="emotion-66"
+                  className="emotion-67"
                 >
                   <svg
                     height="18"
@@ -852,7 +869,7 @@ html:not(.src-focus-disabled) .emotion-60:focus {
               </span>
             </a>
             <div
-              className="emotion-67"
+              className="emotion-68"
             >
               © 
               2022

--- a/client/components/main.tsx
+++ b/client/components/main.tsx
@@ -1,4 +1,4 @@
-import { palette } from '@guardian/source-foundations';
+import { palette, textSansSizes } from '@guardian/source-foundations';
 import type { SignInStatus } from '../services/signInStatus';
 import { serif } from '../styles/fonts';
 import { Footer } from './footer/footer';
@@ -28,6 +28,20 @@ export const Main = ({
 			color: palette.neutral[20],
 		}}
 	>
+		<a
+			css={{
+				color: palette.brand[400],
+				position: 'absolute',
+				textAlign: 'center',
+				fontSize: `${textSansSizes.xxsmall}px`,
+				':focus': {
+					position: 'static',
+				},
+			}}
+			href="#maincontent"
+		>
+			Skip to main content
+		</a>
 		{helpCentrePage ? (
 			<HelpCentreHeader
 				signInStatus={signInStatus}

--- a/client/components/page.tsx
+++ b/client/components/page.tsx
@@ -259,6 +259,7 @@ const PageNavAndContentContainer = (props: PageNavAndContentContainerProps) => (
 			</nav>
 		)}
 		<section
+			id="maincontent"
 			css={{
 				...gridItemPlacement(1, 4),
 


### PR DESCRIPTION
## What does this change?

Adds a 'Skip to content' link as the first tabbable navigation item on the page that links to the main content after all the navigation content.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

On loading the page the 'Skip to content' link should not be visible.
On tabbing once it should become visible once in focus.
Clicking/pressing enter on the link takes the tabbed focus to the main content of the page - skipping the left nav bar.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

![image](https://user-images.githubusercontent.com/114918544/196922069-6bbb3c81-bbf6-4d7f-933c-1a34b0ccddc5.png)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [x] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
