### PR TITLE
Create Thank You - What Happens next text

### DIFF
--- a/client/components/mma/accountoverview/AccountOverview.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.tsx
@@ -127,6 +127,7 @@ const AccountOverviewRenderer = ([mdapiObject, cancelledProductsResponse]: [
 										}
 										productDetail={productDetail}
 										isEligibleToSwitch={isEligibleToSwitch}
+										user={mdaResponse.user}
 									/>
 								) : (
 									<AccountOverviewCard

--- a/client/components/mma/accountoverview/AccountOverviewCardV2.tsx
+++ b/client/components/mma/accountoverview/AccountOverviewCardV2.tsx
@@ -12,7 +12,10 @@ import {
 } from '@guardian/source-react-components';
 import { useNavigate } from 'react-router';
 import { parseDate } from '../../../../shared/dates';
-import type { ProductDetail } from '../../../../shared/productResponse';
+import type {
+	MembersDataApiUser,
+	ProductDetail,
+} from '../../../../shared/productResponse';
 import { getMainPlan, isGift } from '../../../../shared/productResponse';
 import type { ProductTypeKeys } from '../../../../shared/productTypes';
 import { GROUPED_PRODUCT_TYPES } from '../../../../shared/productTypes';
@@ -76,9 +79,11 @@ const productCardConfiguration: {
 export const AccountOverviewCardV2 = ({
 	productDetail,
 	isEligibleToSwitch,
+	user,
 }: {
 	productDetail: ProductDetail;
 	isEligibleToSwitch: boolean;
+	user?: MembersDataApiUser;
 }) => {
 	const navigate = useNavigate();
 
@@ -385,6 +390,7 @@ export const AccountOverviewCardV2 = ({
 										navigate(`/switch`, {
 											state: {
 												productDetail: productDetail,
+												user: user,
 											},
 										})
 									}

--- a/client/components/mma/shared/assets/InverseStarIcon.tsx
+++ b/client/components/mma/shared/assets/InverseStarIcon.tsx
@@ -1,0 +1,27 @@
+import { iconSize } from '@guardian/source-foundations';
+import type { IconProps } from '@guardian/source-react-components';
+
+export const InverseStarIcon = ({ size }: IconProps) => {
+	return (
+		<svg
+			width={size ? iconSize[size] : undefined}
+			height={undefined}
+			viewBox="-3 -3 30 30"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<path
+				fillRule="evenodd"
+				clipRule="evenodd"
+				d="M20.1693 11.2956C20.1693 16.3581 16.0651 20.4622 11.0026 20.4622C5.9401 20.4622 1.83594 16.3581 1.83594 11.2956C1.83594 6.23307 5.9401 2.12891 11.0026 2.12891C16.0651 2.12891 20.1693 6.23307 20.1693 11.2956Z"
+				fill="#0077B6"
+			/>
+			<path
+				fillRule="evenodd"
+				clipRule="evenodd"
+				d="M15.4539 17.5181L13.9424 12.5945L17.8594 9.52595L17.6643 8.86716H12.821L11.3257 3.96094H10.6431L9.16404 8.86716H4.30441L4.10938 9.52595L8.02634 12.5945L6.54732 17.5181L7.05116 17.9341L10.9844 14.8656L14.9176 17.9341L15.4539 17.5181Z"
+				fill="white"
+			/>
+		</svg>
+	);
+};

--- a/client/components/mma/switch/SwitchComplete.stories.tsx
+++ b/client/components/mma/switch/SwitchComplete.stories.tsx
@@ -11,7 +11,11 @@ export default {
 	parameters: {
 		layout: 'fullscreen',
 		reactRouter: {
-			state: { productDetail: contribution },
+			state: {
+				productDetail: contribution,
+				user: { email: 'test@theguardian.com' },
+				amountPayableToday: 5,
+			},
 			container: <SwitchContainer />,
 		},
 	},

--- a/client/components/mma/switch/SwitchComplete.tsx
+++ b/client/components/mma/switch/SwitchComplete.tsx
@@ -103,56 +103,58 @@ const WhatHappensNext = (props: {
 	email: string;
 }) => {
 	return (
-		<Stack
-			cssOverrides={css`
-				svg {
-					fill: ${brand[500]};
-					flex-shrink: 0;
-				}
-			`}
-		>
+		<Stack space={4}>
 			<Heading sansSerif>What happens next?</Heading>
 			<div
 				css={css`
-					display: flex;
-					align-items: start;
-					margin-top: ${space[4]}px;
+					svg {
+						fill: ${brand[500]};
+						flex-shrink: 0;
+					}
 				`}
 			>
-				<SvgEnvelope size="medium" />
-				<div css={whatHappensNextTextCss}>
-					<p>
-						You will receive a confirmation email to {props.email}
-					</p>
+				<div
+					css={css`
+						display: flex;
+						align-items: start;
+					`}
+				>
+					<SvgEnvelope size="medium" />
+					<div css={whatHappensNextTextCss}>
+						<p>
+							You will receive a confirmation email to{' '}
+							{props.email}
+						</p>
+					</div>
 				</div>
-			</div>
-			<div
-				css={css`
-					display: flex;
-					align-items: start;
-				`}
-			>
-				<SvgClock size="medium" />
-				<div css={whatHappensNextTextCss}>
-					<p>
-						Your first billing date is today and you will be charge
-						a reduced rate of {props.currency}
-						{props.amountPayableToday}.
-					</p>
+				<div
+					css={css`
+						display: flex;
+						align-items: start;
+					`}
+				>
+					<SvgClock size="medium" />
+					<div css={whatHappensNextTextCss}>
+						<p>
+							Your first billing date is today and you will be
+							charge a reduced rate of {props.currency}
+							{props.amountPayableToday}.
+						</p>
+					</div>
 				</div>
-			</div>
-			<div
-				css={css`
-					display: flex;
-					align-items: start;
-				`}
-			>
-				<InverseStarIcon size="medium" />
-				<div css={whatHappensNextTextCss}>
-					<p>
-						Your new support will start today. It can take up to an
-						hour for your support to be activated.
-					</p>
+				<div
+					css={css`
+						display: flex;
+						align-items: start;
+					`}
+				>
+					<InverseStarIcon size="medium" />
+					<div css={whatHappensNextTextCss}>
+						<p>
+							Your new support will start today. It can take up to
+							an hour for your support to be activated.
+						</p>
+					</div>
 				</div>
 			</div>
 		</Stack>

--- a/client/components/mma/switch/SwitchContainer.tsx
+++ b/client/components/mma/switch/SwitchContainer.tsx
@@ -1,8 +1,9 @@
-import type { Context, ReactNode } from 'react';
 import { createContext } from 'react';
+import type { Context, ReactNode  } from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router';
 import type {
 	MembersDataApiResponse,
+	MembersDataApiUser,
 	ProductDetail,
 } from '../../../../shared/productResponse';
 import { isProduct } from '../../../../shared/productResponse';
@@ -20,11 +21,14 @@ import { DefaultLoadingView } from '../shared/asyncComponents/DefaultLoadingView
 
 export interface SwitchRouterState {
 	productDetail: ProductDetail;
+	user?: MembersDataApiUser;
+	amountPayableToday: number;
 }
 
 export interface SwitchContextInterface {
 	productDetail: ProductDetail;
 	isFromApp: Boolean;
+	user?: MembersDataApiUser;
 }
 
 export const SwitchContext: Context<SwitchContextInterface | {}> =
@@ -36,12 +40,13 @@ export const SwitchContainer = () => {
 	const location = useLocation();
 	const routerState = location.state as SwitchRouterState;
 	const productDetail = routerState?.productDetail;
+	const user = routerState?.user;
 
 	if (!productDetail) {
 		return <AsyncLoadedSwitchContainer />;
 	}
 
-	return <RenderedPage productDetail={productDetail} />;
+	return <RenderedPage productDetail={productDetail} user={user} />;
 };
 
 const SwitchPageContainer = (props: { children: ReactNode }) => {
@@ -90,16 +95,20 @@ const AsyncLoadedSwitchContainer = () => {
 	}
 
 	const productDetail = data.products.filter(isProduct)[0];
-	return <RenderedPage productDetail={productDetail} />;
+	return <RenderedPage productDetail={productDetail} user={data.user} />;
 };
 
-const RenderedPage = (props: { productDetail: ProductDetail }) => {
+const RenderedPage = (props: {
+	productDetail: ProductDetail;
+	user?: MembersDataApiUser;
+}) => {
 	return (
 		<SwitchPageContainer>
 			<SwitchContext.Provider
 				value={{
 					productDetail: props.productDetail,
 					isFromApp: isFromApp(),
+					user: props.user,
 				}}
 			>
 				<Outlet />

--- a/client/components/mma/switch/SwitchReview.tsx
+++ b/client/components/mma/switch/SwitchReview.tsx
@@ -145,7 +145,7 @@ export const SwitchReview = () => {
 			},
 		);
 
-	const confirmSwitch = async () => {
+	const confirmSwitch = async (amount: number) => {
 		try {
 			setIsSwitching(true);
 			const response = await productMoveFetch(false);
@@ -156,7 +156,9 @@ export const SwitchReview = () => {
 				setSwitchingError(true);
 			} else {
 				// TODO: Navigate to switch complete page when built
-				navigate('/');
+				navigate('/switch/complete', {
+					state: { amountPayableToday: amount },
+				});
 			}
 		} catch (e) {
 			setIsSwitching(false);
@@ -399,7 +401,9 @@ export const SwitchReview = () => {
 						cssOverrides={css`
 							justify-content: center;
 						`}
-						onClick={confirmSwitch}
+						onClick={() =>
+							confirmSwitch(previewResponse.amountPayableToday)
+						}
 					>
 						Confirm change
 					</Button>

--- a/client/components/mma/switch/SwitchReview.tsx
+++ b/client/components/mma/switch/SwitchReview.tsx
@@ -155,7 +155,6 @@ export const SwitchReview = () => {
 				setIsSwitching(false);
 				setSwitchingError(true);
 			} else {
-				// TODO: Navigate to switch complete page when built
 				navigate('/switch/complete', {
 					state: { amountPayableToday: amount },
 				});

--- a/cypress/integration/parallel-2/productSwitch.spec.ts
+++ b/cypress/integration/parallel-2/productSwitch.spec.ts
@@ -251,16 +251,15 @@ describe('product switching', () => {
 				name: 'Add extras with no extra cost',
 			}).click();
 
+			cy.findByRole('button', { name: 'Confirm change' }).click();
+
 			cy.intercept('POST', '/api/product-move/*', {
 				statusCode: 200,
 				body: productMoveSuccessfulResponse,
 			});
 
-			cy.findByRole('button', { name: 'Confirm change' }).click();
-
-			// TODO: Final confirmation page hasn't been built yet so we redirect
-			// back to the Account Overview following a successful switch
-			cy.location('pathname').should('eq', '/');
+			cy.findByText(/Thank you/).should('exist');
+			cy.findByText(/reduced rate of £5/).should('exist');
 		});
 
 		it('shows an error message if switch fails', () => {

--- a/shared/productResponse.ts
+++ b/shared/productResponse.ts
@@ -9,8 +9,14 @@ import type { GroupedProductTypeKeys, ProductType } from './productTypes';
 
 export type DeliveryRecordApiItem = DeliveryRecordDetail;
 
+export type MembersDataApiUser = {
+	firstName: string;
+	lastName: string;
+	email: string;
+};
+
 export type MembersDataApiResponse = {
-	user?: { firstName: string; lastName: string; email: string };
+	user?: MembersDataApiUser;
 	products: MembersDataApiItem[];
 };
 


### PR DESCRIPTION
- store amountPayableToday in routerState
- propagate user info to review pages

## What does this change?

Adds the 'What Happens Next' section to the Thank You page, storing the amount payable today from the Review page in routerState. It also gets the user info to display the email from the mdapi response.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

On the review page click 'Confirm change' and witness the new component on Thank You page with email and amount to pay today.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://user-images.githubusercontent.com/114918544/215122066-ffa47ce2-d3be-41f6-b748-529cbe058c70.png)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
