### PR TITLE
Wire up 'Change to support and extras' button to logic to determine whether to show it

### DIFF
--- a/client/components/accountoverview/accountOverview.stories.tsx
+++ b/client/components/accountoverview/accountOverview.stories.tsx
@@ -36,12 +36,7 @@ export const WithSubscriptions: ComponentStory<typeof AccountOverview> = () => {
 		.restore()
 		.get('/api/cancelled/', { body: [] })
 		.get('/api/me/mma', {
-			body: [
-				guardianWeeklyCard,
-				digitalDD,
-				newspaperVoucherPaypal,
-				contribution,
-			],
+			body: [guardianWeeklyCard, digitalDD, newspaperVoucherPaypal],
 		});
 
 	return <AccountOverview />;

--- a/client/components/accountoverview/accountOverview.stories.tsx
+++ b/client/components/accountoverview/accountOverview.stories.tsx
@@ -1,10 +1,13 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 import fetchMock from 'fetch-mock';
 import { ReactRouterDecorator } from '../../../.storybook/ReactRouterDecorator';
+import { featureSwitches } from '../../../shared/featureSwitches';
 import {
+	contribution,
 	digitalDD,
 	guardianWeeklyCard,
 	newspaperVoucherPaypal,
+	supporterPlus,
 } from '../../fixtures/productDetail';
 import { user } from '../../fixtures/user';
 import AccountOverview from './accountOverview';
@@ -33,7 +36,61 @@ export const WithSubscriptions: ComponentStory<typeof AccountOverview> = () => {
 		.restore()
 		.get('/api/cancelled/', { body: [] })
 		.get('/api/me/mma', {
-			body: [guardianWeeklyCard, digitalDD, newspaperVoucherPaypal],
+			body: [
+				guardianWeeklyCard,
+				digitalDD,
+				newspaperVoucherPaypal,
+				contribution,
+			],
+		});
+
+	return <AccountOverview />;
+};
+
+export const WithContributionNewLayout: ComponentStory<
+	typeof AccountOverview
+> = () => {
+	featureSwitches['accountOverviewNewLayout'] = true;
+
+	fetchMock
+		.restore()
+		.get('/api/cancelled/', { body: [] })
+		.get('/api/me/mma', {
+			body: [contribution],
+		});
+
+	return <AccountOverview />;
+};
+
+export const WithContributionNewLayoutPaymentFailure: ComponentStory<
+	typeof AccountOverview
+> = () => {
+	featureSwitches['accountOverviewNewLayout'] = true;
+	const contributionPaymentFailure = {
+		...contribution,
+		alertText: 'Your payment has failed.',
+	};
+
+	fetchMock
+		.restore()
+		.get('/api/cancelled/', { body: [] })
+		.get('/api/me/mma', {
+			body: [contributionPaymentFailure, supporterPlus],
+		});
+
+	return <AccountOverview />;
+};
+
+export const WithContributionNewLayoutDigisubAndContribution: ComponentStory<
+	typeof AccountOverview
+> = () => {
+	featureSwitches['accountOverviewNewLayout'] = true;
+
+	fetchMock
+		.restore()
+		.get('/api/cancelled/', { body: [] })
+		.get('/api/me/mma', {
+			body: [contribution, digitalDD],
 		});
 
 	return <AccountOverview />;

--- a/client/components/accountoverview/accountOverview.tsx
+++ b/client/components/accountoverview/accountOverview.tsx
@@ -15,9 +15,16 @@ import type {
 	MembersDataApiItem,
 	ProductDetail,
 } from '../../../shared/productResponse';
-import { isProduct, sortByJoinDate } from '../../../shared/productResponse';
+import {
+	isProduct,
+	isSpecificProductType,
+	sortByJoinDate,
+} from '../../../shared/productResponse';
 import type { GroupedProductTypeKeys } from '../../../shared/productTypes';
-import { GROUPED_PRODUCT_TYPES } from '../../../shared/productTypes';
+import {
+	GROUPED_PRODUCT_TYPES,
+	PRODUCT_TYPES,
+} from '../../../shared/productTypes';
 import { fetchWithDefaultParameters } from '../../fetch';
 import { allProductsDetailFetcher } from '../../productUtils';
 import AsyncLoader from '../asyncLoader';
@@ -62,6 +69,18 @@ const AccountOverviewRenderer = ([mdaResponse, cancelledProductsResponse]: [
 		(_) => _.alertText,
 	);
 
+	const hasDigiSubAndContribution =
+		allActiveProductDetails.some((productDetail) =>
+			isSpecificProductType(productDetail, PRODUCT_TYPES.contributions),
+		) &&
+		allActiveProductDetails.some((productDetail) =>
+			isSpecificProductType(productDetail, PRODUCT_TYPES.digipack),
+		);
+
+	const isEligibleToSwitch = !(
+		maybeFirstPaymentFailure || hasDigiSubAndContribution
+	);
+
 	const subHeadingCss = css`
 		margin: ${space[12]}px 0 ${space[6]}px;
 		border-top: 1px solid ${neutral['86']};
@@ -103,6 +122,7 @@ const AccountOverviewRenderer = ([mdaResponse, cancelledProductsResponse]: [
 												.subscriptionId
 										}
 										productDetail={productDetail}
+										isEligibleToSwitch={isEligibleToSwitch}
 									/>
 								) : (
 									<AccountOverviewCard

--- a/client/components/accountoverview/accountOverviewCardV2.tsx
+++ b/client/components/accountoverview/accountOverviewCardV2.tsx
@@ -86,8 +86,10 @@ Card.Section = (props: { children: ReactNode; backgroundColor?: string }) => {
 
 export const AccountOverviewCardV2 = ({
 	productDetail,
+	isEligibleToSwitch,
 }: {
 	productDetail: ProductDetail;
+	isEligibleToSwitch: boolean;
 }) => {
 	const navigate = useNavigate();
 	const [showBenefits, setShowBenefits] = useState<boolean>(false);
@@ -128,10 +130,9 @@ export const AccountOverviewCardV2 = ({
 		hasPaymentFailure,
 	);
 
-	// TODO: Add eligibility criteria logic. This is currently hardcoded to
-	// always show the switch button for Supporter+ to allow testing of design
-	const isEligibleToSwitch =
-		specificProductType === PRODUCT_TYPES.supporterplus;
+	const showSwitchButton =
+		isEligibleToSwitch &&
+		specificProductType === PRODUCT_TYPES.contributions;
 
 	const sectionHeadingCss = css`
 		${textSans.medium({ fontWeight: 'bold' })};
@@ -410,7 +411,7 @@ export const AccountOverviewCardV2 = ({
 								{`Manage ${groupedProductType.friendlyName()}`}
 							</Button>
 						)}
-						{isEligibleToSwitch && (
+						{showSwitchButton && (
 							<ThemeProvider
 								theme={buttonThemeReaderRevenueBrand}
 							>

--- a/shared/productResponse.ts
+++ b/shared/productResponse.ts
@@ -4,7 +4,8 @@ import AsyncLoader from '../client/components/asyncLoader';
 import type { PhoneRegionKey } from '../client/components/callCenterEmailAndNumbers';
 import type { DeliveryRecordDetail } from '../client/components/delivery/records/deliveryRecordsApi';
 import type { CardProps } from '../client/components/payment/cardDisplay';
-import type { GroupedProductTypeKeys } from './productTypes';
+import { GROUPED_PRODUCT_TYPES } from './productTypes';
+import type { GroupedProductTypeKeys, ProductType } from './productTypes';
 
 export type DeliveryRecordApiItem = DeliveryRecordDetail;
 
@@ -215,4 +216,14 @@ export const getMainPlan: (subscription: Subscription) => SubscriptionPlan = (
 		currency: subscription.plan?.currency,
 		currencyISO: subscription.plan?.currencyISO,
 	};
+};
+
+export const isSpecificProductType = (
+	productDetail: ProductDetail,
+	productType: ProductType,
+) => {
+	const groupedProductType = GROUPED_PRODUCT_TYPES[productDetail.mmaCategory];
+	const specificProductType =
+		groupedProductType.mapGroupedToSpecific(productDetail);
+	return specificProductType === productType;
 };

--- a/shared/productResponse.ts
+++ b/shared/productResponse.ts
@@ -220,10 +220,10 @@ export const getMainPlan: (subscription: Subscription) => SubscriptionPlan = (
 
 export const isSpecificProductType = (
 	productDetail: ProductDetail,
-	productType: ProductType,
+	targetProductType: ProductType,
 ) => {
 	const groupedProductType = GROUPED_PRODUCT_TYPES[productDetail.mmaCategory];
 	const specificProductType =
 		groupedProductType.mapGroupedToSpecific(productDetail);
-	return specificProductType === productType;
+	return specificProductType === targetProductType;
 };


### PR DESCRIPTION
## What does this change?

Adds logic to determine when to show 'Change to support and extras' button. The button is shown on a product card if:

- the current product is a Recurring Contribution
- user does not have DigiSub **and** RC
- user is not in payment failure

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Storybook stories have been added to test the different scenarios where

- user has DigiSub and RC
- user is in payment failure
- user only has RC

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->


## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
