### PR TITLE
[RB AH] - update supporter plus productTitle

### DIFF
--- a/shared/productTypes.tsx
+++ b/shared/productTypes.tsx
@@ -1,3 +1,4 @@
+import { capitalize } from 'lodash';
 import type { ReactNode } from 'react';
 import type {
 	CancellationReason,
@@ -21,6 +22,7 @@ import type { SupportTheGuardianButtonProps } from '../client/components/support
 import type { OphanProduct } from './ophanTypes';
 import type {
 	CancelledProductDetail,
+	PaidSubscriptionPlan,
 	ProductDetail,
 	Subscription,
 	SubscriptionPlan,
@@ -573,7 +575,10 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 		},
 	},
 	supporterplus: {
-		productTitle: () => 'Supporter Plus',
+		productTitle: (mainPlan?: SubscriptionPlan) => {
+			const paidMainPlan = mainPlan as PaidSubscriptionPlan;
+			return `${capitalize(paidMainPlan.interval)}ly + extras`;
+		},
 		friendlyName: 'supporter plus',
 		allProductsProductTypeFilterString: 'SupporterPlus',
 		urlPart: 'supporterplus',


### PR DESCRIPTION
## What does this change?
Update supporter plus productTitle to be either 'Monthly + extras' or 'Annually + extras'.

## Images
Before             |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/2510683/197230486-7da64f0d-d540-4b65-bcbb-4c8a06cbe667.png)  |  ![](https://user-images.githubusercontent.com/2510683/197230542-d5eaa49e-1534-47fd-b2e0-85112533f302.png)

