### PR TITLE
[AHE] Update supporter plus friendly name property in ProductTypes

### DIFF
--- a/client/components/MMAPageSkeleton.tsx
+++ b/client/components/MMAPageSkeleton.tsx
@@ -20,7 +20,8 @@ const manageProductLocationObjects: LocationObject[] = Object.values(
 	GROUPED_PRODUCT_TYPES,
 ).map((groupedProductType) => ({
 	title: `Manage ${
-		groupedProductType.shortFriendlyName || groupedProductType.friendlyName
+		groupedProductType.shortFriendlyName ||
+		groupedProductType.friendlyName()
 	}`,
 	path: `/${groupedProductType.urlPart}`,
 	selectedNavItem: NAV_LINKS.accountOverview,
@@ -30,7 +31,7 @@ const cancellationFlowLocationObjects: LocationObject[] = Object.values(
 	PRODUCT_TYPES,
 ).map((productType) => ({
 	title: `Cancel ${
-		productType.shortFriendlyName || productType.friendlyName
+		productType.shortFriendlyName || productType.friendlyName()
 	}`,
 	path: `/cancel/${productType.urlPart}`,
 	selectedNavItem: NAV_LINKS.accountOverview,

--- a/client/components/accountoverview/accountOverviewCard.tsx
+++ b/client/components/accountoverview/accountOverviewCard.tsx
@@ -343,9 +343,9 @@ export const AccountOverviewCard = (props: AccountOverviewCardProps) => {
 							<LinkButton
 								aria-label={`${specificProductType.productTitle(
 									mainPlan,
-								)} : Manage ${groupedProductType.friendlyName}`}
+								)} : Manage ${groupedProductType.friendlyName()}`}
 								tabIndex={0}
-								data-cy={`Manage ${groupedProductType.friendlyName}`}
+								data-cy={`Manage ${groupedProductType.friendlyName()}`}
 								role="link"
 								priority="secondary"
 								size="small"
@@ -362,7 +362,7 @@ export const AccountOverviewCard = (props: AccountOverviewCardProps) => {
 									});
 								}}
 							>
-								{`Manage ${groupedProductType.friendlyName}`}
+								{`Manage ${groupedProductType.friendlyName()}`}
 							</LinkButton>
 						</div>
 					)}

--- a/client/components/accountoverview/manageProduct.tsx
+++ b/client/components/accountoverview/manageProduct.tsx
@@ -332,7 +332,7 @@ const InnerContent = ({
 							`}
 						>
 							To renew this one-off{' '}
-							{specificProductType.friendlyName}, please contact
+							{specificProductType.friendlyName()}, please contact
 							us.
 						</p>
 						<CallCentreEmailAndNumbers />
@@ -342,8 +342,8 @@ const InnerContent = ({
 							`}
 						>
 							Alternatively, if you would prefer to start a
-							recurring {specificProductType.friendlyName} you can
-							explore payment options and subscribe online by
+							recurring {specificProductType.friendlyName()} you
+							can explore payment options and subscribe online by
 							clicking the button below.
 						</p>
 						<SupportTheGuardianButton
@@ -364,7 +364,7 @@ const InnerContent = ({
 			{!hasCancellationPending && (
 				<CancellationCTA
 					productDetail={productDetail}
-					friendlyName={groupedProductType.friendlyName}
+					friendlyName={groupedProductType.friendlyName()}
 					specificProductType={specificProductType}
 				/>
 			)}
@@ -421,7 +421,7 @@ const ManageProduct = (props: WithGroupedProductType<GroupedProductType>) => {
 			selectedNavItem={NAV_LINKS.accountOverview}
 			pageTitle={`Manage ${
 				props.groupedProductType.shortFriendlyName ||
-				props.groupedProductType.friendlyName
+				props.groupedProductType.friendlyName()
 			}`}
 			breadcrumbs={[
 				{
@@ -429,7 +429,7 @@ const ManageProduct = (props: WithGroupedProductType<GroupedProductType>) => {
 					link: NAV_LINKS.accountOverview.link,
 				},
 				{
-					title: `Manage ${props.groupedProductType.friendlyName}`,
+					title: `Manage ${props.groupedProductType.friendlyName()}`,
 					currentPage: true,
 				},
 			]}

--- a/client/components/cancel/CancellationContainer.tsx
+++ b/client/components/cancel/CancellationContainer.tsx
@@ -92,7 +92,7 @@ const CancellationContainer = (props: WithProductType<ProductType>) => {
 	const [pageTitle, setPageTitle] = useState<string>(
 		`Cancel ${
 			props.productType.shortFriendlyName ||
-			props.productType.friendlyName
+			props.productType.friendlyName(productDetail)
 		}`,
 	);
 
@@ -120,7 +120,9 @@ const CancellationContainer = (props: WithProductType<ProductType>) => {
 							render={renderSingleProductOrReturnToAccountOverview(
 								props.productType,
 							)}
-							loadingMessage={`Checking the status of your ${props.productType.friendlyName}...`}
+							loadingMessage={`Checking the status of your ${props.productType.friendlyName(
+								productDetail,
+							)}...`}
 						/>
 					)}
 				</PageContainer>

--- a/client/components/cancel/CancellationReasonSelection.tsx
+++ b/client/components/cancel/CancellationReasonSelection.tsx
@@ -323,7 +323,8 @@ const CancellationReasonSelection = () => {
 				productDetail,
 			)}
 			loadingMessage={`Checking your ${
-				productType.shortFriendlyName || productType.friendlyName
+				productType.shortFriendlyName ||
+				productType.friendlyName(productDetail)
 			} details...`}
 		/>
 	) : (

--- a/client/components/cancel/CancellationSwitchEligibilityCheck.tsx
+++ b/client/components/cancel/CancellationSwitchEligibilityCheck.tsx
@@ -36,7 +36,9 @@ const CancellationSwitchEligibilityCheck = () => {
 		pageTitleContext.setPageTitle(
 			`Cancel ${
 				cancellationContext.productType.shortFriendlyName ||
-				cancellationContext.productType.friendlyName
+				cancellationContext.productType.friendlyName(
+					routerState.productDetail,
+				)
 			}`,
 		);
 		return <CancellationReasonSelection />;
@@ -65,7 +67,9 @@ const CancellationSwitchEligibilityCheck = () => {
 				<Spinner
 					loadingMessage={`Checking your ${
 						cancellationContext.productType.shortFriendlyName ||
-						cancellationContext.productType.friendlyName
+						cancellationContext.productType.friendlyName(
+							routerState.productDetail,
+						)
 					} details...`}
 				/>
 			</WithStandardTopMargin>

--- a/client/components/cancel/cancellationSummary.tsx
+++ b/client/components/cancel/cancellationSummary.tsx
@@ -21,10 +21,10 @@ import { CancellationContributionReminder } from './cancellationContributionRemi
 const actuallyCancelled = (
 	productType: ProductType,
 	productDetail: ProductDetail,
+	productFriendlyName: string,
 ) => {
 	const deliveryRecordsLink: string = `/delivery/${productType.urlPart}/records`;
 	const subscription = productDetail.subscription;
-
 	return (
 		<>
 			<WithStandardTopMargin>
@@ -36,7 +36,7 @@ const actuallyCancelled = (
 						`,
 					]}
 				>
-					Your {productType.friendlyName} is cancelled.
+					Your {productFriendlyName} is cancelled.
 				</Heading>
 				{productType.cancellation &&
 					!productType.cancellation.shouldHideSummaryMainPara && (
@@ -46,8 +46,8 @@ const actuallyCancelled = (
 								(subscription.end ? (
 									<>
 										You will continue to receive the
-										benefits of your{' '}
-										{productType.friendlyName} until{' '}
+										benefits of your {productFriendlyName}{' '}
+										until{' '}
 										<b>
 											{cancellationFormatDate(
 												subscription.cancellationEffectiveDate,
@@ -175,13 +175,14 @@ export const isCancelled = (subscription: Subscription) =>
 	Object.keys(subscription).length === 0 || subscription.cancelledAt;
 
 export const getCancellationSummary =
-	(productType: ProductType) => (productDetail: ProductDetail) =>
+	(productType: ProductType, productFriendlyName: string) =>
+	(productDetail: ProductDetail) =>
 		isCancelled(productDetail.subscription) ? (
-			actuallyCancelled(productType, productDetail)
+			actuallyCancelled(productType, productDetail, productFriendlyName)
 		) : (
 			<GenericErrorScreen
 				loggingMessage={
-					productType.friendlyName +
+					productFriendlyName +
 					" cancellation call succeeded but subsequent product detail doesn't show as cancelled"
 				}
 			/>

--- a/client/components/cancel/stages/executeCancellation.tsx
+++ b/client/components/cancel/stages/executeCancellation.tsx
@@ -106,11 +106,19 @@ const getCancellationSummaryWithReturnButton = (body: ReactNode) => () =>
 	);
 
 const getCaseUpdatingCancellationSummary =
-	(caseId: string | '', productType: ProductTypeWithCancellationFlow) =>
+	(
+		caseId: string | '',
+		productType: ProductTypeWithCancellationFlow,
+		productFriendlyName: string,
+	) =>
 	(productDetails: ProductDetail[]) => {
 		const productDetail = productDetails[0] || { subscription: {} };
+		console.log('executeCancellation productDetail', productDetail);
 		const render = getCancellationSummaryWithReturnButton(
-			getCancellationSummary(productType)(productDetail),
+			getCancellationSummary(
+				productType,
+				productFriendlyName,
+			)(productDetail),
 		);
 		return caseId ? (
 			<CaseUpdateAsyncLoader
@@ -198,6 +206,7 @@ const ExecuteCancellation = () => {
 						render={getCaseUpdatingCancellationSummary(
 							caseId,
 							productType,
+							productType.friendlyName(productDetail),
 						)}
 						loadingMessage="Performing your cancellation..."
 					/>

--- a/client/components/cancel/stages/executeCancellation.tsx
+++ b/client/components/cancel/stages/executeCancellation.tsx
@@ -113,7 +113,6 @@ const getCaseUpdatingCancellationSummary =
 	) =>
 	(productDetails: ProductDetail[]) => {
 		const productDetail = productDetails[0] || { subscription: {} };
-		console.log('executeCancellation productDetail', productDetail);
 		const render = getCancellationSummaryWithReturnButton(
 			getCancellationSummary(
 				productType,

--- a/client/components/delivery/address/deliveryAddressConfirmation.tsx
+++ b/client/components/delivery/address/deliveryAddressConfirmation.tsx
@@ -46,7 +46,7 @@ const AddressConfirmation = (props: ProductType) => {
 		AddressChangedInformationContext,
 	);
 
-	const productName = props.friendlyName;
+	const productName = props.friendlyName();
 
 	if (isAddress(addressContext.addressStateObject)) {
 		productDetail.subscription.deliveryAddress = {

--- a/client/components/delivery/address/deliveryAddressForm.tsx
+++ b/client/components/delivery/address/deliveryAddressForm.tsx
@@ -101,10 +101,9 @@ const Form = (props: FormProps) => {
 	)
 		.flatMap(flattenEquivalent)
 		.map(({ productDetail }) => {
-			const friendlyProductName =
-				GROUPED_PRODUCT_TYPES.subscriptions.mapGroupedToSpecific(
-					productDetail,
-				).friendlyName;
+			const friendlyProductName = GROUPED_PRODUCT_TYPES.subscriptions
+				.mapGroupedToSpecific(productDetail)
+				.friendlyName();
 			return `${friendlyProductName}`;
 		});
 

--- a/client/components/delivery/address/formValidation.tsx
+++ b/client/components/delivery/address/formValidation.tsx
@@ -37,8 +37,9 @@ export const isFormValid = (
 		isPostcodeInM25(formData.postcode);
 
 	const enteredPostcodeIsInValidArea =
-		!subscriptionsNames.includes(PRODUCT_TYPES.homedelivery.friendlyName) ||
-		enteredPostcodeIsInM25;
+		!subscriptionsNames.includes(
+			PRODUCT_TYPES.homedelivery.friendlyName(),
+		) || enteredPostcodeIsInM25;
 
 	const postcode = {
 		isValid: postcodeEnteredCheck && enteredPostcodeIsInValidArea,
@@ -49,7 +50,7 @@ export const isFormValid = (
 	};
 
 	const userHasVoucherSubscription = subscriptionsNames.includes(
-		PRODUCT_TYPES.voucher.friendlyName,
+		PRODUCT_TYPES.voucher.friendlyName(),
 	);
 
 	const country = {

--- a/client/components/delivery/records/DeliveryRecordsContainer.tsx
+++ b/client/components/delivery/records/DeliveryRecordsContainer.tsx
@@ -92,7 +92,7 @@ const DeliveryRecordsContainer = (
 				<MembersDataApiAsyncLoader
 					fetch={createProductDetailFetcher(props.productType)}
 					render={handleMembersDataResponse(props.productType)}
-					loadingMessage={`Retrieving details of your ${props.productType.friendlyName}...`}
+					loadingMessage={`Retrieving details of your ${props.productType.friendlyName()}...`}
 				/>
 			)}
 		</PageContainer>

--- a/client/components/delivery/records/deliveryAddressStep.tsx
+++ b/client/components/delivery/records/deliveryAddressStep.tsx
@@ -168,10 +168,9 @@ export const DeliveryAddressStep = (props: DeliveryAddressStepProps) => {
 		)
 			.flatMap(flattenEquivalent)
 			.map(({ productDetail }) => {
-				const friendlyProductName =
-					GROUPED_PRODUCT_TYPES.subscriptions.mapGroupedToSpecific(
-						productDetail,
-					).friendlyName;
+				const friendlyProductName = GROUPED_PRODUCT_TYPES.subscriptions
+					.mapGroupedToSpecific(productDetail)
+					.friendlyName();
 				return `${friendlyProductName}`;
 			});
 

--- a/client/components/delivery/records/deliveryRecords.tsx
+++ b/client/components/delivery/records/deliveryRecords.tsx
@@ -295,7 +295,7 @@ const DeliveryRecords = () => {
 				`}
 			>
 				<ProductDetailsTable
-					productName={capitalize(productType.friendlyName)}
+					productName={capitalize(productType.friendlyName())}
 					subscriptionId={productDetail.subscription.subscriptionId}
 					isGift={isGift(productDetail.subscription)}
 				/>
@@ -547,7 +547,7 @@ const DeliveryRecords = () => {
 						)}
 						productName={capitalize(
 							productType.shortFriendlyName ||
-								productType.friendlyName,
+								productType.friendlyName(),
 						)}
 					/>
 				),

--- a/client/components/delivery/records/deliveryRecordsProblemConfirmation.tsx
+++ b/client/components/delivery/records/deliveryRecordsProblemConfirmation.tsx
@@ -248,7 +248,7 @@ const DeliveryRecordsProblemConfirmationFC = (
 						<dt css={dtCss}>Product:</dt>
 						<dd css={ddCss}>
 							{productType.shortFriendlyName ||
-								productType.friendlyName}
+								productType.friendlyName()}
 						</dd>
 					</div>
 					<div>

--- a/client/components/delivery/records/deliveryRecordsProblemReview.tsx
+++ b/client/components/delivery/records/deliveryRecordsProblemReview.tsx
@@ -144,7 +144,7 @@ const DeliveryRecordsProblemReviewFC = (
 	const repeatDeliveryProblem = checkForExistingDeliveryProblem(data.results);
 	const subscription = productDetail.subscription;
 	const productName = capitalize(
-		productType.shortFriendlyName || productType.friendlyName,
+		productType.shortFriendlyName || productType.friendlyName(),
 	);
 	const subscriptionCurrency = mainPlan.currency;
 	const deliveryProblemMap = data.deliveryProblemMap;

--- a/client/components/holiday/HolidayStopsContainer.tsx
+++ b/client/components/holiday/HolidayStopsContainer.tsx
@@ -195,7 +195,7 @@ const HolidayStopsContainer = (
 						publicationsImpacted,
 						setPublicationsImpacted,
 					)}
-					loadingMessage={`Retrieving details of your ${props.productType.friendlyName}...`}
+					loadingMessage={`Retrieving details of your ${props.productType.friendlyName()}...`}
 				/>
 			)}
 		</PageContainer>

--- a/client/components/holiday/holidaysOverview.tsx
+++ b/client/components/holiday/holidaysOverview.tsx
@@ -104,7 +104,7 @@ const HolidaysOverview = () => {
 
 	return (
 		<>
-			<h1>Suspend {productType.friendlyName}</h1>
+			<h1>Suspend {productType.friendlyName()}</h1>
 			{productDetail.subscription.autoRenew ? (
 				<OverviewRow heading="How">
 					<>

--- a/client/components/payment/update/PaymentDetailUpdateContainer.tsx
+++ b/client/components/payment/update/PaymentDetailUpdateContainer.tsx
@@ -84,7 +84,7 @@ const PaymentDetailUpdateContainer = (props: WithProductType<ProductType>) => {
 				<MembersDataApiAsyncLoader
 					fetch={createProductDetailFetcher(props.productType)}
 					render={renderContextAndOutletContainer}
-					loadingMessage={`Retrieving current payment details for your ${props.productType.friendlyName}...`}
+					loadingMessage={`Retrieving current payment details for your ${props.productType.friendlyName()}...`}
 				/>
 			)}
 		</PageContainer>

--- a/client/components/productSwitch/CancellationSwitchConfirmed.tsx
+++ b/client/components/productSwitch/CancellationSwitchConfirmed.tsx
@@ -61,7 +61,7 @@ const CancellationSwitchConfirmed = () => {
 				<Heading>Your {newProduct.name} is now active</Heading>
 				<p css={[textSans.medium(), measure.copy]}>
 					Your {newProduct.billing.frequency.name}ly{' '}
-					{productSwitchContext.productType.friendlyName} has
+					{productSwitchContext.productType.friendlyName()} has
 					successfully been changed to a {newProduct.name}. We’ve
 					stopped your previous payments and started you on your new
 					plan. Please check your inbox for an email containing all
@@ -135,9 +135,7 @@ const CancellationSwitchConfirmed = () => {
 						</li>
 						<li>
 							We'll stop your {newProduct.billing.frequency.name}
-							ly {
-								productSwitchContext.productType.friendlyName
-							}{' '}
+							ly {productSwitchContext.productType.friendlyName()}{' '}
 							payments.
 						</li>
 						{newProduct && (

--- a/client/components/productSwitch/CancellationSwitchReview.tsx
+++ b/client/components/productSwitch/CancellationSwitchReview.tsx
@@ -463,14 +463,14 @@ const CancellationSwitchReview = () => {
 					If you decide to change your support to a{' '}
 					{chosenProduct.name} we’ll stop your{' '}
 					{chosenProduct.billing.frequency.name}ly{' '}
-					{productSwitchContext.productType.friendlyName} payments
+					{productSwitchContext.productType.friendlyName()} payments
 					straight away and you’ll have immediate access to the
 					benefits of a {chosenProduct.name}.
 				</p>
 			</Stack>
 			<div css={cardLayoutCss}>
 				<Card
-					heading={`Your ${productSwitchContext.productType.friendlyName}`}
+					heading={`Your ${productSwitchContext.productType.friendlyName()}`}
 				>
 					{chosenProduct.introOffer && (
 						<hr
@@ -717,10 +717,7 @@ const CancellationSwitchReview = () => {
 									We'll stop your{' '}
 									{chosenProduct.billing.frequency.name}
 									ly{' '}
-									{
-										productSwitchContext.productType
-											.friendlyName
-									}{' '}
+									{productSwitchContext.productType.friendlyName()}{' '}
 									payments.
 								</li>
 								<li>

--- a/client/services/deliveryAddress.ts
+++ b/client/services/deliveryAddress.ts
@@ -60,7 +60,7 @@ export const addressChangeAffectedInfo = (
 		.flatMap<ProductDetailAndProductType>(flattenEquivalent)
 		.map(({ productDetail, productType }) => {
 			const friendlyProductName = capitalize(
-				productType.shortFriendlyName || productType.friendlyName,
+				productType.shortFriendlyName || productType.friendlyName(),
 			).trim();
 			const effectiveDate = productDetail.subscription
 				.deliveryAddressChangeEffectiveDate

--- a/cypress/integration/parallel-2/cancelSupporterPlus.spec.ts
+++ b/cypress/integration/parallel-2/cancelSupporterPlus.spec.ts
@@ -73,7 +73,7 @@ describe('Cancel Supporter Plus', () => {
 		cy.wait('@new_product_detail');
 
 		cy.findByRole('heading', {
-			name: 'Your supporter plus is cancelled.',
+			name: 'Your monthly + extras is cancelled.',
 		});
 	});
 });

--- a/server/fulfilmentDateCalculatorReader.ts
+++ b/server/fulfilmentDateCalculatorReader.ts
@@ -72,7 +72,7 @@ export const augmentProductDetailWithDeliveryAddressChangeEffectiveDateForToday 
 			maybeFulfilmentDateCalculatorProductFilenamePart &&
 			!(maybeDeliveryAddressChangeEffectiveDate && maybeDaysOfWeek)
 		) {
-			const errorMessage = `Expected 'deliveryAddressChangeEffectiveDate' to be available for ${productType.friendlyName}, but wasn't.`;
+			const errorMessage = `Expected 'deliveryAddressChangeEffectiveDate' to be available for ${productType.friendlyName()}, but wasn't.`;
 			log.error(errorMessage);
 			Sentry.captureMessage(errorMessage);
 		}


### PR DESCRIPTION
## What does this change?

Change the title 'Supporter Plus' to 'Monthly/Annual + extras' using the friendly name property of ProductType.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Cancel a supporter plus subscription - witness that the title should say 'Cancel monthly/Annual + extras'.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images
Before 
<img width="606" alt="image" src="https://user-images.githubusercontent.com/114918544/197828773-15444df6-88b0-46bb-8228-f1d2e8169531.png">
After
<img width="582" alt="image" src="https://user-images.githubusercontent.com/114918544/197828562-ec940844-e7e3-40e1-b73e-195a12aea26f.png">
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
