### PR TITLE
Change useAsyncLoader to use an enum to track state

### DIFF
--- a/client/components/mma/shared/asyncComponents/LoadingComponent.tsx
+++ b/client/components/mma/shared/asyncComponents/LoadingComponent.tsx
@@ -1,4 +1,3 @@
-import { useAsyncLoader } from '../../../../utilities/hooks/useAsyncLoader';
 import {
 	LoadingState,
 	useAsyncLoader,

--- a/client/components/mma/shared/asyncComponents/LoadingComponent.tsx
+++ b/client/components/mma/shared/asyncComponents/LoadingComponent.tsx
@@ -1,4 +1,8 @@
 import { useAsyncLoader } from '../../../../utilities/hooks/useAsyncLoader';
+import {
+	LoadingState,
+	useAsyncLoader,
+} from '../../../../utilities/hooks/useAsyncLoader';
 import type { ResponseProcessor } from './ResponseProcessor';
 
 export type LoadingProps = {
@@ -16,15 +20,15 @@ export function LoadingComponent({
 	LoadedView,
 	ErrorView,
 }: LoadingProps) {
-	const { data, isLoading, error } = useAsyncLoader<any>(
-		asyncFetch(),
+	const { data, loadingState } = useAsyncLoader<any>(
+		asyncFetch,
 		responseProcessor,
 	);
 
-	if (error) {
+	if (loadingState == LoadingState.HasError) {
 		return <ErrorView />;
 	}
-	if (isLoading) {
+	if (loadingState == LoadingState.IsLoading) {
 		return <LoadingView />;
 	}
 

--- a/client/utilities/hooks/useAsyncLoader.ts
+++ b/client/utilities/hooks/useAsyncLoader.ts
@@ -3,19 +3,28 @@ import { useEffect, useState } from 'react';
 import type { ResponseProcessor } from '../../components/mma/shared/asyncComponents/ResponseProcessor';
 import { trackEvent } from '../analytics';
 
+export enum LoadingState {
+	IsLoading,
+	HasLoaded,
+	HasError,
+}
+
 export function useAsyncLoader<T>(
-	promiseFromAsyncFetch: Promise<any>,
+	asyncFetch: () => Promise<any>,
 	responseProcessor: ResponseProcessor,
 ): {
 	data: T | null;
 	error: Error | ErrorEvent | string | undefined;
-	isLoading: boolean;
+	loadingState: LoadingState;
 } {
 	const [data, setData] = useState<T | null>(null);
 	const [error, setError] = useState<Error | ErrorEvent | string>();
-	const [isLoading, setIsLoading] = useState<boolean>(true);
+	const [loadingState, setLoadingState] = useState<LoadingState>(
+		LoadingState.IsLoading,
+	);
 
 	function handleError(error: Error | ErrorEvent | string): void {
+		setLoadingState(LoadingState.HasError);
 		setError(error);
 		trackEvent({
 			eventCategory: 'asyncLoader',
@@ -26,12 +35,16 @@ export function useAsyncLoader<T>(
 	}
 
 	useEffect(() => {
-		promiseFromAsyncFetch
-			.then((response) => responseProcessor(response))
-			.then(setData)
-			.catch((e) => handleError(e))
-			.finally(() => setIsLoading(false));
-	}, [promiseFromAsyncFetch]);
+		if (loadingState == LoadingState.IsLoading) {
+			asyncFetch()
+				.then((response) => responseProcessor(response))
+				.then((data) => {
+					setData(data);
+					setLoadingState(LoadingState.HasLoaded);
+				})
+				.catch((e) => handleError(e));
+		}
+	}, [loadingState]);
 
-	return { data, error, isLoading };
+	return { data, error, loadingState };
 }


### PR DESCRIPTION
Change promiseFromAsync fetch to be a callback instead of a promise

Co-Authored-By: Kent McClymont <111352918+KentGrm@users.noreply.github.com>

## What does this change?

Changes useAsyncLoader to use an enum to track state. Also change the fetch to be a callback instead of a promise to stop it firing indefinitely. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

