### PR TITLE
Add feature switch for product switching flow

### DIFF
--- a/client/components/mma/MMAPage.tsx
+++ b/client/components/mma/MMAPage.tsx
@@ -4,7 +4,10 @@ import { breakpoints, from, space } from '@guardian/source-foundations';
 import type { ReactNode } from 'react';
 import { lazy, Suspense, useEffect, useState } from 'react';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
-import { initFeatureSwitchUrlParamOverride } from '../../../shared/featureSwitches';
+import {
+	featureSwitches,
+	initFeatureSwitchUrlParamOverride,
+} from '../../../shared/featureSwitches';
 import type {
 	GroupedProductType,
 	ProductType,
@@ -324,14 +327,19 @@ const MMARouter = () => {
 							path="/account-settings"
 							element={<Settings />}
 						/>
-						<Route path="/switch" element={<SwitchContainer />}>
-							<Route index element={<SwitchOptions />} />
-							<Route path="review" element={<SwitchReview />} />
-							<Route
-								path="complete"
-								element={<SwitchComplete />}
-							/>
-						</Route>
+						{featureSwitches.productSwitching && (
+							<Route path="/switch" element={<SwitchContainer />}>
+								<Route index element={<SwitchOptions />} />
+								<Route
+									path="review"
+									element={<SwitchReview />}
+								/>
+								<Route
+									path="complete"
+									element={<SwitchComplete />}
+								/>
+							</Route>
+						)}
 						{Object.values(GROUPED_PRODUCT_TYPES).map(
 							(groupedProductType: GroupedProductType) => (
 								<Route

--- a/client/components/mma/switch/SwitchContainer.tsx
+++ b/client/components/mma/switch/SwitchContainer.tsx
@@ -1,6 +1,7 @@
 import type { Context, ReactNode } from 'react';
 import { createContext } from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router';
+import { featureSwitches } from '../../../../shared/featureSwitches';
 import type {
 	MembersDataApiResponse,
 	ProductDetail,
@@ -36,6 +37,10 @@ export const SwitchContainer = () => {
 	const location = useLocation();
 	const routerState = location.state as SwitchRouterState;
 	const productDetail = routerState?.productDetail;
+
+	if (!featureSwitches.productSwitching) {
+		return <Navigate to="/" />;
+	}
 
 	if (!productDetail) {
 		return <AsyncLoadedSwitchContainer />;

--- a/client/components/mma/switch/SwitchContainer.tsx
+++ b/client/components/mma/switch/SwitchContainer.tsx
@@ -1,7 +1,6 @@
 import type { Context, ReactNode } from 'react';
 import { createContext } from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router';
-import { featureSwitches } from '../../../../shared/featureSwitches';
 import type {
 	MembersDataApiResponse,
 	ProductDetail,
@@ -37,10 +36,6 @@ export const SwitchContainer = () => {
 	const location = useLocation();
 	const routerState = location.state as SwitchRouterState;
 	const productDetail = routerState?.productDetail;
-
-	if (!featureSwitches.productSwitching) {
-		return <Navigate to="/" />;
-	}
 
 	if (!productDetail) {
 		return <AsyncLoadedSwitchContainer />;

--- a/cypress/integration/parallel-2/productSwitch.spec.ts
+++ b/cypress/integration/parallel-2/productSwitch.spec.ts
@@ -211,68 +211,75 @@ describe('product switching', () => {
 		});
 	});
 
-	it('navigates to product switching page from Account Overview', () => {
-		cy.visit('/?withFeature=accountOverviewNewLayout');
-		setSignInStatus();
-		cy.findByText('Change to monthly + extras').click();
-		cy.findByText('Your current support').should('exist');
-	});
+	if (
+		featureSwitches.accountOverviewNewLayout &&
+		featureSwitches.productSwitching
+	) {
+		it('navigates to product switching page from Account Overview', () => {
+			cy.visit('/');
+			setSignInStatus();
+			cy.findByText('Change to monthly + extras').click();
+			cy.findByText('Your current support').should('exist');
+		});
+	}
 
-	it('shows product switching page when visiting URL directly', () => {
-		cy.visit('/switch');
-		setSignInStatus();
-		cy.findByText('Your current support').should('exist');
-	});
-
-	it('shows review page after choosing to switch', () => {
-		cy.visit('/switch');
-		setSignInStatus();
-
-		cy.findByRole('button', {
-			name: 'Add extras with no extra cost',
-		}).click();
-
-		cy.findByText('Review change').should('exist');
-		cy.findByText('Your new support').should('exist');
-		cy.findByText('What happens next?').should('exist');
-	});
-
-	it('successfully switches product', () => {
-		cy.visit('/switch');
-		setSignInStatus();
-
-		cy.findByRole('button', {
-			name: 'Add extras with no extra cost',
-		}).click();
-
-		cy.intercept('POST', '/api/product-move/*', {
-			statusCode: 200,
-			body: productMoveSuccessfulResponse,
+	if (featureSwitches.productSwitching) {
+		it('shows product switching page when visiting URL directly', () => {
+			cy.visit('/switch');
+			setSignInStatus();
+			cy.findByText('Your current support').should('exist');
 		});
 
-		cy.findByRole('button', { name: 'Confirm change' }).click();
+		it('shows review page after choosing to switch', () => {
+			cy.visit('/switch');
+			setSignInStatus();
 
-		// TODO: Final confirmation page hasn't been built yet so we redirect
-		// back to the Account Overview following a successful switch
-		cy.location('pathname').should('eq', '/');
-	});
+			cy.findByRole('button', {
+				name: 'Add extras with no extra cost',
+			}).click();
 
-	it('shows an error message if switch fails', () => {
-		cy.visit('/switch');
-		setSignInStatus();
-
-		cy.findByRole('button', {
-			name: 'Add extras with no extra cost',
-		}).click();
-
-		cy.intercept('POST', '/api/product-move/*', {
-			statusCode: 500,
-			body: {},
+			cy.findByText('Review change').should('exist');
+			cy.findByText('Your new support').should('exist');
+			cy.findByText('What happens next?').should('exist');
 		});
 
-		cy.findByRole('button', { name: 'Confirm change' }).click();
+		it('successfully switches product', () => {
+			cy.visit('/switch');
+			setSignInStatus();
 
-		// TODO: This is a placeholder error message pending final design
-		cy.findByText('An error occurred whilst switching').should('exist');
-	});
+			cy.findByRole('button', {
+				name: 'Add extras with no extra cost',
+			}).click();
+
+			cy.intercept('POST', '/api/product-move/*', {
+				statusCode: 200,
+				body: productMoveSuccessfulResponse,
+			});
+
+			cy.findByRole('button', { name: 'Confirm change' }).click();
+
+			// TODO: Final confirmation page hasn't been built yet so we redirect
+			// back to the Account Overview following a successful switch
+			cy.location('pathname').should('eq', '/');
+		});
+
+		it('shows an error message if switch fails', () => {
+			cy.visit('/switch');
+			setSignInStatus();
+
+			cy.findByRole('button', {
+				name: 'Add extras with no extra cost',
+			}).click();
+
+			cy.intercept('POST', '/api/product-move/*', {
+				statusCode: 500,
+				body: {},
+			});
+
+			cy.findByRole('button', { name: 'Confirm change' }).click();
+
+			// TODO: This is a placeholder error message pending final design
+			cy.findByText('An error occurred whilst switching').should('exist');
+		});
+	}
 });

--- a/shared/featureSwitches.ts
+++ b/shared/featureSwitches.ts
@@ -26,4 +26,5 @@ export const featureSwitches: Record<string, boolean> = {
 	exampleFeature: false,
 	cancellationProductSwitch: false,
 	accountOverviewNewLayout: false,
+	productSwitching: false,
 };


### PR DESCRIPTION
## What does this change?

Adds a feature switch to disable product switching, preventing access to the work in progress pages on production.

## How to test

Navigation to `/switch` or any of the child pages will not be possible.
