### PR TITLE
Update cypress test that failed sometimes

### DIFF
--- a/cypress/integration/parallel-2/cancelContribution.spec.ts
+++ b/cypress/integration/parallel-2/cancelContribution.spec.ts
@@ -164,7 +164,7 @@ describe('Cancel contribution', () => {
 		cy.wait('@get_case');
 
 		cy.findByRole('link', { name: 'Manage payment method' }).click();
-		cy.findByText('Manage payment method').should('exist');
+		cy.findByText('Update your payment method').should('exist');
 	});
 
 	it('cancels contribution with save body string (reason: I would rather make a single contribution)', () => {


### PR DESCRIPTION
## What does this change?

The Cypress test 'Cancel contribution' assertion 'attempts cancellation but then updates payment details instead. (reason: A payment issue)' would fail on some runs of the entire suite. It was searching for text that occurs multiple times on the page if the whole page loads. This is seemingly a timing issue since it usually passes if the test is run alone.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

