### PR TITLE
Create Switch Thank You page and non-app messaging

### DIFF
--- a/client/components/mma/MMAPage.tsx
+++ b/client/components/mma/MMAPage.tsx
@@ -36,6 +36,7 @@ import { Main } from '../shared/Main';
 import { DeliveryAddressUpdate } from './delivery/address/DeliveryAddressForm';
 import { Maintenance } from './maintenance/Maintenance';
 import { MMAPageSkeleton } from './MMAPageSkeleton';
+import { SwitchComplete } from './switch/SwitchComplete';
 import { SwitchContainer } from './switch/SwitchContainer';
 import { SwitchOptions } from './switch/SwitchOptions';
 import { SwitchReview } from './switch/SwitchReview';
@@ -325,9 +326,10 @@ const MMARouter = () => {
 						/>
 						<Route path="/switch" element={<SwitchContainer />}>
 							<Route index element={<SwitchOptions />} />
+							<Route path="review" element={<SwitchReview />} />
 							<Route
-								path="/switch/review"
-								element={<SwitchReview />}
+								path="complete"
+								element={<SwitchComplete />}
 							/>
 						</Route>
 						{Object.values(GROUPED_PRODUCT_TYPES).map(

--- a/client/components/mma/shared/Heading.tsx
+++ b/client/components/mma/shared/Heading.tsx
@@ -13,6 +13,7 @@ interface HeadingProps {
 	cssOverrides?: SerializedStyles | SerializedStyles[];
 	level?: '1' | '2' | '3' | '4';
 	sansSerif?: boolean;
+	noDivider?: boolean;
 }
 
 export const Heading = (props: HeadingProps) => {
@@ -37,7 +38,7 @@ export const Heading = (props: HeadingProps) => {
 	const HeadingElement: keyof JSX.IntrinsicElements = `h${props.level ?? 2}`;
 
 	return (
-		<div css={dividerStyles}>
+		<div css={props.noDivider ? '' : dividerStyles}>
 			<HeadingElement css={[headingStyles, props.cssOverrides]}>
 				{props.children}
 			</HeadingElement>

--- a/client/components/mma/switch/SwitchComplete.stories.tsx
+++ b/client/components/mma/switch/SwitchComplete.stories.tsx
@@ -1,0 +1,22 @@
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import { ReactRouterDecorator } from '../../../../.storybook/ReactRouterDecorator';
+import { contribution } from '../../../fixtures/productDetail';
+import { SwitchComplete } from './SwitchComplete';
+import { SwitchContainer } from './SwitchContainer';
+
+export default {
+	title: 'Pages/SwitchComplete',
+	component: SwitchContainer,
+	decorators: [ReactRouterDecorator],
+	parameters: {
+		layout: 'fullscreen',
+		reactRouter: {
+			state: { productDetail: contribution },
+			container: <SwitchContainer />,
+		},
+	},
+} as ComponentMeta<typeof SwitchContainer>;
+
+export const Default: ComponentStory<typeof SwitchComplete> = () => (
+	<SwitchComplete />
+);

--- a/client/components/mma/switch/SwitchComplete.tsx
+++ b/client/components/mma/switch/SwitchComplete.tsx
@@ -1,0 +1,79 @@
+import { css } from '@emotion/react';
+import { from, palette, until } from '@guardian/source-foundations';
+import { Stack } from '@guardian/source-react-components';
+import { useContext } from 'react';
+import type {
+	PaidSubscriptionPlan} from '../../../../shared/productResponse';
+import {
+	getMainPlan
+} from '../../../../shared/productResponse';
+import { calculateMonthlyOrAnnualFromBillingPeriod } from '../../../../shared/productTypes';
+import { sectionSpacing } from '../../../styles/spacing';
+import { Heading } from '../shared/Heading';
+import type { SwitchContextInterface } from './SwitchContainer';
+import { SwitchContext } from './SwitchContainer';
+
+export const SwitchComplete = () => {
+	const switchContext = useContext(SwitchContext) as SwitchContextInterface;
+	const productDetail = switchContext.productDetail;
+	const mainPlan = getMainPlan(
+		productDetail.subscription,
+	) as PaidSubscriptionPlan;
+
+	// ToDo: hardcoding this for now; need to find out where to get this from for each currency
+	const monthlyThreshold = 10;
+	const annualThreshold = 95;
+	const monthlyOrAnnual = calculateMonthlyOrAnnualFromBillingPeriod(
+		mainPlan.billingPeriod,
+	);
+
+	const threshold =
+		monthlyOrAnnual == 'Monthly' ? monthlyThreshold : annualThreshold;
+	const newAmount = Math.max(threshold, mainPlan.price / 100);
+
+	return (
+		<section css={sectionSpacing}>
+			<Stack space={3}>
+				{!switchContext.isFromApp && (
+					<ThankYouMessaging
+						mainPlan={mainPlan}
+						newAmount={newAmount}
+					/>
+				)}
+			</Stack>
+		</section>
+	);
+};
+
+const extrasStyling = css`
+	${from.tablet} {
+		color: ${palette.brand['500']};
+
+		::before {
+			content: '\\a';
+			white-space: pre;
+		}
+	}
+`;
+
+const ThankYouMessaging = (props: {
+	mainPlan: PaidSubscriptionPlan;
+	newAmount: number;
+}) => {
+	return (
+		<>
+			<Heading
+				cssOverrides={css`
+					${until.mobile} {
+						max-width: 350px;
+					}
+				`}
+				noDivider
+			>
+				Thank you for upgrading to {props.mainPlan.currency}
+				{props.newAmount} per {props.mainPlan.billingPeriod}.{' '}
+				<span css={extrasStyling}>Enjoy your exclusive extras.</span>
+			</Heading>
+		</>
+	);
+};


### PR DESCRIPTION
## What does this change?

Adds the Thank You page to the switch journey with initial thank you messaging for users not referred by the app.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Navigate to `/switch/complete` and witness the new page and component, the styling is different on mobile and desktop views. 

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Desktop
![image](https://user-images.githubusercontent.com/114918544/214807311-6ee99215-d80b-40af-b38c-f20bfeec0d20.png)
Mobile
![image](https://user-images.githubusercontent.com/114918544/214807375-e222631c-c975-4543-894e-8394f26328d8.png)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
