### PR TITLE
Create Change your support section

### DIFF
--- a/client/components/mma/accountoverview/AccountOverviewCardV2.tsx
+++ b/client/components/mma/accountoverview/AccountOverviewCardV2.tsx
@@ -253,10 +253,14 @@ export const AccountOverviewCardV2 = ({
 						{nextPaymentDetails.paymentInterval} support and extra
 						benefits.
 					</p>
-					<SupporterPlusBenefitsSection
+					<div
+						css={css`
+							margin: ${space[5]}px 0 ${space[4]}px 0;
+						`}
 						hidden={!showBenefits}
-						withMargin
-					/>
+					>
+						<SupporterPlusBenefitsSection />
+					</div>
 					<button
 						css={[
 							expanderButtonCss()(showBenefits),

--- a/client/components/mma/accountoverview/AccountOverviewCardV2.tsx
+++ b/client/components/mma/accountoverview/AccountOverviewCardV2.tsx
@@ -9,7 +9,6 @@ import {
 import {
 	Button,
 	buttonThemeReaderRevenueBrand,
-	SvgTickRound,
 } from '@guardian/source-react-components';
 import { useState } from 'react';
 import { useNavigate } from 'react-router';
@@ -25,105 +24,13 @@ import { Card } from '../shared/Card';
 import { CardDisplay } from '../shared/CardDisplay';
 import { DirectDebitDisplay } from '../shared/DirectDebitDisplay';
 import GridPicture from '../shared/images/GridPicture';
-import type { NextPaymentDetails } from '../shared/NextPaymentDetails';
 import {
 	getNextPaymentDetails,
 	NewPaymentPriceAlert,
 } from '../shared/NextPaymentDetails';
 import { PaypalDisplay } from '../shared/PaypalDisplay';
 import { SepaDisplay } from '../shared/SepaDisplay';
-
-const SupporterPlusBenefitsSection = (props: {
-	nextPaymentDetails: NextPaymentDetails;
-}) => {
-	const [showBenefits, setShowBenefits] = useState<boolean>(false);
-
-	const benefitsCss = css`
-		${textSans.medium()};
-		list-style: none;
-		margin: ${space[5]}px 0 ${space[4]}px -4px;
-		padding: 0;
-
-		li + li {
-			margin-top: ${space[2]}px;
-		}
-
-		li {
-			display: flex;
-			align-items: flex-start;
-		}
-
-		svg {
-			flex-shrink: 0;
-			margin-right: ${space[2]}px;
-			fill: ${palette.brand[500]};
-		}
-	`;
-
-	const benefitsButtonCss = css`
-		${textSans.small()}
-		margin-top: ${space[1]}px;
-		padding: 0;
-		color: ${palette.brand[500]};
-		border-bottom: 1px solid ${palette.brand[500]};
-	`;
-
-	return (
-		<Card.Section backgroundColor="#edf5fA">
-			<p
-				css={css`
-					${textSans.medium()}
-					margin: 0;
-					max-width: 35ch;
-				`}
-			>
-				You’re supporting the Guardian with a{' '}
-				{props.nextPaymentDetails.paymentValue} per{' '}
-				{props.nextPaymentDetails.paymentInterval} support and extra
-				benefits.
-			</p>
-			<ul id="benefits" css={benefitsCss} hidden={!showBenefits}>
-				<li>
-					<SvgTickRound size="small" />
-					<span>
-						<strong>A regular supporter newsletter.</strong> Get
-						exclusive insight from our newsroom
-					</span>
-				</li>
-				<li>
-					<SvgTickRound size="small" />
-					<span>
-						<strong>Uninterrupted reading.</strong> See far fewer
-						asks for support
-					</span>
-				</li>
-				<li>
-					<SvgTickRound size="small" />
-					<span>
-						<strong>Full access to our news app.</strong> Read our
-						reporting on the go
-					</span>
-				</li>
-				<li>
-					<SvgTickRound size="small" />
-					<span>
-						<strong>Ad-free reading.</strong> Avoid ads on all your
-						devices
-					</span>
-				</li>
-			</ul>
-			<button
-				css={[expanderButtonCss()(showBenefits), benefitsButtonCss]}
-				type="button"
-				aria-expanded={showBenefits}
-				aria-controls="benefits"
-				onClick={() => setShowBenefits(!showBenefits)}
-			>
-				{showBenefits ? 'hide' : 'view'} benefits
-			</button>
-		</Card.Section>
-	);
-};
+import { SupporterPlusBenefitsSection } from '../shared/SupporterPlusBenefits';
 
 interface ProductCardConfiguration {
 	headerColor: string;
@@ -176,6 +83,7 @@ export const AccountOverviewCardV2 = ({
 	isEligibleToSwitch: boolean;
 }) => {
 	const navigate = useNavigate();
+	const [showBenefits, setShowBenefits] = useState<boolean>(false);
 
 	const mainPlan = getMainPlan(productDetail.subscription);
 	if (!mainPlan) {
@@ -285,6 +193,14 @@ export const AccountOverviewCardV2 = ({
 		}
 	`;
 
+	const benefitsButtonCss = css`
+		${textSans.small()}
+		margin-top: ${space[1]}px;
+		padding: 0;
+		color: ${palette.brand[500]};
+		border-bottom: 1px solid ${palette.brand[500]};
+	`;
+
 	return (
 		<Card>
 			<Card.Header backgroundColor={cardConfig.headerColor}>
@@ -322,10 +238,38 @@ export const AccountOverviewCardV2 = ({
 					)}
 				</div>
 			</Card.Header>
+
 			{cardConfig.showBenefitsSection && nextPaymentDetails && (
-				<SupporterPlusBenefitsSection
-					nextPaymentDetails={nextPaymentDetails}
-				/>
+				<Card.Section backgroundColor="#edf5fA">
+					<p
+						css={css`
+							${textSans.medium()}
+							margin: 0;
+							max-width: 35ch;
+						`}
+					>
+						You’re supporting the Guardian with a{' '}
+						{nextPaymentDetails.paymentValue} per{' '}
+						{nextPaymentDetails.paymentInterval} support and extra
+						benefits.
+					</p>
+					<SupporterPlusBenefitsSection
+						hidden={!showBenefits}
+						withMargin
+					/>
+					<button
+						css={[
+							expanderButtonCss()(showBenefits),
+							benefitsButtonCss,
+						]}
+						type="button"
+						aria-expanded={showBenefits}
+						aria-controls="benefits"
+						onClick={() => setShowBenefits(!showBenefits)}
+					>
+						{showBenefits ? 'hide' : 'view'} benefits
+					</button>
+				</Card.Section>
 			)}
 			<Card.Section>
 				<div css={productDetailLayoutCss}>

--- a/client/components/mma/shared/SupporterPlusBenefits.tsx
+++ b/client/components/mma/shared/SupporterPlusBenefits.tsx
@@ -1,0 +1,69 @@
+import { css } from '@emotion/react';
+import { from, palette, space, textSans } from '@guardian/source-foundations';
+import { SvgTickRound } from '@guardian/source-react-components';
+
+export const SupporterPlusBenefitsSection = (props: {
+	hidden?: boolean;
+	withMargin?: boolean;
+}) => {
+	const benefitsCss = css`
+		${textSans.medium()};
+		list-style: none;
+		margin: ${props.withMargin ? `${space[5]}px 0 ${space[4]}px -4px` : 0};
+		padding: 0;
+
+		li + li {
+			margin-top: ${space[2]}px;
+		}
+
+		li {
+			display: flex;
+			align-items: flex-start;
+		}
+
+		svg {
+			flex-shrink: 0;
+			margin-right: ${space[2]}px;
+			fill: ${palette.brand[500]};
+		}
+	`;
+
+	const lineBreakCss = css`
+		${from.tablet} {
+			display: none;
+		}
+	`;
+
+	return (
+		<ul id="benefits" css={benefitsCss} hidden={props.hidden}>
+			<li>
+				<SvgTickRound size="small" />
+				<span>
+					<strong>Full access to our news app.</strong>
+					<br css={lineBreakCss} /> Read our reporting on the go
+				</span>
+			</li>
+			<li>
+				<SvgTickRound size="small" />
+				<span>
+					<strong>A regular supporter newsletter.</strong> Get
+					exclusive insight from our newsroom
+				</span>
+			</li>
+			<li>
+				<SvgTickRound size="small" />
+				<span>
+					<strong>Uninterrupted reading.</strong>
+					<br css={lineBreakCss} /> See far fewer asks for support
+				</span>
+			</li>
+			<li>
+				<SvgTickRound size="small" />
+				<span>
+					<strong>Ad-free reading.</strong>
+					<br css={lineBreakCss} /> Avoid ads on all your devices
+				</span>
+			</li>
+		</ul>
+	);
+};

--- a/client/components/mma/shared/SupporterPlusBenefits.tsx
+++ b/client/components/mma/shared/SupporterPlusBenefits.tsx
@@ -2,14 +2,11 @@ import { css } from '@emotion/react';
 import { from, palette, space, textSans } from '@guardian/source-foundations';
 import { SvgTickRound } from '@guardian/source-react-components';
 
-export const SupporterPlusBenefitsSection = (props: {
-	hidden?: boolean;
-	withMargin?: boolean;
-}) => {
+export const SupporterPlusBenefitsSection = () => {
 	const benefitsCss = css`
 		${textSans.medium()};
 		list-style: none;
-		margin: ${props.withMargin ? `${space[5]}px 0 ${space[4]}px -4px` : 0};
+		margin: 0 0 0 -4px;
 		padding: 0;
 
 		li + li {
@@ -35,7 +32,7 @@ export const SupporterPlusBenefitsSection = (props: {
 	`;
 
 	return (
-		<ul id="benefits" css={benefitsCss} hidden={props.hidden}>
+		<ul id="benefits" css={benefitsCss}>
 			<li>
 				<SvgTickRound size="small" />
 				<span>

--- a/client/components/mma/switch/SwitchOptions.stories.tsx
+++ b/client/components/mma/switch/SwitchOptions.stories.tsx
@@ -26,8 +26,7 @@ export const BelowThreshold: ComponentStory<typeof SwitchOptions> = () => (
 	<SwitchOptions />
 );
 
-// @ts-ignore: this method is not in our current version of TypeScript
-const contributionBelowThreshold = structuredClone(contribution);
+const contributionBelowThreshold = JSON.parse(JSON.stringify(contribution));
 const plan = contributionBelowThreshold.subscription
 	.currentPlans[0] as PaidSubscriptionPlan;
 plan.amount = 300;

--- a/client/components/mma/switch/SwitchOptions.stories.tsx
+++ b/client/components/mma/switch/SwitchOptions.stories.tsx
@@ -1,0 +1,39 @@
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import { ReactRouterDecorator } from '../../../../.storybook/ReactRouterDecorator';
+import type { PaidSubscriptionPlan } from '../../../../shared/productResponse';
+import { contribution } from '../../../fixtures/productDetail';
+import SwitchContainer from './SwitchContainer';
+import SwitchOptions from './SwitchOptions';
+
+export default {
+	title: 'Pages/SwitchOptions',
+	component: SwitchContainer,
+	decorators: [ReactRouterDecorator],
+	parameters: {
+		layout: 'fullscreen',
+		reactRouter: {
+			state: { productDetail: contribution },
+			container: <SwitchContainer />,
+		},
+	},
+} as ComponentMeta<typeof SwitchContainer>;
+
+export const AboveThreshold: ComponentStory<typeof SwitchOptions> = () => (
+	<SwitchOptions />
+);
+
+export const BelowThreshold: ComponentStory<typeof SwitchOptions> = () => (
+	<SwitchOptions />
+);
+
+// @ts-ignore: this method is not in our current version of TypeScript
+const contributionBelowThreshold = structuredClone(contribution);
+const plan = contributionBelowThreshold.subscription
+	.currentPlans[0] as PaidSubscriptionPlan;
+plan.amount = 300;
+
+BelowThreshold.parameters = {
+	reactRouter: {
+		state: { productDetail: contributionBelowThreshold },
+	},
+};

--- a/client/components/mma/switch/SwitchOptions.tsx
+++ b/client/components/mma/switch/SwitchOptions.tsx
@@ -1,18 +1,24 @@
-import { css } from '@emotion/react';
+import { css, ThemeProvider } from '@emotion/react';
 import {
 	from,
 	headline,
 	palette,
 	space,
 	textSans,
+	until,
 } from '@guardian/source-foundations';
-import { Stack } from '@guardian/source-react-components';
+import {
+	Button,
+	buttonThemeReaderRevenueBrand,
+	Stack,
+} from '@guardian/source-react-components';
 import { useContext } from 'react';
 import type { PaidSubscriptionPlan } from '../../../../shared/productResponse';
 import { getMainPlan } from '../../../../shared/productResponse';
 import { calculateMonthlyOrAnnualFromInterval } from '../../../../shared/productTypes';
 import { Card } from '../shared/Card';
 import { Heading } from '../shared/Heading';
+import { SupporterPlusBenefitsSection } from '../shared/SupporterPlusBenefits';
 import type { SwitchContextInterface } from './SwitchContainer';
 import { SwitchContext } from './SwitchContainer';
 
@@ -48,6 +54,14 @@ const productSubtitleCss = css`
 	max-width: 20ch;
 `;
 
+const buttonCss = css`
+	display: flex;
+
+	${until.tablet} {
+		justify-content: center;
+	}
+`;
+
 const SwitchOptions = () => {
 	const switchContext = useContext(SwitchContext) as SwitchContextInterface;
 
@@ -55,9 +69,20 @@ const SwitchOptions = () => {
 	const mainPlan = getMainPlan(
 		productDetail.subscription,
 	) as PaidSubscriptionPlan;
+
 	const monthlyOrAnnual = calculateMonthlyOrAnnualFromInterval(
 		mainPlan.interval,
 	);
+	const supporterPlusTitle = `${monthlyOrAnnual} + extras`;
+
+	// ToDo: hardcoding this for now; need to find out where to get this from for each currency
+	const monthlyThreshold = 10;
+	const annualThreshold = 95;
+
+	const threshold =
+		monthlyOrAnnual == 'Monthly' ? monthlyThreshold : annualThreshold;
+	const aboveThreshold = mainPlan.amount >= threshold * 100;
+	const currentAmount = mainPlan.amount / 100;
 
 	return (
 		<Stack space={3} cssOverrides={pageTopCss}>
@@ -71,7 +96,7 @@ const SwitchOptions = () => {
 						<h3 css={productTitleCss}>{monthlyOrAnnual} support</h3>
 						<p css={productSubtitleCss}>
 							{mainPlan.currency}
-							{mainPlan.amount / 100}/{mainPlan.interval}
+							{currentAmount}/{mainPlan.interval}
 						</p>
 					</div>
 				</Card.Header>
@@ -84,10 +109,69 @@ const SwitchOptions = () => {
 						You're currently supporting the Guardian with a{' '}
 						{monthlyOrAnnual.toLowerCase()} contribution of{' '}
 						{mainPlan.currency}
-						{mainPlan.amount / 100}.
+						{currentAmount}.
 					</div>
 				</Card.Section>
 			</Card>
+			<div css={pageTopCss}>
+				<Heading sansSerif>
+					{aboveThreshold ? 'Add extras' : 'Change your support'}
+				</Heading>
+				<p
+					css={css`
+						${textSans.medium()}
+					`}
+				>
+					Change to {supporterPlusTitle} and get exclusive supporter
+					benefits
+				</p>
+				<Card>
+					<Card.Header
+						backgroundColor={palette.brand[500]}
+						headerHeight={0}
+					>
+						<div css={cardHeaderDivCss}>
+							<h3 css={productTitleCss}>{supporterPlusTitle}</h3>
+							{!aboveThreshold && (
+								<p css={productSubtitleCss}>
+									{mainPlan.currency}
+									{threshold}/{mainPlan.interval}
+								</p>
+							)}
+						</div>
+					</Card.Header>
+					<Card.Section>
+						<SupporterPlusBenefitsSection />
+					</Card.Section>
+				</Card>
+			</div>
+			<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
+				<div css={buttonCss}>
+					<Button
+						size="small"
+						cssOverrides={css`
+							justify-content: center;
+						`}
+					>
+						{aboveThreshold
+							? 'Add extras with no extra cost'
+							: 'Change to monthly + extras'}
+					</Button>
+				</div>
+			</ThemeProvider>
+			{aboveThreshold && (
+				<p
+					css={css`
+						color: ${palette.neutral[46]};
+					`}
+				>
+					Exclusive supporter extras are unlocked for any monthly
+					support of {mainPlan.currency}
+					{monthlyThreshold} or above and any annual support of{' '}
+					{mainPlan.currency}
+					{annualThreshold} or above.
+				</p>
+			)}
 		</Stack>
 	);
 };


### PR DESCRIPTION
## What does this change?

Adds the 'Change your support' section to the Product Switch Options page.

When attempting to promote switching, we want to highlight to users the benefits of switching and what they can get when switching to Supporter+. Note: there are two different scenarios here and the block should display different content depending on the users payments (below or above threshold)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Navigate to `/switch` with a recurring contribution.

Acceptance criteria:
- H2 should read 'Add extras' if above threshold
- H2 should read 'Change your support' if below threshold
- Change your support subtext should differ depending on Monthly or Annual + extras depending on what the user currently has.

Banner should read Monthly or Annual + extras depending on their current product
List of benefits should be in order as per designs, with app listed first
IF user is spending under threshold, the banner should display the threshold price. I.E spending £8, this should show £10
IF the user is spending £12 no price should show
IF above threshold, CTA should read 'Add extras with no extra cost'
IF below threshold, CTA should read 'change to monthly/annual + extras'
IF above threshold, Ts and Cs should show to allow users to know that there is a minimum spend, and any extra they are giving is out of choice.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Above threshold:
![image](https://user-images.githubusercontent.com/114918544/208479141-7d4eef7f-a76b-4e4a-8e87-9b317611eed1.png)

Below threshold:
![image](https://user-images.githubusercontent.com/114918544/208479071-143167fd-f1ea-4ffe-823a-412c94fa1e07.png)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
