### PR TITLE
chore: Remove Snyk schedule

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,9 +1,7 @@
-# This action runs Snyk Monitor every day at 6 AM and on every push to main
+# This action runs Snyk Monitor on every push to main
 name: Snyk
 
 on:
-  schedule:
-    - cron: 0 6 * * *
   push:
     branches:
       - main


### PR DESCRIPTION
An explicit schedule is not needed; `snyk monitor` already sets up a schedule, and running on push to main is sufficient to always scan the latest version of the code.

At the start of our Snyk adoption push, we set up some repositories with schedules. As it turns out, GitHub disable scheduled workflows (on public repos) from running after 60 days of inactivity. This even seems to affect the other triggers of the workflow!

See: https://trello.com/c/XsBEwUnr.