### PR TITLE
Enable `@typescript-eslint/naming-convention` linting rule and fix errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,7 +28,6 @@ module.exports = {
 		// Overrides for rules from `@guardian/eslint-config-typescript`.
 		// There are a number of these due to applying the config to an existing
 		// codebase. We should progressively fix these and remove the overrides.
-		'@typescript-eslint/naming-convention': ['off'],
 		'@typescript-eslint/no-floating-promises': ['off'],
 		'@typescript-eslint/no-misused-promises': ['off'],
 		'@typescript-eslint/no-unnecessary-condition': ['off'],

--- a/client/__tests__/components/payment/updatePaymentFlow.test.tsx
+++ b/client/__tests__/components/payment/updatePaymentFlow.test.tsx
@@ -8,70 +8,70 @@ describe('updatePaymentFlow.tsx', () => {
 	it('Shows only card when sub/contrib is already using card, and dd is not allowed', () => {
 		const { getByText, queryByText } = render(
 			<SelectPaymentMethod
-				value={PaymentMethod.card}
-				currentPaymentMethod={PaymentMethod.card}
+				value={PaymentMethod.Card}
+				currentPaymentMethod={PaymentMethod.Card}
 				updatePaymentMethod={() => null}
 				directDebitIsAllowed={false}
 			/>,
 		);
 
-		expect(getByText(PaymentMethod.card)).toBeDefined();
-		expect(queryByText(PaymentMethod.dd)).toBeNull();
+		expect(getByText(PaymentMethod.Card)).toBeDefined();
+		expect(queryByText(PaymentMethod.DirectDebit)).toBeNull();
 	});
 
 	it('Shows both card and direct debit when sub/contrib is using card and direct debit is allowed', () => {
 		const { getByText } = render(
 			<SelectPaymentMethod
-				value={PaymentMethod.card}
-				currentPaymentMethod={PaymentMethod.card}
+				value={PaymentMethod.Card}
+				currentPaymentMethod={PaymentMethod.Card}
 				updatePaymentMethod={() => null}
 				directDebitIsAllowed={true}
 			/>,
 		);
 
-		expect(getByText(PaymentMethod.card)).toBeDefined();
-		expect(getByText(PaymentMethod.dd)).toBeDefined();
+		expect(getByText(PaymentMethod.Card)).toBeDefined();
+		expect(getByText(PaymentMethod.DirectDebit)).toBeDefined();
 	});
 
 	it('Shows both card and direct debit when sub/contrib is already using direct debit', () => {
 		const { getByText } = render(
 			<SelectPaymentMethod
-				value={PaymentMethod.dd}
-				currentPaymentMethod={PaymentMethod.dd}
+				value={PaymentMethod.DirectDebit}
+				currentPaymentMethod={PaymentMethod.DirectDebit}
 				updatePaymentMethod={() => null}
 				directDebitIsAllowed={true}
 			/>,
 		);
 
-		expect(getByText(PaymentMethod.card)).toBeDefined();
-		expect(getByText(PaymentMethod.dd)).toBeDefined();
+		expect(getByText(PaymentMethod.Card)).toBeDefined();
+		expect(getByText(PaymentMethod.DirectDebit)).toBeDefined();
 	});
 
 	it('Shows only card when sub/contrib is using Paypal and direct debit is not allowed', () => {
 		const { getByText, queryByText } = render(
 			<SelectPaymentMethod
-				value={PaymentMethod.payPal}
-				currentPaymentMethod={PaymentMethod.payPal}
+				value={PaymentMethod.PayPal}
+				currentPaymentMethod={PaymentMethod.PayPal}
 				updatePaymentMethod={() => null}
 				directDebitIsAllowed={false}
 			/>,
 		);
 
-		expect(getByText(PaymentMethod.card)).toBeDefined();
-		expect(queryByText(PaymentMethod.dd)).toBeNull();
+		expect(getByText(PaymentMethod.Card)).toBeDefined();
+		expect(queryByText(PaymentMethod.DirectDebit)).toBeNull();
 	});
 
 	it('Shows card and dd when sub/contrib is using Paypal and direct debit is allowed', () => {
 		const { getByText } = render(
 			<SelectPaymentMethod
-				value={PaymentMethod.payPal}
-				currentPaymentMethod={PaymentMethod.payPal}
+				value={PaymentMethod.PayPal}
+				currentPaymentMethod={PaymentMethod.PayPal}
 				updatePaymentMethod={() => null}
 				directDebitIsAllowed={true}
 			/>,
 		);
 
-		expect(getByText(PaymentMethod.card)).toBeDefined();
-		expect(getByText(PaymentMethod.dd)).toBeDefined();
+		expect(getByText(PaymentMethod.Card)).toBeDefined();
+		expect(getByText(PaymentMethod.DirectDebit)).toBeDefined();
 	});
 });

--- a/client/components/mma/delivery/address/Select.tsx
+++ b/client/components/mma/delivery/address/Select.tsx
@@ -9,7 +9,7 @@ import {
 import type * as React from 'react';
 import { ErrorIcon } from '../../shared/assets/ErrorIcon';
 
-type setStateFunc = (value: string) => void;
+type SetStateFunc = (value: string) => void;
 
 interface SelectOption {
 	name: string;
@@ -22,7 +22,7 @@ interface SelectProps {
 	width: number;
 	value: string;
 	additionalCSS?: SerializedStyles;
-	changeSetState?: setStateFunc;
+	changeSetState?: SetStateFunc;
 	inErrorState?: boolean;
 	errorMessage?: string;
 }

--- a/client/components/mma/delivery/records/DeliveryAddressStep.tsx
+++ b/client/components/mma/delivery/records/DeliveryAddressStep.tsx
@@ -57,15 +57,15 @@ interface DeliveryAddressStepProps {
 
 export const DeliveryAddressStep = (props: DeliveryAddressStepProps) => {
 	enum Status {
-		READ_ONLY,
-		EDIT,
-		VALIDATION_ERROR,
-		PENDING,
-		CONFIRMATION,
-		ERROR,
+		ReadOnly,
+		Edit,
+		ValidationError,
+		Pending,
+		Confirmation,
+		Error,
 	}
 
-	const [status, setStatus] = useState(Status.READ_ONLY);
+	const [status, setStatus] = useState(Status.ReadOnly);
 
 	const deliveryAddressContext = useContext(DeliveryRecordsAddressContext);
 
@@ -100,7 +100,7 @@ export const DeliveryAddressStep = (props: DeliveryAddressStepProps) => {
 
 			deliveryAddressContext.setProductsAffected?.(productsAffected);
 
-			setStatus(Status.PENDING);
+			setStatus(Status.Pending);
 
 			const isFormValidResponse = isFormValid(
 				newAddress,
@@ -138,9 +138,9 @@ export const DeliveryAddressStep = (props: DeliveryAddressStepProps) => {
 						)})`,
 					].join('\n'),
 				);
-				setStatus(Status.CONFIRMATION);
+				setStatus(Status.Confirmation);
 			} else {
-				setStatus(Status.VALIDATION_ERROR);
+				setStatus(Status.ValidationError);
 			}
 		};
 
@@ -211,7 +211,7 @@ export const DeliveryAddressStep = (props: DeliveryAddressStepProps) => {
 								})
 							}
 							inErrorState={
-								status === Status.VALIDATION_ERROR &&
+								status === Status.ValidationError &&
 								!formErrors.addressLine1?.isValid
 							}
 							errorMessage={formErrors.addressLine1?.message}
@@ -239,7 +239,7 @@ export const DeliveryAddressStep = (props: DeliveryAddressStepProps) => {
 								})
 							}
 							inErrorState={
-								status === Status.VALIDATION_ERROR &&
+								status === Status.ValidationError &&
 								!formErrors.town?.isValid
 							}
 							errorMessage={formErrors.town?.message}
@@ -267,7 +267,7 @@ export const DeliveryAddressStep = (props: DeliveryAddressStepProps) => {
 								})
 							}
 							inErrorState={
-								status === Status.VALIDATION_ERROR &&
+								status === Status.ValidationError &&
 								!formErrors.postcode?.isValid
 							}
 							errorMessage={formErrors.postcode?.message}
@@ -297,7 +297,7 @@ export const DeliveryAddressStep = (props: DeliveryAddressStepProps) => {
 								})
 							}
 							inErrorState={
-								status === Status.VALIDATION_ERROR &&
+								status === Status.ValidationError &&
 								!formErrors.country?.isValid
 							}
 							errorMessage={formErrors.country?.message}
@@ -413,7 +413,7 @@ export const DeliveryAddressStep = (props: DeliveryAddressStepProps) => {
 						`}
 						name="instructions-checkbox"
 						error={
-							status === Status.VALIDATION_ERROR &&
+							status === Status.ValidationError &&
 							!acknowledgementChecked
 								? 'Please indicate that you understand which subscriptions this change will affect.'
 								: undefined
@@ -462,7 +462,7 @@ export const DeliveryAddressStep = (props: DeliveryAddressStepProps) => {
 										.deliveryAddress,
 								);
 								props.setAddressValidationState(true);
-								setStatus(Status.READ_ONLY);
+								setStatus(Status.ReadOnly);
 							}}
 							css={css`
 								margin-top: ${space[5]}px;
@@ -556,9 +556,9 @@ export const DeliveryAddressStep = (props: DeliveryAddressStepProps) => {
 	);
 
 	if (
-		status === Status.EDIT ||
-		status === Status.PENDING ||
-		status === Status.VALIDATION_ERROR
+		status === Status.Edit ||
+		status === Status.Pending ||
+		status === Status.ValidationError
 	) {
 		return (
 			<div
@@ -580,7 +580,7 @@ export const DeliveryAddressStep = (props: DeliveryAddressStepProps) => {
 			</div>
 		);
 	} else if (
-		status === Status.CONFIRMATION &&
+		status === Status.Confirmation &&
 		props.productDetail.subscription.contactId
 	) {
 		return (
@@ -603,7 +603,7 @@ export const DeliveryAddressStep = (props: DeliveryAddressStepProps) => {
 			showEditButton
 			editButtonCallback={() => {
 				props.setAddressValidationState(false);
-				setStatus(Status.EDIT);
+				setStatus(Status.Edit);
 			}}
 			address={newAddress}
 			instructions={

--- a/client/components/mma/delivery/records/DeliveryRecordCard.tsx
+++ b/client/components/mma/delivery/records/DeliveryRecordCard.tsx
@@ -52,22 +52,22 @@ export const DeliveryRecordCard = (props: DeliveryRecordCardProps) => {
 				border: 1px solid ${neutral['86']};
 				margin: 0;
 				padding: ${space[3]}px;
-				${props.pageStatus === PageStatus.REPORT_ISSUE_STEP_2 &&
+				${props.pageStatus === PageStatus.ReportIssueStep2 &&
 				`padding-left: ${space[3] * 2 + 40}px;`}
 				width: 100%;
 				${props.listIndex > 0 && 'border-top: none;'}
 				position: relative;
-				opacity: ${props.pageStatus === PageStatus.REPORT_ISSUE_STEP_1
+				opacity: ${props.pageStatus === PageStatus.ReportIssueStep1
 					? '0.5'
 					: '1'};
 				${from.tablet} {
 					padding: ${space[5]}px;
-					${props.pageStatus === PageStatus.REPORT_ISSUE_STEP_2 &&
+					${props.pageStatus === PageStatus.ReportIssueStep2 &&
 					`padding-left: ${space[5] * 2 + 40}px;`}
 				}
 			`}
 		>
-			{props.pageStatus === PageStatus.REPORT_ISSUE_STEP_2 && (
+			{props.pageStatus === PageStatus.ReportIssueStep2 && (
 				<div
 					css={css`
 						position: absolute;

--- a/client/components/mma/delivery/records/DeliveryRecords.tsx
+++ b/client/components/mma/delivery/records/DeliveryRecords.tsx
@@ -55,12 +55,12 @@ declare global {
 }
 
 export enum PageStatus {
-	READ_ONLY,
-	REPORT_ISSUE_STEP_1,
-	REPORT_ISSUE_STEP_2,
-	CONTINUE_TO_REVIEW,
-	REPORT_ISSUE_CONFIRMATION,
-	CANNOT_REPORT_PROBLEM,
+	ReadOnly,
+	ReportIssueStep1,
+	ReportIssueStep2,
+	ContinueToReview,
+	ReportIssueConfirmation,
+	CannotReportProblem,
 }
 
 interface Step1FormValidationDetails {
@@ -78,7 +78,7 @@ const DeliveryRecords = () => {
 	) as DeliveryRecordsContextInterface;
 
 	const [pageStatus, setPageStatus] = useState<PageStatus>(
-		PageStatus.READ_ONLY,
+		PageStatus.ReadOnly,
 	);
 	const [currentPage, setCurrentPage] = useState(0);
 	const [selectedProblemRecords, setSelectedProblemRecords] = useState<
@@ -177,7 +177,7 @@ const DeliveryRecords = () => {
 				},
 				eventLabel: productType.urlPart,
 			});
-			setPageStatus(PageStatus.REPORT_ISSUE_STEP_2);
+			setPageStatus(PageStatus.ReportIssueStep2);
 		}
 	};
 
@@ -192,12 +192,12 @@ const DeliveryRecords = () => {
 	const resultsPerPage = 7;
 	const totalPages = Math.ceil(data.results.length / resultsPerPage);
 	const scrollToTop = () => window.scrollTo(0, 0);
-	const resetDeliveryRecordsPage = () => setPageStatus(PageStatus.READ_ONLY);
+	const resetDeliveryRecordsPage = () => setPageStatus(PageStatus.ReadOnly);
 
 	const filterData = (overridePageStatusCheck?: boolean) => {
 		if (
-			(pageStatus !== PageStatus.READ_ONLY &&
-				pageStatus !== PageStatus.CANNOT_REPORT_PROBLEM) ||
+			(pageStatus !== PageStatus.ReadOnly &&
+				pageStatus !== PageStatus.CannotReportProblem) ||
 			overridePageStatusCheck
 		) {
 			const numOfReportableRecords =
@@ -276,8 +276,8 @@ const DeliveryRecords = () => {
 				enableDeliveryInstructions,
 			}}
 		>
-			{pageStatus !== PageStatus.READ_ONLY &&
-				pageStatus !== PageStatus.CANNOT_REPORT_PROBLEM && (
+			{pageStatus !== PageStatus.ReadOnly &&
+				pageStatus !== PageStatus.CannotReportProblem && (
 					<ProgressIndicator
 						steps={[
 							{ title: 'Update', isCurrentStep: true },
@@ -317,7 +317,7 @@ const DeliveryRecords = () => {
 					<div
 						css={css`
 							margin-bottom: ${pageStatus !==
-							PageStatus.REPORT_ISSUE_STEP_2
+							PageStatus.ReportIssueStep2
 								? space[12]
 								: space[5]}px;
 							${textSans.medium()};
@@ -360,7 +360,7 @@ const DeliveryRecords = () => {
 						{showTopCallCentreNumbers && (
 							<CallCentreEmailAndNumbers />
 						)}
-						{pageStatus === PageStatus.CANNOT_REPORT_PROBLEM && (
+						{pageStatus === PageStatus.CannotReportProblem && (
 							<span
 								css={css`
 									position: relative;
@@ -389,9 +389,8 @@ const DeliveryRecords = () => {
 								past or have already been reported.
 							</span>
 						)}
-						{(pageStatus === PageStatus.READ_ONLY ||
-							pageStatus ===
-								PageStatus.CANNOT_REPORT_PROBLEM) && (
+						{(pageStatus === PageStatus.ReadOnly ||
+							pageStatus === PageStatus.CannotReportProblem) && (
 							<Button
 								onClick={() => {
 									const filteredDataAtPresent =
@@ -411,11 +410,11 @@ const DeliveryRecords = () => {
 									if (canReportProblem) {
 										setSelectedProblemRecords([]);
 										setPageStatus(
-											PageStatus.REPORT_ISSUE_STEP_1,
+											PageStatus.ReportIssueStep1,
 										);
 									} else {
 										setPageStatus(
-											PageStatus.CANNOT_REPORT_PROBLEM,
+											PageStatus.CannotReportProblem,
 										);
 									}
 								}}
@@ -423,12 +422,11 @@ const DeliveryRecords = () => {
 								Report a problem
 							</Button>
 						)}
-						{(pageStatus === PageStatus.REPORT_ISSUE_STEP_1 ||
-							pageStatus === PageStatus.REPORT_ISSUE_STEP_2) && (
+						{(pageStatus === PageStatus.ReportIssueStep1 ||
+							pageStatus === PageStatus.ReportIssueStep2) && (
 							<DeliveryRecordProblemForm
 								showNextStepButton={
-									pageStatus !==
-									PageStatus.REPORT_ISSUE_STEP_2
+									pageStatus !== PageStatus.ReportIssueStep2
 								}
 								onResetDeliveryRecordsPage={
 									resetDeliveryRecordsPage
@@ -452,11 +450,11 @@ const DeliveryRecords = () => {
 					border-top: 1px solid ${neutral['86']};
 					${headline.small()};
 					font-weight: bold;
-					opacity: ${pageStatus === PageStatus.REPORT_ISSUE_STEP_1 &&
+					opacity: ${pageStatus === PageStatus.ReportIssueStep1 &&
 					filteredData.length > 0
 						? '0.5'
 						: '1'};
-					${pageStatus === PageStatus.REPORT_ISSUE_STEP_2
+					${pageStatus === PageStatus.ReportIssueStep2
 						? `
               background-color: ${neutral['97']};
               border-left: 1px solid ${neutral['86']};
@@ -467,7 +465,7 @@ const DeliveryRecords = () => {
             `
 						: ''}
 					${until.tablet} {
-						${pageStatus === PageStatus.REPORT_ISSUE_STEP_2
+						${pageStatus === PageStatus.ReportIssueStep2
 							? ``
 							: `
               font-size: 1.25rem;
@@ -476,12 +474,12 @@ const DeliveryRecords = () => {
 					}
 				`}
 			>
-				{pageStatus === PageStatus.REPORT_ISSUE_STEP_2
+				{pageStatus === PageStatus.ReportIssueStep2
 					? 'Step 2. Select the date you have experienced the problem'
 					: 'Deliveries'}
 			</h2>
 			{filteredData.length === 0 &&
-				pageStatus !== PageStatus.CANNOT_REPORT_PROBLEM &&
+				pageStatus !== PageStatus.CannotReportProblem &&
 				(data.results.length === 0 ? (
 					<p
 						css={css`
@@ -553,8 +551,8 @@ const DeliveryRecords = () => {
 				),
 			)}
 			{totalPages > 1 &&
-				(pageStatus === PageStatus.READ_ONLY ||
-					pageStatus === PageStatus.CANNOT_REPORT_PROBLEM) && (
+				(pageStatus === PageStatus.ReadOnly ||
+					pageStatus === PageStatus.CannotReportProblem) && (
 					<PaginationNav
 						resultsPerPage={resultsPerPage}
 						totalNumberOfResults={data.results.length}
@@ -563,7 +561,7 @@ const DeliveryRecords = () => {
 						changeCallBack={scrollToTop}
 					/>
 				)}
-			{pageStatus === PageStatus.REPORT_ISSUE_STEP_2 && (
+			{pageStatus === PageStatus.ReportIssueStep2 && (
 				<>
 					<section
 						css={css`
@@ -648,9 +646,7 @@ const DeliveryRecords = () => {
 										},
 										eventLabel: productType.urlPart,
 									});
-									setPageStatus(
-										PageStatus.CONTINUE_TO_REVIEW,
-									);
+									setPageStatus(PageStatus.ContinueToReview);
 									navigate('review', {
 										state: {
 											productDetail,
@@ -682,7 +678,7 @@ const DeliveryRecords = () => {
 								}
 							`}
 							onClick={() => {
-								setPageStatus(PageStatus.READ_ONLY);
+								setPageStatus(PageStatus.ReadOnly);
 							}}
 						>
 							Cancel

--- a/client/components/mma/delivery/records/DeliveryRecordsProblemConfirmation.tsx
+++ b/client/components/mma/delivery/records/DeliveryRecordsProblemConfirmation.tsx
@@ -300,7 +300,7 @@ const DeliveryRecordsProblemConfirmationFC = (
 									deliveryRecord={deliveryRecord}
 									listIndex={listIndex}
 									pageStatus={
-										PageStatus.REPORT_ISSUE_CONFIRMATION
+										PageStatus.ReportIssueConfirmation
 									}
 									showDeliveryInstructions={
 										productType.delivery?.records

--- a/client/components/mma/delivery/records/DeliveryRecordsProblemReview.tsx
+++ b/client/components/mma/delivery/records/DeliveryRecordsProblemReview.tsx
@@ -422,7 +422,7 @@ const DeliveryRecordsProblemReviewFC = (
 									key={deliveryRecord.id}
 									deliveryRecord={deliveryRecord}
 									listIndex={listIndex}
-									pageStatus={PageStatus.READ_ONLY}
+									pageStatus={PageStatus.ReadOnly}
 									showDeliveryInstructions={
 										productType.delivery.records
 											.showDeliveryInstructions

--- a/client/components/mma/identity/models.ts
+++ b/client/components/mma/identity/models.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 export enum Theme {
 	news = 'news',
 	opinion = 'opinion',

--- a/client/components/mma/identity/useConsentOptions.ts
+++ b/client/components/mma/identity/useConsentOptions.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import * as Sentry from '@sentry/browser';
 import { useReducer } from 'react';
 import { trackEvent } from '../../../utilities/analytics';

--- a/client/components/mma/paymentUpdate/PaymentDetailUpdate.tsx
+++ b/client/components/mma/paymentUpdate/PaymentDetailUpdate.tsx
@@ -54,12 +54,12 @@ import { PaymentUpdateProductDetailContext } from './PaymentDetailUpdateContaine
 import { ErrorSummary } from './Summary';
 
 export enum PaymentMethod {
-	card = 'Credit card / debit card',
-	payPal = 'PayPal',
-	dd = 'Direct debit',
-	resetRequired = 'ResetRequired',
-	free = 'FREE',
-	unknown = 'Unknown',
+	Card = 'Credit card / debit card',
+	PayPal = 'PayPal',
+	DirectDebit = 'Direct debit',
+	ResetRequired = 'ResetRequired',
+	Free = 'FREE',
+	Unknown = 'Unknown',
 }
 
 const subHeadingCss = css`
@@ -84,7 +84,7 @@ interface PaymentMethodRadioButtonProps extends PaymentMethodProps {
 }
 
 export function getLogos(paymentMethod: PaymentMethod) {
-	if (paymentMethod === PaymentMethod.card) {
+	if (paymentMethod === PaymentMethod.Card) {
 		return (
 			<>
 				{cardTypeToSVG('visa')}
@@ -92,7 +92,7 @@ export function getLogos(paymentMethod: PaymentMethod) {
 				{cardTypeToSVG('americanexpress')}
 			</>
 		);
-	} else if (paymentMethod === PaymentMethod.dd) {
+	} else if (paymentMethod === PaymentMethod.DirectDebit) {
 		return (
 			<DirectDebitLogo
 				fill={brand[400]}
@@ -170,12 +170,12 @@ export const SelectPaymentMethod = (
 	<form>
 		<RadioGroup label="Select payment method" hideLabel>
 			<PaymentMethodRadioButton
-				paymentMethod={PaymentMethod.card}
+				paymentMethod={PaymentMethod.Card}
 				{...props}
 			/>
 			{props.directDebitIsAllowed ? (
 				<PaymentMethodRadioButton
-					paymentMethod={PaymentMethod.dd}
+					paymentMethod={PaymentMethod.DirectDebit}
 					{...props}
 				/>
 			) : (
@@ -187,28 +187,28 @@ export const SelectPaymentMethod = (
 
 const subscriptionToPaymentMethod = (productDetail: ProductDetail) => {
 	if (!productDetail.subscription.safeToUpdatePaymentMethod) {
-		return PaymentMethod.unknown;
+		return PaymentMethod.Unknown;
 	} else if (
 		productDetail.subscription.paymentMethod === 'Card' &&
 		productDetail.subscription.card
 	) {
-		return PaymentMethod.card;
+		return PaymentMethod.Card;
 	} else if (
 		productDetail.subscription.paymentMethod === 'PayPal' &&
 		productDetail.subscription.payPalEmail
 	) {
-		return PaymentMethod.payPal;
+		return PaymentMethod.PayPal;
 	} else if (
 		productDetail.subscription.paymentMethod === 'DirectDebit' &&
 		productDetail.subscription.mandate
 	) {
-		return PaymentMethod.dd;
+		return PaymentMethod.DirectDebit;
 	} else if (productDetail.subscription.paymentMethod === 'ResetRequired') {
-		return PaymentMethod.resetRequired;
+		return PaymentMethod.ResetRequired;
 	} else if (!productDetail.isPaidTier) {
-		return PaymentMethod.free;
+		return PaymentMethod.Free;
 	}
-	return PaymentMethod.unknown;
+	return PaymentMethod.Unknown;
 };
 
 export interface PaymentUpdaterStepState {
@@ -226,7 +226,7 @@ const PaymentDetailUpdate = (props: WithProductType<ProductType>) => {
 	const mainPlan = getMainPlan(productDetail.subscription);
 
 	const directDebitIsAllowed =
-		currentPaymentMethod === PaymentMethod.dd ||
+		currentPaymentMethod === PaymentMethod.DirectDebit ||
 		(isPaidSubscriptionPlan(mainPlan) &&
 			mainPlan.currencyISO === 'GBP' &&
 			(!productDetail.subscription.deliveryAddress ||
@@ -244,9 +244,9 @@ const PaymentDetailUpdate = (props: WithProductType<ProductType>) => {
 		useState<boolean>(false);
 	const [selectedPaymentMethod, setSelectedPaymentMethod] =
 		useState<PaymentMethod>(
-			currentPaymentMethod === PaymentMethod.dd
-				? PaymentMethod.unknown
-				: PaymentMethod.card,
+			currentPaymentMethod === PaymentMethod.DirectDebit
+				? PaymentMethod.Unknown
+				: PaymentMethod.Card,
 		);
 
 	const navigate = useNavigate();
@@ -282,7 +282,7 @@ const PaymentDetailUpdate = (props: WithProductType<ProductType>) => {
 			if (newPaymentMethodDetail.matchesResponse(response)) {
 				const paymentMethodChangeType: string =
 					productDetail.subscription.paymentMethod ===
-					PaymentMethod.resetRequired
+					PaymentMethod.ResetRequired
 						? 'reset'
 						: 'update';
 
@@ -348,7 +348,7 @@ const PaymentDetailUpdate = (props: WithProductType<ProductType>) => {
 		}
 
 		switch (selectedPaymentMethod) {
-			case PaymentMethod.resetRequired:
+			case PaymentMethod.ResetRequired:
 				return stripePublicKey ? (
 					<CardInputForm
 						stripeApiKey={stripePublicKey}
@@ -364,7 +364,7 @@ const PaymentDetailUpdate = (props: WithProductType<ProductType>) => {
 				) : (
 					<GenericErrorScreen loggingMessage="No Stripe key provided to enable adding a payment method" />
 				);
-			case PaymentMethod.card:
+			case PaymentMethod.Card:
 				return stripePublicKey ? (
 					<CardInputForm
 						stripeApiKey={stripePublicKey}
@@ -380,7 +380,7 @@ const PaymentDetailUpdate = (props: WithProductType<ProductType>) => {
 				) : (
 					<GenericErrorScreen loggingMessage="No existing card information to update from" />
 				);
-			case PaymentMethod.free:
+			case PaymentMethod.Free:
 				return (
 					<div>
 						<p>
@@ -395,7 +395,7 @@ const PaymentDetailUpdate = (props: WithProductType<ProductType>) => {
 						/>
 					</div>
 				);
-			case PaymentMethod.payPal:
+			case PaymentMethod.PayPal:
 				return (
 					<p>
 						Updating your PayPal payment details is not possible
@@ -403,7 +403,7 @@ const PaymentDetailUpdate = (props: WithProductType<ProductType>) => {
 						details.
 					</p>
 				);
-			case PaymentMethod.dd:
+			case PaymentMethod.DirectDebit:
 				return (
 					<DirectDebitInputForm
 						newPaymentMethodDetailUpdater={
@@ -413,7 +413,7 @@ const PaymentDetailUpdate = (props: WithProductType<ProductType>) => {
 						executePaymentUpdate={executePaymentUpdate}
 					/>
 				);
-			case PaymentMethod.unknown:
+			case PaymentMethod.Unknown:
 				return null;
 			default:
 				Sentry.captureException(
@@ -473,7 +473,7 @@ const PaymentDetailUpdate = (props: WithProductType<ProductType>) => {
 					'margin-top: 36px'}
 				`}
 			>
-				{selectedPaymentMethod === PaymentMethod.unknown
+				{selectedPaymentMethod === PaymentMethod.Unknown
 					? 'Choose your payment method'
 					: 'Update your payment method'}
 			</h3>
@@ -489,7 +489,7 @@ const PaymentDetailUpdate = (props: WithProductType<ProductType>) => {
 
 			{
 				/* Dummy button when user has not selected a payment method */
-				selectedPaymentMethod === PaymentMethod.unknown ? (
+				selectedPaymentMethod === PaymentMethod.Unknown ? (
 					<div
 						css={css`
 							margin-top: ${space[9]}px;

--- a/client/components/mma/paymentUpdate/card/FlexCardElement.tsx
+++ b/client/components/mma/paymentUpdate/card/FlexCardElement.tsx
@@ -41,7 +41,7 @@ const numberCornerHint = () => (
 			display: flex;
 		`}
 	>
-		{getLogos(PaymentMethod.card)}
+		{getLogos(PaymentMethod.Card)}
 	</div>
 );
 /*TODO find some way to lock these based on this.props.disabled*/

--- a/client/components/mma/shared/AsyncLoader.tsx
+++ b/client/components/mma/shared/AsyncLoader.tsx
@@ -23,9 +23,9 @@ interface AsyncLoaderProps<T> extends LoadingProps {
 }
 
 enum LoadingState {
-	loading,
-	loaded,
-	error,
+	Loading,
+	Loaded,
+	Error,
 }
 
 interface AsyncLoaderState<T> {
@@ -36,7 +36,7 @@ interface AsyncLoaderState<T> {
 export default class AsyncLoader<
 	T extends NonNullable<unknown>,
 > extends React.Component<AsyncLoaderProps<T>, AsyncLoaderState<T>> {
-	public state: AsyncLoaderState<T> = { loadingState: LoadingState.loading };
+	public state: AsyncLoaderState<T> = { loadingState: LoadingState.Loading };
 	private readerOnOK =
 		this.props.readerOnOK || ((resp: Response) => resp.json());
 
@@ -56,14 +56,14 @@ export default class AsyncLoader<
 					) &&
 					data !== null
 				) {
-					this.setState({ data, loadingState: LoadingState.loaded });
+					this.setState({ data, loadingState: LoadingState.Loaded });
 				}
 			})
 			.catch((exception) => this.handleError(exception));
 	}
 
 	public render(): React.ReactNode {
-		if (this.state.loadingState === LoadingState.loading) {
+		if (this.state.loadingState === LoadingState.Loading) {
 			return this.props.inline ? (
 				<Spinner
 					loadingMessage={this.props.loadingMessage}
@@ -76,12 +76,12 @@ export default class AsyncLoader<
 				</WithStandardTopMargin>
 			);
 		} else if (
-			this.state.loadingState === LoadingState.loaded &&
+			this.state.loadingState === LoadingState.Loaded &&
 			this.state.data !== undefined
 		) {
 			return this.props.render(this.state.data, () =>
 				this.setState(
-					{ loadingState: LoadingState.loading },
+					{ loadingState: LoadingState.Loading },
 					this.componentDidMount,
 				),
 			);
@@ -115,7 +115,7 @@ export default class AsyncLoader<
 				this.props.shouldPreventErrorRender()
 			)
 		) {
-			this.setState({ loadingState: LoadingState.error });
+			this.setState({ loadingState: LoadingState.Error });
 		}
 		trackEvent({
 			eventCategory: 'asyncLoader',

--- a/client/components/mma/shared/assets/GiftIcon.tsx
+++ b/client/components/mma/shared/assets/GiftIcon.tsx
@@ -1,10 +1,10 @@
 import { css } from '@emotion/react';
 import { textSans } from '@guardian/source-foundations';
 
-type giftArrowAlign = 'left' | 'right';
+type GiftArrowAlign = 'left' | 'right';
 
 interface GiftIconProps {
-	alignArrowToThisSide: giftArrowAlign;
+	alignArrowToThisSide: GiftArrowAlign;
 }
 
 export const GiftIcon = (props: GiftIconProps) => (

--- a/client/components/shared/Input.tsx
+++ b/client/components/shared/Input.tsx
@@ -10,7 +10,7 @@ import { useEffect, useRef } from 'react';
 import type * as React from 'react';
 import { ErrorIcon } from '../mma/shared/assets/ErrorIcon';
 
-type setStateFunc = (value: string) => void;
+type SetStateFunc = (value: string) => void;
 
 interface InputProps {
 	type?: string;
@@ -23,7 +23,7 @@ interface InputProps {
 	optional?: boolean;
 	name?: string;
 	id?: string;
-	changeSetState?: setStateFunc;
+	changeSetState?: SetStateFunc;
 	onFocus?: (e: React.FocusEvent<HTMLInputElement>) => void;
 	setFocus?: boolean;
 	inErrorState?: boolean;

--- a/shared/productTypes.tsx
+++ b/shared/productTypes.tsx
@@ -240,13 +240,13 @@ export const calculateMonthlyOrAnnualFromBillingPeriod = (
 ) => (billingPeriod === 'month' ? 'Monthly' : 'Annual');
 
 const FRONT_PAGE_NEWSLETTER_ID = '6009';
-enum SOFT_OPT_IN_IDS {
-	support_onboarding = 'your_support_onboarding',
-	similar_products = 'similar_guardian_products',
-	supporter_newsletter = 'supporter_newsletter',
-	subscriber_preview = 'subscriber_preview',
-	digi_subscriber_preview = 'digital_subscriber_preview',
-	guardian_weekly_newsletter = 'guardian_weekly_newsletter',
+enum SoftOptInIDs {
+	SupportOnboarding = 'your_support_onboarding',
+	SimilarProducts = 'similar_guardian_products',
+	SupporterNewsletter = 'supporter_newsletter',
+	SubscriberPreview = 'subscriber_preview',
+	DigitalSubscriberPreview = 'digital_subscriber_preview',
+	GuardianWeeklyNewsletter = 'guardian_weekly_newsletter',
 }
 
 export type ProductTypeKeys =
@@ -304,9 +304,9 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 		tierLabel: 'Membership tier',
 		shouldShowJoinDateNotStartDate: true,
 		softOptInIDs: [
-			SOFT_OPT_IN_IDS.support_onboarding,
-			SOFT_OPT_IN_IDS.similar_products,
-			SOFT_OPT_IN_IDS.supporter_newsletter,
+			SoftOptInIDs.SupportOnboarding,
+			SoftOptInIDs.SimilarProducts,
+			SoftOptInIDs.SupporterNewsletter,
 		],
 	},
 	contributions: {
@@ -329,9 +329,9 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 		noProductSupportUrlSuffix: '/contribute',
 		updateAmountMdaEndpoint: 'contribution-update-amount',
 		softOptInIDs: [
-			SOFT_OPT_IN_IDS.support_onboarding,
-			SOFT_OPT_IN_IDS.similar_products,
-			SOFT_OPT_IN_IDS.supporter_newsletter,
+			SoftOptInIDs.SupportOnboarding,
+			SoftOptInIDs.SimilarProducts,
+			SoftOptInIDs.SupporterNewsletter,
 		],
 		cancellation: {
 			linkOnProductPage: true,
@@ -394,10 +394,10 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 			enableDeliveryInstructionsUpdate: true,
 		},
 		softOptInIDs: [
-			SOFT_OPT_IN_IDS.support_onboarding,
-			SOFT_OPT_IN_IDS.subscriber_preview,
-			SOFT_OPT_IN_IDS.similar_products,
-			SOFT_OPT_IN_IDS.supporter_newsletter,
+			SoftOptInIDs.SupportOnboarding,
+			SoftOptInIDs.SubscriberPreview,
+			SoftOptInIDs.SimilarProducts,
+			SoftOptInIDs.SupporterNewsletter,
 		],
 	},
 	homedelivery: {
@@ -411,10 +411,10 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 		getOphanProductType: () => 'PRINT_SUBSCRIPTION',
 		productPageNewsletterIDs: [FRONT_PAGE_NEWSLETTER_ID],
 		softOptInIDs: [
-			SOFT_OPT_IN_IDS.support_onboarding,
-			SOFT_OPT_IN_IDS.subscriber_preview,
-			SOFT_OPT_IN_IDS.similar_products,
-			SOFT_OPT_IN_IDS.supporter_newsletter,
+			SoftOptInIDs.SupportOnboarding,
+			SoftOptInIDs.SubscriberPreview,
+			SoftOptInIDs.SimilarProducts,
+			SoftOptInIDs.SupporterNewsletter,
 		],
 		holidayStops: {
 			issueKeyword: 'paper',
@@ -451,10 +451,10 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 		getOphanProductType: () => 'PRINT_SUBSCRIPTION',
 		productPageNewsletterIDs: [FRONT_PAGE_NEWSLETTER_ID],
 		softOptInIDs: [
-			SOFT_OPT_IN_IDS.support_onboarding,
-			SOFT_OPT_IN_IDS.subscriber_preview,
-			SOFT_OPT_IN_IDS.similar_products,
-			SOFT_OPT_IN_IDS.supporter_newsletter,
+			SoftOptInIDs.SupportOnboarding,
+			SoftOptInIDs.SubscriberPreview,
+			SoftOptInIDs.SimilarProducts,
+			SoftOptInIDs.SupporterNewsletter,
 		],
 		holidayStops: {
 			issueKeyword: 'voucher',
@@ -501,10 +501,10 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 		getOphanProductType: () => 'PRINT_SUBSCRIPTION',
 		productPageNewsletterIDs: [FRONT_PAGE_NEWSLETTER_ID],
 		softOptInIDs: [
-			SOFT_OPT_IN_IDS.support_onboarding,
-			SOFT_OPT_IN_IDS.subscriber_preview,
-			SOFT_OPT_IN_IDS.similar_products,
-			SOFT_OPT_IN_IDS.supporter_newsletter,
+			SoftOptInIDs.SupportOnboarding,
+			SoftOptInIDs.SubscriberPreview,
+			SoftOptInIDs.SimilarProducts,
+			SoftOptInIDs.SupporterNewsletter,
 		],
 		holidayStops: {
 			issueKeyword: 'issue',
@@ -526,9 +526,9 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 		allProductsProductTypeFilterString: 'Weekly',
 		urlPart: 'guardianweekly',
 		softOptInIDs: [
-			SOFT_OPT_IN_IDS.support_onboarding,
-			SOFT_OPT_IN_IDS.guardian_weekly_newsletter,
-			SOFT_OPT_IN_IDS.similar_products,
+			SoftOptInIDs.SupportOnboarding,
+			SoftOptInIDs.GuardianWeeklyNewsletter,
+			SoftOptInIDs.SimilarProducts,
 		],
 		getOphanProductType: () => 'PRINT_SUBSCRIPTION', // TODO create a GUARDIAN_WEEKLY Product in Ophan data model
 		renewalMetadata: {
@@ -580,10 +580,10 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 		getOphanProductType: () => 'DIGITAL_SUBSCRIPTION',
 		showTrialRemainingIfApplicable: true,
 		softOptInIDs: [
-			SOFT_OPT_IN_IDS.support_onboarding,
-			SOFT_OPT_IN_IDS.digi_subscriber_preview,
-			SOFT_OPT_IN_IDS.similar_products,
-			SOFT_OPT_IN_IDS.supporter_newsletter,
+			SoftOptInIDs.SupportOnboarding,
+			SoftOptInIDs.DigitalSubscriberPreview,
+			SoftOptInIDs.SimilarProducts,
+			SoftOptInIDs.SupporterNewsletter,
 		],
 		cancellation: {
 			linkOnProductPage: true,
@@ -626,10 +626,10 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 		getOphanProductType: () => 'SUPPORTER_PLUS',
 		showTrialRemainingIfApplicable: true,
 		softOptInIDs: [
-			SOFT_OPT_IN_IDS.support_onboarding,
-			SOFT_OPT_IN_IDS.similar_products,
-			SOFT_OPT_IN_IDS.supporter_newsletter,
-			SOFT_OPT_IN_IDS.digi_subscriber_preview,
+			SoftOptInIDs.SupportOnboarding,
+			SoftOptInIDs.SimilarProducts,
+			SoftOptInIDs.SupporterNewsletter,
+			SoftOptInIDs.DigitalSubscriberPreview,
 		],
 		cancellation: {
 			alternateSummaryMainPara:
@@ -667,10 +667,10 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 		getOphanProductType: () => 'GUARDIAN_PATRON', //TODO: This value doesn't exist in Ophan yet
 		showTrialRemainingIfApplicable: true,
 		softOptInIDs: [
-			SOFT_OPT_IN_IDS.support_onboarding,
-			SOFT_OPT_IN_IDS.digi_subscriber_preview,
-			SOFT_OPT_IN_IDS.similar_products,
-			SOFT_OPT_IN_IDS.supporter_newsletter,
+			SoftOptInIDs.SupportOnboarding,
+			SoftOptInIDs.DigitalSubscriberPreview,
+			SoftOptInIDs.SimilarProducts,
+			SoftOptInIDs.SupporterNewsletter,
 		],
 	},
 };


### PR DESCRIPTION
## What does this change?

Removes override for `@typescript-eslint/naming-convention` linting rule and updates MMA code to follow naming conventions. Due to some uncertainty around coupling between enum values and API responses in Identity code, this has not been updated and the rule disabled in a couple of places.