### PR TITLE
Add default product title

### DIFF
--- a/shared/productTypes.tsx
+++ b/shared/productTypes.tsx
@@ -302,10 +302,13 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 	},
 	contributions: {
 		productTitle: (mainPlan?: SubscriptionPlan) => {
+			if (!mainPlan) {
+				return 'Recurring contribution';
+			}
+
 			const paidPlan = mainPlan as PaidSubscriptionPlan;
-			const interval = paidPlan.interval;
 			return `${calculateMonthlyOrAnnualFromInterval(
-				interval,
+				paidPlan.interval,
 			)} contribution`;
 		},
 		friendlyName: () => 'recurring contribution',
@@ -604,6 +607,10 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 	},
 	supporterplus: {
 		productTitle: (mainPlan?: SubscriptionPlan) => {
+			if (!mainPlan) {
+				return 'Recurring support';
+			}
+
 			const paidMainPlan = mainPlan as PaidSubscriptionPlan;
 			return `${capitalize(
 				calculateSupporterPlusTitle(paidMainPlan.interval),


### PR DESCRIPTION
## What does this change?

`productTitle` has an optional `mainPlan` argument, but contributions and Supporter Plus, which use the plan to generate the title, don't have a fallback if `mainPlan` is empty. This adds a default title for these two products. The only instance of this happening that I'm aware of is in the cancelled product cards on _Account Overview_ due to `CancelledProductDetail` only including a subset of subscription properties. (Crucially, `interval` is not one of these.)

## Images

<img width="809" alt="Screenshot 2022-11-04 at 09 50 17" src="https://user-images.githubusercontent.com/1166188/199944261-3fc2ec82-3661-461e-a41f-a84a9c267eed.png">
