### PR TITLE
Replace test Stripe setup intent with more obviously dummy data

### DIFF
--- a/client/fixtures/payment.ts
+++ b/client/fixtures/payment.ts
@@ -1,9 +1,8 @@
 import type { StripeSetupIntent } from '../../shared/stripeSetupIntent';
 
 export const stripeSetupIntent: StripeSetupIntent = {
-	id: 'seti_0KLFtUItVxyc3M6nBXnYb2jO',
-	client_secret:
-		'seti_0KLFtUItVxyc3Q6nBXnYb2jO_secret_L1IUioSNMNThetlMQnVtbCJu0Gj2cq1M',
+	id: 'seti_test',
+	client_secret: 'seti_test_secret_test',
 };
 
 export const executePaymentUpdateResponse = {


### PR DESCRIPTION
## What does this change?

Changes the stripe setup intent used for tests with a more obviously dummy string.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
