### PR TITLE
Test switching flow from app and back again

### DIFF
--- a/client/components/mma/MMAPage.tsx
+++ b/client/components/mma/MMAPage.tsx
@@ -324,14 +324,27 @@ const MMARouter = () => {
 							path="/account-settings"
 							element={<Settings />}
 						/>
-						<Route path="/switch" element={<SwitchContainer />}>
-							<Route index element={<SwitchOptions />} />
-							<Route path="review" element={<SwitchReview />} />
+						{[
+							{ path: '/switch', fromApp: false },
+							{ path: '/app/switch', fromApp: true },
+						].map(({ path, fromApp }) => (
 							<Route
-								path="complete"
-								element={<SwitchComplete />}
-							/>
-						</Route>
+								key={path}
+								path={path}
+								element={<SwitchContainer fromApp={fromApp} />}
+							>
+								<Route index element={<SwitchOptions />} />
+								<Route
+									path="review"
+									element={<SwitchReview />}
+								/>
+								<Route
+									path="complete"
+									element={<SwitchComplete />}
+								/>
+							</Route>
+						))}
+						;
 						{Object.values(GROUPED_PRODUCT_TYPES).map(
 							(groupedProductType: GroupedProductType) => (
 								<Route
@@ -497,7 +510,6 @@ const MMARouter = () => {
 								</Route>
 							),
 						)}
-
 						{Object.values(PRODUCT_TYPES)
 							.filter(shouldHaveHolidayStopsFlow)
 							.map(

--- a/client/components/mma/switch/SwitchComplete.tsx
+++ b/client/components/mma/switch/SwitchComplete.tsx
@@ -1,12 +1,9 @@
 import { css } from '@emotion/react';
 import { from, palette, until } from '@guardian/source-foundations';
-import { Stack } from '@guardian/source-react-components';
+import { LinkButton, Stack } from '@guardian/source-react-components';
 import { useContext } from 'react';
-import type {
-	PaidSubscriptionPlan} from '../../../../shared/productResponse';
-import {
-	getMainPlan
-} from '../../../../shared/productResponse';
+import type { PaidSubscriptionPlan } from '../../../../shared/productResponse';
+import { getMainPlan } from '../../../../shared/productResponse';
 import { calculateMonthlyOrAnnualFromBillingPeriod } from '../../../../shared/productTypes';
 import { sectionSpacing } from '../../../styles/spacing';
 import { Heading } from '../shared/Heading';
@@ -31,6 +28,10 @@ export const SwitchComplete = () => {
 		monthlyOrAnnual == 'Monthly' ? monthlyThreshold : annualThreshold;
 	const newAmount = Math.max(threshold, mainPlan.price / 100);
 
+	const continueReadingLink = switchContext.isFromApp
+		? 'x-gu://mma/success'
+		: 'https://www.theguardian.com';
+
 	return (
 		<section css={sectionSpacing}>
 			<Stack space={3}>
@@ -40,6 +41,11 @@ export const SwitchComplete = () => {
 						newAmount={newAmount}
 					/>
 				)}
+				<div>
+					<LinkButton href={continueReadingLink}>
+						Continue reading the Guardian
+					</LinkButton>
+				</div>
 			</Stack>
 		</section>
 	);

--- a/client/components/mma/switch/SwitchContainer.tsx
+++ b/client/components/mma/switch/SwitchContainer.tsx
@@ -30,18 +30,18 @@ export interface SwitchContextInterface {
 export const SwitchContext: Context<SwitchContextInterface | {}> =
 	createContext({});
 
-const isFromApp = () => window?.location.hash.includes('from-app');
-
-export const SwitchContainer = () => {
+export const SwitchContainer = (props: { fromApp?: boolean }) => {
 	const location = useLocation();
 	const routerState = location.state as SwitchRouterState;
 	const productDetail = routerState?.productDetail;
 
 	if (!productDetail) {
-		return <AsyncLoadedSwitchContainer />;
+		return <AsyncLoadedSwitchContainer fromApp={props.fromApp} />;
 	}
 
-	return <RenderedPage productDetail={productDetail} />;
+	return (
+		<RenderedPage productDetail={productDetail} fromApp={props.fromApp} />
+	);
 };
 
 const SwitchPageContainer = (props: { children: ReactNode }) => {
@@ -56,7 +56,7 @@ const SwitchPageContainer = (props: { children: ReactNode }) => {
 	);
 };
 
-const AsyncLoadedSwitchContainer = () => {
+const AsyncLoadedSwitchContainer = (props: { fromApp?: boolean }) => {
 	const request = createProductDetailFetcher(
 		PRODUCT_TYPES.contributions.allProductsProductTypeFilterString,
 	);
@@ -90,16 +90,21 @@ const AsyncLoadedSwitchContainer = () => {
 	}
 
 	const productDetail = data.products.filter(isProduct)[0];
-	return <RenderedPage productDetail={productDetail} />;
+	return (
+		<RenderedPage productDetail={productDetail} fromApp={props.fromApp} />
+	);
 };
 
-const RenderedPage = (props: { productDetail: ProductDetail }) => {
+const RenderedPage = (props: {
+	productDetail: ProductDetail;
+	fromApp?: boolean;
+}) => {
 	return (
 		<SwitchPageContainer>
 			<SwitchContext.Provider
 				value={{
 					productDetail: props.productDetail,
-					isFromApp: isFromApp(),
+					isFromApp: props.fromApp,
 				}}
 			>
 				<Outlet />


### PR DESCRIPTION
## What does this change?

Adds a `/app/switch` route for switching journeys initiated by the app and a placeholder 'return to app' button for testing.