### PR TITLE
Enable rule `'@typescript-eslint/unbound-method'`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,7 +42,6 @@ module.exports = {
 		'@typescript-eslint/prefer-reduce-type-parameter': ['off'],
 		'@typescript-eslint/require-await': ['off'],
 		'@typescript-eslint/restrict-template-expressions': ['off'],
-		'@typescript-eslint/unbound-method': ['off'],
 		'import/no-cycle': ['off'],
 		'import/no-default-export': ['off'],
 		// Overrides carried over from old ESLint config.

--- a/client/components/mma/shared/AsyncLoader.tsx
+++ b/client/components/mma/shared/AsyncLoader.tsx
@@ -82,6 +82,7 @@ export default class AsyncLoader<
 			return this.props.render(this.state.data, () =>
 				this.setState(
 					{ loadingState: LoadingState.Loading },
+					// eslint-disable-next-line -- supress @typescript-eslint/unbound-method on this line
 					this.componentDidMount,
 				),
 			);


### PR DESCRIPTION
## What does this change?

Removes override for  `'@typescript-eslint/unbound-method'` rule and suppress the error in the one place it failed, AsyncLoader, which should be deprecated soon 🤞.