### PR TITLE
Update Cancellation Copy for Supporter Plus

### DIFF
--- a/client/components/cancel/CancellationContainer.tsx
+++ b/client/components/cancel/CancellationContainer.tsx
@@ -9,6 +9,7 @@ import {
 	isProduct,
 	MembersDataApiAsyncLoader,
 } from '../../../shared/productResponse';
+import { GROUPED_PRODUCT_TYPES } from '../../../shared/productTypes';
 import type {
 	ProductType,
 	ProductTypeWithCancellationFlow,
@@ -88,11 +89,12 @@ const CancellationContainer = (props: WithProductType<ProductType>) => {
 	const location = useLocation();
 	const routerState = location.state as CancellationRouterState;
 	const productDetail = routerState?.productDetail;
+	const groupedProductType = GROUPED_PRODUCT_TYPES[productDetail.mmaCategory];
 
 	const [pageTitle, setPageTitle] = useState<string>(
 		`Cancel ${
-			props.productType.shortFriendlyName ||
-			props.productType.friendlyName(productDetail)
+			groupedProductType.shortFriendlyName ||
+			groupedProductType.friendlyName()
 		}`,
 	);
 

--- a/client/components/cancel/CancellationSwitchEligibilityCheck.tsx
+++ b/client/components/cancel/CancellationSwitchEligibilityCheck.tsx
@@ -2,6 +2,7 @@ import { useContext } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 import { featureSwitches } from '../../../shared/featureSwitches';
 import { MDA_TEST_USER_HEADER } from '../../../shared/productResponse';
+import { GROUPED_PRODUCT_TYPES } from '../../../shared/productTypes';
 import useFetch from '../../services/useFetch';
 import CancellationSwitchOffer from '../productSwitch/CancellationSwitchOffer';
 import type { AvailableProductsResponse } from '../productSwitch/productSwitchApi';
@@ -32,13 +33,14 @@ const CancellationSwitchEligibilityCheck = () => {
 		return <Navigate to="/" />;
 	}
 
+	const groupedProductType =
+		GROUPED_PRODUCT_TYPES[routerState.productDetail.mmaCategory];
+
 	if (routerState?.dontShowOffer) {
 		pageTitleContext.setPageTitle(
 			`Cancel ${
-				cancellationContext.productType.shortFriendlyName ||
-				cancellationContext.productType.friendlyName(
-					routerState.productDetail,
-				)
+				groupedProductType.shortFriendlyName ||
+				groupedProductType.friendlyName()
 			}`,
 		);
 		return <CancellationReasonSelection />;

--- a/client/components/cancel/cancellationSummary.tsx
+++ b/client/components/cancel/cancellationSummary.tsx
@@ -193,9 +193,8 @@ export const getCancellationSummary =
 			)
 		) : (
 			<GenericErrorScreen
-				loggingMessage={
-					productType.friendlyName(cancelledProductDetail) +
-					" cancellation call succeeded but subsequent product detail doesn't show as cancelled"
-				}
+				loggingMessage={`${productType.friendlyName(
+					cancelledProductDetail,
+				)} cancellation call succeeded but subsequent product detail doesn't show as cancelled`}
 			/>
 		);

--- a/client/components/cancel/cancellationSummary.tsx
+++ b/client/components/cancel/cancellationSummary.tsx
@@ -21,7 +21,7 @@ import { CancellationContributionReminder } from './cancellationContributionRemi
 const actuallyCancelled = (
 	productType: ProductType,
 	productDetail: ProductDetail,
-	productFriendlyName: string,
+	cancelledProductDetail: ProductDetail,
 ) => {
 	const deliveryRecordsLink: string = `/delivery/${productType.urlPart}/records`;
 	const subscription = productDetail.subscription;
@@ -36,7 +36,12 @@ const actuallyCancelled = (
 						`,
 					]}
 				>
-					Your {productFriendlyName} is cancelled.
+					{productType.cancellation?.alternateSummaryHeading(
+						cancelledProductDetail,
+					) ||
+						`Your ${productType.friendlyName(
+							cancelledProductDetail,
+						)} is cancelled.`}
 				</Heading>
 				{productType.cancellation &&
 					!productType.cancellation.shouldHideSummaryMainPara && (
@@ -46,7 +51,10 @@ const actuallyCancelled = (
 								(subscription.end ? (
 									<>
 										You will continue to receive the
-										benefits of your {productFriendlyName}{' '}
+										benefits of your{' '}
+										{productType.friendlyName(
+											cancelledProductDetail,
+										)}{' '}
 										until{' '}
 										<b>
 											{cancellationFormatDate(
@@ -175,14 +183,18 @@ export const isCancelled = (subscription: Subscription) =>
 	Object.keys(subscription).length === 0 || subscription.cancelledAt;
 
 export const getCancellationSummary =
-	(productType: ProductType, productFriendlyName: string) =>
+	(productType: ProductType, cancelledProductDetail: ProductDetail) =>
 	(productDetail: ProductDetail) =>
 		isCancelled(productDetail.subscription) ? (
-			actuallyCancelled(productType, productDetail, productFriendlyName)
+			actuallyCancelled(
+				productType,
+				productDetail,
+				cancelledProductDetail,
+			)
 		) : (
 			<GenericErrorScreen
 				loggingMessage={
-					productFriendlyName +
+					productType.friendlyName(cancelledProductDetail) +
 					" cancellation call succeeded but subsequent product detail doesn't show as cancelled"
 				}
 			/>

--- a/client/components/cancel/stages/executeCancellation.tsx
+++ b/client/components/cancel/stages/executeCancellation.tsx
@@ -109,14 +109,14 @@ const getCaseUpdatingCancellationSummary =
 	(
 		caseId: string | '',
 		productType: ProductTypeWithCancellationFlow,
-		productFriendlyName: string,
+		cancelledProductDetail: ProductDetail,
 	) =>
 	(productDetails: ProductDetail[]) => {
 		const productDetail = productDetails[0] || { subscription: {} };
 		const render = getCancellationSummaryWithReturnButton(
 			getCancellationSummary(
 				productType,
-				productFriendlyName,
+				cancelledProductDetail,
 			)(productDetail),
 		);
 		return caseId ? (
@@ -205,7 +205,7 @@ const ExecuteCancellation = () => {
 						render={getCaseUpdatingCancellationSummary(
 							caseId,
 							productType,
-							productType.friendlyName(productDetail),
+							productDetail,
 						)}
 						loadingMessage="Performing your cancellation..."
 					/>

--- a/cypress/integration/parallel-2/cancelSupporterPlus.spec.ts
+++ b/cypress/integration/parallel-2/cancelSupporterPlus.spec.ts
@@ -77,7 +77,7 @@ describe('Cancel Supporter Plus', () => {
 		cy.wait('@new_product_detail');
 
 		cy.findByRole('heading', {
-			name: 'Your monthly + extras is cancelled.',
+			name: 'Monthly support + extras cancelled.',
 		});
 	});
 });

--- a/shared/productTypes.tsx
+++ b/shared/productTypes.tsx
@@ -92,6 +92,9 @@ interface CancellationFlowProperties {
 	startPageOfferEffectiveDateOptions?: true;
 	hideReasonTitlePrefix?: true;
 	alternateSummaryMainPara?: string;
+	alternateSummaryHeading: (
+		productDetail?: ProductDetail,
+	) => string | undefined;
 	shouldHideSummaryMainPara?: true;
 	summaryReasonSpecificPara: (
 		reasonId: OptionalCancellationReasonId,
@@ -277,6 +280,7 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 			reasons: membershipCancellationReasons,
 			sfCaseProduct: 'Membership',
 			startPageBody: membershipCancellationFlowStart,
+			alternateSummaryHeading: () => undefined,
 			hideReasonTitlePrefix: true,
 			summaryReasonSpecificPara: () => undefined,
 			onlyShowSupportSectionIfAlternateText: false,
@@ -312,6 +316,7 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 			sfCaseProduct: 'Recurring - Contributions',
 			startPageBody: contributionsCancellationFlowStart,
 			shouldHideSummaryMainPara: true,
+			alternateSummaryHeading: () => undefined,
 			summaryReasonSpecificPara: (
 				reasonId: OptionalCancellationReasonId,
 			) => {
@@ -450,6 +455,7 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 			startPageOfferEffectiveDateOptions: true,
 			summaryReasonSpecificPara: () => undefined,
 			onlyShowSupportSectionIfAlternateText: false,
+			alternateSummaryHeading: () => undefined,
 			alternateSupportButtonText: (
 				reasonId: OptionalCancellationReasonId,
 			) =>
@@ -530,6 +536,7 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 			startPageOfferEffectiveDateOptions: true,
 			summaryReasonSpecificPara: () => undefined,
 			onlyShowSupportSectionIfAlternateText: false,
+			alternateSummaryHeading: () => undefined,
 			alternateSupportButtonText: (
 				reasonId: OptionalCancellationReasonId,
 			) =>
@@ -570,6 +577,7 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 			startPageBody: digipackCancellationFlowStart,
 			summaryReasonSpecificPara: () => undefined,
 			onlyShowSupportSectionIfAlternateText: false,
+			alternateSummaryHeading: () => undefined,
 			alternateSupportButtonText: (
 				reasonId: OptionalCancellationReasonId,
 			) =>
@@ -613,6 +621,22 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 			SOFT_OPT_IN_IDS.digi_subscriber_preview,
 		],
 		cancellation: {
+			alternateSummaryMainPara:
+				"This is immediate and you will not be charged again. If you've cancelled within the first 14 days, we'll send you a full refund.",
+			alternateSummaryHeading: (productDetail?: ProductDetail) => {
+				if (!productDetail) {
+					return undefined;
+				}
+
+				const interval = (
+					getMainPlan(
+						productDetail.subscription,
+					) as PaidSubscriptionPlan
+				).interval;
+				return `${
+					interval === 'month' ? 'Monthly' : 'Annual'
+				} support + extras cancelled.`;
+			},
 			linkOnProductPage: true,
 			reasons: supporterplusCancellationReasons,
 			sfCaseProduct: 'Supporter Plus',

--- a/shared/productTypes.tsx
+++ b/shared/productTypes.tsx
@@ -93,7 +93,7 @@ interface CancellationFlowProperties {
 	hideReasonTitlePrefix?: true;
 	alternateSummaryMainPara?: string;
 	alternateSummaryHeading: (
-		productDetail?: ProductDetail,
+		productDetail: ProductDetail,
 	) => string | undefined;
 	shouldHideSummaryMainPara?: true;
 	summaryReasonSpecificPara: (
@@ -623,11 +623,7 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 		cancellation: {
 			alternateSummaryMainPara:
 				"This is immediate and you will not be charged again. If you've cancelled within the first 14 days, we'll send you a full refund.",
-			alternateSummaryHeading: (productDetail?: ProductDetail) => {
-				if (!productDetail) {
-					return undefined;
-				}
-
+			alternateSummaryHeading: (productDetail: ProductDetail) => {
 				const interval = (
 					getMainPlan(
 						productDetail.subscription,


### PR DESCRIPTION
## What does this change?

Update the copy on the cancellation journey for supporter plus.

- Change headline to say Cancel **INSERT Product Group** for all product journeys

Copy to read: 
- Monthly OR Annual support + extras cancelled 
- This is immediate and you will not be charged again. If you've cancelled within the first 14 days, we'll send you a full refund.
for supporter plus.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

When cancelling a supporter plus produc: the new copy should show. When cancelling any other product: the old copy should show except for the headline that should now use the group of the product (e.g. subscription).

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

![image](https://user-images.githubusercontent.com/114918544/199009614-f531b505-5f38-4795-b8a7-fa6dd8ca8820.png)

Before
<img width="863" alt="image" src="https://user-images.githubusercontent.com/114918544/199014947-0cfd77c9-0a96-4701-a088-ff88fe94708b.png">
After
<img width="854" alt="image" src="https://user-images.githubusercontent.com/114918544/199015181-3d190817-708f-4b50-bc6a-0281a79d7226.png">
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
