### PR TITLE
Product switch confirmation section and Ts&Cs

### DIFF
--- a/client/components/mma/switch/SwitchReview.stories.tsx
+++ b/client/components/mma/switch/SwitchReview.stories.tsx
@@ -2,7 +2,7 @@ import type { ComponentMeta, ComponentStory } from '@storybook/react';
 import { rest } from 'msw';
 import { ReactRouterDecorator } from '../../../../.storybook/ReactRouterDecorator';
 import { contribution } from '../../../fixtures/productDetail';
-import { switchPreview } from '../../../fixtures/switchPreview';
+import { productMovePreviewResponse } from '../../../fixtures/productMove';
 import { SwitchContainer } from './SwitchContainer';
 import { SwitchReview } from './SwitchReview';
 
@@ -18,7 +18,7 @@ export default {
 		},
 		msw: [
 			rest.post('/api/product-move/*', (_req, res, ctx) => {
-				return res(ctx.json(switchPreview));
+				return res(ctx.json(productMovePreviewResponse));
 			}),
 		],
 	},

--- a/client/components/mma/switch/SwitchReview.tsx
+++ b/client/components/mma/switch/SwitchReview.tsx
@@ -1,12 +1,15 @@
-import { css } from '@emotion/react';
+import { css, ThemeProvider } from '@emotion/react';
 import {
 	from,
 	headline,
 	palette,
 	space,
 	textSans,
+	until,
 } from '@guardian/source-foundations';
 import {
+	Button,
+	buttonThemeReaderRevenueBrand,
 	Stack,
 	SvgClock,
 	SvgCreditCard,
@@ -56,12 +59,30 @@ const whatHappensNextTextCss = css`
 	width: 100%;
 `;
 
+const buttonLayoutCss = css`
+	margin-top: ${space[5]}px;
+	padding-top: 32px;
+	border-top: 1px solid ${palette.neutral[86]};
+
+	> * + * {
+		margin-left: ${space[3]}px;
+	}
+
+	${until.tablet} {
+		display: flex;
+		flex-direction: column;
+
+		> * + * {
+			margin-left: 0;
+			margin-top: ${space[3]}px;
+		}
+	}
+`;
 interface PreviewResponse {
 	amountPayableToday: number;
 	contributionRefundAmount: number;
 	supporterPlusPurchaseAmount: number;
 }
-
 export const SwitchReview = () => {
 	const switchContext = useContext(SwitchContext) as SwitchContextInterface;
 	const productDetail = switchContext.productDetail;
@@ -330,6 +351,25 @@ export const SwitchReview = () => {
 						</div>
 					</Stack>
 				</section>
+			</section>
+			<section css={buttonLayoutCss}>
+				<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
+					<Button
+						cssOverrides={css`
+							justify-content: center;
+						`}
+					>
+						Confirm change
+					</Button>
+				</ThemeProvider>
+				<Button
+					priority="tertiary"
+					cssOverrides={css`
+						justify-content: center;
+					`}
+				>
+					Back
+				</Button>
 			</section>
 		</>
 	);

--- a/client/components/mma/switch/SwitchReview.tsx
+++ b/client/components/mma/switch/SwitchReview.tsx
@@ -5,7 +5,6 @@ import {
 	palette,
 	space,
 	textSans,
-	until,
 } from '@guardian/source-foundations';
 import {
 	Button,
@@ -14,8 +13,8 @@ import {
 	SvgClock,
 	SvgCreditCard,
 } from '@guardian/source-react-components';
-import { useContext } from 'react';
-import { Navigate } from 'react-router';
+import { useContext, useState } from 'react';
+import { Navigate, useNavigate } from 'react-router';
 import {
 	dateAddMonths,
 	dateAddYears,
@@ -60,21 +59,19 @@ const whatHappensNextTextCss = css`
 `;
 
 const buttonLayoutCss = css`
+	display: flex;
+	flex-direction: column;
 	margin-top: ${space[5]}px;
 	padding-top: 32px;
 	border-top: 1px solid ${palette.neutral[86]};
-
 	> * + * {
-		margin-left: ${space[3]}px;
+		margin-top: ${space[3]}px;
 	}
-
-	${until.tablet} {
-		display: flex;
-		flex-direction: column;
-
+	${from.tablet} {
+		flex-direction: row;
 		> * + * {
-			margin-left: 0;
-			margin-top: ${space[3]}px;
+			margin-top: 0;
+			margin-left: ${space[3]}px;
 		}
 	}
 `;
@@ -157,6 +154,14 @@ export const SwitchReview = () => {
 	if (previewResponse == null) {
 		return <Navigate to="/" />;
 	}
+
+	const navigate = useNavigate();
+	const [isConfirmingSwitch, setIsConfirmingSwitch] =
+		useState<boolean>(false);
+
+	const confirmSwitch = () => {
+		setIsConfirmingSwitch(true);
+	};
 
 	return (
 		<>
@@ -371,9 +376,11 @@ export const SwitchReview = () => {
 			<section css={buttonLayoutCss}>
 				<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
 					<Button
+						isLoading={isConfirmingSwitch}
 						cssOverrides={css`
-							justify-content: center;
+							/* justify-content: center; */
 						`}
+						onClick={confirmSwitch}
 					>
 						Confirm change
 					</Button>
@@ -383,6 +390,7 @@ export const SwitchReview = () => {
 					cssOverrides={css`
 						justify-content: center;
 					`}
+					onClick={() => navigate('..')}
 				>
 					Back
 				</Button>
@@ -406,8 +414,8 @@ export const SwitchReview = () => {
 					.
 				</p>
 				<p css={smallPrintCss}>
-					To find out what personal data we collect and how we use
-					it, please visit our{' '}
+					To find out what personal data we collect and how we use it,
+					please visit our{' '}
 					<a href="https://www.theguardian.com/help/privacy-policy">
 						Privacy Policy
 					</a>

--- a/client/components/mma/switch/SwitchReview.tsx
+++ b/client/components/mma/switch/SwitchReview.tsx
@@ -83,7 +83,7 @@ const smallPrintCss = css`
 	${textSans.xxsmall()};
 	margin-top: 0;
 	margin-bottom: 0;
-	color: ${palette.neutral[46]};
+	color: #606060;
 	> a {
 		color: inherit;
 		text-decoration: underline;
@@ -422,12 +422,14 @@ export const SwitchReview = () => {
 				<p css={smallPrintCss}>
 					This arrangement auto-renews and you will be charged the
 					applicable monthly amount each time it renews unless you
-					cancel. You can change how much you pay at any time but £10
-					per month is the minimum payment to receive these benefits.
-					You can cancel any time before your next payment date and if
-					you cancel within the first 14 days, you’ll receive a full
-					refund. Cancellation of your payment will result in the
-					cancellation of these benefits.
+					cancel. You can change how much you pay at any time but{' '}
+					{mainPlan.currency}
+					{threshold} per {mainPlan.billingPeriod}, is the minimum
+					payment to receive these benefits. You can cancel any time
+					before your next payment date and if you cancel within the
+					first 14 days, you’ll receive a full refund. Cancellation of
+					your payment will result in the cancellation of these
+					benefits.
 				</p>
 				<p css={smallPrintCss}>
 					By proceeding, you are agreeing to our{' '}

--- a/client/components/mma/switch/SwitchReview.tsx
+++ b/client/components/mma/switch/SwitchReview.tsx
@@ -78,11 +78,27 @@ const buttonLayoutCss = css`
 		}
 	}
 `;
+
+const smallPrintCss = css`
+	${textSans.xxsmall()};
+	margin-top: 0;
+	margin-bottom: 0;
+	color: ${palette.neutral[46]};
+	> a {
+		color: inherit;
+		text-decoration: underline;
+	}
+	& + & {
+		margin-top: ${space[1]}px;
+	}
+`;
+
 interface PreviewResponse {
 	amountPayableToday: number;
 	contributionRefundAmount: number;
 	supporterPlusPurchaseAmount: number;
 }
+
 export const SwitchReview = () => {
 	const switchContext = useContext(SwitchContext) as SwitchContextInterface;
 	const productDetail = switchContext.productDetail;
@@ -370,6 +386,33 @@ export const SwitchReview = () => {
 				>
 					Back
 				</Button>
+			</section>
+			<section css={sectionSpacing}>
+				<p css={smallPrintCss}>
+					This arrangement auto-renews and you will be charged the
+					applicable monthly amount each time it renews unless you
+					cancel. You can change how much you pay at any time but £10
+					per month is the minimum payment to receive these benefits.
+					You can cancel any time before your next payment date and if
+					you cancel within the first 14 days, you’ll receive a full
+					refund. Cancellation of your payment will result in the
+					cancellation of these benefits.
+				</p>
+				<p css={smallPrintCss}>
+					By proceeding, you are agreeing to our{' '}
+					<a href="https://www.theguardian.com/info/2014/aug/06/guardian-observer-digital-subscriptions-terms-conditions">
+						Terms and Conditions
+					</a>
+					.
+				</p>
+				<p css={smallPrintCss}>
+					To find out what personal data we collect and how we use
+					it, please visit our{' '}
+					<a href="https://www.theguardian.com/help/privacy-policy">
+						Privacy Policy
+					</a>
+					.
+				</p>
 			</section>
 		</>
 	);

--- a/client/components/mma/switch/SwitchReview.tsx
+++ b/client/components/mma/switch/SwitchReview.tsx
@@ -21,7 +21,10 @@ import {
 	dateString,
 } from '../../../../shared/dates';
 import type { PaidSubscriptionPlan } from '../../../../shared/productResponse';
-import { getMainPlan } from '../../../../shared/productResponse';
+import {
+	getMainPlan,
+	MDA_TEST_USER_HEADER,
+} from '../../../../shared/productResponse';
 import { calculateMonthlyOrAnnualFromBillingPeriod } from '../../../../shared/productTypes';
 import { sectionSpacing } from '../../../styles/spacing';
 import {
@@ -159,8 +162,28 @@ export const SwitchReview = () => {
 	const [isConfirmingSwitch, setIsConfirmingSwitch] =
 		useState<boolean>(false);
 
-	const confirmSwitch = () => {
+	const confirmSwitch = async () => {
 		setIsConfirmingSwitch(true);
+		try {
+			const res = await fetch(
+				`/api/product-move/${productDetail.subscription.subscriptionId}`,
+				{
+					method: 'POST',
+					body: JSON.stringify({
+						targetProductId: '123', // TODO: Get correct product ID
+					}),
+					headers: {
+						[MDA_TEST_USER_HEADER]: `${productDetail.isTestUser}`,
+					},
+				},
+			);
+
+			const json = await res.json();
+			console.log(json);
+			setIsConfirmingSwitch(false);
+		} catch (error) {
+			// TODO: Show error message
+		}
 	};
 
 	return (
@@ -378,7 +401,7 @@ export const SwitchReview = () => {
 					<Button
 						isLoading={isConfirmingSwitch}
 						cssOverrides={css`
-							/* justify-content: center; */
+							justify-content: center;
 						`}
 						onClick={confirmSwitch}
 					>

--- a/client/components/mma/switch/SwitchReview.tsx
+++ b/client/components/mma/switch/SwitchReview.tsx
@@ -97,11 +97,6 @@ interface PreviewResponse {
 	supporterPlusPurchaseAmount: number;
 }
 
-interface AsyncLoader {
-	data: PreviewResponse | null;
-	loadingState: LoadingState;
-}
-
 export const SwitchReview = () => {
 	const navigate = useNavigate();
 
@@ -151,10 +146,11 @@ export const SwitchReview = () => {
 		);
 
 	const confirmSwitch = async () => {
-		setIsSwitching(true);
 		try {
+			setIsSwitching(true);
 			const response = await productMoveFetch(false);
-			const data = await response.json();
+			const data = await JsonResponseHandler(response);
+
 			if (data === null) {
 				setIsSwitching(false);
 				setSwitchingError(true);
@@ -168,10 +164,13 @@ export const SwitchReview = () => {
 		}
 	};
 
-	const { data: previewResponse, loadingState }: AsyncLoader = useAsyncLoader(
-		() => productMoveFetch(true),
-		JsonResponseHandler,
-	);
+	const {
+		data: previewResponse,
+		loadingState,
+	}: {
+		data: PreviewResponse | null;
+		loadingState: LoadingState;
+	} = useAsyncLoader(() => productMoveFetch(true), JsonResponseHandler);
 
 	if (loadingState == LoadingState.HasError) {
 		return <GenericErrorScreen loggingMessage={false} />;

--- a/client/components/mma/switch/SwitchReview.tsx
+++ b/client/components/mma/switch/SwitchReview.tsx
@@ -126,6 +126,34 @@ export const SwitchReview = () => {
 		'd MMMM',
 	);
 
+	const navigate = useNavigate();
+	const [isConfirmingSwitch, setIsConfirmingSwitch] =
+		useState<boolean>(false);
+
+	const confirmSwitch = async () => {
+		setIsConfirmingSwitch(true);
+		try {
+			const res = await fetch(
+				`/api/product-move/${productDetail.subscription.subscriptionId}`,
+				{
+					method: 'POST',
+					body: JSON.stringify({
+						targetProductId: '123', // TODO: Get correct product ID
+					}),
+					headers: {
+						[MDA_TEST_USER_HEADER]: `${productDetail.isTestUser}`,
+					},
+				},
+			);
+
+			const json = await res.json();
+			console.log(json);
+			setIsConfirmingSwitch(false);
+		} catch (error) {
+			// TODO: Show error message
+		}
+	};
+
 	const {
 		data: previewResponse,
 		loadingState,
@@ -157,34 +185,6 @@ export const SwitchReview = () => {
 	if (previewResponse == null) {
 		return <Navigate to="/" />;
 	}
-
-	const navigate = useNavigate();
-	const [isConfirmingSwitch, setIsConfirmingSwitch] =
-		useState<boolean>(false);
-
-	const confirmSwitch = async () => {
-		setIsConfirmingSwitch(true);
-		try {
-			const res = await fetch(
-				`/api/product-move/${productDetail.subscription.subscriptionId}`,
-				{
-					method: 'POST',
-					body: JSON.stringify({
-						targetProductId: '123', // TODO: Get correct product ID
-					}),
-					headers: {
-						[MDA_TEST_USER_HEADER]: `${productDetail.isTestUser}`,
-					},
-				},
-			);
-
-			const json = await res.json();
-			console.log(json);
-			setIsConfirmingSwitch(false);
-		} catch (error) {
-			// TODO: Show error message
-		}
-	};
 
 	return (
 		<>

--- a/client/fixtures/productMove.ts
+++ b/client/fixtures/productMove.ts
@@ -1,0 +1,9 @@
+export const productMovePreviewResponse = {
+	amountPayableToday: 5.0,
+	contributionRefundAmount: -5.0,
+	supporterPlusPurchaseAmount: 10.0,
+};
+
+export const productMoveResponse = {
+	message: 'Product move completed successfully',
+};

--- a/client/fixtures/productMove.ts
+++ b/client/fixtures/productMove.ts
@@ -4,6 +4,6 @@ export const productMovePreviewResponse = {
 	supporterPlusPurchaseAmount: 10.0,
 };
 
-export const productMoveResponse = {
+export const productMoveSuccessfulResponse = {
 	message: 'Product move completed successfully',
 };

--- a/client/fixtures/switchPreview.ts
+++ b/client/fixtures/switchPreview.ts
@@ -1,5 +1,0 @@
-export const switchPreview = {
-	amountPayableToday: 5.0,
-	contributionRefundAmount: -5.0,
-	supporterPlusPurchaseAmount: 10.0,
-};


### PR DESCRIPTION
## What does this change?

Updates switch review page to add 'Confirm change' and 'Back' buttons, and terms & conditions section. The confirmation button is hooked up to the `product-move` API allowing product switches to be made. The final 'thank you' page hasn't been built yet so you'll be redirected back to the _Account Overview_ following a successful switch. If the switch fails you'll see a placeholder error message, pending the final design.

## How to test

Clicking 'Confirm change' should switch your recurring contribution to the _monthly / yearly + extras_ product as appropriate. Clicking 'Back' returns you to the initial switch landing page.

## Images

<img width="808" alt="Screenshot 2023-01-25 at 10 12 49" src="https://user-images.githubusercontent.com/1166188/214537404-631d2db8-4de4-4c44-b2de-e0775a58bdd4.png">

<img width="317" alt="Screenshot 2023-01-25 at 10 14 24" src="https://user-images.githubusercontent.com/1166188/214537485-a69a7421-956f-4f80-8a8c-836b4dc54ec9.png">
