### PR TITLE
Recurring Contribution should change to say Monthly/Annual contribution

### DIFF
--- a/shared/productTypes.tsx
+++ b/shared/productTypes.tsx
@@ -229,6 +229,9 @@ const calculateProductTitle =
 const calculateSupporterPlusTitle = (interval: string) =>
 	interval === 'month' ? 'monthly + extras' : 'annual + extras';
 
+const calculateMonthlyOrAnnualFromInterval = (interval: string) =>
+	interval === 'month' ? 'Monthly' : 'Annual';
+
 const FRONT_PAGE_NEWSLETTER_ID = '6009';
 enum SOFT_OPT_IN_IDS {
 	support_onboarding = 'your_support_onboarding',
@@ -298,7 +301,13 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 		],
 	},
 	contributions: {
-		productTitle: () => 'Recurring contribution',
+		productTitle: (mainPlan?: SubscriptionPlan) => {
+			const paidPlan = mainPlan as PaidSubscriptionPlan;
+			const interval = paidPlan.interval;
+			return `${calculateMonthlyOrAnnualFromInterval(
+				interval,
+			)} contribution`;
+		},
 		friendlyName: () => 'recurring contribution',
 		allProductsProductTypeFilterString: 'Contribution',
 		urlPart: 'contributions',
@@ -629,9 +638,9 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 						productDetail.subscription,
 					) as PaidSubscriptionPlan
 				).interval;
-				return `${
-					interval === 'month' ? 'Monthly' : 'Annual'
-				} support + extras cancelled.`;
+				return `${calculateMonthlyOrAnnualFromInterval(
+					interval,
+				)} support + extras cancelled.`;
 			},
 			linkOnProductPage: true,
 			reasons: supporterplusCancellationReasons,


### PR DESCRIPTION
## What does this change?

Recurring Contribution should change to say Monthly/Annual contribution within product tab

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Navigate to the account overview page - witness a recurring contribution title says Monthly (or Annual) Contribution.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

Before
<img width="866" alt="image" src="https://user-images.githubusercontent.com/114918544/199208528-b71e86fb-c62e-4d2e-bc6d-b836d84bdc94.png">
After
<img width="849" alt="image" src="https://user-images.githubusercontent.com/114918544/199208431-c27d7eb6-f607-4fa4-a2d0-aece6e1181d4.png">

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [x] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
