### PR TITLE
Add Headline Summary to review page

### DIFF
--- a/client/components/mma/switch/SwitchReview.tsx
+++ b/client/components/mma/switch/SwitchReview.tsx
@@ -51,6 +51,19 @@ const SwitchReview = () => {
 		<>
 			<section css={sectionSpacing}>
 				<Stack space={3}>
+					<section>
+						<Heading sansSerif>Review change</Heading>
+						<p
+							css={css`
+								${textSans.medium()};
+							`}
+						>
+							You will now support us with {mainPlan.currency}
+							{threshold} every month, giving you exclusive
+							supporter extras, including unlimited reading in our
+							news app
+						</p>
+					</section>
 					<Heading sansSerif>Your new support</Heading>
 					<Card>
 						<Card.Header backgroundColor={palette.brand[500]}>

--- a/client/components/mma/switch/SwitchReview.tsx
+++ b/client/components/mma/switch/SwitchReview.tsx
@@ -59,9 +59,9 @@ const SwitchReview = () => {
 							`}
 						>
 							You will now support us with {mainPlan.currency}
-							{threshold} every month, giving you exclusive
-							supporter extras, including unlimited reading in our
-							news app
+							{threshold} every {mainPlan.billingPeriod}, giving
+							you exclusive supporter extras, including unlimited
+							reading in our news app
 						</p>
 					</section>
 					<Heading sansSerif>Your new support</Heading>
@@ -77,8 +77,8 @@ const SwitchReview = () => {
 									max-width: 40ch;
 								`}
 							>
-								Monthly support with exclusive extras including
-								unlimited access to the App
+								{monthlyOrAnnual} support with exclusive extras
+								including unlimited access to the App
 							</p>
 							<SupporterPlusBenefitsToggle />
 							<p


### PR DESCRIPTION
## What does this change?

Add a summary of the user's changes

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Navigate to `/switch` then click the 'Change to monthly + extras' button. Witness the new page navigated to.


<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->


<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->


<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
![image](https://user-images.githubusercontent.com/114918544/212718093-90a04a73-ce07-4969-9f83-40db7932f05e.png)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
