### PR TITLE
Card component mobile layout tweaks

### DIFF
--- a/client/components/mma/accountoverview/AccountOverviewCardV2.tsx
+++ b/client/components/mma/accountoverview/AccountOverviewCardV2.tsx
@@ -203,7 +203,10 @@ export const AccountOverviewCardV2 = ({
 
 	return (
 		<Card>
-			<Card.Header backgroundColor={cardConfig.headerColor}>
+			<Card.Header
+				backgroundColor={cardConfig.headerColor}
+				minHeightTablet={true}
+			>
 				<div
 					css={css`
 						display: flex;

--- a/client/components/mma/accountoverview/AccountOverviewCardV2.tsx
+++ b/client/components/mma/accountoverview/AccountOverviewCardV2.tsx
@@ -205,7 +205,7 @@ export const AccountOverviewCardV2 = ({
 		<Card>
 			<Card.Header
 				backgroundColor={cardConfig.headerColor}
-				minHeightTablet={true}
+				minHeightTablet
 			>
 				<div
 					css={css`

--- a/client/components/mma/shared/Card.tsx
+++ b/client/components/mma/shared/Card.tsx
@@ -19,10 +19,7 @@ Card.Header = (props: {
 		border-top-right-radius: 8px;
 		${from.tablet} {
 			border-radius: 0;
-			${props.minHeightTablet &&
-			`
-				min-height: 128px;
-			`}
+			min-height: ${props.minHeightTablet ? '128px' : 'auto'};
 		}
 	`;
 

--- a/client/components/mma/shared/Card.tsx
+++ b/client/components/mma/shared/Card.tsx
@@ -9,7 +9,7 @@ export const Card = (props: { children: ReactNode }) => {
 Card.Header = (props: {
 	children: ReactNode;
 	backgroundColor?: string;
-	headerHeight?: number;
+	minHeightTablet?: boolean;
 }) => {
 	const headerCss = css`
 		padding: ${space[3]}px ${space[4]}px;
@@ -17,10 +17,12 @@ Card.Header = (props: {
 		background-color: ${props.backgroundColor ?? palette.neutral[97]};
 		border-top-left-radius: 8px;
 		border-top-right-radius: 8px;
-
 		${from.tablet} {
-			min-height: ${props.headerHeight ?? 128}px;
 			border-radius: 0;
+			${props.minHeightTablet &&
+			`
+				min-height: 128px;
+			`}
 		}
 	`;
 

--- a/client/components/mma/shared/Card.tsx
+++ b/client/components/mma/shared/Card.tsx
@@ -15,9 +15,12 @@ Card.Header = (props: {
 		padding: ${space[3]}px ${space[4]}px;
 		min-height: 64px;
 		background-color: ${props.backgroundColor ?? palette.neutral[97]};
+		border-top-left-radius: 8px;
+		border-top-right-radius: 8px;
 
 		${from.tablet} {
 			min-height: ${props.headerHeight ?? 128}px;
+			border-radius: 0;
 		}
 	`;
 
@@ -29,6 +32,14 @@ Card.Section = (props: { children: ReactNode; backgroundColor?: string }) => {
 		padding: ${space[5]}px ${space[4]}px;
 		border: 1px solid ${palette.neutral[86]};
 		border-top: none;
+		:last-of-type {
+			border-bottom-left-radius: 8px;
+			border-bottom-right-radius: 8px;
+			${from.tablet} {
+				border-radius: 0;
+			}
+		}
+
 		${props.backgroundColor &&
 		`
 			background-color: ${props.backgroundColor};

--- a/client/components/mma/switch/SwitchOptions.tsx
+++ b/client/components/mma/switch/SwitchOptions.tsx
@@ -132,10 +132,7 @@ const SwitchOptions = () => {
 					Your current support
 				</Heading>
 				<Card>
-					<Card.Header
-						backgroundColor={palette.brand[600]}
-						headerHeight={0}
-					>
+					<Card.Header backgroundColor={palette.brand[600]}>
 						<div css={cardHeaderDivCss}>
 							<h3 css={productTitleCss}>
 								{monthlyOrAnnual} support
@@ -175,10 +172,7 @@ const SwitchOptions = () => {
 					benefits
 				</p>
 				<Card>
-					<Card.Header
-						backgroundColor={palette.brand[500]}
-						headerHeight={0}
-					>
+					<Card.Header backgroundColor={palette.brand[500]}>
 						<div css={cardHeaderDivCss}>
 							<h3 css={productTitleCss}>{supporterPlusTitle}</h3>
 							{!aboveThreshold && (


### PR DESCRIPTION
## What does this change?

Adds rounded corners to cards on small viewports (to better match the design of the mobile app) and removes the default minimum header height applied at the `tablet` breakpoint as this is an exception that is only required on the _Account Overview_ page. (The new `minHeightTablet` prop can be used to opt in to this.)

## Images

<img width="383" alt="Screenshot 2023-01-04 at 17 29 04" src="https://user-images.githubusercontent.com/1166188/210615384-835930e8-85c5-4826-99cd-3c849c9cd9a4.png">
