### PR TITLE
Use product friendly name in 'contact us to cancel' message

### DIFF
--- a/client/components/accountoverview/manageProduct.tsx
+++ b/client/components/accountoverview/manageProduct.tsx
@@ -391,7 +391,7 @@ const CancellationCTA = (props: CancellationCTAProps) => {
 			`}
 		>
 			{shouldContactUsToCancel &&
-				'Would you like to cancel your subscription? '}
+				`Would you like to cancel your ${props.friendlyName}? `}
 			<Link
 				css={css`
 					color: ${brand['500']};


### PR DESCRIPTION
## What does this change?

Updates the 'Would you like to cancel your subscription?' message on the manage product page to use the grouped product type's friendly name as 'subscription' is currently hardcoded and shown for _all_ products.

Contributions and Supporter Plus, for example, will now show 'Would you like to cancel your recurring support?' instead.

## Images

<img width="835" alt="Screenshot 2022-11-04 at 10 37 52" src="https://user-images.githubusercontent.com/1166188/199954104-8ba9f036-b743-46e3-97f7-5876363481e7.png">
