### PR TITLE
Allow display of Supporter ID

### DIFF
--- a/client/components/accountoverview/accountOverviewCancelledCard.tsx
+++ b/client/components/accountoverview/accountOverviewCancelledCard.tsx
@@ -173,14 +173,16 @@ export const AccountOverviewCancelledCard = (
 						}
 					`}
 				>
-					{groupedProductType.shouldRevealSubscriptionId && (
-						<ul css={keyValuePairCss}>
-							<li css={keyCss}>Subscription ID</li>
-							<li css={valueCss}>
-								{props.product.subscription.subscriptionId}
-							</li>
-						</ul>
-					)}
+					<ul css={keyValuePairCss}>
+						<li css={keyCss}>
+							{groupedProductType.showSupporterId
+								? 'Supporter ID'
+								: 'Subscription ID'}
+						</li>
+						<li css={valueCss}>
+							{props.product.subscription.subscriptionId}
+						</li>
+					</ul>
 					{groupedProductType.tierLabel && (
 						<ul css={keyValuePairCss}>
 							<li css={keyCss}>{groupedProductType.tierLabel}</li>

--- a/client/components/accountoverview/accountOverviewCard.tsx
+++ b/client/components/accountoverview/accountOverviewCard.tsx
@@ -263,17 +263,16 @@ export const AccountOverviewCard = (props: AccountOverviewCardProps) => {
 						}
 					`}
 				>
-					{groupedProductType.shouldRevealSubscriptionId && (
-						<ul css={keyValuePairCss}>
-							<li css={keyCss}>Subscription ID</li>
-							<li css={valueCss}>
-								{
-									props.productDetail.subscription
-										.subscriptionId
-								}
-							</li>
-						</ul>
-					)}
+					<ul css={keyValuePairCss}>
+						<li css={keyCss}>
+							{groupedProductType.showSupporterId
+								? 'Supporter ID'
+								: 'Subscription ID'}
+						</li>
+						<li css={valueCss}>
+							{props.productDetail.subscription.subscriptionId}
+						</li>
+					</ul>
 					{groupedProductType.tierLabel && (
 						<ul css={keyValuePairCss}>
 							<li css={keyCss}>{groupedProductType.tierLabel}</li>

--- a/client/components/accountoverview/contributionUpdateAmount.tsx
+++ b/client/components/accountoverview/contributionUpdateAmount.tsx
@@ -67,6 +67,10 @@ export const ContributionUpdateAmount = (
 				borderColour={neutral[86]}
 				content={[
 					{
+						title: 'Supporter ID',
+						value: props.subscriptionId,
+					},
+					{
 						title: `${capitalize(
 							augmentInterval(props.mainPlan.interval),
 						)} amount`,

--- a/client/components/basicProductInfoTable.tsx
+++ b/client/components/basicProductInfoTable.tsx
@@ -12,15 +12,12 @@ export const BasicProductInfoTable = (props: BasicProductInfoTableProps) => {
 	return (
 		<ProductDescriptionListTable
 			content={[
-				...(props.groupedProductType.shouldRevealSubscriptionId
-					? [
-							{
-								title: 'Subscription ID',
-								value: props.productDetail.subscription
-									.subscriptionId,
-							},
-					  ]
-					: []),
+				{
+					title: props.groupedProductType.showSupporterId
+						? 'Supporter ID'
+						: 'Subscription ID',
+					value: props.productDetail.subscription.subscriptionId,
+				},
 				...(props.groupedProductType.tierLabel
 					? [
 							{

--- a/client/components/cancel/CancellationReasonSelection.tsx
+++ b/client/components/cancel/CancellationReasonSelection.tsx
@@ -18,7 +18,11 @@ import { useContext, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { DATE_FNS_LONG_OUTPUT_FORMAT, parseDate } from '../../../shared/dates';
 import type { ProductDetail } from '../../../shared/productResponse';
-import type { ProductTypeWithCancellationFlow } from '../../../shared/productTypes';
+import type {
+	ProductTypeWithCancellationFlow} from '../../../shared/productTypes';
+import {
+	GROUPED_PRODUCT_TYPES
+} from '../../../shared/productTypes';
 import { hasCancellationFlow } from '../../productUtils';
 import { ProgressIndicator } from '../progressIndicator';
 import { WithStandardTopMargin } from '../WithStandardTopMargin';
@@ -331,7 +335,9 @@ const CancellationReasonSelection = () => {
 		<ContactUsToCancel
 			selfServiceCancellation={productDetail.selfServiceCancellation}
 			subscriptionId={productDetail.subscription.subscriptionId}
-			productType={productType}
+			groupedProductType={
+				GROUPED_PRODUCT_TYPES[productDetail.mmaCategory]
+			}
 		/>
 	);
 };

--- a/client/components/cancel/contactUsToCancel.tsx
+++ b/client/components/cancel/contactUsToCancel.tsx
@@ -9,7 +9,7 @@ import {
 } from '@guardian/source-foundations';
 import { LinkButton } from '@guardian/source-react-components';
 import type { SelfServiceCancellation } from '../../../shared/productResponse';
-import type { ProductType } from '../../../shared/productTypes';
+import type { GroupedProductType } from '../../../shared/productTypes';
 import { CallCentreEmailAndNumbers } from '../callCenterEmailAndNumbers';
 import { NAV_LINKS } from '../nav/navConfig';
 import { ProductDescriptionListTable } from '../productDescriptionListTable';
@@ -17,26 +17,29 @@ import { ProductDescriptionListTable } from '../productDescriptionListTable';
 interface ContactUsToCancelProps {
 	selfServiceCancellation: SelfServiceCancellation;
 	subscriptionId: string;
-	productType: ProductType;
+	groupedProductType: GroupedProductType;
 }
 
 export const ContactUsToCancel = (props: ContactUsToCancelProps) => {
 	const subHeadingTitleCss = `
-    ${headline.small()};
-    font-weight: bold;
-    ${until.tablet} {
-      font-size: 1.25rem;
-      line-height: 1.6;
-    };
-  `;
+		${headline.small()};
+		font-weight: bold;
+		${until.tablet} {
+			font-size: 1.25rem;
+			line-height: 1.6;
+		};
+	`;
+
 	const subHeadingBorderTopCss = `
-    border-top: 1px solid ${neutral['86']};
-    margin: 50px 0 ${space[5]}px;
-  `;
+		border-top: 1px solid ${neutral['86']};
+		margin: 50px 0 ${space[5]}px;
+	`;
+
 	const subHeadingCss = `
-    ${subHeadingBorderTopCss}
-    ${subHeadingTitleCss}
-  `;
+		${subHeadingBorderTopCss}
+		${subHeadingTitleCss}
+	`;
+
 	return (
 		<>
 			<h2
@@ -49,7 +52,9 @@ export const ContactUsToCancel = (props: ContactUsToCancelProps) => {
 			<ProductDescriptionListTable
 				content={[
 					{
-						title: 'Subscription ID',
+						title: props.groupedProductType.showSupporterId
+							? 'Supporter ID'
+							: 'Subscription ID',
 						value: props.subscriptionId,
 					},
 				]}

--- a/shared/productTypes.tsx
+++ b/shared/productTypes.tsx
@@ -166,7 +166,7 @@ export interface ProductType {
 	getOphanProductType?: (
 		productDetail: ProductDetail,
 	) => OphanProduct | undefined;
-	shouldRevealSubscriptionId?: boolean;
+	showSupporterId?: boolean;
 	tierLabel?: string;
 	renewalMetadata?: SupportTheGuardianButtonProps;
 	noProductSupportUrlSuffix?: string;
@@ -679,6 +679,7 @@ export const GROUPED_PRODUCT_TYPES: {
 		...PRODUCT_TYPES.membership,
 		mapGroupedToSpecific: () => PRODUCT_TYPES.membership,
 		groupFriendlyName: 'membership',
+		showSupporterId: true,
 		supportTheGuardianSectionProps: {
 			supportReferer: 'account_overview_membership_section',
 			message:
@@ -692,6 +693,7 @@ export const GROUPED_PRODUCT_TYPES: {
 		...PRODUCT_TYPES.contributions,
 		mapGroupedToSpecific: () => PRODUCT_TYPES.contributions,
 		groupFriendlyName: 'contributions',
+		showSupporterId: true,
 	},
 	recurringSupport: {
 		productTitle: () => 'Recurring support',
@@ -710,7 +712,7 @@ export const GROUPED_PRODUCT_TYPES: {
 			return GROUPED_PRODUCT_TYPES.recurringSupport; // This should never happen!
 		},
 		softOptInIDs: [], // this is only here for the sake of the typescript type and the unlikely scenario where the mapGroupedToSpecific function returns a grouped product type
-		shouldRevealSubscriptionId: true,
+		showSupporterId: true,
 	},
 	subscriptions: {
 		productTitle: () => 'Subscription',
@@ -741,6 +743,5 @@ export const GROUPED_PRODUCT_TYPES: {
 		softOptInIDs: [], // this is only here for the sake of the typescript type and the unlikely scenario where the mapGroupedToSpecific function returns a grouped product type
 		cancelledCopy:
 			'Your subscription has been cancelled. You are able to access your subscription until',
-		shouldRevealSubscriptionId: true,
 	},
 };


### PR DESCRIPTION
## What does this change?

Previously Subscription ID was hidden for non-subscription products. This is now displayed as Supporter ID for membership and recurring support products.

## Images

<img width="850" alt="Screenshot 2022-10-14 at 16 45 57" src="https://user-images.githubusercontent.com/1166188/199206553-5f9087f4-07fa-443c-a935-0267d48f7ba0.png">

<img width="834" alt="Screenshot 2022-10-31 at 17 27 09" src="https://user-images.githubusercontent.com/1166188/199206586-149bd0ad-5d76-44c5-a7fb-092e3b891dc7.png">

<img width="836" alt="Screenshot 2022-10-31 at 17 57 00" src="https://user-images.githubusercontent.com/1166188/199206732-16561301-9196-431a-8d23-b86e6d415bd8.png">
