### PR TITLE
AB TEST -  hide the default onboarding trial newsletter

### DIFF
--- a/client/components/mma/identity/identity.ts
+++ b/client/components/mma/identity/identity.ts
@@ -113,7 +113,14 @@ export const ConsentOptions: ConsentOptionCollection = {
 		return await RemoveSubscriptionsAPI.execute();
 	},
 	newsletters(options: ConsentOption[]): ConsentOption[] {
-		return options.filter(isNewsletter);
+		return (
+			options
+				.filter(isNewsletter)
+				// @AB_TEST: Default Onboarding Newsletter Test: START
+				// Prevent trial newsletter from displaying.
+				.filter((newsletter: ConsentOption) => newsletter.id !== '6028') // identityId: 'saturday-roundup-trial'
+			// @AB_TEST: Default Onboarding Newsletter Test: END
+		);
 	},
 	consents(options: ConsentOption[]): ConsentOption[] {
 		return options.filter(isConsent);


### PR DESCRIPTION
## What does this change?

We a running a one month trial of a soft opt in default onboarding newsletter in the new registration onboarding flow.
https://github.com/guardian/gateway/pull/2105
 

Becasue this is a trial, we need to hide the newsletter from appearing in MMA. 
Users can still unsubscribe from the trial newsletter via the email footer, or by hitting unscubscribe ALL in MMA

This will be reverted when trial is over.


