### PR TITLE
Refactor page grid, update title styles and remove breadcrumbs

### DIFF
--- a/client/__tests__/__snapshots__/main.test.tsx.snap
+++ b/client/__tests__/__snapshots__/main.test.tsx.snap
@@ -45,10 +45,9 @@ exports[`Main renders something 1`] = `
 }
 
 .emotion-3 {
+  display: grid;
   padding-left: 12px;
   padding-right: 12px;
-  display: -ms-grid;
-  -ms-grid-columns: (minmax(0, 1fr))[4];
   grid-template-columns: repeat(4, minmax(0, 1fr));
   grid-auto-columns: max-content;
   -webkit-column-gap: 20px;
@@ -62,24 +61,16 @@ exports[`Main renders something 1`] = `
   margin: auto;
 }
 
-@supports (display: grid) {
-  .emotion-3 {
-    display: grid;
-  }
-}
-
 @media (min-width: 740px) {
   .emotion-3 {
     padding-left: 20px;
     padding-right: 20px;
-    -ms-grid-columns: (minmax(0, 1fr))[12];
     grid-template-columns: repeat(12, minmax(0, 1fr));
   }
 }
 
 @media (min-width: 1300px) {
   .emotion-3 {
-    -ms-grid-columns: (minmax(0, 1fr))[16];
     grid-template-columns: repeat(16, minmax(0, 1fr));
   }
 }
@@ -87,9 +78,6 @@ exports[`Main renders something 1`] = `
 .emotion-4 {
   grid-column-start: -2;
   grid-column-end: span 1;
-  -ms-grid-column: 4;
-  -ms-grid-column-span: 1;
-  -ms-grid-row: 1;
   display: inline-block;
 }
 
@@ -99,9 +87,6 @@ exports[`Main renders something 1`] = `
     max-height: 51px;
     grid-column-start: -2;
     grid-column-end: span 1;
-    -ms-grid-column: 12;
-    -ms-grid-column-span: 1;
-    -ms-grid-row: 1;
   }
 }
 
@@ -109,9 +94,6 @@ exports[`Main renders something 1`] = `
   .emotion-4 {
     grid-column-start: -2;
     grid-column-end: span 1;
-    -ms-grid-column: 16;
-    -ms-grid-column-span: 1;
-    -ms-grid-row: 1;
   }
 }
 

--- a/client/__tests__/styles/grid.test.ts
+++ b/client/__tests__/styles/grid.test.ts
@@ -5,9 +5,6 @@ describe('grid.ts unit tests', () => {
 		const expected = {
 			gridColumnStart: '1',
 			gridColumnEnd: 'span 4',
-			msGridColumn: '1',
-			msGridColumnSpan: '4',
-			msGridRow: '1',
 		};
 		const result = gridItemPlacement(1, 4);
 		expect(JSON.stringify(result)).toEqual(JSON.stringify(expected));
@@ -17,11 +14,8 @@ describe('grid.ts unit tests', () => {
 		const expected = {
 			gridColumnStart: '-4',
 			gridColumnEnd: 'span 3',
-			msGridColumn: '8',
-			msGridColumnSpan: '3',
-			msGridRow: '1',
 		};
-		const result = gridItemPlacement(-4, 3, 10);
+		const result = gridItemPlacement(-4, 3);
 		expect(JSON.stringify(result)).toEqual(JSON.stringify(expected));
 	});
 });

--- a/client/components/mma/Page.tsx
+++ b/client/components/mma/Page.tsx
@@ -15,12 +15,19 @@ import type { LeftSideNavProps } from '../shared/nav/LeftSideNav';
 import { LeftSideNav } from '../shared/nav/LeftSideNav';
 import type { NavItem } from '../shared/nav/NavConfig';
 
+interface Breadcrumbs {
+	title: string;
+	link?: string;
+	currentPage?: boolean;
+}
+
 export interface PageContainerProps {
 	children: React.ReactNode;
 	selectedNavItem: NavItem;
 	pageTitle: string | ReactElement;
 	breadcrumbs?: Breadcrumbs[] | undefined;
 }
+
 export const PageContainer = (props: PageContainerProps) => (
 	<>
 		<PageHeaderContainer
@@ -40,24 +47,6 @@ interface PageHeaderContainerProps extends LeftSideNavProps {
 }
 
 const PageHeaderContainer = (props: PageHeaderContainerProps) => {
-	const gridBasev2 = css`
-		display: grid;
-		grid-template-columns: repeat(${gridColumns.default}, minmax(0, 1fr));
-		grid-auto-columns: max-content;
-		column-gap: ${space[5]}px;
-		${from.tablet} {
-			padding-left: ${space[5]}px;
-			padding-right: ${space[5]}px;
-			grid-template-columns: repeat(
-				${gridColumns.tabletAndDesktop},
-				minmax(0, 1fr)
-			);
-		}
-		${from.wide} {
-			grid-template-columns: repeat(${gridColumns.wide}, minmax(0, 1fr));
-		} ;
-	`;
-
 	const gridItemPlacementv2 = (
 		targetRow: number = 1,
 		rowSpan: number = 1,
@@ -71,50 +60,115 @@ const PageHeaderContainer = (props: PageHeaderContainerProps) => {
 			grid-row-end: span ${rowSpan};
 		`;
 	};
+
+	const containerCss = css`
+		border-bottom: 1px solid ${palette.neutral['86']};
+		margin-left: auto;
+		margin-right: auto;
+		background: ${palette.brand[300]};
+		${from.tablet} {
+			${!props.breadcrumbs && `padding-top: 100px;`}
+		}
+		${from.desktop} {
+			position: relative;
+		}
+	`;
+
+	const gridCss = css`
+		display: grid;
+		grid-template-columns: repeat(${gridColumns.default}, minmax(0, 1fr));
+		grid-auto-columns: max-content;
+		column-gap: ${space[5]}px;
+		padding-left: ${space[3]}px;
+		padding-right: ${space[3]}px;
+		max-width: calc(${breakpoints.wide}px + 2.5rem);
+		margin: auto;
+		color: ${palette.neutral['100']};
+		${from.tablet} {
+			padding-left: ${space[5]}px;
+			padding-right: ${space[5]}px;
+			grid-template-columns: repeat(
+				${gridColumns.tabletAndDesktop},
+				minmax(0, 1fr)
+			);
+		}
+		${from.wide} {
+			grid-template-columns: repeat(${gridColumns.wide}, minmax(0, 1fr));
+		} ;
+	`;
+
+	const breadcrumbCss = css`
+		display: none;
+		${gridItemPlacementv2(1, 1, 1, 3)};
+		${from.tablet} {
+			display: block;
+			padding: ${space[2]}px 0 0;
+			min-height: 100px;
+			${gridItemPlacementv2(1, 1, 1, 10)};
+		}
+		${from.desktop} {
+			${gridItemPlacementv2(1, 1, 5, 8)};
+		}
+		${from.wide} {
+			${gridItemPlacementv2(1, 1, 6, 10)};
+		}
+	`;
+
+	const titleCss = css`
+		max-width: calc(${breakpoints.wide}px + 2.5rem);
+		margin: 32px 0 0 0;
+		color: ${palette.neutral['100']};
+		${headline.medium({ fontWeight: 'bold' })};
+		font-size: 1.5rem;
+		padding: 8px;
+		border: 1px solid ${palette.brand[600]};
+		border-bottom: 0;
+		${from.tablet} {
+			line-height: 57px;
+			margin-top: 0;
+			padding: 0 8px;
+		}
+
+		${props.breadcrumbs
+			? `
+			${gridItemPlacementv2(2, 1, 1, 4)};
+			${from.mobileMedium} {
+				${gridItemPlacementv2(2, 1, 1, 3)};
+			};
+			${from.tablet} {
+				${gridItemPlacementv2(2, 1, 1, 10)};
+			};
+			${from.desktop} {
+				${gridItemPlacementv2(2, 1, 5, 8)};
+				font-size: 2.625rem;
+			};
+			${from.wide} {
+				${gridItemPlacementv2(2, 1, 6, 10)};
+			};
+		`
+			: `
+			${gridItemPlacementv2(1, 1, 1, 4)};
+			${from.mobileMedium} {
+				${gridItemPlacementv2(1, 1, 1, 3)};
+			};
+			${from.tablet} {
+				${gridItemPlacementv2(1, 1, 1, 10)};
+			};
+			${from.desktop} {
+				${gridItemPlacementv2(1, 1, 5, 8)};
+				font-size: 2.625rem;
+			};
+			${from.wide} {
+				${gridItemPlacementv2(1, 1, 6, 10)};
+			};
+		`}
+	`;
+
 	return (
-		<div
-			css={css`
-				border-bottom: 1px solid ${palette.neutral['86']};
-				margin-left: auto;
-				margin-right: auto;
-				background: ${palette.brand[300]};
-				${from.tablet} {
-					${!props.breadcrumbs && `padding-top: 100px;`}
-				}
-				${from.desktop} {
-					position: relative;
-				}
-			`}
-		>
-			<div
-				css={css`
-					padding-left: ${space[3]}px;
-					padding-right: ${space[3]}px;
-					max-width: calc(${breakpoints.wide}px + 2.5rem);
-					margin: auto;
-					color: ${palette.neutral['100']};
-					${gridBasev2};
-				`}
-			>
+		<div css={containerCss}>
+			<div css={gridCss}>
 				{props.breadcrumbs && (
-					<div
-						css={css`
-							display: none;
-							${gridItemPlacementv2(1, 1, 1, 3)};
-							${from.tablet} {
-								display: block;
-								padding: ${space[2]}px 0 0;
-								min-height: 100px;
-								${gridItemPlacementv2(1, 1, 1, 10)};
-							}
-							${from.desktop} {
-								${gridItemPlacementv2(1, 1, 5, 8)};
-							}
-							${from.wide} {
-								${gridItemPlacementv2(1, 1, 6, 10)};
-							}
-						`}
-					>
+					<div css={breadcrumbCss}>
 						{props.breadcrumbs.map((breadcrumbItem, index) => (
 							<React.Fragment key={`breadcrumb-${index}`}>
 								{breadcrumbItem.link ? (
@@ -150,59 +204,7 @@ const PageHeaderContainer = (props: PageHeaderContainerProps) => {
 						))}
 					</div>
 				)}
-				<h1
-					css={css`
-						max-width: calc(${breakpoints.wide}px + 2.5rem);
-						margin: 32px 0 0 0;
-						color: ${palette.neutral['100']};
-						${headline.medium({ fontWeight: 'bold' })};
-						font-size: 1.5rem;
-						padding: 8px;
-						border: 1px solid ${palette.brand[600]};
-						border-bottom: 0;
-						${from.tablet} {
-							line-height: 57px;
-							margin-top: 0;
-							padding: 0 8px;
-						}
-
-						${props.breadcrumbs
-							? `
-							${gridItemPlacementv2(2, 1, 1, 4)};
-							${from.mobileMedium} {
-								${gridItemPlacementv2(2, 1, 1, 3)};
-							};
-							${from.tablet} {
-								${gridItemPlacementv2(2, 1, 1, 10)};
-							};
-							${from.desktop} {
-								${gridItemPlacementv2(2, 1, 5, 8)};
-								font-size: 2.625rem;
-							};
-							${from.wide} {
-								${gridItemPlacementv2(2, 1, 6, 10)};
-							};
-						`
-							: `
-							${gridItemPlacementv2(1, 1, 1, 4)};
-							${from.mobileMedium} {
-								${gridItemPlacementv2(1, 1, 1, 3)};
-							};
-							${from.tablet} {
-								${gridItemPlacementv2(1, 1, 1, 10)};
-							};
-							${from.desktop} {
-								${gridItemPlacementv2(1, 1, 5, 8)};
-								font-size: 2.625rem;
-							};
-							${from.wide} {
-								${gridItemPlacementv2(1, 1, 6, 10)};
-							};
-						`}
-					`}
-				>
-					{props.title || <>&nbsp;</>}
-				</h1>
+				<h1 css={titleCss}>{props.title || <>&nbsp;</>}</h1>
 			</div>
 		</div>
 	);
@@ -268,9 +270,3 @@ const PageNavAndContentContainer = (props: PageNavAndContentContainerProps) => (
 		</section>
 	</div>
 );
-
-interface Breadcrumbs {
-	title: string;
-	link?: string;
-	currentPage?: boolean;
-}

--- a/client/components/mma/Page.tsx
+++ b/client/components/mma/Page.tsx
@@ -26,6 +26,7 @@ export interface PageContainerProps {
 	selectedNavItem: NavItem;
 	pageTitle: string | ReactElement;
 	breadcrumbs?: Breadcrumbs[] | undefined;
+	compactTitle?: boolean;
 }
 
 export const PageContainer = (props: PageContainerProps) => (
@@ -34,6 +35,7 @@ export const PageContainer = (props: PageContainerProps) => (
 			selectedNavItem={props.selectedNavItem}
 			title={props.pageTitle}
 			breadcrumbs={props.breadcrumbs}
+			compactTitle={props.compactTitle}
 		/>
 		<PageNavAndContentContainer selectedNavItem={props.selectedNavItem}>
 			{props.children}
@@ -44,6 +46,7 @@ export const PageContainer = (props: PageContainerProps) => (
 interface PageHeaderContainerProps extends LeftSideNavProps {
 	breadcrumbs?: Breadcrumbs[];
 	title: string | ReactElement;
+	compactTitle?: boolean;
 }
 
 const PageHeaderContainer = (props: PageHeaderContainerProps) => {
@@ -112,12 +115,24 @@ const PageHeaderContainer = (props: PageHeaderContainerProps) => {
 
 		${props.breadcrumbs && `grid-row: 2 / 3;`}
 
+		${props.compactTitle &&
+		`
+			${textSans.small({ fontWeight: 'bold' })};
+			margin-top: ${space[2]}px;
+		`}
+
 		${from.mobileMedium} {
 			grid-column: 1 / span 3;
 		}
 
 		${from.tablet} {
 			grid-column: 1 / span 10;
+
+			${props.compactTitle &&
+			`
+				${headline.xsmall({ fontWeight: 'bold' })};
+				margin-top: 28px;
+			`}
 		}
 
 		${from.desktop} {

--- a/client/components/mma/Page.tsx
+++ b/client/components/mma/Page.tsx
@@ -106,13 +106,9 @@ const PageHeaderContainer = (props: PageHeaderContainerProps) => {
 	const titleCss = css`
 		${headline.xsmall({ fontWeight: 'bold' })};
 		grid-column: 1 / span 4;
-		margin-top: 32px;
-		margin-bottom: 0;
-		padding: ${space[2]}px;
-		max-width: calc(${breakpoints.wide}px + 2.5rem);
+		margin-top: 28px;
+		margin-bottom: ${space[2]}px;
 		color: ${palette.neutral['100']};
-		border: 1px solid ${palette.brand[600]};
-		border-bottom: 0;
 
 		${props.breadcrumbs && `grid-row: 2 / 3;`}
 
@@ -122,16 +118,15 @@ const PageHeaderContainer = (props: PageHeaderContainerProps) => {
 
 		${from.tablet} {
 			grid-column: 1 / span 10;
-			margin-top: 0;
-			padding-top: 0;
-			padding-bottom: 0;
-			line-height: 57px;
 		}
 
 		${from.desktop} {
 			${headline.large({ fontWeight: 'bold' })};
-			line-height: 57px; // TODO: Replace with padding
 			grid-column: 5 / span 8;
+			margin: 0;
+			padding: ${space[1]}px ${space[2]}px;
+			border: 1px solid ${palette.brand[600]};
+			border-bottom: 0;
 		}
 
 		${from.wide} {

--- a/client/components/mma/Page.tsx
+++ b/client/components/mma/Page.tsx
@@ -47,20 +47,6 @@ interface PageHeaderContainerProps extends LeftSideNavProps {
 }
 
 const PageHeaderContainer = (props: PageHeaderContainerProps) => {
-	const gridItemPlacementv2 = (
-		targetRow: number = 1,
-		rowSpan: number = 1,
-		startingPos: number,
-		span: number,
-	) => {
-		return `
-			grid-column-start: ${startingPos};
-			grid-column-end: span ${span};
-			grid-row-start: ${targetRow};
-			grid-row-end: span ${rowSpan};
-		`;
-	};
-
 	const containerCss = css`
 		border-bottom: 1px solid ${palette.neutral['86']};
 		margin-left: auto;
@@ -79,10 +65,10 @@ const PageHeaderContainer = (props: PageHeaderContainerProps) => {
 		grid-template-columns: repeat(${gridColumns.default}, minmax(0, 1fr));
 		grid-auto-columns: max-content;
 		column-gap: ${space[5]}px;
+		margin: auto;
 		padding-left: ${space[3]}px;
 		padding-right: ${space[3]}px;
 		max-width: calc(${breakpoints.wide}px + 2.5rem);
-		margin: auto;
 		color: ${palette.neutral['100']};
 		${from.tablet} {
 			padding-left: ${space[5]}px;
@@ -99,69 +85,55 @@ const PageHeaderContainer = (props: PageHeaderContainerProps) => {
 
 	const breadcrumbCss = css`
 		display: none;
-		${gridItemPlacementv2(1, 1, 1, 3)};
+		grid-column: 1 / span 3;
 		${from.tablet} {
 			display: block;
 			padding: ${space[2]}px 0 0;
 			min-height: 100px;
-			${gridItemPlacementv2(1, 1, 1, 10)};
+			grid-column: 1 / span 10;
 		}
 		${from.desktop} {
-			${gridItemPlacementv2(1, 1, 5, 8)};
+			grid-column: 5 / span 8;
 		}
 		${from.wide} {
-			${gridItemPlacementv2(1, 1, 6, 10)};
+			grid-column: 6 / span 10;
 		}
 	`;
 
 	const titleCss = css`
-		max-width: calc(${breakpoints.wide}px + 2.5rem);
-		margin: 32px 0 0 0;
-		color: ${palette.neutral['100']};
 		${headline.medium({ fontWeight: 'bold' })};
+		grid-column: 1 / span 4;
+		max-width: calc(${breakpoints.wide}px + 2.5rem);
+		margin-top: 32px;
+		margin-bottom: 0;
+		padding: ${space[2]}px;
+		color: ${palette.neutral['100']};
 		font-size: 1.5rem;
-		padding: 8px;
 		border: 1px solid ${palette.brand[600]};
 		border-bottom: 0;
-		${from.tablet} {
-			line-height: 57px;
-			margin-top: 0;
-			padding: 0 8px;
+
+		${from.mobileMedium} {
+			grid-column: 1 / span 3;
 		}
 
-		${props.breadcrumbs
-			? `
-			${gridItemPlacementv2(2, 1, 1, 4)};
-			${from.mobileMedium} {
-				${gridItemPlacementv2(2, 1, 1, 3)};
-			};
-			${from.tablet} {
-				${gridItemPlacementv2(2, 1, 1, 10)};
-			};
-			${from.desktop} {
-				${gridItemPlacementv2(2, 1, 5, 8)};
-				font-size: 2.625rem;
-			};
-			${from.wide} {
-				${gridItemPlacementv2(2, 1, 6, 10)};
-			};
-		`
-			: `
-			${gridItemPlacementv2(1, 1, 1, 4)};
-			${from.mobileMedium} {
-				${gridItemPlacementv2(1, 1, 1, 3)};
-			};
-			${from.tablet} {
-				${gridItemPlacementv2(1, 1, 1, 10)};
-			};
-			${from.desktop} {
-				${gridItemPlacementv2(1, 1, 5, 8)};
-				font-size: 2.625rem;
-			};
-			${from.wide} {
-				${gridItemPlacementv2(1, 1, 6, 10)};
-			};
-		`}
+		${from.tablet} {
+			grid-column: 1 / span 10;
+			line-height: 57px;
+			margin-top: 0;
+			padding-top: 0;
+			padding-bottom: 0;
+		}
+
+		${from.desktop} {
+			grid-column: 5 / span 8;
+			font-size: 2.625rem;
+		}
+
+		${from.wide} {
+			grid-column: 6 / span 10;
+		}
+
+		${props.breadcrumbs && `grid-row: 2 / 3;`}
 	`;
 
 	return (

--- a/client/components/mma/Page.tsx
+++ b/client/components/mma/Page.tsx
@@ -1,10 +1,9 @@
 import { css } from '@emotion/react';
 import {
-	brand,
 	breakpoints,
 	from,
 	headline,
-	neutral,
+	palette,
 	space,
 	textSans,
 } from '@guardian/source-foundations';
@@ -41,55 +40,44 @@ interface PageHeaderContainerProps extends LeftSideNavProps {
 }
 
 const PageHeaderContainer = (props: PageHeaderContainerProps) => {
-	const gridBasev2 = () => {
-		return `
-      display: grid;
-      display: -ms-grid;
-      -ms-grid-columns: (minmax(0, 1fr))[${gridColumns.default}];
-      grid-template-columns: repeat(${gridColumns.default}, minmax(0, 1fr));
-      grid-auto-columns: max-content;
-      column-gap: ${space[5]}px;
-      ${from.tablet} {
-        padding-left: ${space[5]}px;
-        padding-right: ${space[5]}px;
-        -ms-grid-columns: (minmax(0, 1fr))[${gridColumns.tabletAndDesktop}];
-        grid-template-columns: repeat(${gridColumns.tabletAndDesktop}, minmax(0, 1fr));
-      };
-      ${from.wide} {
-        -ms-grid-columns: (minmax(0, 1fr))[${gridColumns.wide}];
-        grid-template-columns: repeat(${gridColumns.wide}, minmax(0, 1fr));
-      };
-    `;
-	};
+	const gridBasev2 = css`
+		display: grid;
+		grid-template-columns: repeat(${gridColumns.default}, minmax(0, 1fr));
+		grid-auto-columns: max-content;
+		column-gap: ${space[5]}px;
+		${from.tablet} {
+			padding-left: ${space[5]}px;
+			padding-right: ${space[5]}px;
+			grid-template-columns: repeat(
+				${gridColumns.tabletAndDesktop},
+				minmax(0, 1fr)
+			);
+		}
+		${from.wide} {
+			grid-template-columns: repeat(${gridColumns.wide}, minmax(0, 1fr));
+		} ;
+	`;
+
 	const gridItemPlacementv2 = (
 		targetRow: number = 1,
 		rowSpan: number = 1,
 		startingPos: number,
 		span: number,
-		columnsBreakpoint: number = gridColumns.default,
 	) => {
 		return `
-      grid-column-start: ${startingPos};
-      grid-column-end: span ${span};
-      grid-row-start: ${targetRow};
-      grid-row-end: span ${rowSpan};
-      ${startingPos > 0 ? `-ms-grid-column: ${startingPos};` : ''}
-      ${
-			startingPos < 0
-				? `-ms-grid-column: ${columnsBreakpoint + 2 + startingPos};`
-				: ''
-		}
-      -ms-grid-column-span: ${span};
-      -ms-grid-row: ${targetRow};
-    `;
+			grid-column-start: ${startingPos};
+			grid-column-end: span ${span};
+			grid-row-start: ${targetRow};
+			grid-row-end: span ${rowSpan};
+		`;
 	};
 	return (
 		<div
 			css={css`
-				border-bottom: 1px solid ${neutral['86']};
+				border-bottom: 1px solid ${palette.neutral['86']};
 				margin-left: auto;
 				margin-right: auto;
-				background: #0a1f47;
+				background: ${palette.brand[300]};
 				${from.tablet} {
 					${!props.breadcrumbs && `padding-top: 100px;`}
 				}
@@ -104,8 +92,8 @@ const PageHeaderContainer = (props: PageHeaderContainerProps) => {
 					padding-right: ${space[3]}px;
 					max-width: calc(${breakpoints.wide}px + 2.5rem);
 					margin: auto;
-					color: ${neutral['100']};
-					${gridBasev2()}
+					color: ${palette.neutral['100']};
+					${gridBasev2};
 				`}
 			>
 				{props.breadcrumbs && (
@@ -134,7 +122,7 @@ const PageHeaderContainer = (props: PageHeaderContainerProps) => {
 										to={breadcrumbItem.link}
 										css={css`
 											${textSans.medium()};
-											color: ${neutral[100]};
+											color: ${palette.neutral[100]};
 										`}
 									>
 										{breadcrumbItem.title}
@@ -148,7 +136,7 @@ const PageHeaderContainer = (props: PageHeaderContainerProps) => {
 														? 'bold'
 														: 'regular',
 											})};
-											color: ${neutral[100]};
+											color: ${palette.neutral[100]};
 										`}
 									>
 										{breadcrumbItem.title}
@@ -166,11 +154,11 @@ const PageHeaderContainer = (props: PageHeaderContainerProps) => {
 					css={css`
 						max-width: calc(${breakpoints.wide}px + 2.5rem);
 						margin: 32px 0 0 0;
-						color: ${neutral['100']};
+						color: ${palette.neutral['100']};
 						${headline.medium({ fontWeight: 'bold' })};
 						font-size: 1.5rem;
 						padding: 8px;
-						border: 1px solid ${brand[600]};
+						border: 1px solid ${palette.brand[600]};
 						border-bottom: 0;
 						${from.tablet} {
 							line-height: 57px;
@@ -180,37 +168,37 @@ const PageHeaderContainer = (props: PageHeaderContainerProps) => {
 
 						${props.breadcrumbs
 							? `
-                ${gridItemPlacementv2(2, 1, 1, 4)};
-                ${from.mobileMedium} {
-                  ${gridItemPlacementv2(2, 1, 1, 3)};
-                };
-                ${from.tablet} {
-                  ${gridItemPlacementv2(2, 1, 1, 10)};
-                };
-                ${from.desktop} {
-                  ${gridItemPlacementv2(2, 1, 5, 8)};
-                  font-size: 2.625rem;
-                };
-                ${from.wide} {
-                  ${gridItemPlacementv2(2, 1, 6, 10)};
-                };
-              `
+							${gridItemPlacementv2(2, 1, 1, 4)};
+							${from.mobileMedium} {
+								${gridItemPlacementv2(2, 1, 1, 3)};
+							};
+							${from.tablet} {
+								${gridItemPlacementv2(2, 1, 1, 10)};
+							};
+							${from.desktop} {
+								${gridItemPlacementv2(2, 1, 5, 8)};
+								font-size: 2.625rem;
+							};
+							${from.wide} {
+								${gridItemPlacementv2(2, 1, 6, 10)};
+							};
+						`
 							: `
-                ${gridItemPlacementv2(1, 1, 1, 4)};
-                ${from.mobileMedium} {
-                  ${gridItemPlacementv2(1, 1, 1, 3)};
-                };
-                ${from.tablet} {
-                  ${gridItemPlacementv2(1, 1, 1, 10)};
-                };
-                ${from.desktop} {
-                  ${gridItemPlacementv2(1, 1, 5, 8)};
-                  font-size: 2.625rem;
-                };
-                ${from.wide} {
-                  ${gridItemPlacementv2(1, 1, 6, 10)};
-                };
-              `}
+							${gridItemPlacementv2(1, 1, 1, 4)};
+							${from.mobileMedium} {
+								${gridItemPlacementv2(1, 1, 1, 3)};
+							};
+							${from.tablet} {
+								${gridItemPlacementv2(1, 1, 1, 10)};
+							};
+							${from.desktop} {
+								${gridItemPlacementv2(1, 1, 5, 8)};
+								font-size: 2.625rem;
+							};
+							${from.wide} {
+								${gridItemPlacementv2(1, 1, 6, 10)};
+							};
+						`}
 					`}
 				>
 					{props.title || <>&nbsp;</>}

--- a/client/components/mma/Page.tsx
+++ b/client/components/mma/Page.tsx
@@ -8,24 +8,15 @@ import {
 	textSans,
 } from '@guardian/source-foundations';
 import type { ReactElement } from 'react';
-import * as React from 'react';
-import { Link } from 'react-router-dom';
 import { gridBase, gridColumns, gridItemPlacement } from '../../styles/grid';
 import type { LeftSideNavProps } from '../shared/nav/LeftSideNav';
 import { LeftSideNav } from '../shared/nav/LeftSideNav';
 import type { NavItem } from '../shared/nav/NavConfig';
 
-interface Breadcrumbs {
-	title: string;
-	link?: string;
-	currentPage?: boolean;
-}
-
 export interface PageContainerProps {
 	children: React.ReactNode;
 	selectedNavItem: NavItem;
 	pageTitle: string | ReactElement;
-	breadcrumbs?: Breadcrumbs[] | undefined;
 	compactTitle?: boolean;
 }
 
@@ -34,7 +25,6 @@ export const PageContainer = (props: PageContainerProps) => (
 		<PageHeaderContainer
 			selectedNavItem={props.selectedNavItem}
 			title={props.pageTitle}
-			breadcrumbs={props.breadcrumbs}
 			compactTitle={props.compactTitle}
 		/>
 		<PageNavAndContentContainer selectedNavItem={props.selectedNavItem}>
@@ -44,22 +34,19 @@ export const PageContainer = (props: PageContainerProps) => (
 );
 
 interface PageHeaderContainerProps extends LeftSideNavProps {
-	breadcrumbs?: Breadcrumbs[];
 	title: string | ReactElement;
 	compactTitle?: boolean;
 }
 
 const PageHeaderContainer = (props: PageHeaderContainerProps) => {
 	const containerCss = css`
-		border-bottom: 1px solid ${palette.neutral['86']};
 		margin-left: auto;
 		margin-right: auto;
 		background: ${palette.brand[300]};
-		${from.tablet} {
-			${!props.breadcrumbs && `padding-top: 100px;`}
-		}
+		border-bottom: 1px solid ${palette.neutral['86']};
+
 		${from.desktop} {
-			position: relative;
+			padding-top: 100px;
 		}
 	`;
 
@@ -73,6 +60,7 @@ const PageHeaderContainer = (props: PageHeaderContainerProps) => {
 		padding-right: ${space[3]}px;
 		max-width: calc(${breakpoints.wide}px + 2.5rem);
 		color: ${palette.neutral['100']};
+
 		${from.tablet} {
 			padding-left: ${space[5]}px;
 			padding-right: ${space[5]}px;
@@ -81,29 +69,10 @@ const PageHeaderContainer = (props: PageHeaderContainerProps) => {
 				minmax(0, 1fr)
 			);
 		}
+
 		${from.wide} {
 			grid-template-columns: repeat(${gridColumns.wide}, minmax(0, 1fr));
 		} ;
-	`;
-
-	const breadcrumbCss = css`
-		display: none;
-		grid-column: 1 / span 3;
-
-		${from.tablet} {
-			display: block;
-			padding: ${space[2]}px 0 0;
-			min-height: 100px;
-			grid-column: 1 / span 10;
-		}
-
-		${from.desktop} {
-			grid-column: 5 / span 8;
-		}
-
-		${from.wide} {
-			grid-column: 6 / span 10;
-		}
 	`;
 
 	const titleCss = css`
@@ -113,8 +82,6 @@ const PageHeaderContainer = (props: PageHeaderContainerProps) => {
 		margin-top: 28px;
 		margin-bottom: ${space[2]}px;
 		color: ${palette.neutral['100']};
-
-		${props.breadcrumbs && `grid-row: 2 / 3;`}
 
 		${props.compactTitle &&
 		`
@@ -153,44 +120,7 @@ const PageHeaderContainer = (props: PageHeaderContainerProps) => {
 	return (
 		<div css={containerCss}>
 			<div css={gridCss}>
-				{props.breadcrumbs && (
-					<div css={breadcrumbCss}>
-						{props.breadcrumbs.map((breadcrumbItem, index) => (
-							<React.Fragment key={`breadcrumb-${index}`}>
-								{breadcrumbItem.link ? (
-									<Link
-										to={breadcrumbItem.link}
-										css={css`
-											${textSans.medium()};
-											color: ${palette.neutral[100]};
-										`}
-									>
-										{breadcrumbItem.title}
-									</Link>
-								) : (
-									<span
-										css={css`
-											${textSans.medium({
-												fontWeight:
-													breadcrumbItem.currentPage
-														? 'bold'
-														: 'regular',
-											})};
-											color: ${palette.neutral[100]};
-										`}
-									>
-										{breadcrumbItem.title}
-									</span>
-								)}
-								{props.breadcrumbs?.length &&
-									index < props.breadcrumbs?.length - 1 && (
-										<span>{' / '}</span>
-									)}
-							</React.Fragment>
-						))}
-					</div>
-				)}
-				<h1 css={titleCss}>{props.title || <>&nbsp;</>}</h1>
+				<h1 css={titleCss}>{props.title}</h1>
 			</div>
 		</div>
 	);

--- a/client/components/mma/Page.tsx
+++ b/client/components/mma/Page.tsx
@@ -108,7 +108,8 @@ const PageHeaderContainer = (props: PageHeaderContainerProps) => {
 
 	const titleCss = css`
 		${headline.xsmall({ fontWeight: 'bold' })};
-		grid-column: 1 / span 4;
+		font-size: 1.4375rem;
+		grid-column: 1 / -1;
 		margin-top: 28px;
 		margin-bottom: ${space[2]}px;
 		color: ${palette.neutral['100']};
@@ -118,20 +119,20 @@ const PageHeaderContainer = (props: PageHeaderContainerProps) => {
 		${props.compactTitle &&
 		`
 			${textSans.small({ fontWeight: 'bold' })};
-			margin-top: ${space[2]}px;
+			margin-top: ${space[1]}px;
+			margin-bottom: ${space[1]}px;
 		`}
 
 		${from.mobileMedium} {
-			grid-column: 1 / span 3;
+			${!props.compactTitle && `font-size: 1.5rem`};
 		}
 
 		${from.tablet} {
-			grid-column: 1 / span 10;
-
 			${props.compactTitle &&
 			`
 				${headline.xsmall({ fontWeight: 'bold' })};
 				margin-top: 28px;
+				margin-bottom: ${space[2]}px;
 			`}
 		}
 

--- a/client/components/mma/Page.tsx
+++ b/client/components/mma/Page.tsx
@@ -86,31 +86,35 @@ const PageHeaderContainer = (props: PageHeaderContainerProps) => {
 	const breadcrumbCss = css`
 		display: none;
 		grid-column: 1 / span 3;
+
 		${from.tablet} {
 			display: block;
 			padding: ${space[2]}px 0 0;
 			min-height: 100px;
 			grid-column: 1 / span 10;
 		}
+
 		${from.desktop} {
 			grid-column: 5 / span 8;
 		}
+
 		${from.wide} {
 			grid-column: 6 / span 10;
 		}
 	`;
 
 	const titleCss = css`
-		${headline.medium({ fontWeight: 'bold' })};
+		${headline.xsmall({ fontWeight: 'bold' })};
 		grid-column: 1 / span 4;
-		max-width: calc(${breakpoints.wide}px + 2.5rem);
 		margin-top: 32px;
 		margin-bottom: 0;
 		padding: ${space[2]}px;
+		max-width: calc(${breakpoints.wide}px + 2.5rem);
 		color: ${palette.neutral['100']};
-		font-size: 1.5rem;
 		border: 1px solid ${palette.brand[600]};
 		border-bottom: 0;
+
+		${props.breadcrumbs && `grid-row: 2 / 3;`}
 
 		${from.mobileMedium} {
 			grid-column: 1 / span 3;
@@ -118,22 +122,21 @@ const PageHeaderContainer = (props: PageHeaderContainerProps) => {
 
 		${from.tablet} {
 			grid-column: 1 / span 10;
-			line-height: 57px;
 			margin-top: 0;
 			padding-top: 0;
 			padding-bottom: 0;
+			line-height: 57px;
 		}
 
 		${from.desktop} {
+			${headline.large({ fontWeight: 'bold' })};
+			line-height: 57px; // TODO: Replace with padding
 			grid-column: 5 / span 8;
-			font-size: 2.625rem;
 		}
 
 		${from.wide} {
 			grid-column: 6 / span 10;
 		}
-
-		${props.breadcrumbs && `grid-row: 2 / 3;`}
 	`;
 
 	return (

--- a/client/components/mma/accountoverview/ManageProduct.tsx
+++ b/client/components/mma/accountoverview/ManageProduct.tsx
@@ -423,16 +423,6 @@ const ManageProduct = (props: WithGroupedProductType<GroupedProductType>) => {
 				props.groupedProductType.shortFriendlyName ||
 				props.groupedProductType.friendlyName()
 			}`}
-			breadcrumbs={[
-				{
-					title: NAV_LINKS.accountOverview.title,
-					link: NAV_LINKS.accountOverview.link,
-				},
-				{
-					title: `Manage ${props.groupedProductType.friendlyName()}`,
-					currentPage: true,
-				},
-			]}
 		>
 			{productDetail ? (
 				<InnerContent

--- a/client/components/mma/delivery/address/DeliveryAddressChangeContainer.tsx
+++ b/client/components/mma/delivery/address/DeliveryAddressChangeContainer.tsx
@@ -144,16 +144,6 @@ const DeliveryAddressChangeContainer = (
 					delivery details
 				</span>
 			}
-			breadcrumbs={[
-				{
-					title: NAV_LINKS.accountOverview.title,
-					link: NAV_LINKS.accountOverview.link,
-				},
-				{
-					title: 'Edit delivery address',
-					currentPage: true,
-				},
-			]}
 		>
 			<MembersDataApiAsyncLoader
 				render={renderContextAndOutletContainer(props.productType)}

--- a/client/components/mma/delivery/records/DeliveryRecordsContainer.tsx
+++ b/client/components/mma/delivery/records/DeliveryRecordsContainer.tsx
@@ -65,16 +65,6 @@ const DeliveryRecordsContainer = (
 		<PageContainer
 			selectedNavItem={NAV_LINKS.accountOverview}
 			pageTitle="Delivery history"
-			breadcrumbs={[
-				{
-					title: NAV_LINKS.accountOverview.title,
-					link: NAV_LINKS.accountOverview.link,
-				},
-				{
-					title: 'Delivery history',
-					currentPage: true,
-				},
-			]}
 		>
 			{productDetail ? (
 				<DeliveryRecordsApiAsyncLoader

--- a/client/components/mma/holiday/HolidayStopsContainer.tsx
+++ b/client/components/mma/holiday/HolidayStopsContainer.tsx
@@ -149,16 +149,6 @@ const HolidayStopsContainer = (
 		<PageContainer
 			selectedNavItem={NAV_LINKS.accountOverview}
 			pageTitle="Manage suspensions"
-			breadcrumbs={[
-				{
-					title: NAV_LINKS.accountOverview.title,
-					link: NAV_LINKS.accountOverview.link,
-				},
-				{
-					title: 'Manage suspensions',
-					currentPage: true,
-				},
-			]}
 		>
 			{productDetail ? (
 				productDetail.subscription.start ? (

--- a/client/components/mma/paymentUpdate/PaymentDetailUpdateContainer.tsx
+++ b/client/components/mma/paymentUpdate/PaymentDetailUpdateContainer.tsx
@@ -63,16 +63,6 @@ const PaymentDetailUpdateContainer = (props: WithProductType<ProductType>) => {
 		<PageContainer
 			selectedNavItem={navItemReferrer}
 			pageTitle="Manage payment method"
-			breadcrumbs={[
-				{
-					title: navItemReferrer.title,
-					link: navItemReferrer.link,
-				},
-				{
-					title: 'Manage payment method',
-					currentPage: true,
-				},
-			]}
 		>
 			{productDetail ? (
 				<PaymentUpdateProductDetailContext.Provider

--- a/client/components/mma/shared/assets/GridRoundel.tsx
+++ b/client/components/mma/shared/assets/GridRoundel.tsx
@@ -1,5 +1,5 @@
 import { from } from '@guardian/source-foundations';
-import { gridColumns, gridItemPlacement } from '../../../../styles/grid';
+import { gridItemPlacement } from '../../../../styles/grid';
 import type { RoundelProps } from './Roundel';
 import { Roundel } from './Roundel';
 
@@ -11,10 +11,10 @@ export const GridRoundel = (props: RoundelProps) => (
 			[from.tablet]: {
 				margin: 'auto',
 				maxHeight: '51px',
-				...gridItemPlacement(-2, 1, gridColumns.tabletAndDesktop),
+				...gridItemPlacement(-2, 1),
 			},
 			[from.wide]: {
-				...gridItemPlacement(-2, 1, gridColumns.wide),
+				...gridItemPlacement(-2, 1),
 			},
 		}}
 	>

--- a/client/components/mma/switch/SwitchContainer.tsx
+++ b/client/components/mma/switch/SwitchContainer.tsx
@@ -60,6 +60,7 @@ const SwitchContainer = () => {
 		<PageContainer
 			selectedNavItem={NAV_LINKS.accountOverview}
 			pageTitle={'Change your support'}
+			compactTitle
 		>
 			{productDetail ? (
 				contextAndOutletContainer(productDetail, isFromApp())

--- a/client/components/shared/Header.tsx
+++ b/client/components/shared/Header.tsx
@@ -1,6 +1,6 @@
 import { breakpoints, from, palette } from '@guardian/source-foundations';
 import { Link } from 'react-router-dom';
-import { gridBase, gridColumns, gridItemPlacement } from '../../styles/grid';
+import { gridBase, gridItemPlacement } from '../../styles/grid';
 import type { SignInStatus } from '../../utilities/signInStatus';
 import { GridRoundel } from '../mma/shared/assets/GridRoundel';
 import { DropdownNav } from './nav/DropdownNav';
@@ -76,15 +76,11 @@ const Header = ({ signInStatus, requiresSignIn }: HeaderProps) => (
 						[from.desktop]: {
 							position: 'relative',
 							left: '0.5rem',
-							...gridItemPlacement(
-								-4,
-								2,
-								gridColumns.tabletAndDesktop,
-							),
+							...gridItemPlacement(-4, 2),
 							marginLeft: 'auto',
 						},
 						[from.wide]: {
-							...gridItemPlacement(-4, 2, gridColumns.wide),
+							...gridItemPlacement(-4, 2),
 						},
 					}}
 				>

--- a/client/components/shared/nav/DropdownNav.tsx
+++ b/client/components/shared/nav/DropdownNav.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { brand, from, neutral, space } from '@guardian/source-foundations';
 import { useEffect, useRef, useState } from 'react';
-import { gridColumns, gridItemPlacement } from '../../../styles/grid';
+import { gridItemPlacement } from '../../../styles/grid';
 import { ProfileIcon } from '../../mma/shared/assets/ProfileIcon';
 import { expanderButtonCss } from '../ExpanderButton';
 import type { MenuSpecificNavItem } from './NavConfig';
@@ -151,11 +151,11 @@ export const DropdownNav = () => {
 				[from.desktop]: {
 					position: 'relative',
 					left: '0.5rem',
-					...gridItemPlacement(-4, 2, gridColumns.tabletAndDesktop),
+					...gridItemPlacement(-4, 2),
 					marginLeft: 'auto',
 				},
 				[from.wide]: {
-					...gridItemPlacement(-4, 2, gridColumns.wide),
+					...gridItemPlacement(-4, 2),
 				},
 				' button': {
 					[from.tablet]: {

--- a/client/styles/grid.ts
+++ b/client/styles/grid.ts
@@ -7,13 +7,9 @@ export const gridColumns = {
 };
 
 export const gridBase = {
+	display: 'grid',
 	paddingLeft: `${space[3]}px`,
 	paddingRight: `${space[3]}px`,
-	display: '-ms-grid',
-	'@supports (display: grid)': {
-		display: 'grid',
-	},
-	msGridColumns: `(minmax(0, 1fr))[${gridColumns.default}]`,
 	gridTemplateColumns: `repeat(${gridColumns.default}, minmax(0, 1fr))`,
 
 	gridAutoColumns: 'max-content',
@@ -21,11 +17,9 @@ export const gridBase = {
 	[from.tablet]: {
 		paddingLeft: `${space[5]}px`,
 		paddingRight: `${space[5]}px`,
-		msGridColumns: `(minmax(0, 1fr))[${gridColumns.tabletAndDesktop}]`,
 		gridTemplateColumns: `repeat(${gridColumns.tabletAndDesktop}, minmax(0, 1fr))`,
 	},
 	[from.wide]: {
-		msGridColumns: `(minmax(0, 1fr))[${gridColumns.wide}]`,
 		gridTemplateColumns: `repeat(${gridColumns.wide}, minmax(0, 1fr))`,
 	},
 };
@@ -33,16 +27,9 @@ export const gridBase = {
 export const gridItemPlacement = (
 	startingPos: number,
 	span: number,
-	columnsBreakpoint: number = gridColumns.default,
 ): object => {
 	return {
 		gridColumnStart: `${startingPos}`,
 		gridColumnEnd: `span ${span}`,
-		...(startingPos > 0 && { msGridColumn: `${startingPos}` }),
-		...(startingPos < 0 && {
-			msGridColumn: `${columnsBreakpoint + 2 + startingPos}`,
-		}),
-		msGridColumnSpan: `${span}`,
-		msGridRow: '1',
 	};
 };


### PR DESCRIPTION
## What does this change?

Removes the breadcrumb trail from the page header and updates page title styles for mobile, adding a new 'compact' style for the product switching flow.

As part of this change the grid layout styles have been refactored and simplified, and IE-specific `-ms` prefixed grid properties removed.

## Images

### Regular mobile title style

<img width="400" alt="Screenshot 2023-01-11 at 09 52 55" src="https://user-images.githubusercontent.com/1166188/211777882-1dc52c82-a979-4d7e-b6ad-7f236f6a40b1.png">

### Compact mobile title style

<img width="400" alt="Screenshot 2023-01-11 at 09 53 28" src="https://user-images.githubusercontent.com/1166188/211777893-a6c46f34-938e-4bb5-b9b1-8a7745971f52.png">
