### PR TITLE
Refactor zuora properties - remove old properties

### DIFF
--- a/client/components/mma/accountoverview/ContributionUpdateAmount.tsx
+++ b/client/components/mma/accountoverview/ContributionUpdateAmount.tsx
@@ -33,8 +33,7 @@ export const ContributionUpdateAmount = (
 	const [confirmedAmount, setConfirmedAmount] = useState<number | null>(null);
 
 	const mainPlan = props.mainPlan;
-	const currentAmount =
-		confirmedAmount || (mainPlan.price || mainPlan.amount || 0) / 100;
+	const currentAmount = confirmedAmount || mainPlan.price / 100;
 
 	if (status === Status.EDITING) {
 		return (
@@ -74,11 +73,7 @@ export const ContributionUpdateAmount = (
 					},
 					{
 						title: `${capitalize(
-							augmentBillingPeriod(
-								props.mainPlan.billingPeriod ||
-									props.mainPlan.interval ||
-									'',
-							),
+							augmentBillingPeriod(props.mainPlan.billingPeriod),
 						)} amount`,
 						value: `${
 							props.mainPlan.currency

--- a/client/components/mma/accountoverview/ContributionUpdateAmountForm.tsx
+++ b/client/components/mma/accountoverview/ContributionUpdateAmountForm.tsx
@@ -398,6 +398,7 @@ export const ContributionUpdateAmountForm = (
 						{shouldShowChoices && (
 							<ChoiceCardGroup
 								name="amounts"
+								data-cy="contribution-amount-choices"
 								label="Choose the amount to contribute"
 								columns={2}
 							>

--- a/client/components/mma/accountoverview/ContributionUpdateAmountForm.tsx
+++ b/client/components/mma/accountoverview/ContributionUpdateAmountForm.tsx
@@ -368,11 +368,7 @@ export const ContributionUpdateAmountForm = (
 						`}
 					>
 						{capitalize(
-							augmentBillingPeriod(
-								props.mainPlan.billingPeriod ||
-									props.mainPlan.interval ||
-									'',
-							),
+							augmentBillingPeriod(props.mainPlan.billingPeriod),
 						)}{' '}
 						amount
 					</dt>

--- a/client/components/mma/billing/Billing.tsx
+++ b/client/components/mma/billing/Billing.tsx
@@ -151,13 +151,10 @@ const BillingRenderer = ([mdaResponse, invoiceResponse]: [
 											productUrlPart:
 												specificProductType.urlPart,
 										}));
-									const resultsPerPage = (
-										paidPlan.billingPeriod ||
-										paidPlan.interval ||
-										''
-									)?.includes('year')
-										? productInvoiceData.length
-										: 6;
+									const resultsPerPage =
+										paidPlan.billingPeriod?.includes('year')
+											? productInvoiceData.length
+											: 6;
 									return (
 										<Fragment
 											key={

--- a/client/components/mma/cancel/contributions/ContributionsCancellationFlowFinancialSaveAttempt.tsx
+++ b/client/components/mma/cancel/contributions/ContributionsCancellationFlowFinancialSaveAttempt.tsx
@@ -120,9 +120,7 @@ const ContributionsCancellationFlowFinancialSaveAttempt: React.FC<
 
 					{showAmountUpdateForm ? (
 						<ContributionUpdateAmountForm
-							currentAmount={
-								(mainPlan.price || mainPlan.amount || 0) / 100
-							}
+							currentAmount={mainPlan.price / 100}
 							subscriptionId={
 								productDetail.subscription.subscriptionId
 							}

--- a/client/components/mma/cancel/contributions/ContributionsCancellationFlowPaymentIssueSaveAttempt.tsx
+++ b/client/components/mma/cancel/contributions/ContributionsCancellationFlowPaymentIssueSaveAttempt.tsx
@@ -151,9 +151,7 @@ const ContributionsCancellationFlowPaymentIssueSaveAttempt = (
 
 					{showAmountUpdateForm ? (
 						<ContributionUpdateAmountForm
-							currentAmount={
-								(mainPlan.price || mainPlan.amount || 0) / 100
-							}
+							currentAmount={mainPlan.price / 100}
 							subscriptionId={
 								productDetail.subscription.subscriptionId
 							}

--- a/client/components/mma/cancel/contributions/utils.ts
+++ b/client/components/mma/cancel/contributions/utils.ts
@@ -9,8 +9,5 @@ export const getIsPayingMinAmount = (mainPlan: PaidSubscriptionPlan) => {
 		mainPlan.billingPeriod as ContributionInterval
 	];
 
-	return (
-		(mainPlan.price || mainPlan.amount || 0) / 100 <=
-		currentContributionOptions.minAmount
-	);
+	return mainPlan.price / 100 <= currentContributionOptions.minAmount;
 };

--- a/client/components/mma/cancel/productSwitch/CancellationSwitchConfirmed.tsx
+++ b/client/components/mma/cancel/productSwitch/CancellationSwitchConfirmed.tsx
@@ -60,9 +60,7 @@ const CancellationSwitchConfirmed = () => {
 			<Stack space={3}>
 				<Heading>Your {newProduct.name} is now active</Heading>
 				<p css={[textSans.medium(), measure.copy]}>
-					Your{' '}
-					{newProduct.billing.billingPeriod?.name ||
-						newProduct.billing.interval?.name}
+					Your {newProduct.billing.billingPeriod.name}
 					ly {productSwitchContext.productType.friendlyName()} has
 					successfully been changed to a {newProduct.name}. We’ve
 					stopped your previous payments and started you on your new
@@ -137,8 +135,7 @@ const CancellationSwitchConfirmed = () => {
 						</li>
 						<li>
 							We'll stop your{' '}
-							{newProduct.billing.billingPeriod?.name ||
-								newProduct.billing.interval?.name}
+							{newProduct.billing.billingPeriod.name}
 							ly {productSwitchContext.productType.friendlyName()}{' '}
 							payments.
 						</li>

--- a/client/components/mma/cancel/productSwitch/CancellationSwitchReview.tsx
+++ b/client/components/mma/cancel/productSwitch/CancellationSwitchReview.tsx
@@ -246,9 +246,9 @@ const CancellationSwitchReview = () => {
 			return '';
 		}
 
-		return `${plan.currency}${(
-			(plan.price || plan.amount || 0) / 100
-		).toFixed(2)} per ${plan.billingPeriod || plan.interval || ''}`;
+		return `${plan.currency}${(plan.price / 100).toFixed(2)} per ${
+			plan.billingPeriod
+		}`;
 	};
 
 	const arrowIconWidth = 36;
@@ -462,8 +462,7 @@ const CancellationSwitchReview = () => {
 				<p css={[textSans.medium(), measure.copy]}>
 					If you decide to change your support to a{' '}
 					{chosenProduct.name} we’ll stop your{' '}
-					{chosenProduct.billing.billingPeriod?.name ||
-						chosenProduct.billing.interval?.name}
+					{chosenProduct.billing.billingPeriod.name}
 					ly {productSwitchContext.productType.friendlyName()}{' '}
 					payments straight away and you’ll have immediate access to
 					the benefits of a {chosenProduct.name}.
@@ -716,9 +715,7 @@ const CancellationSwitchReview = () => {
 							<ul css={listCss}>
 								<li>
 									We'll stop your{' '}
-									{chosenProduct.billing.billingPeriod
-										?.name ||
-										chosenProduct.billing.interval?.name}
+									{chosenProduct.billing.billingPeriod.name}
 									ly{' '}
 									{productSwitchContext.productType.friendlyName()}{' '}
 									payments.

--- a/client/components/mma/cancel/productSwitch/productSwitchApi.ts
+++ b/client/components/mma/cancel/productSwitch/productSwitchApi.ts
@@ -12,11 +12,7 @@ interface Currency {
 export interface Billing {
 	price: number;
 	currency: Currency;
-	billingPeriod?: {
-		name: BillingFrequency;
-		count: number;
-	};
-	interval?: {
+	billingPeriod: {
 		name: BillingFrequency;
 		count: number;
 	};
@@ -27,11 +23,7 @@ export interface IntroOfferBilling {
 	price?: number;
 	percentage?: number;
 	currency: Currency;
-	billingPeriod?: {
-		name: BillingFrequency;
-		count: number;
-	};
-	interval?: {
+	billingPeriod: {
 		name: BillingFrequency;
 		count: number;
 	};

--- a/client/components/mma/cancel/productSwitch/productSwitchHelpers.ts
+++ b/client/components/mma/cancel/productSwitch/productSwitchHelpers.ts
@@ -94,9 +94,7 @@ export const regularPrice = (product: AvailableProductsResponse): string => {
 export const regularBillingFrequency = (
 	product: AvailableProductsResponse,
 ): string => {
-	return `per ${
-		product.billing.billingPeriod?.name || product.billing.interval?.name
-	}`;
+	return `per ${product.billing.billingPeriod.name}`;
 };
 
 /**

--- a/client/components/mma/paymentUpdate/PaymentDetailUpdateConfirmation.tsx
+++ b/client/components/mma/paymentUpdate/PaymentDetailUpdateConfirmation.tsx
@@ -280,9 +280,7 @@ export const ConfirmedNewPaymentDetailsRenderer = ({
 										).toFixed(2)}{' '}
 										/{' '}
 										{getPaymentInterval(
-											mainPlan.billingPeriod ||
-												mainPlan.interval ||
-												'',
+											mainPlan.billingPeriod,
 										)}
 										{subscription.stripePublicKeyForCardAddition && (
 											<span>No Payment Method</span>

--- a/client/components/mma/shared/NextPaymentDetails.tsx
+++ b/client/components/mma/shared/NextPaymentDetails.tsx
@@ -39,10 +39,8 @@ export const getNextPaymentDetails = (
 			subscription.currentPlans.length !== 0 &&
 			isSixForSix(mainPlan.name) &&
 			planAfterMainPlan
-				? planAfterMainPlan.billingPeriod ||
-				  planAfterMainPlan.interval ||
-				  ''
-				: mainPlan.billingPeriod || mainPlan.interval || '';
+				? planAfterMainPlan.billingPeriod
+				: mainPlan.billingPeriod;
 
 		const paymentKey = `Next ${augmentBillingPeriod(
 			paymentInterval,
@@ -53,8 +51,8 @@ export const getNextPaymentDetails = (
 				? 'not applicable'
 				: `${mainPlan.currency}${(
 						overiddenAmount ||
-						(subscription.nextPaymentPrice ??
-							(mainPlan.price || mainPlan.amount || 0)) / 100.0
+						(subscription.nextPaymentPrice ?? mainPlan.price) /
+							100.0
 				  ).toFixed(2)} ${mainPlan.currencyISO}`;
 
 		const nextPaymentDateValue =
@@ -70,8 +68,7 @@ export const getNextPaymentDetails = (
 
 		const isNewPaymentValue =
 			planAfterMainPlan &&
-			(mainPlan.price || mainPlan.amount || 0) !==
-				planAfterMainPlan.price &&
+			mainPlan.price !== planAfterMainPlan.price &&
 			!isSixForSix(mainPlan.name);
 
 		return {

--- a/client/components/mma/switch/SwitchOptions.tsx
+++ b/client/components/mma/switch/SwitchOptions.tsx
@@ -83,7 +83,7 @@ const SwitchOptions = () => {
 	) as PaidSubscriptionPlan;
 
 	const monthlyOrAnnual = calculateMonthlyOrAnnualFromBillingPeriod(
-		mainPlan.interval || mainPlan.billingPeriod || '',
+		mainPlan.billingPeriod,
 	);
 	const supporterPlusTitle = `${monthlyOrAnnual} + extras`;
 
@@ -93,9 +93,8 @@ const SwitchOptions = () => {
 
 	const threshold =
 		monthlyOrAnnual == 'Monthly' ? monthlyThreshold : annualThreshold;
-	const aboveThreshold =
-		(mainPlan.amount || mainPlan.price || 0) >= threshold * 100;
-	const currentAmount = (mainPlan.amount || mainPlan.price || 0) / 100;
+	const aboveThreshold = mainPlan.price >= threshold * 100;
+	const currentAmount = mainPlan.price / 100;
 
 	const buttonContainerRef = useRef(null);
 	const [buttonIsStuck, setButtonIsStuck] = useState(false);
@@ -141,10 +140,7 @@ const SwitchOptions = () => {
 							</h3>
 							<p css={productSubtitleCss}>
 								{mainPlan.currency}
-								{currentAmount}/
-								{mainPlan.interval ||
-									mainPlan.billingPeriod ||
-									''}
+								{currentAmount}/{mainPlan.billingPeriod}
 							</p>
 						</div>
 					</Card.Header>
@@ -186,10 +182,7 @@ const SwitchOptions = () => {
 							{!aboveThreshold && (
 								<p css={productSubtitleCss}>
 									{mainPlan.currency}
-									{threshold}/
-									{mainPlan.interval ||
-										mainPlan.billingPeriod ||
-										''}
+									{threshold}/{mainPlan.billingPeriod}
 								</p>
 							)}
 						</div>

--- a/cypress/integration/parallel-2/updateContributionAmount.spec.ts
+++ b/cypress/integration/parallel-2/updateContributionAmount.spec.ts
@@ -1,0 +1,69 @@
+import { contribution } from '../../../client/fixtures/productDetail';
+import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
+
+describe('Update contribution amount', () => {
+	const setSignInStatus = () => {
+		cy.window().then((window) => {
+			// @ts-ignore
+			window.guardian.identityDetails = {
+				signInStatus: 'signedInRecently',
+				userId: '200006712',
+				displayName: 'user',
+				email: 'example@example.com',
+			};
+		});
+	};
+
+	beforeEach(() => {
+		cy.setCookie('GU_mvt_id', '0');
+
+		signInAndAcceptCookies();
+
+		cy.intercept('GET', '/api/me/mma?productType=Contribution', {
+			statusCode: 200,
+			body: [contribution],
+		});
+
+		cy.intercept('GET', '/api/me/mma', {
+			statusCode: 200,
+			body: [contribution],
+		});
+
+		cy.intercept('GET', '/api/cancelled/', {
+			statusCode: 200,
+			body: [],
+		}).as('cancelled');
+
+		cy.intercept('GET', '/api/me/mma/**', {
+			statusCode: 200,
+			body: { subscription: {} },
+		}).as('new_product_detail');
+
+		cy.intercept('POST', '/api/update/amount/contributions/**', {
+			statusCode: 200,
+		}).as('update_contribution_amount');
+	});
+
+	it('Update contribution amount', () => {
+		cy.visit('/');
+
+		setSignInStatus();
+
+		cy.findByText('Manage recurring support').click();
+		cy.wait('@cancelled');
+
+		cy.findByText('Change amount').click();
+
+		cy.get(
+			'[data-cy="contribution-amount-choices"] label:first-of-type',
+		).click();
+
+		cy.findByText('Change amount').click();
+
+		cy.wait('@update_contribution_amount');
+
+		cy.contains(
+			'We have successfully updated the amount of your contribution.',
+		).should('exist');
+	});
+});

--- a/shared/productResponse.ts
+++ b/shared/productResponse.ts
@@ -102,8 +102,7 @@ interface SepaDetails {
 interface CurrenyAndBillingPeriodDetail {
 	currency: string;
 	currencyISO: string;
-	billingPeriod?: string;
-	interval?: string;
+	billingPeriod: string;
 }
 
 // 6 weeks billingPeriod referes to GW 6 for 6 up front payment (not to be confused with one off contributions which don't come through in this response
@@ -119,8 +118,7 @@ export interface PaidSubscriptionPlan
 	start: string;
 	end: string;
 	chargedThrough?: string | null;
-	price?: number;
-	amount?: number;
+	price: number;
 }
 
 export function isPaidSubscriptionPlan(

--- a/shared/productTypes.tsx
+++ b/shared/productTypes.tsx
@@ -317,7 +317,7 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 
 			const paidPlan = mainPlan as PaidSubscriptionPlan;
 			return `${calculateMonthlyOrAnnualFromBillingPeriod(
-				paidPlan.billingPeriod || paidPlan.interval || '',
+				paidPlan.billingPeriod,
 			)} contribution`;
 		},
 		friendlyName: () => 'recurring contribution',
@@ -606,9 +606,7 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 
 			const paidMainPlan = mainPlan as PaidSubscriptionPlan;
 			return `${capitalize(
-				calculateSupporterPlusTitle(
-					paidMainPlan.billingPeriod || paidMainPlan.interval || '',
-				),
+				calculateSupporterPlusTitle(paidMainPlan.billingPeriod),
 			)}`;
 		},
 		friendlyName: (productDetail?: ProductDetail) => {
@@ -616,18 +614,9 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 				return 'recurring support';
 			}
 
-			const billingPeriod =
-				(
-					getMainPlan(
-						productDetail.subscription,
-					) as PaidSubscriptionPlan
-				).billingPeriod ||
-				(
-					getMainPlan(
-						productDetail.subscription,
-					) as PaidSubscriptionPlan
-				).interval ||
-				'';
+			const billingPeriod = (
+				getMainPlan(productDetail.subscription) as PaidSubscriptionPlan
+			).billingPeriod;
 			return calculateSupporterPlusTitle(billingPeriod);
 		},
 		productType: 'supporterplus',
@@ -646,18 +635,11 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 			alternateSummaryMainPara:
 				"This is immediate and you will not be charged again. If you've cancelled within the first 14 days, we'll send you a full refund.",
 			alternateSummaryHeading: (productDetail: ProductDetail) => {
-				const billingPeriod =
-					(
-						getMainPlan(
-							productDetail.subscription,
-						) as PaidSubscriptionPlan
-					).billingPeriod ||
-					(
-						getMainPlan(
-							productDetail.subscription,
-						) as PaidSubscriptionPlan
-					).interval ||
-					'';
+				const billingPeriod = (
+					getMainPlan(
+						productDetail.subscription,
+					) as PaidSubscriptionPlan
+				).billingPeriod;
 				return `${calculateMonthlyOrAnnualFromBillingPeriod(
 					billingPeriod,
 				)} support + extras cancelled`;


### PR DESCRIPTION
As mentioned in the [previous PR](https://github.com/guardian/manage-frontend/pull/947). This PR removes the old properties.

 The best way to review this PR would be to do a diff of this branch and the main branch before my last PR, and assert that the property names have changed accordingly.

I have also added a new Cypress test for the update contribution amount journey:

<img width="1509" alt="Screenshot 2023-01-06 at 14 48 14" src="https://user-images.githubusercontent.com/91546670/211035705-f020016e-5807-4c50-8132-62fc6372b571.png">