### PR TITLE
MMA: Randomise Cancellation Reasons

### DIFF
--- a/client/components/mma/cancel/Cancellation.stories.tsx
+++ b/client/components/mma/cancel/Cancellation.stories.tsx
@@ -11,6 +11,13 @@ import { CancellationContainer } from './CancellationContainer';
 import { CancellationReasonReview } from './CancellationReasonReview';
 import { CancellationReasonSelection } from './CancellationReasonSelection';
 import { getCancellationSummary } from './CancellationSummary';
+import { contributionsCancellationReasons } from './contributions/ContributionsCancellationReasons';
+import { otherCancellationReason } from './supporterplus/SupporterplusCancellationReasons';
+
+const contributions = PRODUCT_TYPES.contributions;
+contributions.cancellation!.reasons = contributionsCancellationReasons.concat(
+	otherCancellationReason,
+);
 
 export default {
 	title: 'Pages/Cancellation',
@@ -20,11 +27,7 @@ export default {
 		layout: 'fullscreen',
 		reactRouter: {
 			state: { productDetail: contribution },
-			container: (
-				<CancellationContainer
-					productType={PRODUCT_TYPES.contributions}
-				/>
-			),
+			container: <CancellationContainer productType={contributions} />,
 		},
 	},
 } as ComponentMeta<typeof CancellationContainer>;

--- a/client/components/mma/cancel/contributions/ContributionsCancellationReasons.tsx
+++ b/client/components/mma/cancel/contributions/ContributionsCancellationReasons.tsx
@@ -104,9 +104,19 @@ export const contributionsCancellationReasons: CancellationReason[] = [
 		linkLabel: 'I no longer read the Guardian enough to justify my support',
 		alternateFeedbackIntro: standardAlternateFeedbackIntro,
 	},
+];
+
+export const otherCancellationReason: CancellationReason[] = [
 	{
 		reasonId: 'mma_other',
 		linkLabel: 'Another reason (please specify)',
 		alternateFeedbackIntro: standardAlternateFeedbackIntro,
 	},
 ];
+
+const shuffledArray = contributionsCancellationReasons.sort(
+	() => 0.5 - Math.random(),
+);
+
+export const shuffledContributionsCancellationReasons: CancellationReason[] =
+	shuffledArray.concat(otherCancellationReason);

--- a/client/components/mma/cancel/contributions/ContributionsCancellationReasons.tsx
+++ b/client/components/mma/cancel/contributions/ContributionsCancellationReasons.tsx
@@ -114,9 +114,11 @@ export const otherCancellationReason: CancellationReason[] = [
 	},
 ];
 
-const shuffledArray = contributionsCancellationReasons.sort(
+const shuffledArray = [...contributionsCancellationReasons].sort(
 	() => 0.5 - Math.random(),
 );
 
-export const shuffledContributionsCancellationReasons: CancellationReason[] =
-	shuffledArray.concat(otherCancellationReason);
+export const shuffledContributionsCancellationReasons: CancellationReason[] = [
+	...shuffledArray,
+	...otherCancellationReason,
+];

--- a/client/components/mma/cancel/supporterplus/SupporterplusCancellationReasons.tsx
+++ b/client/components/mma/cancel/supporterplus/SupporterplusCancellationReasons.tsx
@@ -84,9 +84,19 @@ export const supporterplusCancellationReasons: CancellationReason[] = [
 		linkLabel: 'I no longer read the Guardian enough to justify my support',
 		alternateFeedbackIntro: standardAlternateFeedbackIntro,
 	},
+];
+
+export const otherCancellationReason: CancellationReason[] = [
 	{
 		reasonId: 'mma_other',
 		linkLabel: 'Another reason (please specify)',
 		alternateFeedbackIntro: standardAlternateFeedbackIntro,
 	},
 ];
+
+const shuffledArray = supporterplusCancellationReasons.sort(
+	() => 0.5 - Math.random(),
+);
+
+export const shuffledSupporterPlusCancellationReasons: CancellationReason[] =
+	shuffledArray.concat(otherCancellationReason);

--- a/client/components/mma/cancel/supporterplus/SupporterplusCancellationReasons.tsx
+++ b/client/components/mma/cancel/supporterplus/SupporterplusCancellationReasons.tsx
@@ -94,9 +94,11 @@ export const otherCancellationReason: CancellationReason[] = [
 	},
 ];
 
-const shuffledArray = supporterplusCancellationReasons.sort(
+const shuffledArray = [...supporterplusCancellationReasons].sort(
 	() => 0.5 - Math.random(),
 );
 
-export const shuffledSupporterPlusCancellationReasons: CancellationReason[] =
-	shuffledArray.concat(otherCancellationReason);
+export const shuffledSupporterPlusCancellationReasons: CancellationReason[] = [
+	...shuffledArray,
+	...otherCancellationReason,
+];

--- a/cypress/integration/parallel-2/cancelContribution.spec.ts
+++ b/cypress/integration/parallel-2/cancelContribution.spec.ts
@@ -79,7 +79,9 @@ describe('Cancel contribution', () => {
 
 	it('cancels contribution (reason: As a result of a specific article I read)', () => {
 		setupCancellation();
-		cy.findAllByRole('radio').eq(0).click();
+		cy.findByRole('radio', {
+			name: 'As the result of a specific article I read',
+		}).click();
 		cy.findByRole('button', { name: 'Continue' }).click();
 
 		cy.wait('@get_case');
@@ -137,7 +139,9 @@ describe('Cancel contribution', () => {
 
 	it('cancels contribution with save body string (reason: I’d like to get something in return for my support)', () => {
 		setupCancellation();
-		cy.findAllByRole('radio').eq(5).click();
+		cy.findAllByRole('radio', {
+			name: 'I’d like to get something ‘in return’ for my support, e.g. digital features',
+		}).click();
 		cy.findByRole('button', { name: 'Continue' }).click();
 
 		cy.wait('@get_case');

--- a/shared/productTypes.tsx
+++ b/shared/productTypes.tsx
@@ -5,7 +5,7 @@ import type {
 	OptionalCancellationReasonId,
 } from '../client/components/mma/cancel/cancellationReason';
 import { contributionsCancellationFlowStart } from '../client/components/mma/cancel/contributions/ContributionsCancellationFlowStart';
-import { contributionsCancellationReasons } from '../client/components/mma/cancel/contributions/ContributionsCancellationReasons';
+import { shuffledContributionsCancellationReasons } from '../client/components/mma/cancel/contributions/ContributionsCancellationReasons';
 import { digipackCancellationFlowStart } from '../client/components/mma/cancel/digipack/DigipackCancellationFlowStart';
 import { digipackCancellationReasons } from '../client/components/mma/cancel/digipack/DigipackCancellationReasons';
 import { gwCancellationFlowStart } from '../client/components/mma/cancel/gw/GwCancellationFlowStart';
@@ -15,7 +15,7 @@ import { membershipCancellationReasons } from '../client/components/mma/cancel/m
 import type { RestOfCancellationFlow } from '../client/components/mma/cancel/PhysicalSubsCancellationFlowWrapper';
 import { physicalSubsCancellationFlowWrapper } from '../client/components/mma/cancel/PhysicalSubsCancellationFlowWrapper';
 import { supporterplusCancellationFlowStart } from '../client/components/mma/cancel/supporterplus/SupporterplusCancellationFlowStart';
-import { supporterplusCancellationReasons } from '../client/components/mma/cancel/supporterplus/SupporterplusCancellationReasons';
+import { shuffledSupporterPlusCancellationReasons } from '../client/components/mma/cancel/supporterplus/SupporterplusCancellationReasons';
 import { voucherCancellationFlowStart } from '../client/components/mma/cancel/voucher/VoucherCancellationFlowStart';
 import { voucherCancellationReasons } from '../client/components/mma/cancel/voucher/VoucherCancellationReasons';
 import type { SupportTheGuardianButtonProps } from '../client/components/shared/SupportTheGuardianButton';
@@ -335,7 +335,7 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 		],
 		cancellation: {
 			linkOnProductPage: true,
-			reasons: contributionsCancellationReasons,
+			reasons: shuffledContributionsCancellationReasons,
 			sfCaseProduct: 'Recurring - Contributions',
 			startPageBody: contributionsCancellationFlowStart,
 			shouldHideSummaryMainPara: true,
@@ -645,7 +645,7 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 				)} support + extras cancelled`;
 			},
 			linkOnProductPage: true,
-			reasons: supporterplusCancellationReasons,
+			reasons: shuffledSupporterPlusCancellationReasons,
 			sfCaseProduct: 'Supporter Plus',
 			startPageBody: supporterplusCancellationFlowStart,
 			summaryReasonSpecificPara: () => undefined,


### PR DESCRIPTION
## What does this change?
When a customer wants to cancel the cancellation reasons are in a fixed order meaning that there could be bias to the options at the top of the list. This change shuffles the cancellation reasons whilst keeping 'another reason' fixed at the bottom.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Checked on storybook and CODE that when trying to cancel the reasons provided are shuffled differently each time, but 'Other Reasons' always remains at the bottom of the list. On Prod when on the cancel recurring contributions page the reasons should be in a random order with another reason at the bottom. Refresh the same page and the reasons should be shuffled with another reason remaining at the bottom of the list.


## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
Before <img width="940" alt="image" src="https://user-images.githubusercontent.com/115992455/214064378-4ae23cf6-05e5-4b01-9c14-23ce3279582e.png">

After
![image](https://user-images.githubusercontent.com/115992455/214064508-20c9242e-a129-4bb6-89ce-225059b75bc1.png)

After refresh
![image](https://user-images.githubusercontent.com/115992455/214064529-f1d9cd4c-ba93-4ba2-bd29-7de42645fc1d.png)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
