### PR TITLE
Create new Product Switching route and options page

### DIFF
--- a/client/components/mma/MMAPage.tsx
+++ b/client/components/mma/MMAPage.tsx
@@ -36,6 +36,8 @@ import { Main } from '../shared/Main';
 import { DeliveryAddressUpdate } from './delivery/address/DeliveryAddressForm';
 import Maintenance from './maintenance/Maintenance';
 import MMAPageSkeleton from './MMAPageSkeleton';
+import SwitchContainer from './switch/SwitchContainer';
+import SwitchOptions from './switch/SwitchOptions';
 
 const record = (event: any) => {
 	if (window.guardian?.ophan?.record) {
@@ -322,6 +324,9 @@ const MMARouter = () => {
 							path="/account-settings"
 							element={<Settings />}
 						/>
+						<Route path="/switch" element={<SwitchContainer />}>
+							<Route index element={<SwitchOptions />} />
+						</Route>
 						{Object.values(GROUPED_PRODUCT_TYPES).map(
 							(groupedProductType: GroupedProductType) => (
 								<Route

--- a/client/components/mma/accountoverview/AccountOverviewCardV2.tsx
+++ b/client/components/mma/accountoverview/AccountOverviewCardV2.tsx
@@ -11,7 +11,6 @@ import {
 	buttonThemeReaderRevenueBrand,
 	SvgTickRound,
 } from '@guardian/source-react-components';
-import type { ReactNode } from 'react';
 import { useState } from 'react';
 import { useNavigate } from 'react-router';
 import { parseDate } from '../../../../shared/dates';
@@ -22,6 +21,7 @@ import { GROUPED_PRODUCT_TYPES } from '../../../../shared/productTypes';
 import { trackEvent } from '../../../utilities/analytics';
 import { expanderButtonCss } from '../../shared/ExpanderButton';
 import { ErrorIcon } from '../shared/assets/ErrorIcon';
+import { Card } from '../shared/Card';
 import { CardDisplay } from '../shared/CardDisplay';
 import { DirectDebitDisplay } from '../shared/DirectDebitDisplay';
 import GridPicture from '../shared/images/GridPicture';
@@ -32,38 +32,6 @@ import {
 } from '../shared/NextPaymentDetails';
 import { PaypalDisplay } from '../shared/PaypalDisplay';
 import { SepaDisplay } from '../shared/SepaDisplay';
-
-const Card = (props: { children: ReactNode }) => {
-	return <div>{props.children}</div>;
-};
-
-Card.Header = (props: { children: ReactNode; backgroundColor?: string }) => {
-	const headerCss = css`
-		padding: ${space[3]}px ${space[4]}px;
-		min-height: 64px;
-		background-color: ${props.backgroundColor ?? palette.neutral[97]};
-
-		${from.tablet} {
-			min-height: 128px;
-		}
-	`;
-
-	return <header css={headerCss}>{props.children}</header>;
-};
-
-Card.Section = (props: { children: ReactNode; backgroundColor?: string }) => {
-	const sectionCss = css`
-		padding: ${space[5]}px ${space[4]}px;
-		border: 1px solid ${palette.neutral[86]};
-		border-top: none;
-		${props.backgroundColor &&
-		`
-			background-color: ${props.backgroundColor};
-		`}
-	`;
-
-	return <div css={sectionCss}>{props.children}</div>;
-};
 
 const SupporterPlusBenefitsSection = (props: {
 	nextPaymentDetails: NextPaymentDetails;
@@ -492,6 +460,13 @@ export const AccountOverviewCardV2 = ({
 									cssOverrides={css`
 										justify-content: center;
 									`}
+									onClick={() =>
+										navigate(`/switch`, {
+											state: {
+												productDetail: productDetail,
+											},
+										})
+									}
 								>
 									Change to monthly + extras
 								</Button>

--- a/client/components/mma/shared/Card.tsx
+++ b/client/components/mma/shared/Card.tsx
@@ -1,4 +1,3 @@
-import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { from, palette, space } from '@guardian/source-foundations';
 import type { ReactNode } from 'react';
@@ -10,7 +9,7 @@ export const Card = (props: { children: ReactNode }) => {
 Card.Header = (props: {
 	children: ReactNode;
 	backgroundColor?: string;
-	cssOverrides?: SerializedStyles | SerializedStyles[];
+	headerHeight?: number;
 }) => {
 	const headerCss = css`
 		padding: ${space[3]}px ${space[4]}px;
@@ -18,13 +17,11 @@ Card.Header = (props: {
 		background-color: ${props.backgroundColor ?? palette.neutral[97]};
 
 		${from.tablet} {
-			min-height: 128px;
+			min-height: ${props.headerHeight ?? 128}px;
 		}
 	`;
 
-	return (
-		<header css={[headerCss, props.cssOverrides]}>{props.children}</header>
-	);
+	return <header css={headerCss}>{props.children}</header>;
 };
 
 Card.Section = (props: { children: ReactNode; backgroundColor?: string }) => {

--- a/client/components/mma/shared/Card.tsx
+++ b/client/components/mma/shared/Card.tsx
@@ -1,0 +1,42 @@
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
+import { from, palette, space } from '@guardian/source-foundations';
+import type { ReactNode } from 'react';
+
+export const Card = (props: { children: ReactNode }) => {
+	return <div>{props.children}</div>;
+};
+
+Card.Header = (props: {
+	children: ReactNode;
+	backgroundColor?: string;
+	cssOverrides?: SerializedStyles | SerializedStyles[];
+}) => {
+	const headerCss = css`
+		padding: ${space[3]}px ${space[4]}px;
+		min-height: 64px;
+		background-color: ${props.backgroundColor ?? palette.neutral[97]};
+
+		${from.tablet} {
+			min-height: 128px;
+		}
+	`;
+
+	return (
+		<header css={[headerCss, props.cssOverrides]}>{props.children}</header>
+	);
+};
+
+Card.Section = (props: { children: ReactNode; backgroundColor?: string }) => {
+	const sectionCss = css`
+		padding: ${space[5]}px ${space[4]}px;
+		border: 1px solid ${palette.neutral[86]};
+		border-top: none;
+		${props.backgroundColor &&
+		`
+			background-color: ${props.backgroundColor};
+		`}
+	`;
+
+	return <div css={sectionCss}>{props.children}</div>;
+};

--- a/client/components/mma/shared/Heading.tsx
+++ b/client/components/mma/shared/Heading.tsx
@@ -1,12 +1,18 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { from, headline, palette } from '@guardian/source-foundations';
+import {
+	from,
+	headline,
+	palette,
+	textSans,
+} from '@guardian/source-foundations';
 import type { ReactNode } from 'react';
 
 interface HeadingProps {
 	children: ReactNode;
 	cssOverrides?: SerializedStyles | SerializedStyles[];
 	level?: '1' | '2' | '3' | '4';
+	sansSerif?: boolean;
 }
 
 export const Heading = (props: HeadingProps) => {
@@ -15,11 +21,16 @@ export const Heading = (props: HeadingProps) => {
 	`;
 
 	const headingStyles = css`
-		${headline.xsmall({ fontWeight: 'bold' })};
+		${props.sansSerif
+			? textSans.xxlarge({ fontWeight: 'bold' })
+			: headline.xsmall({ fontWeight: 'bold' })};
+
 		margin-top: 0;
 		margin-bottom: 0;
 		${from.tablet} {
-			${headline.small({ fontWeight: 'bold' })};
+			${props.sansSerif
+				? textSans.xxlarge({ fontWeight: 'bold' })
+				: headline.small({ fontWeight: 'bold' })};
 		} ;
 	`;
 

--- a/client/components/mma/switch/SwitchContainer.tsx
+++ b/client/components/mma/switch/SwitchContainer.tsx
@@ -1,0 +1,71 @@
+import type { Context } from 'react';
+import { createContext } from 'react';
+import { Navigate, Outlet, useLocation } from 'react-router';
+import type {
+	MembersDataApiItem,
+	ProductDetail,
+} from '../../../../shared/productResponse';
+import {
+	isProduct,
+	MembersDataApiAsyncLoader,
+} from '../../../../shared/productResponse';
+import { PRODUCT_TYPES } from '../../../../shared/productTypes';
+import { createProductDetailFetcher } from '../../../utilities/productUtils';
+import { NAV_LINKS } from '../../shared/nav/NavConfig';
+import { PageContainer } from '../Page';
+
+export interface SwitchRouterState {
+	productDetail: ProductDetail;
+}
+
+export interface SwitchContextInterface {
+	productDetail: ProductDetail;
+}
+
+export const SwitchContext: Context<SwitchContextInterface | {}> =
+	createContext({});
+
+const renderSingleProductOrReturnToAccountOverview = (
+	data: MembersDataApiItem[],
+) => {
+	const filteredProductDetails = data.filter(isProduct);
+
+	if (filteredProductDetails.length === 1) {
+		return contextAndOutletContainer(filteredProductDetails[0]);
+	}
+	return <Navigate to="/" />;
+};
+
+const contextAndOutletContainer = (productDetail: ProductDetail) => (
+	<SwitchContext.Provider value={{ productDetail }}>
+		<Outlet />
+	</SwitchContext.Provider>
+);
+
+const SwitchContainer = () => {
+	const location = useLocation();
+	const routerState = location.state as SwitchRouterState;
+	const productDetail = routerState?.productDetail;
+
+	return (
+		<PageContainer
+			selectedNavItem={NAV_LINKS.accountOverview}
+			pageTitle={'Change your support'}
+		>
+			{productDetail ? (
+				contextAndOutletContainer(productDetail)
+			) : (
+				<MembersDataApiAsyncLoader
+					fetch={createProductDetailFetcher(
+						PRODUCT_TYPES.contributions
+							.allProductsProductTypeFilterString,
+					)}
+					render={renderSingleProductOrReturnToAccountOverview}
+					loadingMessage={'Fetching your current support'}
+				/>
+			)}
+		</PageContainer>
+	);
+};
+
+export default SwitchContainer;

--- a/client/components/mma/switch/SwitchOptions.tsx
+++ b/client/components/mma/switch/SwitchOptions.tsx
@@ -1,0 +1,109 @@
+import { css } from '@emotion/react';
+import {
+	from,
+	headline,
+	palette,
+	space,
+	textSans,
+} from '@guardian/source-foundations';
+import { Stack } from '@guardian/source-react-components';
+import { useContext } from 'react';
+import type { PaidSubscriptionPlan } from '../../../../shared/productResponse';
+import { getMainPlan } from '../../../../shared/productResponse';
+import { calculateMonthlyOrAnnualFromInterval } from '../../../../shared/productTypes';
+import { Card } from '../shared/Card';
+import { Heading } from '../shared/Heading';
+import type { SwitchContextInterface } from './SwitchContainer';
+import { SwitchContext } from './SwitchContainer';
+
+//TODO: this is copied from AccountOverviewV2, share it
+const pageTopCss = css`
+	margin-top: ${space[6]}px;
+	${from.tablet} {
+		margin-top: ${space[9]}px;
+	}
+`;
+
+const cardHeaderDivCss = css`
+	display: flex;
+	justify-content: space-between;
+	align-items: flex-end;
+`;
+
+const productTitleCss = css`
+	${headline.xsmall({ fontWeight: 'bold' })};
+	color: ${palette.neutral[100]};
+	margin: 0;
+	max-width: 20ch;
+
+	${from.tablet} {
+		${headline.small({ fontWeight: 'bold' })};
+	}
+`;
+
+const productSubtitleCss = css`
+	${textSans.medium({ fontWeight: 'bold' })};
+	color: ${palette.neutral[100]};
+	margin: 0;
+	max-width: 20ch;
+`;
+
+const cardHeaderCss = css`
+	${from.tablet} {
+		min-height: 0px;
+	}
+`;
+
+const pageHeadingCss = css`
+	${from.mobile} {
+		${textSans.xxlarge({ fontWeight: 'bold' })}
+	}
+`;
+
+const SwitchOptions = () => {
+	const switchContext = useContext(SwitchContext) as SwitchContextInterface;
+
+	const productDetail = switchContext.productDetail;
+	const mainPlan = getMainPlan(
+		productDetail.subscription,
+	) as PaidSubscriptionPlan;
+	const monthlyOrAnnual = calculateMonthlyOrAnnualFromInterval(
+		mainPlan.interval,
+	);
+
+	return (
+		<Stack space={3} cssOverrides={pageTopCss}>
+			<Heading cssOverrides={pageHeadingCss}>
+				Your current support
+			</Heading>
+			<Card>
+				<Card.Header
+					backgroundColor={palette.brand[600]}
+					cssOverrides={cardHeaderCss}
+				>
+					<div css={cardHeaderDivCss}>
+						<h3 css={productTitleCss}>{monthlyOrAnnual} support</h3>
+						<p css={productSubtitleCss}>
+							{mainPlan.currency}
+							{mainPlan.amount / 100}/{mainPlan.interval}
+						</p>
+					</div>
+				</Card.Header>
+				<Card.Section>
+					<div
+						css={css`
+							${textSans.medium()}
+						`}
+					>
+						You're currently supporting the Guardian with a{' '}
+						{monthlyOrAnnual.toLowerCase()} contribution of{' '}
+						{mainPlan.currency}
+						{mainPlan.amount / 100}.
+					</div>
+				</Card.Section>
+			</Card>
+		</Stack>
+	);
+};
+
+export default SwitchOptions;

--- a/client/components/mma/switch/SwitchOptions.tsx
+++ b/client/components/mma/switch/SwitchOptions.tsx
@@ -48,18 +48,6 @@ const productSubtitleCss = css`
 	max-width: 20ch;
 `;
 
-const cardHeaderCss = css`
-	${from.tablet} {
-		min-height: 0px;
-	}
-`;
-
-const pageHeadingCss = css`
-	${from.mobile} {
-		${textSans.xxlarge({ fontWeight: 'bold' })}
-	}
-`;
-
 const SwitchOptions = () => {
 	const switchContext = useContext(SwitchContext) as SwitchContextInterface;
 
@@ -73,13 +61,11 @@ const SwitchOptions = () => {
 
 	return (
 		<Stack space={3} cssOverrides={pageTopCss}>
-			<Heading cssOverrides={pageHeadingCss}>
-				Your current support
-			</Heading>
+			<Heading sansSerif>Your current support</Heading>
 			<Card>
 				<Card.Header
 					backgroundColor={palette.brand[600]}
-					cssOverrides={cardHeaderCss}
+					headerHeight={0}
 				>
 					<div css={cardHeaderDivCss}>
 						<h3 css={productTitleCss}>{monthlyOrAnnual} support</h3>

--- a/cypress/integration/parallel-2/productSwitch.spec.ts
+++ b/cypress/integration/parallel-2/productSwitch.spec.ts
@@ -166,3 +166,60 @@ if (featureSwitches.cancellationProductSwitch) {
 		});
 	});
 }
+
+describe('product switching', () => {
+	beforeEach(() => {
+		signInAndAcceptCookies();
+
+		cy.setCookie('GU_mvt_id', '999999');
+
+		cy.intercept('GET', '/api/me/mma?productType=Contribution', {
+			statusCode: 200,
+			body: [contribution],
+		});
+
+		cy.intercept('GET', '/api/me/mma', {
+			statusCode: 200,
+			body: [contribution],
+		});
+
+		cy.intercept('GET', '/api/cancelled/', {
+			statusCode: 200,
+			body: [],
+		}).as('cancelled');
+	});
+
+	it('goes to product switching page when clicking CTA button', () => {
+		cy.visit('/?withFeature=accountOverviewNewLayout');
+
+		cy.window().then((window) => {
+			// @ts-ignore
+			window.guardian.identityDetails = {
+				signInStatus: 'signedInRecently',
+				userId: '200006712',
+				displayName: 'user',
+				email: 'example@example.com',
+			};
+		});
+
+		cy.findByText('Change to monthly + extras').click();
+
+		cy.findByText('Your current support');
+	});
+
+	it('goes to product switching page when hitting URL directly', () => {
+		cy.visit('/switch');
+
+		cy.window().then((window) => {
+			// @ts-ignore
+			window.guardian.identityDetails = {
+				signInStatus: 'signedInRecently',
+				userId: '200006712',
+				displayName: 'user',
+				email: 'example@example.com',
+			};
+		});
+
+		cy.findByText('Your current support');
+	});
+});

--- a/shared/productTypes.tsx
+++ b/shared/productTypes.tsx
@@ -235,7 +235,7 @@ const calculateProductTitle =
 const calculateSupporterPlusTitle = (interval: string) =>
 	interval === 'month' ? 'monthly + extras' : 'annual + extras';
 
-const calculateMonthlyOrAnnualFromInterval = (interval: string) =>
+export const calculateMonthlyOrAnnualFromInterval = (interval: string) =>
 	interval === 'month' ? 'Monthly' : 'Annual';
 
 const FRONT_PAGE_NEWSLETTER_ID = '6009';


### PR DESCRIPTION
## What does this change?

This PR adds a new route and first page for the product switching journey under `/switch` and the 'Your current support' block of the Options page. 

## How to test

This is behind the 'Change to monthly + extras' button which is behind the feature flag 'accountOverviewNewLayout'. Alternatively navigate to '/switch' with a contribution product.

Acceptance criteria:
Wording should display 'Monthly' or 'Annual' support
Should display current spend per month / year
Should display correct currency
Should include a message
'You're currently supporting the Guardian with a [insert monthly OR annual] contribution of [insert spend here].

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://user-images.githubusercontent.com/114918544/208067724-6bb3eee6-ba6f-4ddf-880b-2b4ad63dec0f.png)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
