### PR TITLE
move the known issues config/copy into the client codebase so that it…

### DIFF
--- a/client/components/helpCentre/HelpCenterContentWrapper.tsx
+++ b/client/components/helpCentre/HelpCenterContentWrapper.tsx
@@ -2,8 +2,10 @@ import { useLocation } from 'react-router-dom';
 import { SectionContent } from '../shared/SectionContent';
 import { SectionHeader } from '../shared/SectionHeader';
 import { KnownIssues } from './KnownIssues';
+import type { KnownIssueObj } from './KnownIssues';
 
 interface HelpCenterContentWrapperProps {
+	knownIssues: KnownIssueObj[];
 	children: React.ReactNode;
 }
 
@@ -27,7 +29,7 @@ export const HelpCenterContentWrapper = (
 	return (
 		<>
 			<SectionHeader title={headerTitle} />
-			<KnownIssues />
+			<KnownIssues issues={props.knownIssues} />
 			<SectionContent>{props.children}</SectionContent>
 		</>
 	);

--- a/client/components/helpCentre/HelpCentre.stories.tsx
+++ b/client/components/helpCentre/HelpCentre.stories.tsx
@@ -17,7 +17,7 @@ export const Default: ComponentStory<typeof HelpCentre> = () => {
 	fetchMock.restore().get('/api/known-issues/', { body: [] });
 
 	return (
-		<HelpCenterContentWrapper>
+		<HelpCenterContentWrapper knownIssues={[]}>
 			<HelpCentre />
 		</HelpCenterContentWrapper>
 	);
@@ -31,10 +31,8 @@ export const WithKnownIssue: ComponentStory<typeof HelpCentre> = () => {
 		},
 	];
 
-	fetchMock.restore().get('/api/known-issues/', { body: knownIssue });
-
 	return (
-		<HelpCenterContentWrapper>
+		<HelpCenterContentWrapper knownIssues={knownIssue}>
 			<HelpCentre />
 		</HelpCenterContentWrapper>
 	);

--- a/client/components/helpCentre/HelpCentrePage.tsx
+++ b/client/components/helpCentre/HelpCentrePage.tsx
@@ -15,6 +15,7 @@ import { GenericErrorScreen } from '../shared/GenericErrorScreen';
 import { Main } from '../shared/Main';
 import { HelpCenterContentWrapper } from './HelpCenterContentWrapper';
 import HelpCentreLoadingContent from './HelpCentreLoadingContent';
+import type { KnownIssueObj } from './KnownIssues';
 import { LiveChat } from './liveChat/LiveChat';
 
 initFeatureSwitchUrlParamOverride();
@@ -54,6 +55,18 @@ const HelpCentreRouter = () => {
 	useConsent();
 	useScrollToTop();
 
+	/*
+	 * EXAMPLE ISSUE:
+	 * leave as a blank array if there are no issues to render
+	[
+	  {
+		"date": "29 Aug 1997 02:40",
+		"message": "No papers today, it's judgment day"
+	  }
+	]
+	*/
+	const knownIssues: KnownIssueObj[] = [];
+
 	return (
 		<Main
 			signInStatus={signInStatus}
@@ -62,7 +75,7 @@ const HelpCentreRouter = () => {
 		>
 			<Global styles={css(`${global}`)} />
 			<Global styles={css(`${fonts}`)} />
-			<HelpCenterContentWrapper>
+			<HelpCenterContentWrapper knownIssues={knownIssues}>
 				<Suspense fallback={<HelpCentreLoadingContent />}>
 					<ErrorBoundary
 						fallback={(error) => (

--- a/client/components/helpCentre/KnownIssues.tsx
+++ b/client/components/helpCentre/KnownIssues.tsx
@@ -12,26 +12,45 @@ import { gridBase, gridItemPlacement } from '../../styles/grid';
 import { allProductsDetailFetcher } from '../../utilities/productUtils';
 import { ErrorIcon } from '../mma/shared/assets/ErrorIcon';
 
-interface Issue {
-	date: string;
+/*
+ * NOTE: The abililty to load the known issues from a json file in an S3 bucket exists.
+ * The code to do so has been commented out on the client and server in:
+ *  - client/components/helpCentre/KnownIssues.tsx
+ *  - server/routes/api.ts (the '/known-issues route')
+ *
+ *  If in the future a CMS of some kind can be constructed to enable
+ *  a non-developer to curate the issues then this code can be
+ *  reinstated (if the issues are to be stored in s3)
+ */
+
+export interface KnownIssueObj {
+	date: string; // "29 Aug 1997 02:40"
 	message: string;
-	link?: string;
-	affectedProducts?: string[];
+	link?: string; // optional href that is rendered after the message
+	affectedProducts?: string[]; // maps to productDetail.tier property
 }
 
-export const KnownIssues = () => {
-	const [issuesData, setIssuesData] = useState<Issue[]>([]);
+interface KownIssuesProp {
+	issues: KnownIssueObj[];
+}
+
+export const KnownIssues = (props: KownIssuesProp) => {
+	const [issuesData, setIssuesData] = useState<KnownIssueObj[]>([]);
 	useEffect(() => {
 		(async () => {
+			/*
+			 * client side implementation of loading known issues
+			 * externally (s3)
 			const knownIssuesResponse = await fetch('/api/known-issues/');
-			const unfilteredKnownIssues: Issue[] = knownIssuesResponse.ok
+			const knownIssues: Issue[] = knownIssuesResponse.ok
 				? await knownIssuesResponse.json()
 				: [];
-			const unfilteredDateSortedIssues = unfilteredKnownIssues.sort(
+			*/
+			const unfilteredDateSortedIssues = props.issues.sort(
 				(a, b) => Date.parse(a.date) - Date.parse(b.date),
 			);
-			const responseContainsProductIssues = unfilteredKnownIssues.some(
-				(issue: Issue) => !!issue.affectedProducts?.length,
+			const responseContainsProductIssues = props.issues.some(
+				(issue: KnownIssueObj) => !!issue.affectedProducts?.length,
 			);
 			const globalIssues = unfilteredDateSortedIssues.filter(
 				(issue) => !issue.affectedProducts,

--- a/client/components/helpCentre/contactUs/ContactUs.stories.tsx
+++ b/client/components/helpCentre/contactUs/ContactUs.stories.tsx
@@ -21,7 +21,7 @@ export const Default: ComponentStory<typeof ContactUs> = () => {
 	return (
 		<>
 			<SectionHeader title="Need to contact us?" />
-			<KnownIssues />
+			<KnownIssues issues={[]} />
 			<SectionContent>
 				<ContactUs />
 			</SectionContent>
@@ -42,7 +42,7 @@ export const WithKnownIssue: ComponentStory<typeof ContactUs> = () => {
 	return (
 		<>
 			<SectionHeader title="Need to contact us?" />
-			<KnownIssues />
+			<KnownIssues issues={knownIssue} />
 			<SectionContent>
 				<ContactUs />
 			</SectionContent>
@@ -50,19 +50,15 @@ export const WithKnownIssue: ComponentStory<typeof ContactUs> = () => {
 	);
 };
 
-export const TopicSelected: ComponentStory<typeof ContactUs> = () => {
-	fetchMock.restore().get('/api/known-issues/', { body: [] });
-
-	return (
-		<>
-			<SectionHeader title="Need to contact us?" />
-			<KnownIssues />
-			<SectionContent>
-				<ContactUs />
-			</SectionContent>
-		</>
-	);
-};
+export const TopicSelected: ComponentStory<typeof ContactUs> = () => (
+	<>
+		<SectionHeader title="Need to contact us?" />
+		<KnownIssues issues={[]} />
+		<SectionContent>
+			<ContactUs />
+		</SectionContent>
+	</>
+);
 TopicSelected.parameters = {
 	reactRouter: {
 		location: '/contact-us/billing',


### PR DESCRIPTION
## What does this change?
Move the known issues config/copy from a json file in an S3 bucket into the client codebase so that it is documented.

An entry has been made in the wiki to explain the process of adding an issue to the help centre (https://github.com/guardian/manage-frontend/wiki/HOW-TOs#adding-a-known-issue-banner-to-the-help-centre)
