### PR TITLE
Update grouped product types

### DIFF
--- a/client/components/accountoverview/accountOverview.tsx
+++ b/client/components/accountoverview/accountOverview.tsx
@@ -7,6 +7,7 @@ import {
 	until,
 } from '@guardian/source-foundations';
 import { Stack } from '@guardian/source-react-components';
+import { capitalize } from 'lodash';
 import { Fragment } from 'react';
 import type {
 	CancelledProductDetail,
@@ -89,7 +90,7 @@ const AccountOverviewRenderer = ([mdaResponse, cancelledProductsResponse]: [
 				return (
 					<Fragment key={category}>
 						<h2 css={subHeadingCss}>
-							My {groupedProductType.groupFriendlyName}
+							{capitalize(groupedProductType.groupFriendlyName)}
 						</h2>
 						<Stack space={6}>
 							{activeProductsInCategory.map((productDetail) => (
@@ -112,10 +113,7 @@ const AccountOverviewRenderer = ([mdaResponse, cancelledProductsResponse]: [
 									/>
 								),
 							)}
-							{(groupedProductType.groupFriendlyName ===
-								'membership' ||
-								groupedProductType.groupFriendlyName ===
-									'contribution') &&
+							{groupedProductType.supportTheGuardianSectionProps &&
 								(cancelledProductsInCategory.length > 0 ||
 									activeProductsInCategory.some(
 										(productDetail) =>

--- a/client/components/accountoverview/accountOverviewCancelledCard.tsx
+++ b/client/components/accountoverview/accountOverviewCancelledCard.tsx
@@ -32,7 +32,8 @@ export const AccountOverviewCancelledCard = (
 
 	const showSubscribeAgainButton =
 		props.product.mmaCategory !== 'membership' &&
-		props.product.mmaCategory !== 'contributions';
+		props.product.mmaCategory !== 'contributions' &&
+		props.product.mmaCategory !== 'recurringSupport';
 
 	const shouldShowJoinDateNotStartDate =
 		groupedProductType.shouldShowJoinDateNotStartDate;

--- a/client/fixtures/productDetail.ts
+++ b/client/fixtures/productDetail.ts
@@ -389,7 +389,7 @@ export const homeDeliverySubscription: ProductDetail = {
 };
 
 export const contribution: ProductDetail = {
-	mmaCategory: 'contributions',
+	mmaCategory: 'recurringSupport',
 	tier: 'Contributor',
 	isPaidTier: true,
 	selfServiceCancellation: {
@@ -513,10 +513,11 @@ export const patronDigitalSub = {
 	},
 };
 
-export const supporterPlus = {
-	mmaCategory: 'subscriptions',
+export const supporterPlus: ProductDetail = {
+	mmaCategory: 'recurringSupport',
 	tier: 'Supporter Plus',
 	isPaidTier: true,
+	isTestUser: false,
 	selfServiceCancellation: {
 		isAllowed: false,
 		shouldDisplayEmail: false,
@@ -537,7 +538,6 @@ export const supporterPlus = {
 			email: 'test.user@example.com',
 		},
 		contactId: '0039E00001VVNb5QAH',
-		deliveryAddress: {},
 		safeToUpdatePaymentMethod: true,
 		start: '2022-07-20',
 		end: '2022-08-20',
@@ -552,13 +552,6 @@ export const supporterPlus = {
 		subscriptionId: 'A-S00393340',
 		trialLength: -2,
 		autoRenew: true,
-		plan: {
-			name: 'Supporter Plus',
-			amount: 5000,
-			currency: '£',
-			currencyISO: 'GBP',
-			interval: 'month',
-		},
 		currentPlans: [
 			{
 				name: null,
@@ -575,6 +568,5 @@ export const supporterPlus = {
 		futurePlans: [],
 		readerType: 'Direct',
 		accountId: '8ad088718219a6b601821bbe9e6210f2',
-		cancellationEffectiveDate: null,
 	},
 };

--- a/cypress/integration/parallel-2/cancelContribution.spec.ts
+++ b/cypress/integration/parallel-2/cancelContribution.spec.ts
@@ -2,6 +2,27 @@ import { contribution } from '../../../client/fixtures/productDetail';
 import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
 
 describe('Cancel contribution', () => {
+	const setupCancellation = () => {
+		cy.visit('/');
+
+		cy.window().then((window) => {
+			// @ts-ignore
+			window.guardian.identityDetails = {
+				signInStatus: 'signedInRecently',
+				userId: '200006712',
+				displayName: 'user',
+				email: 'example@example.com',
+			};
+		});
+
+		cy.findByText('Manage recurring support').click();
+		cy.wait('@cancelled');
+
+		cy.findByRole('link', {
+			name: 'Cancel recurring support',
+		}).click();
+	};
+
 	beforeEach(() => {
 		cy.setCookie('GU_mvt_id', '0');
 
@@ -50,24 +71,7 @@ describe('Cancel contribution', () => {
 	});
 
 	it('cancels contribution (reason: As a result of a specific article I read)', () => {
-		cy.visit('/');
-
-		cy.window().then((window) => {
-			// @ts-ignore
-			window.guardian.identityDetails = {
-				signInStatus: 'signedInRecently',
-				userId: '200006712',
-				displayName: 'user',
-				email: 'example@example.com',
-			};
-		});
-
-		cy.findByText('Manage recurring contribution').click();
-		cy.wait('@cancelled');
-
-		cy.findByRole('link', {
-			name: 'Cancel recurring contribution',
-		}).click();
+		setupCancellation();
 		cy.findAllByRole('radio').eq(0).click();
 		cy.findByRole('button', { name: 'Continue' }).click();
 
@@ -92,24 +96,7 @@ describe('Cancel contribution', () => {
 			statusCode: 500,
 		}).as('get_case');
 
-		cy.visit('/');
-
-		cy.window().then((window) => {
-			// @ts-ignore
-			window.guardian.identityDetails = {
-				signInStatus: 'signedInRecently',
-				userId: '200006712',
-				displayName: 'user',
-				email: 'example@example.com',
-			};
-		});
-
-		cy.findByText('Manage recurring contribution').click();
-		cy.wait('@cancelled');
-
-		cy.findByRole('link', {
-			name: 'Cancel recurring contribution',
-		}).click();
+		setupCancellation();
 		cy.findAllByRole('radio').eq(0).click();
 		cy.findByRole('button', { name: 'Continue' }).click();
 
@@ -119,24 +106,7 @@ describe('Cancel contribution', () => {
 	});
 
 	it('cancels contribution with custom save body component (reason: I can no longer afford it)', () => {
-		cy.visit('/');
-
-		cy.window().then((window) => {
-			// @ts-ignore
-			window.guardian.identityDetails = {
-				signInStatus: 'signedInRecently',
-				userId: '200006712',
-				displayName: 'user',
-				email: 'example@example.com',
-			};
-		});
-
-		cy.findByText('Manage recurring contribution').click();
-		cy.wait('@cancelled');
-
-		cy.findByRole('link', {
-			name: 'Cancel recurring contribution',
-		}).click();
+		setupCancellation();
 		cy.findAllByRole('radio').eq(4).click();
 		cy.findByRole('button', { name: 'Continue' }).click();
 
@@ -159,24 +129,7 @@ describe('Cancel contribution', () => {
 	});
 
 	it('cancels contribution with custom save body component (reason: A payment issue)', () => {
-		cy.visit('/');
-
-		cy.window().then((window) => {
-			// @ts-ignore
-			window.guardian.identityDetails = {
-				signInStatus: 'signedInRecently',
-				userId: '200006712',
-				displayName: 'user',
-				email: 'example@example.com',
-			};
-		});
-
-		cy.findByText('Manage recurring contribution').click();
-		cy.wait('@cancelled');
-
-		cy.findByRole('link', {
-			name: 'Cancel recurring contribution',
-		}).click();
+		setupCancellation();
 		cy.findAllByRole('radio').eq(6).click();
 		cy.findByRole('button', { name: 'Continue' }).click();
 
@@ -204,24 +157,7 @@ describe('Cancel contribution', () => {
 	});
 
 	it('cancels contribution with save body string (reason: I would rather make a single contribution)', () => {
-		cy.visit('/');
-
-		cy.window().then((window) => {
-			// @ts-ignore
-			window.guardian.identityDetails = {
-				signInStatus: 'signedInRecently',
-				userId: '200006712',
-				displayName: 'user',
-				email: 'example@example.com',
-			};
-		});
-
-		cy.findByText('Manage recurring contribution').click();
-		cy.wait('@cancelled');
-
-		cy.findByRole('link', {
-			name: 'Cancel recurring contribution',
-		}).click();
+		setupCancellation();
 		cy.findAllByRole('radio').eq(8).click();
 		cy.findByRole('button', { name: 'Continue' }).click();
 
@@ -250,24 +186,7 @@ describe('Cancel contribution', () => {
 			body: { status: 'success' },
 		});
 
-		cy.visit('/');
-
-		cy.window().then((window) => {
-			// @ts-ignore
-			window.guardian.identityDetails = {
-				signInStatus: 'signedInRecently',
-				userId: '200006712',
-				displayName: 'user',
-				email: 'example@example.com',
-			};
-		});
-
-		cy.findByText('Manage recurring contribution').click();
-		cy.wait('@cancelled');
-
-		cy.findByRole('link', {
-			name: 'Cancel recurring contribution',
-		}).click();
+		setupCancellation();
 		cy.findAllByRole('radio').eq(4).click();
 		cy.findByRole('button', { name: 'Continue' }).click();
 

--- a/cypress/integration/parallel-2/cancelSupporterPlus.spec.ts
+++ b/cypress/integration/parallel-2/cancelSupporterPlus.spec.ts
@@ -2,6 +2,17 @@ import { supporterPlus } from '../../../client/fixtures/productDetail';
 import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
 
 describe('Cancel Supporter Plus', () => {
+	const setupCancellation = () => {
+		cy.visit('/');
+
+		cy.findByText('Manage recurring support').click();
+		cy.wait('@cancelled');
+
+		cy.findByRole('link', {
+			name: 'Cancel recurring support',
+		}).click();
+	};
+
 	beforeEach(() => {
 		cy.setCookie('GU_mvt_id', '0');
 
@@ -52,14 +63,7 @@ describe('Cancel Supporter Plus', () => {
 	});
 
 	it('allows self-service cancellation of Supporter Plus', () => {
-		cy.visit('/');
-
-		cy.findByText('Manage subscription').click();
-		cy.wait('@cancelled');
-
-		cy.findByRole('link', {
-			name: 'Cancel subscription',
-		}).click();
+		setupCancellation();
 
 		cy.findAllByRole('radio').eq(0).click();
 		cy.findByRole('button', { name: 'Continue' }).click();

--- a/shared/productTypes.tsx
+++ b/shared/productTypes.tsx
@@ -31,7 +31,6 @@ import type {
 import { getMainPlan, isGift } from './productResponse';
 
 type ProductFriendlyName =
-	| 'support' // TODO confirm if this is acceptable fallback for supporter plus where 'monthly' or 'annual' cannot be calculated
 	| 'membership'
 	| 'recurring contribution' // TODO use payment frequency instead of 'recurring' e.g. monthly annual etc
 	| 'newspaper subscription'
@@ -43,6 +42,7 @@ type ProductFriendlyName =
 	| 'annual + extras'
 	| 'Guardian Weekly subscription'
 	| 'subscription'
+	| 'recurring support'
 	| 'guardian patron';
 type ProductUrlPart =
 	| 'membership'
@@ -55,6 +55,7 @@ type ProductUrlPart =
 	| 'support'
 	| 'guardianweekly'
 	| 'subscriptions'
+	| 'recurringsupport'
 	| 'guardianpatron';
 type SfCaseProduct =
 	| 'Membership'
@@ -75,7 +76,8 @@ type AllProductsProductTypeFilterString =
 	| 'Digipack'
 	| 'SupporterPlus'
 	| 'ContentSubscription'
-	| 'GuardianPatron';
+	| 'GuardianPatron'
+	| 'RecurringSupport';
 
 interface CancellationFlowProperties {
 	reasons: CancellationReason[];
@@ -184,7 +186,7 @@ export interface GroupedProductType extends ProductType {
 		productDetail: ProductDetail | CancelledProductDetail,
 	) => ProductType;
 	groupFriendlyName: string;
-	supportTheGuardianSectionProps: SupportTheGuardianButtonProps & {
+	supportTheGuardianSectionProps?: SupportTheGuardianButtonProps & {
 		message: string;
 	};
 }
@@ -249,6 +251,7 @@ type ProductTypeKeys =
 export type GroupedProductTypeKeys =
 	| 'membership'
 	| 'contributions'
+	| 'recurringSupport'
 	| 'subscriptions';
 
 export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
@@ -588,7 +591,7 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 		},
 		friendlyName: (productDetail?: ProductDetail) => {
 			if (!productDetail) {
-				return 'support';
+				return 'recurring support';
 			}
 
 			const interval = (
@@ -602,9 +605,9 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 		showTrialRemainingIfApplicable: true,
 		softOptInIDs: [
 			SOFT_OPT_IN_IDS.support_onboarding,
-			// SOFT_OPT_IN_IDS.digi_subscriber_preview, TODO: is there an equivalent of this for the new product?
 			SOFT_OPT_IN_IDS.similar_products,
 			SOFT_OPT_IN_IDS.supporter_newsletter,
+			SOFT_OPT_IN_IDS.digi_subscriber_preview,
 		],
 		cancellation: {
 			linkOnProductPage: true,
@@ -656,20 +659,32 @@ export const GROUPED_PRODUCT_TYPES: {
 		supportTheGuardianSectionProps: {
 			supportReferer: 'account_overview_membership_section',
 			message:
-				'We no longer have a membership programme but you can still continue to support The Guardian via a contribution or subscription.',
+				'We no longer have a membership programme but you can still continue to support The Guardian.',
 		},
 	},
 	contributions: {
 		...PRODUCT_TYPES.contributions,
 		mapGroupedToSpecific: () => PRODUCT_TYPES.contributions,
 		groupFriendlyName: 'contributions',
-		supportTheGuardianSectionProps: {
-			alternateButtonText: 'Contribute again',
-			supportReferer: 'account_overview_contributions_section',
-			urlSuffix: 'contribute',
-			message:
-				'You can use your existing payment details, so setting up a new recurring contribution only takes a minute.',
+	},
+	recurringSupport: {
+		productTitle: () => 'Recurring support',
+		friendlyName: () => 'recurring support',
+		groupFriendlyName: 'recurring support',
+		allProductsProductTypeFilterString: 'RecurringSupport',
+		urlPart: 'recurringsupport',
+		mapGroupedToSpecific: (
+			productDetail: ProductDetail | CancelledProductDetail,
+		) => {
+			if (productDetail.tier === 'Supporter Plus') {
+				return PRODUCT_TYPES.supporterplus;
+			} else if (productDetail.tier === 'Contributor') {
+				return PRODUCT_TYPES.contributions;
+			}
+			return GROUPED_PRODUCT_TYPES.recurringSupport; // This should never happen!
 		},
+		softOptInIDs: [], // this is only here for the sake of the typescript type and the unlikely scenario where the mapGroupedToSpecific function returns a grouped product type
+		shouldRevealSubscriptionId: true,
 	},
 	subscriptions: {
 		productTitle: () => 'Subscription',
@@ -677,10 +692,6 @@ export const GROUPED_PRODUCT_TYPES: {
 		groupFriendlyName: 'subscriptions',
 		allProductsProductTypeFilterString: 'ContentSubscription',
 		urlPart: 'subscriptions',
-		softOptInIDs: [
-			SOFT_OPT_IN_IDS.similar_products,
-			SOFT_OPT_IN_IDS.supporter_newsletter,
-		],
 		mapGroupedToSpecific: (
 			productDetail: ProductDetail | CancelledProductDetail,
 		) => {
@@ -698,19 +709,12 @@ export const GROUPED_PRODUCT_TYPES: {
 				return PRODUCT_TYPES.guardianweekly;
 			} else if (productDetail.tier.startsWith('guardianpatron')) {
 				return PRODUCT_TYPES.guardianpatron;
-			} else if (productDetail.tier.startsWith('Supporter Plus')) {
-				return PRODUCT_TYPES.supporterplus;
 			}
 			return GROUPED_PRODUCT_TYPES.subscriptions; // This should never happen!
 		},
+		softOptInIDs: [], // this is only here for the sake of the typescript type and the unlikely scenario where the mapGroupedToSpecific function returns a grouped product type
 		cancelledCopy:
 			'Your subscription has been cancelled. You are able to access your subscription until',
 		shouldRevealSubscriptionId: true,
-		supportTheGuardianSectionProps: {
-			alternateButtonText: 'Subscribe again',
-			supportReferer: 'account_overview_subscriptions_section',
-			urlSuffix: 'subscribe',
-			message: '', // TODO : copy here!!
-		},
 	},
 };


### PR DESCRIPTION
## What does this change?
This is in support of changes to `members-data-api` to recategorise recurring
contributions and Supporter+ as `recurringSupport` so that they are grouped
together on the Account Overview.

Additionally this adds the required soft opt-ins for the `supporterplus` product
whilst removing these from the grouped product types where they're only required
due to typing. (The `softOptInIDs` property has been retained, but set to a blank array.)

The 'Support The Guardian' section is now only shown for `membership` so the
config for this has been removed from all other products.