### PR TITLE
Create Review Change Page - Your New Support Component

### DIFF
--- a/client/components/mma/MMAPage.tsx
+++ b/client/components/mma/MMAPage.tsx
@@ -38,6 +38,7 @@ import Maintenance from './maintenance/Maintenance';
 import MMAPageSkeleton from './MMAPageSkeleton';
 import SwitchContainer from './switch/SwitchContainer';
 import SwitchOptions from './switch/SwitchOptions';
+import SwitchReview from './switch/SwitchReview';
 
 const record = (event: any) => {
 	if (window.guardian?.ophan?.record) {
@@ -326,6 +327,10 @@ const MMARouter = () => {
 						/>
 						<Route path="/switch" element={<SwitchContainer />}>
 							<Route index element={<SwitchOptions />} />
+							<Route
+								path="/switch/review"
+								element={<SwitchReview />}
+							/>
 						</Route>
 						{Object.values(GROUPED_PRODUCT_TYPES).map(
 							(groupedProductType: GroupedProductType) => (

--- a/client/components/mma/accountoverview/AccountOverviewCardV2.tsx
+++ b/client/components/mma/accountoverview/AccountOverviewCardV2.tsx
@@ -10,7 +10,6 @@ import {
 	Button,
 	buttonThemeReaderRevenueBrand,
 } from '@guardian/source-react-components';
-import { useState } from 'react';
 import { useNavigate } from 'react-router';
 import { parseDate } from '../../../../shared/dates';
 import type { ProductDetail } from '../../../../shared/productResponse';
@@ -18,7 +17,6 @@ import { getMainPlan, isGift } from '../../../../shared/productResponse';
 import type { ProductTypeKeys } from '../../../../shared/productTypes';
 import { GROUPED_PRODUCT_TYPES } from '../../../../shared/productTypes';
 import { trackEvent } from '../../../utilities/analytics';
-import { expanderButtonCss } from '../../shared/ExpanderButton';
 import { ErrorIcon } from '../shared/assets/ErrorIcon';
 import { Card } from '../shared/Card';
 import { CardDisplay } from '../shared/CardDisplay';
@@ -30,7 +28,7 @@ import {
 } from '../shared/NextPaymentDetails';
 import { PaypalDisplay } from '../shared/PaypalDisplay';
 import { SepaDisplay } from '../shared/SepaDisplay';
-import { SupporterPlusBenefitsSection } from '../shared/SupporterPlusBenefits';
+import { SupporterPlusBenefitsToggle } from '../shared/SupporterPlusBenefits';
 
 interface ProductCardConfiguration {
 	headerColor: string;
@@ -83,7 +81,6 @@ export const AccountOverviewCardV2 = ({
 	isEligibleToSwitch: boolean;
 }) => {
 	const navigate = useNavigate();
-	const [showBenefits, setShowBenefits] = useState<boolean>(false);
 
 	const mainPlan = getMainPlan(productDetail.subscription);
 	if (!mainPlan) {
@@ -193,14 +190,6 @@ export const AccountOverviewCardV2 = ({
 		}
 	`;
 
-	const benefitsButtonCss = css`
-		${textSans.small()}
-		margin-top: ${space[1]}px;
-		padding: 0;
-		color: ${palette.brand[500]};
-		border-bottom: 1px solid ${palette.brand[500]};
-	`;
-
 	return (
 		<Card>
 			<Card.Header
@@ -256,26 +245,7 @@ export const AccountOverviewCardV2 = ({
 						{nextPaymentDetails.paymentInterval} support and extra
 						benefits.
 					</p>
-					<div
-						css={css`
-							margin: ${space[5]}px 0 ${space[4]}px 0;
-						`}
-						hidden={!showBenefits}
-					>
-						<SupporterPlusBenefitsSection />
-					</div>
-					<button
-						css={[
-							expanderButtonCss()(showBenefits),
-							benefitsButtonCss,
-						]}
-						type="button"
-						aria-expanded={showBenefits}
-						aria-controls="benefits"
-						onClick={() => setShowBenefits(!showBenefits)}
-					>
-						{showBenefits ? 'hide' : 'view'} benefits
-					</button>
+					<SupporterPlusBenefitsToggle />
 				</Card.Section>
 			)}
 			<Card.Section>

--- a/client/components/mma/shared/SupporterPlusBenefits.tsx
+++ b/client/components/mma/shared/SupporterPlusBenefits.tsx
@@ -1,6 +1,16 @@
 import { css } from '@emotion/react';
 import { from, palette, space, textSans } from '@guardian/source-foundations';
 import { SvgTickRound } from '@guardian/source-react-components';
+import { useState } from 'react';
+import { expanderButtonCss } from '../../shared/ExpanderButton';
+
+const benefitsButtonCss = css`
+	${textSans.small()}
+	margin-top: ${space[1]}px;
+	padding: 0;
+	color: ${palette.brand[500]};
+	border-bottom: 1px solid ${palette.brand[500]};
+`;
 
 export const SupporterPlusBenefitsSection = () => {
 	const benefitsCss = css`
@@ -62,5 +72,31 @@ export const SupporterPlusBenefitsSection = () => {
 				</span>
 			</li>
 		</ul>
+	);
+};
+
+export const SupporterPlusBenefitsToggle = () => {
+	const [showBenefits, setShowBenefits] = useState<boolean>(false);
+
+	return (
+		<>
+			<div
+				css={css`
+					margin: ${space[5]}px 0 ${space[4]}px 0;
+				`}
+				hidden={!showBenefits}
+			>
+				<SupporterPlusBenefitsSection />
+			</div>
+			<button
+				css={[expanderButtonCss()(showBenefits), benefitsButtonCss]}
+				type="button"
+				aria-expanded={showBenefits}
+				aria-controls="benefits"
+				onClick={() => setShowBenefits(!showBenefits)}
+			>
+				{showBenefits ? 'hide' : 'view'} benefits
+			</button>
+		</>
 	);
 };

--- a/client/components/mma/switch/SwitchOptions.tsx
+++ b/client/components/mma/switch/SwitchOptions.tsx
@@ -12,22 +12,16 @@ import {
 	buttonThemeReaderRevenueBrand,
 } from '@guardian/source-react-components';
 import { useContext, useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router';
 import type { PaidSubscriptionPlan } from '../../../../shared/productResponse';
 import { getMainPlan } from '../../../../shared/productResponse';
 import { calculateMonthlyOrAnnualFromBillingPeriod } from '../../../../shared/productTypes';
+import { sectionSpacing } from '../../../styles/spacing';
 import { Card } from '../shared/Card';
 import { Heading } from '../shared/Heading';
 import { SupporterPlusBenefitsSection } from '../shared/SupporterPlusBenefits';
 import type { SwitchContextInterface } from './SwitchContainer';
 import { SwitchContext } from './SwitchContainer';
-
-//TODO: this is copied from AccountOverviewV2, share it
-const sectionSpacing = css`
-	margin-top: ${space[6]}px;
-	${from.tablet} {
-		margin-top: ${space[9]}px;
-	}
-`;
 
 const cardHeaderDivCss = css`
 	display: flex;
@@ -111,6 +105,7 @@ const SwitchOptions = () => {
 	// top edge is similarly extended upwards so the button is considered fully
 	// visible when scrolling off the top of the screen.
 
+	// TODO: 'To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.' error in console
 	useEffect(() => {
 		const observer = new IntersectionObserver(
 			([entry]) => {
@@ -123,6 +118,8 @@ const SwitchOptions = () => {
 			observer.observe(buttonContainerRef.current);
 		}
 	}, [buttonContainerRef]);
+
+	const navigate = useNavigate();
 
 	return (
 		<>
@@ -221,6 +218,7 @@ const SwitchOptions = () => {
 						cssOverrides={css`
 							justify-content: center;
 						`}
+						onClick={() => navigate(`/switch/review`)}
 					>
 						{aboveThreshold
 							? 'Add extras with no extra cost'

--- a/client/components/mma/switch/SwitchOptions.tsx
+++ b/client/components/mma/switch/SwitchOptions.tsx
@@ -105,7 +105,6 @@ const SwitchOptions = () => {
 	// top edge is similarly extended upwards so the button is considered fully
 	// visible when scrolling off the top of the screen.
 
-	// TODO: 'To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.' error in console
 	useEffect(() => {
 		const observer = new IntersectionObserver(
 			([entry]) => {
@@ -117,6 +116,10 @@ const SwitchOptions = () => {
 		if (buttonContainerRef.current) {
 			observer.observe(buttonContainerRef.current);
 		}
+
+		return () => {
+			observer.disconnect();
+		};
 	}, [buttonContainerRef]);
 
 	const navigate = useNavigate();

--- a/client/components/mma/switch/SwitchReview.stories.tsx
+++ b/client/components/mma/switch/SwitchReview.stories.tsx
@@ -1,0 +1,22 @@
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import { ReactRouterDecorator } from '../../../../.storybook/ReactRouterDecorator';
+import { contribution } from '../../../fixtures/productDetail';
+import SwitchContainer from './SwitchContainer';
+import SwitchReview from './SwitchReview';
+
+export default {
+	title: 'Pages/SwitchReview',
+	component: SwitchContainer,
+	decorators: [ReactRouterDecorator],
+	parameters: {
+		layout: 'fullscreen',
+		reactRouter: {
+			state: { productDetail: contribution },
+			container: <SwitchContainer />,
+		},
+	},
+} as ComponentMeta<typeof SwitchContainer>;
+
+export const Default: ComponentStory<typeof SwitchReview> = () => (
+	<SwitchReview />
+);

--- a/client/components/mma/switch/SwitchReview.tsx
+++ b/client/components/mma/switch/SwitchReview.tsx
@@ -40,6 +40,12 @@ const SwitchReview = () => {
 		mainPlan.billingPeriod,
 	);
 	const supporterPlusTitle = `${monthlyOrAnnual} + extras`;
+	// ToDo: hardcoding this for now; need to find out where to get this from for each currency
+	const monthlyThreshold = 10;
+	const annualThreshold = 95;
+
+	const threshold =
+		monthlyOrAnnual == 'Monthly' ? monthlyThreshold : annualThreshold;
 
 	return (
 		<>
@@ -71,7 +77,8 @@ const SwitchReview = () => {
 									border-top: 1px solid ${palette.neutral[86]};
 								`}
 							>
-								£10/month
+								{mainPlan.currency}
+								{threshold}/{mainPlan.billingPeriod}
 							</p>
 						</Card.Section>
 					</Card>

--- a/client/components/mma/switch/SwitchReview.tsx
+++ b/client/components/mma/switch/SwitchReview.tsx
@@ -1,0 +1,79 @@
+import { css } from '@emotion/react';
+import {
+	from,
+	headline,
+	palette,
+	space,
+	textSans,
+} from '@guardian/source-foundations';
+import { useContext } from 'react';
+import type {
+	PaidSubscriptionPlan} from '../../../../shared/productResponse';
+import {
+	getMainPlan
+} from '../../../../shared/productResponse';
+import { calculateMonthlyOrAnnualFromBillingPeriod } from '../../../../shared/productTypes';
+import { sectionSpacing } from '../../../styles/spacing';
+import { Card } from '../shared/Card';
+import { Heading } from '../shared/Heading';
+import { SupporterPlusBenefitsToggle } from '../shared/SupporterPlusBenefits';
+import type { SwitchContextInterface } from './SwitchContainer';
+import { SwitchContext } from './SwitchContainer';
+
+// TODO: this is copied from SwitchOptions, share it
+const productTitleCss = css`
+	${headline.xsmall({ fontWeight: 'bold' })};
+	color: ${palette.neutral[100]};
+	margin: 0;
+	max-width: 20ch;
+	${from.tablet} {
+		${headline.small({ fontWeight: 'bold' })};
+	}
+`;
+
+const SwitchReview = () => {
+	const switchContext = useContext(SwitchContext) as SwitchContextInterface;
+	const productDetail = switchContext.productDetail;
+	const mainPlan = getMainPlan(
+		productDetail.subscription,
+	) as PaidSubscriptionPlan;
+
+	const monthlyOrAnnual = calculateMonthlyOrAnnualFromBillingPeriod(
+		mainPlan.billingPeriod,
+	);
+	const supporterPlusTitle = `${monthlyOrAnnual} + extras`;
+
+	return (
+		<>
+			<section css={sectionSpacing}>
+				<Heading
+					sansSerif
+					cssOverrides={css`
+						margin-bottom: ${space[3]}px;
+					`}
+				>
+					Your new support
+				</Heading>
+				<Card>
+					<Card.Header backgroundColor={palette.brand[500]}>
+						<h3 css={productTitleCss}>{supporterPlusTitle}</h3>
+					</Card.Header>
+					<Card.Section>
+						<div
+							css={css`
+								${textSans.medium()}
+							`}
+						>
+							Monthly support with exclusive extras including
+							unlimited access to the App
+						</div>
+						<SupporterPlusBenefitsToggle />
+						<div>£10</div>
+					</Card.Section>
+				</Card>
+			</section>
+		</>
+	);
+};
+
+export default SwitchReview;

--- a/client/components/mma/switch/SwitchReview.tsx
+++ b/client/components/mma/switch/SwitchReview.tsx
@@ -6,12 +6,10 @@ import {
 	space,
 	textSans,
 } from '@guardian/source-foundations';
+import { Stack } from '@guardian/source-react-components';
 import { useContext } from 'react';
-import type {
-	PaidSubscriptionPlan} from '../../../../shared/productResponse';
-import {
-	getMainPlan
-} from '../../../../shared/productResponse';
+import type { PaidSubscriptionPlan } from '../../../../shared/productResponse';
+import { getMainPlan } from '../../../../shared/productResponse';
 import { calculateMonthlyOrAnnualFromBillingPeriod } from '../../../../shared/productTypes';
 import { sectionSpacing } from '../../../styles/spacing';
 import { Card } from '../shared/Card';
@@ -46,31 +44,38 @@ const SwitchReview = () => {
 	return (
 		<>
 			<section css={sectionSpacing}>
-				<Heading
-					sansSerif
-					cssOverrides={css`
-						margin-bottom: ${space[3]}px;
-					`}
-				>
-					Your new support
-				</Heading>
-				<Card>
-					<Card.Header backgroundColor={palette.brand[500]}>
-						<h3 css={productTitleCss}>{supporterPlusTitle}</h3>
-					</Card.Header>
-					<Card.Section>
-						<div
-							css={css`
-								${textSans.medium()}
-							`}
-						>
-							Monthly support with exclusive extras including
-							unlimited access to the App
-						</div>
-						<SupporterPlusBenefitsToggle />
-						<div>£10</div>
-					</Card.Section>
-				</Card>
+				<Stack space={3}>
+					<Heading sansSerif>Your new support</Heading>
+					<Card>
+						<Card.Header backgroundColor={palette.brand[500]}>
+							<h3 css={productTitleCss}>{supporterPlusTitle}</h3>
+						</Card.Header>
+						<Card.Section>
+							<p
+								css={css`
+									${textSans.medium()};
+									margin: 0;
+									max-width: 40ch;
+								`}
+							>
+								Monthly support with exclusive extras including
+								unlimited access to the App
+							</p>
+							<SupporterPlusBenefitsToggle />
+							<p
+								css={css`
+									${textSans.medium({ fontWeight: 'bold' })};
+									padding-top: ${space[3]}px;
+									margin-top: ${space[4]}px;
+									margin-bottom: 0;
+									border-top: 1px solid ${palette.neutral[86]};
+								`}
+							>
+								£10/month
+							</p>
+						</Card.Section>
+					</Card>
+				</Stack>
 			</section>
 		</>
 	);

--- a/client/styles/spacing.ts
+++ b/client/styles/spacing.ts
@@ -1,0 +1,9 @@
+import { css } from '@emotion/react';
+import { from, space } from '@guardian/source-foundations';
+
+export const sectionSpacing = css`
+	margin-top: ${space[6]}px;
+	${from.tablet} {
+		margin-top: ${space[9]}px;
+	}
+`;


### PR DESCRIPTION
## What does this change?

Adds the Review Change page and the 'Your New Support Component'

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Navigate to `/switch` then click the 'Change to monthly + extras' button. Witness the new page navigated to.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->


<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->


<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://user-images.githubusercontent.com/114918544/212652251-2b40769c-5e7c-4666-9626-670efeda1fd2.png)
![image](https://user-images.githubusercontent.com/114918544/212652288-47357c77-cbd8-4146-ba3d-80e100dc488d.png)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
