### PR TITLE
Create app only URL and add text to Switch options page

### DIFF
--- a/client/components/mma/switch/SwitchContainer.tsx
+++ b/client/components/mma/switch/SwitchContainer.tsx
@@ -20,10 +20,13 @@ export interface SwitchRouterState {
 
 export interface SwitchContextInterface {
 	productDetail: ProductDetail;
+	isFromApp: Boolean;
 }
 
 export const SwitchContext: Context<SwitchContextInterface | {}> =
 	createContext({});
+
+const isFromApp = () => window?.location.hash.includes('from-app');
 
 const renderSingleProductOrReturnToAccountOverview = (
 	data: MembersDataApiItem[],
@@ -31,13 +34,19 @@ const renderSingleProductOrReturnToAccountOverview = (
 	const filteredProductDetails = data.filter(isProduct);
 
 	if (filteredProductDetails.length === 1) {
-		return contextAndOutletContainer(filteredProductDetails[0]);
+		return contextAndOutletContainer(
+			filteredProductDetails[0],
+			isFromApp(),
+		);
 	}
 	return <Navigate to="/" />;
 };
 
-const contextAndOutletContainer = (productDetail: ProductDetail) => (
-	<SwitchContext.Provider value={{ productDetail }}>
+const contextAndOutletContainer = (
+	productDetail: ProductDetail,
+	isFromApp: Boolean,
+) => (
+	<SwitchContext.Provider value={{ productDetail, isFromApp }}>
 		<Outlet />
 	</SwitchContext.Provider>
 );
@@ -53,7 +62,7 @@ const SwitchContainer = () => {
 			pageTitle={'Change your support'}
 		>
 			{productDetail ? (
-				contextAndOutletContainer(productDetail)
+				contextAndOutletContainer(productDetail, isFromApp())
 			) : (
 				<MembersDataApiAsyncLoader
 					fetch={createProductDetailFetcher(

--- a/client/components/mma/switch/SwitchOptions.tsx
+++ b/client/components/mma/switch/SwitchOptions.tsx
@@ -77,10 +77,8 @@ const buttonStuckCss = css`
 `;
 
 const fromAppHeadingCss = css`
-	${textSans.large({ fontWeight: 'bold' })}
+	${textSans.large({ fontWeight: 'bold', lineHeight: 'regular' })}
 	color:${palette.brand[500]};
-	line-height: 1.35;
-	border: 0;
 	margin-bottom: 0;
 `;
 
@@ -143,8 +141,8 @@ const SwitchOptions = () => {
 					>
 						To unlock unlimited reading in our news app, please make
 						a small change to your support type. If this doesn't
-						suit you, no change is needed, but note you will continue
-						to have limited app access.
+						suit you, no change is needed, but note you will
+						continue to have limited app access.
 					</p>
 				</div>
 			)}

--- a/client/components/mma/switch/SwitchOptions.tsx
+++ b/client/components/mma/switch/SwitchOptions.tsx
@@ -143,7 +143,7 @@ const SwitchOptions = () => {
 					>
 						To unlock unlimited reading in our news app, please make
 						a small change to your support type. If this doesn't
-						suit you, no change is needed, but not you will continue
+						suit you, no change is needed, but note you will continue
 						to have limited app access.
 					</p>
 				</div>

--- a/client/components/mma/switch/SwitchOptions.tsx
+++ b/client/components/mma/switch/SwitchOptions.tsx
@@ -76,6 +76,14 @@ const buttonStuckCss = css`
 	}
 `;
 
+const fromAppHeadingCss = css`
+	${textSans.large({ fontWeight: 'bold' })}
+	color:${palette.brand[500]};
+	line-height: 1.35;
+	border: 0;
+	margin-bottom: 0;
+`;
+
 const SwitchOptions = () => {
 	const switchContext = useContext(SwitchContext) as SwitchContextInterface;
 
@@ -122,6 +130,24 @@ const SwitchOptions = () => {
 
 	return (
 		<>
+			{switchContext.isFromApp && (
+				<div css={sectionSpacing}>
+					<h2 css={fromAppHeadingCss}>
+						Change your support to unlock unlimited reading in our
+						news app
+					</h2>
+					<p
+						css={css`
+							${textSans.medium()}
+						`}
+					>
+						To unlock unlimited reading in our news app, please make
+						a small change to your support type. If this doesn't
+						suit you, no change is needed, but not you will continue
+						to have limited app access.
+					</p>
+				</div>
+			)}
 			<section css={sectionSpacing}>
 				<Heading
 					sansSerif


### PR DESCRIPTION
## What does this change?

Background: Due to Apple laws we aren't able to express all of the copy we'd like to within the app, therefore we'd like a box to display if users come from the app. The expectation from our side is that users from the app would come directly to this page via a url with a string of text that would therefore expose the box of text.

This PR adds a specific URL for users coming from the app and persists this in context, and also adds additional copy on the switch options page

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Navigate to `/switch#from-app` and see the additional copy, without the extra URL specifier it should not be visible.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://user-images.githubusercontent.com/114918544/210846762-2371d1fb-0701-4159-a625-de95e8d2090c.png)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
