### PR TITLE
Enable `eslint-comments/require-description` rule and add comments

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,7 +43,6 @@ module.exports = {
 		'@typescript-eslint/require-await': ['off'],
 		'@typescript-eslint/restrict-template-expressions': ['off'],
 		'@typescript-eslint/unbound-method': ['off'],
-		'eslint-comments/require-description': ['off'],
 		'import/no-cycle': ['off'],
 		'import/no-default-export': ['off'],
 		// Overrides carried over from old ESLint config.

--- a/client/__tests__/components/accountoverview/contributionUpdateAmount.test.tsx
+++ b/client/__tests__/components/accountoverview/contributionUpdateAmount.test.tsx
@@ -1,5 +1,4 @@
 // @ts-nocheck
-/* eslint jest/no-standalone-expect: "off", jest/no-done-callback: "off" */
 import { fireEvent, render, screen } from '@testing-library/react';
 import { ContributionUpdateAmount } from '../../../components/mma/accountoverview/ContributionUpdateAmount';
 

--- a/client/components/mma/identity/models.ts
+++ b/client/components/mma/identity/models.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable @typescript-eslint/naming-convention -- disabling this rule due to uncertainty around coupling between enum values and API responses in Identity code */
 export enum Theme {
 	news = 'news',
 	opinion = 'opinion',

--- a/client/components/mma/identity/useConsentOptions.ts
+++ b/client/components/mma/identity/useConsentOptions.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable @typescript-eslint/naming-convention -- disabling this rule due to uncertainty around coupling between enum values and API responses in Identity code */
 import * as Sentry from '@sentry/browser';
 import { useReducer } from 'react';
 import { trackEvent } from '../../../utilities/analytics';

--- a/client/components/shared/SectionContent.tsx
+++ b/client/components/shared/SectionContent.tsx
@@ -82,10 +82,9 @@ const divCss = (hasNav: boolean | undefined) => css`
 	}
 `;
 
-// TODO: refactor this var to remove need for disabling eslint rule
 export const SelectedTopicObjectContext = createContext<
 	Dispatch<SetStateAction<string | undefined>>
->(undefined!); // eslint-disable-line @typescript-eslint/no-non-null-assertion
+>(undefined!); // eslint-disable-line @typescript-eslint/no-non-null-assertion -- // TODO: refactor this var to remove need for disabling eslint rule
 
 export const SectionContent = (props: SectionContentProps) => {
 	const [selectedTopicId, setSelectedTopicId] = useState<string | undefined>(

--- a/client/utilities/gaStub.ts
+++ b/client/utilities/gaStub.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck : Ignoring next few lines to maintain GA's code snippet
 
 export const runGaStub = () => {
-	/* eslint-disable */
+	/* eslint-disable -- Ignoring next few lines to maintain GA's code snippet */
 	(function (i, s, o, g, r, a, m) {
 		i['GoogleAnalyticsObject'] = r;
 		(i[r] =


### PR DESCRIPTION
## What does this change?

Removes override for `eslint-comments/require-description` and adds comments where they are missing from `eslint-disable` comments 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

