### PR TITLE
More TypeScript linting fixes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,7 +39,6 @@ module.exports = {
 		'@typescript-eslint/no-unsafe-call': ['off'],
 		'@typescript-eslint/no-unsafe-member-access': ['off'],
 		'@typescript-eslint/no-unsafe-return': ['off'],
-		'@typescript-eslint/prefer-includes': ['off'],
 		'@typescript-eslint/prefer-nullish-coalescing': ['off'],
 		'@typescript-eslint/prefer-optional-chain': ['off'],
 		'@typescript-eslint/prefer-reduce-type-parameter': ['off'],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,7 +41,6 @@ module.exports = {
 		'@typescript-eslint/prefer-nullish-coalescing': ['off'],
 		'@typescript-eslint/prefer-optional-chain': ['off'],
 		'@typescript-eslint/prefer-reduce-type-parameter': ['off'],
-		'@typescript-eslint/prefer-ts-expect-error': ['off'],
 		'@typescript-eslint/require-await': ['off'],
 		'@typescript-eslint/restrict-template-expressions': ['off'],
 		'@typescript-eslint/unbound-method': ['off'],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,7 +45,6 @@ module.exports = {
 		'@typescript-eslint/prefer-reduce-type-parameter': ['off'],
 		'@typescript-eslint/prefer-ts-expect-error': ['off'],
 		'@typescript-eslint/require-await': ['off'],
-		'@typescript-eslint/restrict-plus-operands': ['off'],
 		'@typescript-eslint/restrict-template-expressions': ['off'],
 		'@typescript-eslint/unbound-method': ['off'],
 		'eslint-comments/require-description': ['off'],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,7 +32,6 @@ module.exports = {
 		'@typescript-eslint/no-floating-promises': ['off'],
 		'@typescript-eslint/no-misused-promises': ['off'],
 		'@typescript-eslint/no-unnecessary-condition': ['off'],
-		'@typescript-eslint/no-unnecessary-type-arguments': ['off'],
 		'@typescript-eslint/no-unnecessary-type-assertion': ['off'],
 		'@typescript-eslint/no-unsafe-argument': ['off'],
 		'@typescript-eslint/no-unsafe-assignment': ['off'],

--- a/client/__tests__/components/accountoverview/contributionUpdateAmount.test.tsx
+++ b/client/__tests__/components/accountoverview/contributionUpdateAmount.test.tsx
@@ -1,7 +1,6 @@
 // @ts-nocheck
 /* eslint jest/no-standalone-expect: "off", jest/no-done-callback: "off" */
 import { fireEvent, render, screen } from '@testing-library/react';
-import each from 'jest-each';
 import { ContributionUpdateAmount } from '../../../components/mma/accountoverview/ContributionUpdateAmount';
 
 const mainPlan = (interval) => ({
@@ -21,17 +20,16 @@ const productType = {
 	urlPart: 'contributions',
 };
 
-each`
-  interval    | expectedMinAmount
-  ${'month'}  | ${2}
-  ${'year'}   | ${10}
-`.test(
-	'renders validation error if $interval.interval amount below $expectedMinAmount',
-	(params, done) => {
+it.each([
+	['month', 2],
+	['year', 10],
+])(
+	'renders validation error if %s amount below %i',
+	(interval, expectedMinAmount) => {
 		const { container } = render(
 			<ContributionUpdateAmount
 				subscriptionId="A-123"
-				mainPlan={mainPlan(params.interval)}
+				mainPlan={mainPlan(interval)}
 				amountUpdateStateChange={jest.fn()}
 				nextPaymentDate="2050-10-29"
 				productType={productType}
@@ -44,7 +42,7 @@ each`
 
 		const otherInputElem = container.querySelector('input[type="number"]');
 		fireEvent.change(otherInputElem, {
-			target: { value: params.expectedMinAmount - 1 },
+			target: { value: expectedMinAmount - 1 },
 		});
 
 		// click on the change amount button again and then check to make sure that the validation error message shows up
@@ -53,29 +51,24 @@ each`
 		// assert that the minimum amount validation error message is shown
 		expect(
 			screen.queryByText(
-				`There is a minimum ${
-					params.interval
-				}ly contribution amount of £${params.expectedMinAmount.toFixed(
+				`There is a minimum ${interval}ly contribution amount of £${expectedMinAmount.toFixed(
 					2,
 				)} GBP`,
 			),
 		).toBeTruthy();
-
-		done();
 	},
 );
 
-each`
-  interval    | expectedMaxAmount
-  ${'month'}  | ${166}
-  ${'year'}   | ${2000}
-`.test(
-	'renders validation error if $interval.interval amount above $expectedMaxAmount',
-	(params, done) => {
+it.each([
+	['month', 166],
+	['year', 2000],
+])(
+	'renders validation error if %s amount above %i',
+	(interval, expectedMaxAmount) => {
 		const { container } = render(
 			<ContributionUpdateAmount
 				subscriptionId="A-123"
-				mainPlan={mainPlan(params.interval)}
+				mainPlan={mainPlan(interval)}
 				amountUpdateStateChange={jest.fn()}
 				nextPaymentDate="2050-10-29"
 				productType={productType}
@@ -88,7 +81,7 @@ each`
 
 		const otherInputElem = container.querySelector('input[type="number"]');
 		fireEvent.change(otherInputElem, {
-			target: { value: params.expectedMaxAmount + 1 },
+			target: { value: expectedMaxAmount + 1 },
 		});
 
 		// click on the change amount button again and then check to make sure that the validation error message shows up
@@ -97,19 +90,15 @@ each`
 		// assert that the maximum amount validation error message is shown
 		expect(
 			screen.queryByText(
-				`There is a maximum ${
-					params.interval
-				}ly contribution amount of £${params.expectedMaxAmount.toFixed(
+				`There is a maximum ${interval}ly contribution amount of £${expectedMaxAmount.toFixed(
 					2,
 				)} GBP`,
 			),
 		).toBeTruthy();
-
-		done();
 	},
 );
 
-test('renders validation error if blank input is provided', (done) => {
+it('renders validation error if blank input is provided', () => {
 	const { container } = render(
 		<ContributionUpdateAmount
 			subscriptionId="A-123"
@@ -138,11 +127,9 @@ test('renders validation error if blank input is provided', (done) => {
 			'There is a problem with the amount you have selected, please make sure it is a valid amount',
 		),
 	).toBeTruthy();
-
-	done();
 });
 
-test('renders validation error if a string is attempted to be input', (done) => {
+it('renders validation error if a string is attempted to be input', () => {
 	const { container } = render(
 		<ContributionUpdateAmount
 			subscriptionId="A-123"
@@ -171,11 +158,9 @@ test('renders validation error if a string is attempted to be input', (done) => 
 			'There is a problem with the amount you have selected, please make sure it is a valid amount',
 		),
 	).toBeTruthy();
-
-	done();
 });
 
-test('input correct value', (done) => {
+it('updates amount is valid value is input', () => {
 	// mock the console error for this test case to mute "Cannot update a component (`Unknown`) while rendering a different component" error
 	const mockedError = () => true;
 	// tslint:disable-next-line
@@ -203,6 +188,4 @@ test('input correct value', (done) => {
 	// click on the change amount button again and then check to make sure that the validation error message shows up
 	fireEvent.click(screen.queryByText('Change amount'));
 	expect(screen.queryByText('Updating...')).toBeTruthy();
-
-	done();
 });

--- a/client/__tests__/components/payment/stripe.test.ts
+++ b/client/__tests__/components/payment/stripe.test.ts
@@ -4,7 +4,7 @@ import {
 } from '../../../fixtures/subscription';
 import { getStripeKey } from '../../../utilities/stripe';
 
-// @ts-ignore
+// @ts-expect-error
 window.guardian = {
 	stripeKeyAustralia: {
 		uat: 'uatKeyAustralia',

--- a/client/components/helpCentre/HelpCentreArticle.tsx
+++ b/client/components/helpCentre/HelpCentreArticle.tsx
@@ -168,7 +168,7 @@ const ArticleBody = (props: ArticleBodyProps) => {
 
 	// This is to appease React's "Lists need a unique key" error
 	let keyCounter = 0;
-	const getKey = () => props.articleCode + keyCounter++;
+	const getKey = () => `${props.articleCode}${keyCounter++}`;
 
 	const parseBody = (body: BaseNode[] | BaseNode): React.ReactNode => {
 		if (Array.isArray(body)) {

--- a/client/components/mma/cancel/Cancellation.stories.tsx
+++ b/client/components/mma/cancel/Cancellation.stories.tsx
@@ -71,7 +71,7 @@ Review.parameters = {
 export const Confirmation: ComponentStory<
 	typeof CancellationContainer
 > = () => {
-	// @ts-ignore set identity details email in the window
+	// @ts-expect-error set identity details email in the window
 	window.guardian = { identityDetails: { email: 'test' } };
 
 	return getCancellationSummary(

--- a/client/components/mma/cancel/ResubscribeThrasher.tsx
+++ b/client/components/mma/cancel/ResubscribeThrasher.tsx
@@ -44,8 +44,7 @@ const getThrasher =
 				(option) =>
 					!!option.subscriptions.find(
 						(sub) =>
-							sub.isActive &&
-							sub.name.indexOf('Contribution') !== -1,
+							sub.isActive && sub.name.includes('Contribution'),
 					),
 			)
 				? []

--- a/client/components/mma/cancel/contributions/ContributionsCancellationFlowFinancialSaveAttempt.tsx
+++ b/client/components/mma/cancel/contributions/ContributionsCancellationFlowFinancialSaveAttempt.tsx
@@ -80,9 +80,7 @@ const ContributionsCancellationFlowFinancialSaveAttempt: React.FC<
 		});
 	};
 
-	const onReturnClicked = (
-		event: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
-	) => {
+	const onReturnClicked = (event: React.MouseEvent<HTMLAnchorElement>) => {
 		event.preventDefault();
 		navigate('/');
 	};

--- a/client/components/mma/cancel/contributions/ContributionsCancellationFlowPaymentIssueSaveAttempt.tsx
+++ b/client/components/mma/cancel/contributions/ContributionsCancellationFlowPaymentIssueSaveAttempt.tsx
@@ -42,9 +42,7 @@ const ContributionsCancellationFlowPaymentIssueSaveAttempt = (
 		return <Navigate to="../" />;
 	}
 
-	const onManageClicked = (
-		event: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
-	) => {
+	const onManageClicked = (event: React.MouseEvent<HTMLAnchorElement>) => {
 		event.preventDefault();
 		trackEventInOphanOnly({
 			eventCategory: 'cancellation_flow_payment_issue',
@@ -97,9 +95,7 @@ const ContributionsCancellationFlowPaymentIssueSaveAttempt = (
 		});
 	};
 
-	const onReturnClicked = (
-		event: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
-	) => {
+	const onReturnClicked = (event: React.MouseEvent<HTMLAnchorElement>) => {
 		event.preventDefault();
 		navigate('/');
 	};

--- a/client/components/mma/cancel/stages/SavedCancellation.tsx
+++ b/client/components/mma/cancel/stages/SavedCancellation.tsx
@@ -45,9 +45,7 @@ const SavedCancellation = () => {
 		(reason) => reason.reasonId === selectedReasonId,
 	) as CancellationReason;
 
-	const onReturnClicked = (
-		event: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
-	) => {
+	const onReturnClicked = (event: React.MouseEvent<HTMLAnchorElement>) => {
 		event.preventDefault();
 		navigate('/');
 	};

--- a/client/components/mma/cancel/voucher/VoucherCancellationFlowStart.tsx
+++ b/client/components/mma/cancel/voucher/VoucherCancellationFlowStart.tsx
@@ -25,7 +25,7 @@ export const voucherCancellationFlowStart = ({
 	}
 
 	const isEligibleForFreeDigipackAccess =
-		mainPlan.name?.indexOf('plus Digi') === -1;
+		mainPlan.name?.includes('plus Digi');
 
 	return (
 		<Stack space={4}>

--- a/client/components/mma/identity/GenericErrorMessage.tsx
+++ b/client/components/mma/identity/GenericErrorMessage.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from 'react';
 import { errorMessageCss } from './sharedStyles';
 
 export type GenericErrorMessageRef = HTMLDivElement;
-export const GenericErrorMessage = forwardRef<GenericErrorMessageRef, {}>(
+export const GenericErrorMessage = forwardRef<GenericErrorMessageRef>(
 	(_, ref) => {
 		return (
 			<div ref={ref} css={errorMessageCss}>

--- a/client/components/mma/paymentUpdate/FieldWrapper.tsx
+++ b/client/components/mma/paymentUpdate/FieldWrapper.tsx
@@ -44,7 +44,7 @@ export class FieldWrapper extends React.Component<
 		const hydratedChildren = React.Children.map(
 			this.props.children,
 			(child) => {
-				return React.cloneElement(child as React.ReactElement<any>, {
+				return React.cloneElement(child as React.ReactElement, {
 					onChange: this.validateField(this.props.onChange),
 					onFocus: this.toggleFocus,
 					onBlur: this.toggleFocus,

--- a/client/components/mma/paymentUpdate/UpdatePayment.stories.tsx
+++ b/client/components/mma/paymentUpdate/UpdatePayment.stories.tsx
@@ -16,7 +16,7 @@ export default {
 } as ComponentMeta<typeof PaymentDetailUpdateContainer>;
 
 const setSiteKey = () => {
-	// @ts-ignore set the recaptcha key in the window for the recaptcha to render
+	// @ts-expect-error set the recaptcha key in the window for the recaptcha to render
 	window.guardian = {
 		recaptchaPublicKey: '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI',
 	};

--- a/client/components/shared/nav/DropdownNav.tsx
+++ b/client/components/shared/nav/DropdownNav.tsx
@@ -47,7 +47,7 @@ const dropdownNavCss = (showMenu: boolean, isHelpCentre: boolean) =>
 				height: 0,
 				position: 'absolute',
 				top: `-${space[2]}px`,
-				right: `${isHelpCentre ? '85px' : space[3] + 'px'}`,
+				right: `${isHelpCentre ? '85' : space[3]}px`,
 				borderLeft: `${space[2]}px solid transparent`,
 				borderRight: `${space[2]}px solid transparent`,
 				borderBottom: `${space[2]}px solid ${neutral['100']}`,

--- a/client/utilities/hooks/useAnalytics.ts
+++ b/client/utilities/hooks/useAnalytics.ts
@@ -85,7 +85,7 @@ const useAnalytics = () => {
 						consentState,
 					);
 
-					// @ts-ignore: Suppressing "element implicitly has an 'any' type because index expression is not of type 'number'."
+					// @ts-expect-error: Suppressing "element implicitly has an 'any' type because index expression is not of type 'number'."
 					window[`ga-disable-${GA_UA}`] = !gaConsentState;
 
 					if (gaConsentState && !gaIsInitialised) {

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "git-revision-webpack-plugin": "^3.0.6",
     "husky": "^1.3.1",
     "jest": "^27.3.1",
-    "jest-each": "^26.6.2",
     "jest-teamcity-reporter": "^0.9.0",
     "lint-staged": "^13.0.3",
     "mini-css-extract-plugin": "^2.5.2",

--- a/shared/identity.ts
+++ b/shared/identity.ts
@@ -1,7 +1,7 @@
 export const X_GU_ID_FORWARDED_SCOPE = 'X-GU-ID-FORWARDED-SCOPE';
 
 export const getScopeFromRequestPathOrEmptyString = (requestPath: string) => {
-	if (requestPath.indexOf('/payment/') !== -1) {
+	if (requestPath.includes('/payment/')) {
 		return 'payment-flow';
 	}
 	return '';

--- a/shared/productResponse.ts
+++ b/shared/productResponse.ts
@@ -109,7 +109,7 @@ export const augmentInterval = (interval: string) =>
 	interval === '6 weeks' ? 'one-off' : `${interval}ly`;
 
 export const isSixForSix = (planName: string | null) =>
-	!!planName && planName.indexOf('6 for 6') !== -1;
+	!!planName && planName.includes('6 for 6');
 
 export interface PaidSubscriptionPlan
 	extends SubscriptionPlan,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11390,17 +11390,6 @@ jest-docblock@^27.4.0:
   dependencies:
     detect-newline "^3.0.0"
 
-jest-each@^26.6.2:
-  version "26.6.2"
-  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-26.6.2.tgz#02526438a77a67401c8a6382dfe5999952c167cb"
-  integrity sha512-Mer/f0KaATbjl8MCJ+0GEpNdqmnVmDYqCTJYTvoo7rqmRiDllmp2AYN+06F93nXcY3ur9ShIjS+CO/uD+BbH4A==
-  dependencies:
-    "@jest/types" "^26.6.2"
-    chalk "^4.0.0"
-    jest-get-type "^26.3.0"
-    jest-util "^26.6.2"
-    pretty-format "^26.6.2"
-
 jest-each@^27.4.2:
   version "27.4.2"
   resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-27.4.2.tgz#19364c82a692d0d26557642098d1f4619c9ee7d3"
@@ -11441,11 +11430,6 @@ jest-get-type@^25.2.6:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-25.2.6.tgz#0b0a32fab8908b44d508be81681487dbabb8d877"
   integrity sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==
-
-jest-get-type@^26.3.0:
-  version "26.3.0"
-  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
-  integrity sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==
 
 jest-get-type@^27.4.0:
   version "27.4.0"
@@ -14180,16 +14164,6 @@ pretty-format@^25.2.1, pretty-format@^25.5.0:
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
-
-pretty-format@^26.6.2:
-  version "26.6.2"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
-  integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
-  dependencies:
-    "@jest/types" "^26.6.2"
-    ansi-regex "^5.0.0"
-    ansi-styles "^4.0.0"
-    react-is "^17.0.1"
 
 pretty-format@^27.0.0, pretty-format@^27.4.2:
   version "27.4.2"


### PR DESCRIPTION
## What does this change?

Fixes the following linting errors and removes overrides to disable these rules from the ESLint config:

`@typescript-eslint/no-unnecessary-type-arguments`
`@typescript-eslint/prefer-includes`
`@typescript-eslint/prefer-ts-expect-error`
`@typescript-eslint/restrict-plus-operands`
