### PR TITLE
Personalised header on Account Overview

### DIFF
--- a/client/components/mma/accountoverview/AccountOverview.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.tsx
@@ -39,6 +39,7 @@ import { AccountOverviewCancelledCard } from './AccountOverviewCancelledCard';
 import { AccountOverviewCard } from './AccountOverviewCard';
 import { AccountOverviewCardV2 } from './AccountOverviewCardV2';
 import { EmptyAccountOverview } from './EmptyAccountOverview';
+import { PersonalisedHeader } from './PersonalisedHeader';
 
 const AccountOverviewRenderer = ([mdapiObject, cancelledProductsResponse]: [
 	MembersDataApiResponse | MembersDataApiItem[],
@@ -97,6 +98,8 @@ const AccountOverviewRenderer = ([mdapiObject, cancelledProductsResponse]: [
 
 	return (
 		<>
+			<PersonalisedHeader mdapiResponse={mdaResponse} />
+
 			<PaymentFailureAlertIfApplicable
 				productDetail={maybeFirstPaymentFailure}
 			/>

--- a/client/components/mma/accountoverview/PersonalisedHeader.tsx
+++ b/client/components/mma/accountoverview/PersonalisedHeader.tsx
@@ -1,0 +1,58 @@
+import { css } from '@emotion/react';
+import { headline, space } from '@guardian/source-foundations';
+import type { MembersDataApiResponse } from '../../../../shared/productResponse';
+import { isProduct, sortByJoinDate } from '../../../../shared/productResponse';
+
+interface PersonalisedHeaderProps {
+	mdapiResponse: MembersDataApiResponse;
+}
+
+export const PersonalisedHeader = ({
+	mdapiResponse,
+}: PersonalisedHeaderProps) => {
+	const userDetails = mdapiResponse.user;
+
+	const productDetails = mdapiResponse.products
+		.filter(isProduct)
+		.sort(sortByJoinDate);
+	const oldestProduct = productDetails[productDetails.length - 1];
+	const supportStartYear = new Date(oldestProduct.joinDate).getFullYear();
+
+	const calculatedTimeOfDay = () => {
+		const userDate = new Date().getHours();
+
+		if (userDate >= 0 && userDate <= 11) {
+			return 'Good Morning';
+		}
+		if (userDate >= 12 && userDate <= 17) {
+			return 'Good Afternoon';
+		}
+		if (userDate >= 18 && userDate <= 23) {
+			return 'Good Evening';
+		}
+	};
+
+	return userDetails ? (
+		<hgroup
+			css={css`
+				margin-top: ${space[12]}px;
+			`}
+		>
+			<h2
+				css={css`
+					${headline.large({ fontWeight: 'bold' })};
+					margin-bottom: 0;
+				`}
+			>
+				{calculatedTimeOfDay()} {userDetails.firstName ?? 'Reader'}
+			</h2>
+			<p
+				css={css`
+					${headline.xxxsmall()};
+				`}
+			>
+				Thanks for supporting the Guardian since {supportStartYear}
+			</p>
+		</hgroup>
+	) : null;
+};

--- a/client/components/mma/accountoverview/PersonalisedHeader.tsx
+++ b/client/components/mma/accountoverview/PersonalisedHeader.tsx
@@ -19,15 +19,14 @@ export const PersonalisedHeader = ({
 	const supportStartYear = new Date(oldestProduct.joinDate).getFullYear();
 
 	const calculatedTimeOfDay = () => {
-		const userDate = new Date().getHours();
+		const currentHour = new Date().getHours();
 
-		if (userDate >= 0 && userDate <= 11) {
+		if (currentHour < 12) {
 			return 'Good Morning';
 		}
-		if (userDate >= 12 && userDate <= 17) {
+		if (currentHour < 18) {
 			return 'Good Afternoon';
-		}
-		if (userDate >= 18 && userDate <= 23) {
+		} else {
 			return 'Good Evening';
 		}
 	};


### PR DESCRIPTION
Added new file to create the personalised header when a user accesses their account overview:

Depending on the time of day the user will see a different welcome greeting. This is determined by pulling the hour from the user and setting either Good [morning, afternoon, evening]. 

The User's name is pulled from mdapi, if the first name is not present then Reader is set as the default. The year which the user has supported The Guardian is also pulled from the mdapi response which has the product details. The products are ordered by join date and the oldest product year is used.

## What does this change?

A new personalised header on the account overview page, including a welcome greeting, the user name and the year they started supporting The Guardian

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Head to your Account Overview page and you should see a greeting for the right time of the day, your name (or reader if this is not present and the year of your oldest product.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
Before: 
![image](https://user-images.githubusercontent.com/115992455/215540310-0db73279-37bd-47d2-96ea-9487e32fc20c.png)

After: 
![image](https://user-images.githubusercontent.com/115992455/215541471-b6c351eb-4fb8-4ed7-91f0-bd54704bdfbb.png)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
