### PR TITLE
Add personalised welcome message to Account Overview

### DIFF
--- a/client/components/accountoverview/WelcomeMessage.tsx
+++ b/client/components/accountoverview/WelcomeMessage.tsx
@@ -1,26 +1,29 @@
 import { css } from '@emotion/react';
 import { headline, space } from '@guardian/source-foundations';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ProductDetail } from '../../../shared/productResponse';
 import { Users } from '../identity/identity';
+import type { User } from '../identity/models';
 
 interface WelcomeMessageProps {
 	activeProducts: ProductDetail[];
 }
 
 export const WelcomeMessage = ({ activeProducts }: WelcomeMessageProps) => {
-	const [userFirstName, setUserFirstName] = useState<String>();
+	const [userDetails, setUserDetails] = useState<User>();
 
-	Users.getCurrentUser().then((userDetails) =>
-		setUserFirstName(userDetails.firstName),
-	);
+	useEffect(() => {
+		Users.getCurrentUser().then((userDetails) =>
+			setUserDetails(userDetails),
+		);
+	}, []);
 
 	// The product detail array from AccountOverview is sorted by `joinDate` in
 	// descending order so the last entry is the oldest product
 	const oldestProduct = activeProducts[activeProducts.length - 1];
 	const supportStartYear = new Date(oldestProduct.joinDate).getFullYear();
 
-	return (
+	return userDetails ? (
 		<hgroup
 			css={css`
 				margin-top: ${space[12]}px;
@@ -32,7 +35,7 @@ export const WelcomeMessage = ({ activeProducts }: WelcomeMessageProps) => {
 					margin-bottom: 0;
 				`}
 			>
-				Hello {userFirstName}
+				Hello {userDetails.firstName}
 			</h2>
 			<p
 				css={css`
@@ -42,5 +45,5 @@ export const WelcomeMessage = ({ activeProducts }: WelcomeMessageProps) => {
 				Thanks for supporting the Guardian since {supportStartYear}
 			</p>
 		</hgroup>
-	);
+	) : null;
 };

--- a/client/components/accountoverview/WelcomeMessage.tsx
+++ b/client/components/accountoverview/WelcomeMessage.tsx
@@ -1,0 +1,28 @@
+import { css } from '@emotion/react';
+import { headline, space } from '@guardian/source-foundations';
+
+export const WelcomeMessage = () => {
+	return (
+		<hgroup
+			css={css`
+				margin-top: ${space[12]}px;
+			`}
+		>
+			<h2
+				css={css`
+					${headline.large({ fontWeight: 'bold' })};
+					margin-bottom: 0;
+				`}
+			>
+				Hello James
+			</h2>
+			<p
+				css={css`
+					${headline.xxxsmall()};
+				`}
+			>
+				Thanks for supporting the Guardian since 2016
+			</p>
+		</hgroup>
+	);
+};

--- a/client/components/accountoverview/WelcomeMessage.tsx
+++ b/client/components/accountoverview/WelcomeMessage.tsx
@@ -1,7 +1,25 @@
 import { css } from '@emotion/react';
 import { headline, space } from '@guardian/source-foundations';
+import { useState } from 'react';
+import type { ProductDetail } from '../../../shared/productResponse';
+import { Users } from '../identity/identity';
 
-export const WelcomeMessage = () => {
+interface WelcomeMessageProps {
+	activeProducts: ProductDetail[];
+}
+
+export const WelcomeMessage = ({ activeProducts }: WelcomeMessageProps) => {
+	const [userFirstName, setUserFirstName] = useState<String>();
+
+	Users.getCurrentUser().then((userDetails) =>
+		setUserFirstName(userDetails.firstName),
+	);
+
+	// The product detail array from AccountOverview is sorted by `joinDate` in
+	// descending order so the last entry is the oldest product
+	const oldestProduct = activeProducts[activeProducts.length - 1];
+	const supportStartYear = new Date(oldestProduct.joinDate).getFullYear();
+
 	return (
 		<hgroup
 			css={css`
@@ -14,14 +32,14 @@ export const WelcomeMessage = () => {
 					margin-bottom: 0;
 				`}
 			>
-				Hello James
+				Hello {userFirstName}
 			</h2>
 			<p
 				css={css`
 					${headline.xxxsmall()};
 				`}
 			>
-				Thanks for supporting the Guardian since 2016
+				Thanks for supporting the Guardian since {supportStartYear}
 			</p>
 		</hgroup>
 	);

--- a/client/components/accountoverview/accountOverview.tsx
+++ b/client/components/accountoverview/accountOverview.tsx
@@ -72,19 +72,19 @@ const AccountOverviewRenderer = ([mdaResponse, cancelledProductsResponse]: [
 
 	return (
 		<>
-			<div
+			<hgroup
 				css={css`
 					margin-top: ${space[12]}px;
 				`}
 			>
-				<p
+				<h2
 					css={css`
 						${headline.large({ fontWeight: 'bold' })};
 						margin-bottom: 0;
 					`}
 				>
 					Hello James
-				</p>
+				</h2>
 				<p
 					css={css`
 						${headline.xxxsmall()};
@@ -92,7 +92,7 @@ const AccountOverviewRenderer = ([mdaResponse, cancelledProductsResponse]: [
 				>
 					Thanks for supporting the Guardian since 2016
 				</p>
-			</div>
+			</hgroup>
 
 			<PaymentFailureAlertIfApplicable
 				productDetail={maybeFirstPaymentFailure}

--- a/client/components/accountoverview/accountOverview.tsx
+++ b/client/components/accountoverview/accountOverview.tsx
@@ -9,6 +9,7 @@ import {
 import { Stack } from '@guardian/source-react-components';
 import { capitalize } from 'lodash';
 import { Fragment } from 'react';
+import { featureSwitches } from '../../../shared/featureSwitches';
 import type {
 	CancelledProductDetail,
 	MembersDataApiItem,
@@ -28,6 +29,7 @@ import { SupportTheGuardianButton } from '../supportTheGuardianButton';
 import { AccountOverviewCancelledCard } from './accountOverviewCancelledCard';
 import { AccountOverviewCard } from './accountOverviewCard';
 import { EmptyAccountOverview } from './emptyAccountOverview';
+import { WelcomeMessage } from './WelcomeMessage';
 
 const AccountOverviewRenderer = ([mdaResponse, cancelledProductsResponse]: [
 	MembersDataApiItem[],
@@ -72,27 +74,7 @@ const AccountOverviewRenderer = ([mdaResponse, cancelledProductsResponse]: [
 
 	return (
 		<>
-			<hgroup
-				css={css`
-					margin-top: ${space[12]}px;
-				`}
-			>
-				<h2
-					css={css`
-						${headline.large({ fontWeight: 'bold' })};
-						margin-bottom: 0;
-					`}
-				>
-					Hello James
-				</h2>
-				<p
-					css={css`
-						${headline.xxxsmall()};
-					`}
-				>
-					Thanks for supporting the Guardian since 2016
-				</p>
-			</hgroup>
+			{featureSwitches.showWelcomeMessage && <WelcomeMessage />}
 
 			<PaymentFailureAlertIfApplicable
 				productDetail={maybeFirstPaymentFailure}

--- a/client/components/accountoverview/accountOverview.tsx
+++ b/client/components/accountoverview/accountOverview.tsx
@@ -72,9 +72,32 @@ const AccountOverviewRenderer = ([mdaResponse, cancelledProductsResponse]: [
 
 	return (
 		<>
+			<div
+				css={css`
+					margin-top: ${space[12]}px;
+				`}
+			>
+				<p
+					css={css`
+						${headline.large({ fontWeight: 'bold' })};
+						margin-bottom: 0;
+					`}
+				>
+					Hello James
+				</p>
+				<p
+					css={css`
+						${headline.xxxsmall()};
+					`}
+				>
+					Thanks for supporting the Guardian since 2016
+				</p>
+			</div>
+
 			<PaymentFailureAlertIfApplicable
 				productDetail={maybeFirstPaymentFailure}
 			/>
+
 			{productCategories.map((category) => {
 				const groupedProductType =
 					GROUPED_PRODUCT_TYPES[category as GroupedProductTypeKeys];

--- a/client/components/accountoverview/accountOverview.tsx
+++ b/client/components/accountoverview/accountOverview.tsx
@@ -74,7 +74,9 @@ const AccountOverviewRenderer = ([mdaResponse, cancelledProductsResponse]: [
 
 	return (
 		<>
-			{featureSwitches.showWelcomeMessage && <WelcomeMessage />}
+			{featureSwitches.showWelcomeMessage && (
+				<WelcomeMessage activeProducts={allActiveProductDetails} />
+			)}
 
 			<PaymentFailureAlertIfApplicable
 				productDetail={maybeFirstPaymentFailure}

--- a/shared/featureSwitches.ts
+++ b/shared/featureSwitches.ts
@@ -25,4 +25,5 @@ export const initFeatureSwitchUrlParamOverride = () => {
 export const featureSwitches: Record<string, boolean> = {
 	exampleFeature: false,
 	cancellationProductSwitch: false,
+	showWelcomeMessage: true,
 };


### PR DESCRIPTION
## What does this change?

Adds a personalised welcome message to the Account Overview page showing the user's name and the year they began supporting the Guardian. This is currently hidden behind the `showWelcomeMessage` feature switch.

## Images

<img width="827" alt="Screenshot 2022-11-11 at 17 18 24" src="https://user-images.githubusercontent.com/1166188/201394857-f440ea44-ec45-4ca9-b810-125256a0c0e5.png">

<img width="834" alt="Screenshot 2022-11-11 at 17 19 13" src="https://user-images.githubusercontent.com/1166188/201394865-66d707bb-410e-40f0-8109-45e23cc31ef0.png">
