### PR TITLE
s3 bucket path fix

### DIFF
--- a/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
@@ -2287,7 +2287,7 @@ systemctl start manage-frontend
             Object {
               "Action": "s3:GetObject",
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::fulfilment-date-calculator-PROD/*",
+              "Resource": "arn:aws:s3:::fulfilment-date-calculator-prod/*",
             },
           ],
           "Version": "2012-10-17",

--- a/cdk/lib/manage-frontend.ts
+++ b/cdk/lib/manage-frontend.ts
@@ -134,7 +134,7 @@ systemctl start manage-frontend
 						this,
 						'ReadFulfilmentDateCalculatorOutput',
 						{
-							bucketName: `fulfilment-date-calculator-${this.stage}`,
+							bucketName: `fulfilment-date-calculator-${this.stage.toLowerCase()}`,
 							paths: ['*'],
 						},
 					),


### PR DESCRIPTION
 We were getting [403 errors in Sentry](https://sentry.io/organizations/the-guardian/issues/3422642449/?project=1208607&query=is%3Aunresolved&referrer=issue-stream) for a specific bucket [`fulfilment-date-calculator-code` and `fulfilment-date-calculator-prod`](https://s3.console.aws.amazon.com/s3/buckets/fulfilment-date-calculator-prod?region=eu-west-1&tab=objects). The generated [policy](https://us-east-1.console.aws.amazon.com/iamv2/home#/roles/details/support-PROD-manage-front-InstanceRoleManagefronte-3I9WNVJB6KFC?section=permissions) had an incorrect bucket path, which had the stage name in uppercase. This PR converts the stage name [to lowercase](https://github.com/guardian/manage-frontend/pull/927/files#diff-02efc8938d4b3eac80fe423090cbf66845e0a3203382bb9e94c569323fd81d76R137).