### PR TITLE
Rebuild Account Overview product cards

### DIFF
--- a/client/components/accountoverview/accountOverview.tsx
+++ b/client/components/accountoverview/accountOverview.tsx
@@ -9,6 +9,7 @@ import {
 import { Stack } from '@guardian/source-react-components';
 import { capitalize } from 'lodash';
 import { Fragment } from 'react';
+import { featureSwitches } from '../../../shared/featureSwitches';
 import type {
 	CancelledProductDetail,
 	MembersDataApiItem,
@@ -27,6 +28,7 @@ import { PaymentFailureAlertIfApplicable } from '../payment/paymentFailureAlertI
 import { SupportTheGuardianButton } from '../supportTheGuardianButton';
 import { AccountOverviewCancelledCard } from './accountOverviewCancelledCard';
 import { AccountOverviewCard } from './accountOverviewCard';
+import { AccountOverviewCardV2 } from './accountOverviewCardV2';
 import { EmptyAccountOverview } from './emptyAccountOverview';
 
 const AccountOverviewRenderer = ([mdaResponse, cancelledProductsResponse]: [
@@ -93,15 +95,25 @@ const AccountOverviewRenderer = ([mdaResponse, cancelledProductsResponse]: [
 							{capitalize(groupedProductType.groupFriendlyName)}
 						</h2>
 						<Stack space={6}>
-							{activeProductsInCategory.map((productDetail) => (
-								<AccountOverviewCard
-									key={
-										productDetail.subscription
-											.subscriptionId
-									}
-									productDetail={productDetail}
-								/>
-							))}
+							{activeProductsInCategory.map((productDetail) =>
+								featureSwitches.accountOverviewNewLayout ? (
+									<AccountOverviewCardV2
+										key={
+											productDetail.subscription
+												.subscriptionId
+										}
+										productDetail={productDetail}
+									/>
+								) : (
+									<AccountOverviewCard
+										key={
+											productDetail.subscription
+												.subscriptionId
+										}
+										productDetail={productDetail}
+									/>
+								),
+							)}
 							{cancelledProductsInCategory.map(
 								(cancelledProductDetail) => (
 									<AccountOverviewCancelledCard

--- a/client/components/accountoverview/accountOverviewCardV2.tsx
+++ b/client/components/accountoverview/accountOverviewCardV2.tsx
@@ -1,5 +1,6 @@
 import { css, ThemeProvider } from '@emotion/react';
 import {
+	from,
 	headline,
 	palette,
 	space,
@@ -39,15 +40,23 @@ const Card = (props: CardProps) => {
 
 	const headingContainerCss = css`
 		padding: ${space[3]}px ${space[4]}px;
-		min-height: 128px;
+		min-height: 64px;
 		color: ${palette.neutral[100]};
 		background-color: ${palette.brand[500]};
+
+		${from.tablet} {
+			min-height: 128px;
+		}
 	`;
 
 	const headingCss = css`
-		${headline.small({ fontWeight: 'bold' })};
+		${headline.xxsmall({ fontWeight: 'bold' })};
 		margin: 0;
 		max-width: 20ch;
+
+		${from.tablet} {
+			${headline.small({ fontWeight: 'bold' })};
+		}
 	`;
 
 	return (
@@ -64,7 +73,6 @@ Card.Section = (props: { children: ReactNode }) => {
 	const sectionCss = css`
 		padding: ${space[5]}px ${space[4]}px;
 		& + & {
-			margin-top: ${space[5]}px;
 			border-top: 1px solid ${palette.neutral[86]};
 		}
 	`;
@@ -123,13 +131,19 @@ export const AccountOverviewCardV2 = ({
 		margin-bottom: ${space[2]}px;
 	`;
 
-	const panelCss = css`
-		display: flex;
-		flex-direction: row;
+	const productDetailLayoutCss = css`
+		> :last-child {
+			margin-top: ${space[5]}px;
+		}
 
-		> :first-child {
-			flex-grow: 1;
-			margin-right: ${space[4]}px;
+		${from.tablet} {
+			display: flex;
+			flex-direction: row;
+			> :last-child {
+				margin-top: 0;
+				margin-left: auto;
+				padding-left: ${space[4]}px;
+			}
 		}
 	`;
 
@@ -168,7 +182,7 @@ export const AccountOverviewCardV2 = ({
 		<Card heading={productTitle}>
 			<Card.Section>
 				<h4 css={sectionHeadingCss}>Billing and payment</h4>
-				<div css={panelCss}>
+				<div css={productDetailLayoutCss}>
 					<dl css={keyValueCss}>
 						<div>
 							<dt>
@@ -281,7 +295,7 @@ export const AccountOverviewCardV2 = ({
 			{productDetail.isPaidTier && (
 				<Card.Section>
 					<h4 css={sectionHeadingCss}>Payment method</h4>
-					<div css={panelCss}>
+					<div css={productDetailLayoutCss}>
 						<div
 							css={css`
 								${textSans.medium()};
@@ -333,35 +347,40 @@ export const AccountOverviewCardV2 = ({
 							)}
 						</div>
 						{!isGifted && isSafeToUpdatePaymentMethod && (
-							<Button
-								aria-label={`${specificProductType.productTitle(
-									mainPlan,
-								)} : Update payment method`}
-								size="small"
-								priority="primary"
-								icon={
-									hasPaymentFailure ? (
-										<ErrorIcon
-											fill={palette.neutral[100]}
-										/>
-									) : undefined
-								}
-								onClick={() => {
-									trackEvent({
-										eventCategory: 'account_overview',
-										eventAction: 'click',
-										eventLabel: 'manage_payment_method',
-									});
-									navigate(
-										`/payment/${specificProductType.urlPart}`,
-										{
-											state: { productDetail },
-										},
-									);
-								}}
-							>
-								Update payment method
-							</Button>
+							<div css={buttonLayoutCss}>
+								<Button
+									aria-label={`${specificProductType.productTitle(
+										mainPlan,
+									)} : Update payment method`}
+									size="small"
+									cssOverrides={css`
+										justify-content: center;
+									`}
+									priority="primary"
+									icon={
+										hasPaymentFailure ? (
+											<ErrorIcon
+												fill={palette.neutral[100]}
+											/>
+										) : undefined
+									}
+									onClick={() => {
+										trackEvent({
+											eventCategory: 'account_overview',
+											eventAction: 'click',
+											eventLabel: 'manage_payment_method',
+										});
+										navigate(
+											`/payment/${specificProductType.urlPart}`,
+											{
+												state: { productDetail },
+											},
+										);
+									}}
+								>
+									Update payment method
+								</Button>
+							</div>
 						)}
 					</div>
 				</Card.Section>

--- a/client/components/accountoverview/accountOverviewCardV2.tsx
+++ b/client/components/accountoverview/accountOverviewCardV2.tsx
@@ -1,6 +1,42 @@
+import { css } from '@emotion/react';
+import { headline, palette, space } from '@guardian/source-foundations';
+import type { ReactNode } from 'react';
 import type { ProductDetail } from '../../../shared/productResponse';
 import { getMainPlan } from '../../../shared/productResponse';
 import { GROUPED_PRODUCT_TYPES } from '../../../shared/productTypes';
+
+interface CardProps {
+	heading: string;
+	children: ReactNode;
+}
+
+const Card = (props: CardProps) => {
+	const containerCss = css`
+		width: 100%;
+		border: 1px solid ${palette.neutral[86]};
+	`;
+
+	const headingContainerCss = css`
+		padding: ${space[3]}px ${space[4]}px;
+		min-height: 128px;
+		color: ${palette.neutral[100]};
+		background-color: ${palette.brand[500]};
+	`;
+
+	const headingCss = css`
+		${headline.small({ fontWeight: 'bold' })};
+		margin: 0;
+	`;
+
+	return (
+		<div css={containerCss}>
+			<div css={headingContainerCss}>
+				<h3 css={headingCss}>{props.heading}</h3>
+			</div>
+			{props.children}
+		</div>
+	);
+};
 
 export const AccountOverviewCardV2 = ({
 	productDetail,
@@ -18,8 +54,8 @@ export const AccountOverviewCardV2 = ({
 		groupedProductType.mapGroupedToSpecific(productDetail);
 
 	return (
-		<div>
-			<h3>{specificProductType.productTitle(mainPlan)}</h3>
-		</div>
+		<Card heading={specificProductType.productTitle(mainPlan)}>
+			<p>Product details go here…</p>
+		</Card>
 	);
 };

--- a/client/components/accountoverview/accountOverviewCardV2.tsx
+++ b/client/components/accountoverview/accountOverviewCardV2.tsx
@@ -1,0 +1,25 @@
+import type { ProductDetail } from '../../../shared/productResponse';
+import { getMainPlan } from '../../../shared/productResponse';
+import { GROUPED_PRODUCT_TYPES } from '../../../shared/productTypes';
+
+export const AccountOverviewCardV2 = ({
+	productDetail,
+}: {
+	productDetail: ProductDetail;
+}) => {
+	const mainPlan = getMainPlan(productDetail.subscription);
+
+	if (!mainPlan) {
+		throw new Error('mainPlan does not exist in accountOverviewCard');
+	}
+
+	const groupedProductType = GROUPED_PRODUCT_TYPES[productDetail.mmaCategory];
+	const specificProductType =
+		groupedProductType.mapGroupedToSpecific(productDetail);
+
+	return (
+		<div>
+			<h3>{specificProductType.productTitle(mainPlan)}</h3>
+		</div>
+	);
+};

--- a/client/components/accountoverview/accountOverviewCardV2.tsx
+++ b/client/components/accountoverview/accountOverviewCardV2.tsx
@@ -236,6 +236,25 @@ export const AccountOverviewCardV2 = ({
 									</dd>
 								</div>
 							)}
+							{specificProductType.showTrialRemainingIfApplicable &&
+								productDetail.subscription.trialLength > 0 &&
+								!isGifted &&
+								productDetail.subscription.readerType !==
+									'Patron' && (
+									<div>
+										<dt>Trial remaining</dt>
+										<dd>
+											{
+												productDetail.subscription
+													.trialLength
+											}{' '}
+											{productDetail.subscription
+												.trialLength !== 1
+												? 'days'
+												: 'day'}
+										</dd>
+									</div>
+								)}
 							{isGifted && !userIsGifter && (
 								<div>
 									<dt>End date</dt>

--- a/client/components/accountoverview/accountOverviewCardV2.tsx
+++ b/client/components/accountoverview/accountOverviewCardV2.tsx
@@ -1,11 +1,14 @@
-import { css } from '@emotion/react';
+import { css, ThemeProvider } from '@emotion/react';
 import {
 	headline,
 	palette,
 	space,
 	textSans,
 } from '@guardian/source-foundations';
-import { LinkButton } from '@guardian/source-react-components';
+import {
+	Button,
+	buttonThemeReaderRevenueBrand,
+} from '@guardian/source-react-components';
 import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router';
 import { parseDate } from '../../../shared/dates';
@@ -112,6 +115,8 @@ export const AccountOverviewCardV2 = ({
 		hasPaymentFailure,
 	);
 
+	const isEligibleToSwitch = true;
+
 	const sectionHeadingCss = css`
 		${textSans.medium({ fontWeight: 'bold' })};
 		margin-top: 0;
@@ -147,6 +152,15 @@ export const AccountOverviewCardV2 = ({
 		dd {
 			display: inline-block;
 			margin-left: 0;
+		}
+	`;
+
+	const buttonLayoutCss = css`
+		display: flex;
+		flex-direction: column;
+
+		> * + * {
+			margin-top: ${space[4]}px;
 		}
 	`;
 
@@ -220,14 +234,17 @@ export const AccountOverviewCardV2 = ({
 								</div>
 							)}
 					</dl>
-					<div>
+					<div css={buttonLayoutCss}>
 						{!isGifted && (
-							<LinkButton
+							<Button
 								aria-label={`${specificProductType.productTitle(
 									mainPlan,
 								)} : Manage ${groupedProductType.friendlyName()}`}
 								data-cy={`Manage ${groupedProductType.friendlyName()}`}
 								size="small"
+								cssOverrides={css`
+									justify-content: center;
+								`}
 								onClick={() => {
 									trackEvent({
 										eventCategory: 'account_overview',
@@ -242,7 +259,21 @@ export const AccountOverviewCardV2 = ({
 								}}
 							>
 								{`Manage ${groupedProductType.friendlyName()}`}
-							</LinkButton>
+							</Button>
+						)}
+						{isEligibleToSwitch && (
+							<ThemeProvider
+								theme={buttonThemeReaderRevenueBrand}
+							>
+								<Button
+									size="small"
+									cssOverrides={css`
+										justify-content: center;
+									`}
+								>
+									Change to monthly + extras
+								</Button>
+							</ThemeProvider>
 						)}
 					</div>
 				</div>
@@ -302,7 +333,7 @@ export const AccountOverviewCardV2 = ({
 							)}
 						</div>
 						{!isGifted && isSafeToUpdatePaymentMethod && (
-							<LinkButton
+							<Button
 								aria-label={`${specificProductType.productTitle(
 									mainPlan,
 								)} : Update payment method`}
@@ -330,7 +361,7 @@ export const AccountOverviewCardV2 = ({
 								}}
 							>
 								Update payment method
-							</LinkButton>
+							</Button>
 						)}
 					</div>
 				</Card.Section>

--- a/client/components/accountoverview/accountOverviewCardV2.tsx
+++ b/client/components/accountoverview/accountOverviewCardV2.tsx
@@ -350,7 +350,7 @@ export const AccountOverviewCardV2 = ({
 								)}
 								{productDetail.subscription.mandate && (
 									<DirectDebitDisplay
-										inErrorState={hasPaymentFailure}
+										inline={true}
 										{...productDetail.subscription.mandate}
 									/>
 								)}

--- a/client/components/accountoverview/accountOverviewCardV2.tsx
+++ b/client/components/accountoverview/accountOverviewCardV2.tsx
@@ -330,6 +330,7 @@ export const AccountOverviewCardV2 = ({
 								)}
 								{productDetail.subscription.payPalEmail && (
 									<PayPalDisplay
+										inline={true}
 										payPalId={
 											productDetail.subscription
 												.payPalEmail
@@ -338,6 +339,7 @@ export const AccountOverviewCardV2 = ({
 								)}
 								{productDetail.subscription.sepaMandate && (
 									<SepaDisplay
+										inline={true}
 										accountName={
 											productDetail.subscription
 												.sepaMandate.accountName
@@ -356,13 +358,7 @@ export const AccountOverviewCardV2 = ({
 								)}
 								{productDetail.subscription
 									.stripePublicKeyForCardAddition && (
-									<p
-										css={css`
-											margin: 0;
-										`}
-									>
-										No Payment Method
-									</p>
+									<span>No Payment Method</span>
 								)}
 							</div>
 						</div>

--- a/client/components/accountoverview/accountOverviewCardV2.tsx
+++ b/client/components/accountoverview/accountOverviewCardV2.tsx
@@ -1,9 +1,14 @@
 import { css } from '@emotion/react';
-import { headline, palette, space } from '@guardian/source-foundations';
+import {
+	headline,
+	palette,
+	space,
+	textSans,
+} from '@guardian/source-foundations';
 import type { ReactNode } from 'react';
 import { parseDate } from '../../../shared/dates';
 import type { ProductDetail } from '../../../shared/productResponse';
-import { getMainPlan , isGift } from '../../../shared/productResponse';
+import { getMainPlan, isGift } from '../../../shared/productResponse';
 import { GROUPED_PRODUCT_TYPES } from '../../../shared/productTypes';
 import {
 	getNextPaymentDetails,
@@ -42,6 +47,14 @@ const Card = (props: CardProps) => {
 			{props.children}
 		</div>
 	);
+};
+
+Card.Section = (props: { children: ReactNode }) => {
+	const sectionCss = css`
+		padding: ${space[5]}px ${space[4]}px;
+	`;
+
+	return <div css={sectionCss}>{props.children}</div>;
 };
 
 export const AccountOverviewCardV2 = ({
@@ -83,64 +96,99 @@ export const AccountOverviewCardV2 = ({
 		hasPaymentFailure,
 	);
 
+	const sectionHeadingCss = css`
+		${textSans.medium({ fontWeight: 'bold' })};
+		margin-top: 0;
+		margin-bottom: ${space[2]}px;
+	`;
+
+	const keyValueCss = css`
+		${textSans.medium()};
+		margin: 0;
+
+		div + div {
+			margin-top: ${space[1]}px;
+		}
+
+		dt {
+			display: inline-block;
+			:after {
+				content: ':';
+			}
+		}
+
+		dd {
+			display: inline-block;
+			margin-left: 0.5ch;
+		}
+	`;
+
 	return (
 		<Card heading={productTitle}>
-			<h4>Billing and payment</h4>
-			<dl>
-				<dt>
-					{groupedProductType.showSupporterId
-						? 'Supporter ID'
-						: 'Subscription ID'}
-				</dt>
-				<dd>{productDetail.subscription.subscriptionId}</dd>
-				{groupedProductType.tierLabel && (
-					<>
-						<dt>{groupedProductType.tierLabel}</dt>
-						<dd>{productDetail.tier}</dd>
-					</>
-				)}
-				{subscriptionStartDate && shouldShowStartDate && (
-					<>
-						<dt>Start date</dt>
-						<dd>{parseDate(subscriptionStartDate).dateStr()}</dd>
-					</>
-				)}
-				{shouldShowJoinDateNotStartDate && (
-					<>
-						<dt>Join date</dt>
-						<dd>{parseDate(productDetail.joinDate).dateStr()}</dd>
-					</>
-				)}
-				{userIsGifter && giftPurchaseDate && (
-					<>
-						<dt>Purchase date</dt>
-						<dd>{parseDate(giftPurchaseDate).dateStr()}</dd>
-					</>
-				)}
-				{isGifted && !userIsGifter && (
-					<>
-						<dt>End date</dt>
-						<dd>{parseDate(subscriptionEndDate).dateStr()}</dd>
-					</>
-				)}
-				{nextPaymentDetails &&
-					productDetail.subscription.autoRenew &&
-					!hasCancellationPending && (
-						<>
-							<dt>{nextPaymentDetails.paymentKey}</dt>
-							<dd>
-								{nextPaymentDetails.isNewPaymentValue && (
-									<NewPaymentPriceAlert />
-								)}
-								{nextPaymentDetails.paymentValue}
-								{nextPaymentDetails.nextPaymentDateValue &&
-									productDetail.subscription.readerType !==
-										'Patron' &&
-									` on ${nextPaymentDetails.nextPaymentDateValue}`}
-							</dd>
-						</>
+			<Card.Section>
+				<h4 css={sectionHeadingCss}>Billing and payment</h4>
+				<dl css={keyValueCss}>
+					<div>
+						<dt>
+							{groupedProductType.showSupporterId
+								? 'Supporter ID'
+								: 'Subscription ID'}
+						</dt>
+						<dd>{productDetail.subscription.subscriptionId}</dd>
+					</div>
+					{groupedProductType.tierLabel && (
+						<div>
+							<dt>{groupedProductType.tierLabel}</dt>
+							<dd>{productDetail.tier}</dd>
+						</div>
 					)}
-			</dl>
+					{subscriptionStartDate && shouldShowStartDate && (
+						<div>
+							<dt>Start date</dt>
+							<dd>
+								{parseDate(subscriptionStartDate).dateStr()}
+							</dd>
+						</div>
+					)}
+					{shouldShowJoinDateNotStartDate && (
+						<div>
+							<dt>Join date</dt>
+							<dd>
+								{parseDate(productDetail.joinDate).dateStr()}
+							</dd>
+						</div>
+					)}
+					{userIsGifter && giftPurchaseDate && (
+						<div>
+							<dt>Purchase date</dt>
+							<dd>{parseDate(giftPurchaseDate).dateStr()}</dd>
+						</div>
+					)}
+					{isGifted && !userIsGifter && (
+						<div>
+							<dt>End date</dt>
+							<dd>{parseDate(subscriptionEndDate).dateStr()}</dd>
+						</div>
+					)}
+					{nextPaymentDetails &&
+						productDetail.subscription.autoRenew &&
+						!hasCancellationPending && (
+							<div>
+								<dt>{nextPaymentDetails.paymentKey}</dt>
+								<dd>
+									{nextPaymentDetails.isNewPaymentValue && (
+										<NewPaymentPriceAlert />
+									)}
+									{nextPaymentDetails.paymentValue}
+									{nextPaymentDetails.nextPaymentDateValue &&
+										productDetail.subscription
+											.readerType !== 'Patron' &&
+										` on ${nextPaymentDetails.nextPaymentDateValue}`}
+								</dd>
+							</div>
+						)}
+				</dl>
+			</Card.Section>
 		</Card>
 	);
 };

--- a/client/components/payment/directDebitDisplay.tsx
+++ b/client/components/payment/directDebitDisplay.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { brand, from } from '@guardian/source-foundations';
+import { brand, from, space } from '@guardian/source-foundations';
 import type { DirectDebitDetails } from '../../../shared/productResponse';
 import { DirectDebitLogo } from './directDebitLogo';
 import type { Inlineable } from './inlineable';
@@ -59,6 +59,7 @@ interface DirectDebitDisplayProps extends DirectDebitDetails, Inlineable {
 	inErrorState?: boolean;
 	onlyAccountEnding?: true;
 	onlySortCode?: true;
+	inline?: true;
 }
 
 export const DirectDebitDisplay = (props: DirectDebitDisplayProps) => {
@@ -106,6 +107,27 @@ export const DirectDebitDisplay = (props: DirectDebitDisplayProps) => {
 					`}
 				>
 					{dashifySortCode(props.sortCode)}
+				</span>
+			</div>
+		);
+	}
+
+	if (props.inline) {
+		return (
+			<div
+				css={css`
+					display: flex;
+					align-items: center;
+				`}
+			>
+				<DirectDebitLogo fill={brand[400]} />
+				<span
+					css={css`
+						margin-left: ${space[2]}px;
+					`}
+				>
+					{dashifySortCode(props.sortCode)}{' '}
+					{sanitiseAccountNumber(props.accountNumber)}
 				</span>
 			</div>
 		);

--- a/client/components/payment/directDebitDisplay.tsx
+++ b/client/components/payment/directDebitDisplay.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { brand, from, space } from '@guardian/source-foundations';
+import { from, palette } from '@guardian/source-foundations';
 import type { DirectDebitDetails } from '../../../shared/productResponse';
 import { DirectDebitLogo } from './directDebitLogo';
 import type { Inlineable } from './inlineable';
@@ -59,7 +59,6 @@ interface DirectDebitDisplayProps extends DirectDebitDetails, Inlineable {
 	inErrorState?: boolean;
 	onlyAccountEnding?: true;
 	onlySortCode?: true;
-	inline?: true;
 }
 
 export const DirectDebitDisplay = (props: DirectDebitDisplayProps) => {
@@ -72,7 +71,7 @@ export const DirectDebitDisplay = (props: DirectDebitDisplayProps) => {
 				`}
 			>
 				<DirectDebitLogo
-					fill={brand[400]}
+					fill={palette.brand[400]}
 					additionalCss={css`
 						margin-right: 10px;
 					`}
@@ -94,7 +93,7 @@ export const DirectDebitDisplay = (props: DirectDebitDisplayProps) => {
 				`}
 			>
 				<DirectDebitLogo
-					fill={brand[400]}
+					fill={palette.brand[400]}
 					additionalCss={css`
 						margin: auto 10px auto 0;
 						width: 47px;
@@ -120,10 +119,10 @@ export const DirectDebitDisplay = (props: DirectDebitDisplayProps) => {
 					align-items: center;
 				`}
 			>
-				<DirectDebitLogo fill={brand[400]} />
+				<DirectDebitLogo fill={palette.brand[400]} />
 				<span
 					css={css`
-						margin-left: ${space[2]}px;
+						margin-left: 0.5ch;
 					`}
 				>
 					{dashifySortCode(props.sortCode)}{' '}
@@ -136,7 +135,7 @@ export const DirectDebitDisplay = (props: DirectDebitDisplayProps) => {
 	return (
 		<>
 			<DirectDebitLogo
-				fill={brand[400]}
+				fill={palette.brand[400]}
 				additionalCss={css`
 					margin: 0 10px 0 0;
 				`}

--- a/client/components/payment/paypalDisplay.tsx
+++ b/client/components/payment/paypalDisplay.tsx
@@ -1,8 +1,10 @@
+import { css } from '@emotion/react';
 import { PaypalLogo } from './paypalLogo';
 
 interface PayPalProps {
 	payPalId?: string;
 	shouldIncludePrefixCopy?: true;
+	inline?: true;
 }
 
 // Regex to split a PayPal ID into 3 groups:
@@ -21,10 +23,10 @@ interface PayPalProps {
 // ID                    | 1 | 2   | 3
 // ----------------------|---|-----|---------
 // james                 | j | ame | s
-// james@thegulocal.com | j | ame | s@thegulocal.com
-// jim@thegulocal.com   | j | i   | m@thegulocal.com
-// jm@thegulocal.com    | j |     | m@thegulocal.com
-// j@thegulocal.com     | j |     | @thegulocal.com
+// james@thegulocal.com  | j | ame | s@thegulocal.com
+// jim@thegulocal.com    | j | i   | m@thegulocal.com
+// jm@thegulocal.com     | j |     | m@thegulocal.com
+// j@thegulocal.com      | j |     | @thegulocal.com
 
 const SPLIT_PAYPAL_ID_REGEX = /^(.)(.*?)(.?|.?@.+)$/;
 
@@ -36,21 +38,41 @@ export const getObfuscatedPayPalId = (rawId: string) => {
 	);
 };
 
-export const PayPalDisplay = (props: PayPalProps) => (
-	<>
-		<PaypalLogo />
-		{props.payPalId && (
-			<p>
-				{props.shouldIncludePrefixCopy && (
-					<>
-						To update your payment details, please login to your
-						PayPal account.
-						<br />
-						Your PayPal ID is&nbsp;
-					</>
-				)}
-				{getObfuscatedPayPalId(props.payPalId)}
-			</p>
-		)}
-	</>
-);
+export const PayPalDisplay = (props: PayPalProps) => {
+	const layoutCss = css`
+		${props.inline &&
+		`
+			display: flex;
+			align-items: center;
+			svg {
+				flex-shrink: 0;
+				margin-right: 0.5ch;
+			}
+		`}
+
+		p {
+			overflow: hidden;
+			text-overflow: ellipsis;
+			margin: 0;
+		}
+	`;
+
+	return (
+		<div css={layoutCss}>
+			<PaypalLogo />
+			{props.payPalId && (
+				<p>
+					{props.shouldIncludePrefixCopy && (
+						<>
+							To update your payment details, please login to your
+							PayPal account.
+							<br />
+							Your PayPal ID is&nbsp;
+						</>
+					)}
+					{getObfuscatedPayPalId(props.payPalId)}
+				</p>
+			)}
+		</div>
+	);
+};

--- a/client/components/payment/sepaDisplay.tsx
+++ b/client/components/payment/sepaDisplay.tsx
@@ -1,18 +1,33 @@
+import { css } from '@emotion/react';
+
 interface SepaDisplayProps {
 	accountName: string;
 	iban: string;
+	inline?: boolean;
 }
 
-export const SepaDisplay = ({ accountName, iban }: SepaDisplayProps) => {
+export const SepaDisplay = ({
+	accountName,
+	iban,
+	inline,
+}: SepaDisplayProps) => {
 	return (
-		<div>
-			<div>SEPA</div>
-
-			<div>
-				{accountName}
-				<br />
-				{iban}
-			</div>
-		</div>
+		<p
+			css={css`
+				margin: 0;
+			`}
+		>
+			{inline ? (
+				`SEPA ${accountName} ${iban}`
+			) : (
+				<>
+					SEPA
+					<br />
+					{accountName}
+					<br />
+					{iban}
+				</>
+			)}
+		</p>
 	);
 };

--- a/shared/featureSwitches.ts
+++ b/shared/featureSwitches.ts
@@ -25,4 +25,5 @@ export const initFeatureSwitchUrlParamOverride = () => {
 export const featureSwitches: Record<string, boolean> = {
 	exampleFeature: false,
 	cancellationProductSwitch: false,
+	accountOverviewNewLayout: false,
 };


### PR DESCRIPTION
## What does this change?

Updates the Account Overview product cards to give them a visual refresh and reorganise their content to make space for the product switch button. (These changes are currently hidden behind the `accountOverviewNewLayout` feature flag.)

This is the first of a series of PRs. Product-specific header colours and images, product benefits and support for cancelled and gifted subscriptions will be added in subsequent PRs.

## Images

### Before

<img width="827" alt="Screenshot 2022-11-30 at 14 47 19" src="https://user-images.githubusercontent.com/1166188/204826963-78c2221e-0a62-4c62-94bb-4bed1ebe9e9b.png">


### After

<img width="824" alt="Screenshot 2022-11-30 at 14 47 38" src="https://user-images.githubusercontent.com/1166188/204826979-395d8616-aa15-4920-a821-7c829db085bb.png">

#### Long PayPal email address truncation

<img width="737" alt="Screenshot 2022-11-30 at 16 51 04" src="https://user-images.githubusercontent.com/1166188/204868413-5a5ffe93-2f2a-4545-bbdf-ab26bd2ea85d.png">

<img width="391" alt="Screenshot 2022-11-30 at 16 51 22" src="https://user-images.githubusercontent.com/1166188/204868445-c85b225c-511d-424c-83f5-ca196b0f0c0b.png">
