### PR TITLE
Fix error when augmenting `members-data-api` response with `deliveryAddressChangeEffectiveDate`

### DIFF
--- a/server/fulfilmentDateCalculatorReader.ts
+++ b/server/fulfilmentDateCalculatorReader.ts
@@ -43,6 +43,10 @@ const getDeliveryAddressChangeEffectiveDateForToday = async (
 
 export const augmentProductDetailWithDeliveryAddressChangeEffectiveDateForToday =
 	async (productDetail: ProductDetail) => {
+		if (productDetail.mmaCategory !== 'subscriptions') {
+			return productDetail;
+		}
+
 		const mainPlan = getMainPlan(productDetail.subscription);
 		if (!mainPlan) {
 			const missingMainPlanErrorMsg =


### PR DESCRIPTION
## What does this change?

Adds a test to ensure the current product is a subscription when augmenting with `deliveryAddressChangeEffectiveDate` in the server-side layer. It iterates through all of the products returned by `members-data-api`, but assumes they're subscriptions as it calls `mapGroupedToSpecific` against the `subscriptions` grouped product type. Previously this worked even if a product was not a subscription as the function would return the parent `GroupedProductType` instead of a specific `ProductType` if there was no match. As something like a contribution lacks the fulfilment data properties the function is interested in it would return `productDetail` untouched.

In order to clean up the typing of the product type definitions we no longer return a `GroupedProductType` object if there's no match and throw an error instead. Whilst this _should_ never happen it will in this case as the code is assuming everything is a subscription so there will be no match for non-subscription products.

We should look to decouple the `mapGroupedToSpecific` from `GroupedProductType` and provide a generic function that can map a given `ProductDetail` object to a specific `ProductType` without needing to know which product group it belongs to. (Currently we can determine this with the `mmaCategory` property, but this is something we would like to remove.)