### PR TITLE
Update support button URL and surrounding copy

### DIFF
--- a/client/components/accountoverview/emptyAccountOverview.tsx
+++ b/client/components/accountoverview/emptyAccountOverview.tsx
@@ -88,6 +88,7 @@ export const EmptyAccountOverview = () => {
 				or contribution.
 			</p>
 			<SupportTheGuardianButton
+				urlSuffix="contribute"
 				supportReferer={'account_overview_no_product'}
 			/>
 			<div
@@ -113,7 +114,7 @@ export const EmptyAccountOverview = () => {
 						${textSans.medium()}
 					`}
 				>
-					If you are already supporting The Guardian, it may be linked
+					If you are already supporting the Guardian, it may be linked
 					to a different email address. Please check that you are
 					logged in using the correct account or contact our customer
 					service team for help.{' '}

--- a/client/components/accountoverview/emptyAccountOverview.tsx
+++ b/client/components/accountoverview/emptyAccountOverview.tsx
@@ -88,7 +88,6 @@ export const EmptyAccountOverview = () => {
 				or contribution.
 			</p>
 			<SupportTheGuardianButton
-				urlSuffix="contribute"
 				supportReferer={'account_overview_no_product'}
 			/>
 			<div

--- a/client/components/footer/footer.tsx
+++ b/client/components/footer/footer.tsx
@@ -282,7 +282,6 @@ export const Footer = () => {
 									</div>
 									<div css={supportButtonContainerStyles}>
 										<SupportTheGuardianButton
-											urlSuffix="contribute"
 											supportReferer="footer_support_contribute"
 											alternateButtonText="Support us"
 											theme="brand"

--- a/client/components/resubscribeThrasher.tsx
+++ b/client/components/resubscribeThrasher.tsx
@@ -67,8 +67,7 @@ const getThrasher =
 				>
 					<div>
 						<h2 css={{ fontWeight: 'bold', margin: '0' }}>
-							Have you considered a monthly or annual
-							contribution?
+							Support us another way?
 						</h2>
 						<p
 							css={{
@@ -80,13 +79,13 @@ const getThrasher =
 								},
 							}}
 						>
-							Support the Guardian with a recurring contribution
-							of your choice. You can use your existing payment
-							details so setting it up only takes a minute.
+							From just $1, or a little more on a regular basis,
+							you can fund independent Guardian journalism. No
+							need to update your payment details. It only takes a
+							minute but makes a big difference.
 						</p>
 						<SupportTheGuardianButton
 							supportReferer={`resubscribe_thrasher_${args.usageContext}`}
-							alternateButtonText="Make a recurring contribution"
 							theme="brandAlt"
 						/>
 					</div>

--- a/client/components/resubscribeThrasher.tsx
+++ b/client/components/resubscribeThrasher.tsx
@@ -80,14 +80,13 @@ const getThrasher =
 								},
 							}}
 						>
-							Support The Guardian with a recurring contribution
+							Support the Guardian with a recurring contribution
 							of your choice. You can use your existing payment
 							details so setting it up only takes a minute.
 						</p>
 						<SupportTheGuardianButton
 							supportReferer={`resubscribe_thrasher_${args.usageContext}`}
 							alternateButtonText="Make a recurring contribution"
-							urlSuffix="contribute"
 							theme="brandAlt"
 						/>
 					</div>

--- a/client/components/supportTheGuardianButton.tsx
+++ b/client/components/supportTheGuardianButton.tsx
@@ -79,7 +79,7 @@ export const SupportTheGuardianButton = (
 					});
 				}}
 			>
-				{props.alternateButtonText || 'Support The Guardian'}
+				{props.alternateButtonText || 'Support the Guardian'}
 			</LinkButton>
 		</ThemeProvider>
 	);

--- a/client/components/supportTheGuardianButton.tsx
+++ b/client/components/supportTheGuardianButton.tsx
@@ -42,7 +42,7 @@ const buildSupportHref = (props: SupportTheGuardianButtonProps) =>
 	url.format({
 		protocol: 'https',
 		host: `support.${domain || 'theguardian.com'}`,
-		pathname: props.urlSuffix || '',
+		pathname: props.urlSuffix || 'contribute',
 		query: {
 			INTCMP: `mma_${props.supportReferer}`,
 			acquisitionData: JSON.stringify(

--- a/shared/productTypes.tsx
+++ b/shared/productTypes.tsx
@@ -366,7 +366,7 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 						return undefined;
 				}
 			},
-			alternateSupportButtonUrlSuffix: () => '/contribute', // TODO tweak the support url to preselect single/monthly/annual once functionality is available
+			alternateSupportButtonUrlSuffix: () => undefined,
 			swapFeedbackAndContactUs: true,
 			shouldHideThrasher: true,
 			shouldShowReminder: true,
@@ -475,18 +475,8 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 			summaryReasonSpecificPara: () => undefined,
 			onlyShowSupportSectionIfAlternateText: false,
 			alternateSummaryHeading: () => undefined,
-			alternateSupportButtonText: (
-				reasonId: OptionalCancellationReasonId,
-			) =>
-				reasonId === 'mma_financial_circumstances'
-					? '/contribute'
-					: undefined,
-			alternateSupportButtonUrlSuffix: (
-				reasonId: OptionalCancellationReasonId,
-			) =>
-				reasonId === 'mma_financial_circumstances'
-					? '/contribute'
-					: undefined,
+			alternateSupportButtonText: () => undefined,
+			alternateSupportButtonUrlSuffix: () => undefined,
 			swapFeedbackAndContactUs: true,
 		},
 	},
@@ -558,18 +548,8 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 			summaryReasonSpecificPara: () => undefined,
 			onlyShowSupportSectionIfAlternateText: false,
 			alternateSummaryHeading: () => undefined,
-			alternateSupportButtonText: (
-				reasonId: OptionalCancellationReasonId,
-			) =>
-				reasonId === 'mma_financial_circumstances'
-					? '/contribute'
-					: undefined,
-			alternateSupportButtonUrlSuffix: (
-				reasonId: OptionalCancellationReasonId,
-			) =>
-				reasonId === 'mma_financial_circumstances'
-					? '/contribute'
-					: undefined,
+			alternateSupportButtonText: () => undefined,
+			alternateSupportButtonUrlSuffix: () => undefined,
 			swapFeedbackAndContactUs: true,
 		},
 		fulfilmentDateCalculator: {
@@ -600,18 +580,8 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 			summaryReasonSpecificPara: () => undefined,
 			onlyShowSupportSectionIfAlternateText: false,
 			alternateSummaryHeading: () => undefined,
-			alternateSupportButtonText: (
-				reasonId: OptionalCancellationReasonId,
-			) =>
-				reasonId === 'mma_financial_circumstances'
-					? '/contribute'
-					: undefined,
-			alternateSupportButtonUrlSuffix: (
-				reasonId: OptionalCancellationReasonId,
-			) =>
-				reasonId === 'mma_financial_circumstances'
-					? '/contribute'
-					: undefined,
+			alternateSupportButtonText: () => undefined,
+			alternateSupportButtonUrlSuffix: () => undefined,
 			swapFeedbackAndContactUs: true,
 		},
 	},
@@ -666,18 +636,8 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 			startPageBody: supporterplusCancellationFlowStart,
 			summaryReasonSpecificPara: () => undefined,
 			onlyShowSupportSectionIfAlternateText: false,
-			alternateSupportButtonText: (
-				reasonId: OptionalCancellationReasonId,
-			) =>
-				reasonId === 'mma_financial_circumstances'
-					? '/contribute'
-					: undefined,
-			alternateSupportButtonUrlSuffix: (
-				reasonId: OptionalCancellationReasonId,
-			) =>
-				reasonId === 'mma_financial_circumstances'
-					? '/contribute'
-					: undefined,
+			alternateSupportButtonText: () => undefined,
+			alternateSupportButtonUrlSuffix: () => undefined,
 			swapFeedbackAndContactUs: true,
 			shouldHideThrasher: true,
 		},
@@ -711,7 +671,7 @@ export const GROUPED_PRODUCT_TYPES: {
 		supportTheGuardianSectionProps: {
 			supportReferer: 'account_overview_membership_section',
 			message:
-				'We no longer have a membership programme but you can still continue to support The Guardian.',
+				'We no longer have a membership programme but you can still continue to support the Guardian.',
 		},
 	},
 	/*


### PR DESCRIPTION
## What does this change?

Updates the `<SupportTheGuardianButton>` component so that it points to the new contribute page by default. The default button text has also been changed from 'Support The Guardian' to 'Support the Guardian' to follow Guardian style. Surrounding copy on pages where this button appears have also been updated accordingly.

## Images

<img width="778" alt="Screenshot 2022-11-17 at 12 43 48" src="https://user-images.githubusercontent.com/1166188/202505851-84b24bee-de93-4a74-a514-3ff6c9440b49.png">

<img width="826" alt="Screenshot 2022-11-23 at 10 25 47" src="https://user-images.githubusercontent.com/1166188/203524404-45218c47-5e49-4f21-91d3-6b58d4c97feb.png">
