### PR TITLE
Show product info table on Billing page for contributions

### DIFF
--- a/client/components/billing/billing.tsx
+++ b/client/components/billing/billing.tsx
@@ -19,7 +19,6 @@ import type {
 import {
 	getMainPlan,
 	isGift,
-	isPaidSubscriptionPlan,
 	isProduct,
 	sortByJoinDate,
 } from '../../../shared/productResponse';
@@ -122,11 +121,6 @@ const BillingRenderer = ([mdaResponse, invoiceResponse]: [
 									const cancelledCopy =
 										specificProductType.cancelledCopy ||
 										groupedProductType.cancelledCopy;
-									const isAmountOveridable =
-										specificProductType.updateAmountMdaEndpoint;
-									const isContribution =
-										isAmountOveridable &&
-										isPaidSubscriptionPlan(mainPlan);
 									const nextPaymentDetails =
 										getNextPaymentDetails(
 											mainPlan,
@@ -231,16 +225,12 @@ const BillingRenderer = ([mdaResponse, invoiceResponse]: [
 													.
 												</p>
 											)}
-											{!isContribution && (
-												<BasicProductInfoTable
-													groupedProductType={
-														groupedProductType
-													}
-													productDetail={
-														productDetail
-													}
-												/>
-											)}
+											<BasicProductInfoTable
+												groupedProductType={
+													groupedProductType
+												}
+												productDetail={productDetail}
+											/>
 											<SixForSixExplainerIfApplicable
 												additionalCss={css`
 													${textSans.medium()};


### PR DESCRIPTION
## What does this change?

Reveals the product info table for contributions on the _Billing_ page. Previously this was shown for all other products, but explicitly hidden for contributions. Now that we're able to show _Supporter ID_ in place of _Subscription ID_ for recurring support products there's no longer any need to hide this information.

## Images


### Before

<img width="841" alt="Screenshot 2022-11-02 at 12 28 03" src="https://user-images.githubusercontent.com/1166188/199493474-9bd9f697-f595-4d62-b7c9-14808e52377a.png">

### After

<img width="840" alt="Screenshot 2022-11-02 at 12 29 25" src="https://user-images.githubusercontent.com/1166188/199493485-edb50983-5a80-45cd-afde-0b26717ff3b3.png">
