### PR TITLE
Product switch refactoring and post design review refinement

### DIFF
--- a/client/components/mma/shared/Heading.tsx
+++ b/client/components/mma/shared/Heading.tsx
@@ -13,7 +13,6 @@ interface HeadingProps {
 	cssOverrides?: SerializedStyles | SerializedStyles[];
 	level?: '1' | '2' | '3' | '4';
 	sansSerif?: boolean;
-	noDivider?: boolean;
 }
 
 export const Heading = (props: HeadingProps) => {
@@ -38,7 +37,7 @@ export const Heading = (props: HeadingProps) => {
 	const HeadingElement: keyof JSX.IntrinsicElements = `h${props.level ?? 2}`;
 
 	return (
-		<div css={props.noDivider ? '' : dividerStyles}>
+		<div css={dividerStyles}>
 			<HeadingElement css={[headingStyles, props.cssOverrides]}>
 				{props.children}
 			</HeadingElement>

--- a/client/components/mma/switch/SwitchComplete.tsx
+++ b/client/components/mma/switch/SwitchComplete.tsx
@@ -26,6 +26,7 @@ import type {
 } from './SwitchContainer';
 import { SwitchContext } from './SwitchContainer';
 import { SwitchSignInImage } from './SwitchSignInImage';
+import { iconListCss } from './SwitchStyles';
 
 export const SwitchComplete = () => {
 	const switchContext = useContext(SwitchContext) as SwitchContextInterface;
@@ -92,14 +93,9 @@ const extrasStyling = css`
 	}
 `;
 
-const whatHappensNextTextCss = css`
-	width: 100%;
-	margin-left: 0.5rem;
-
-	p {
-		${textSans.medium()}
-		margin-top: 0;
-		margin-bottom: ${space[2]}px;
+const whatHappensNextCss = css`
+	li > svg {
+		fill: ${brand[500]};
 	}
 `;
 
@@ -111,58 +107,29 @@ const WhatHappensNext = (props: {
 	return (
 		<Stack space={4}>
 			<Heading sansSerif>What happens next?</Heading>
-			<div
-				css={css`
-					svg {
-						fill: ${brand[500]};
-						flex-shrink: 0;
-					}
-				`}
-			>
-				<div
-					css={css`
-						display: flex;
-						align-items: start;
-					`}
-				>
+			<ul css={[iconListCss, whatHappensNextCss]}>
+				<li>
 					<SvgEnvelope size="medium" />
-					<div css={whatHappensNextTextCss}>
-						<p>
-							You will receive a confirmation email to{' '}
-							{props.email}
-						</p>
-					</div>
-				</div>
-				<div
-					css={css`
-						display: flex;
-						align-items: start;
-					`}
-				>
+					<span>
+						You will receive a confirmation email to {props.email}
+					</span>
+				</li>
+				<li>
 					<SvgClock size="medium" />
-					<div css={whatHappensNextTextCss}>
-						<p>
-							Your first billing date is today and you will be
-							charge a reduced rate of {props.currency}
-							{props.amountPayableToday}.
-						</p>
-					</div>
-				</div>
-				<div
-					css={css`
-						display: flex;
-						align-items: start;
-					`}
-				>
+					<span>
+						Your first billing date is today and you will be charge
+						a reduced rate of {props.currency}
+						{props.amountPayableToday}.
+					</span>
+				</li>
+				<li>
 					<InverseStarIcon size="medium" />
-					<div css={whatHappensNextTextCss}>
-						<p>
-							Your new support will start today. It can take up to
-							an hour for your support to be activated.
-						</p>
-					</div>
-				</div>
-			</div>
+					<span>
+						Your new support will start today. It can take up to an
+						hour for your support to be activated.
+					</span>
+				</li>
+			</ul>
 		</Stack>
 	);
 };

--- a/client/components/mma/switch/SwitchComplete.tsx
+++ b/client/components/mma/switch/SwitchComplete.tsx
@@ -2,10 +2,10 @@ import { css } from '@emotion/react';
 import {
 	brand,
 	from,
+	headline,
 	palette,
 	space,
 	textSans,
-	until,
 } from '@guardian/source-foundations';
 import {
 	Stack,
@@ -82,17 +82,6 @@ export const SwitchComplete = () => {
 	);
 };
 
-const extrasStyling = css`
-	${from.tablet} {
-		color: ${palette.brand['500']};
-
-		::before {
-			content: '\\a';
-			white-space: pre;
-		}
-	}
-`;
-
 const whatHappensNextCss = css`
 	li > svg {
 		fill: ${brand[500]};
@@ -134,25 +123,30 @@ const WhatHappensNext = (props: {
 	);
 };
 
+const thankYouCss = css`
+	${headline.xsmall({ fontWeight: 'bold' })};
+	margin-top: 0;
+	margin-bottom: 0;
+
+	${from.tablet} {
+		${headline.small({ fontWeight: 'bold' })};
+		span {
+			display: block;
+			color: ${palette.brand['500']};
+		}
+	}
+`;
+
 const ThankYouMessaging = (props: {
 	mainPlan: PaidSubscriptionPlan;
 	newAmount: number;
 }) => {
 	return (
-		<>
-			<Heading
-				cssOverrides={css`
-					${until.mobile} {
-						max-width: 350px;
-					}
-				`}
-				noDivider
-			>
-				Thank you for upgrading to {props.mainPlan.currency}
-				{props.newAmount} per {props.mainPlan.billingPeriod}.{' '}
-				<span css={extrasStyling}>Enjoy your exclusive extras.</span>
-			</Heading>
-		</>
+		<h2 css={thankYouCss}>
+			Thank you for upgrading to {props.mainPlan.currency}
+			{props.newAmount} per {props.mainPlan.billingPeriod}.{' '}
+			<span>Enjoy your exclusive extras.</span>
+		</h2>
 	);
 };
 

--- a/client/components/mma/switch/SwitchComplete.tsx
+++ b/client/components/mma/switch/SwitchComplete.tsx
@@ -17,7 +17,6 @@ import { Navigate, useLocation } from 'react-router';
 import type { PaidSubscriptionPlan } from '../../../../shared/productResponse';
 import { getMainPlan } from '../../../../shared/productResponse';
 import { calculateMonthlyOrAnnualFromBillingPeriod } from '../../../../shared/productTypes';
-import { sectionSpacing } from '../../../styles/spacing';
 import { InverseStarIcon } from '../shared/assets/InverseStarIcon';
 import { Heading } from '../shared/Heading';
 import type {
@@ -26,7 +25,7 @@ import type {
 } from './SwitchContainer';
 import { SwitchContext } from './SwitchContainer';
 import { SwitchSignInImage } from './SwitchSignInImage';
-import { iconListCss } from './SwitchStyles';
+import { iconListCss, sectionSpacing } from './SwitchStyles';
 
 export const SwitchComplete = () => {
 	const switchContext = useContext(SwitchContext) as SwitchContextInterface;

--- a/client/components/mma/switch/SwitchOptions.tsx
+++ b/client/components/mma/switch/SwitchOptions.tsx
@@ -3,6 +3,7 @@ import { palette, space, textSans, until } from '@guardian/source-foundations';
 import {
 	Button,
 	buttonThemeReaderRevenueBrand,
+	Stack,
 } from '@guardian/source-react-components';
 import { useContext, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
@@ -169,34 +170,40 @@ export const SwitchOptions = () => {
 			</section>
 
 			<section css={sectionSpacing}>
-				<Heading sansSerif>
-					{aboveThreshold ? 'Add extras' : 'Change your support'}
-				</Heading>
-				<p
-					css={css`
-						${textSans.medium()}
-						margin-bottom: ${space[3]}px;
-					`}
-				>
-					Change to {supporterPlusTitle} and get exclusive supporter
-					benefits
-				</p>
-				<Card>
-					<Card.Header backgroundColor={palette.brand[500]}>
-						<div css={cardHeaderDivCss}>
-							<h3 css={productTitleCss}>{supporterPlusTitle}</h3>
-							{!aboveThreshold && (
-								<p css={productSubtitleCss}>
-									{mainPlan.currency}
-									{threshold}/{mainPlan.billingPeriod}
-								</p>
-							)}
-						</div>
-					</Card.Header>
-					<Card.Section>
-						<SupporterPlusBenefitsSection />
-					</Card.Section>
-				</Card>
+				<Stack space={3}>
+					<Heading sansSerif>
+						{aboveThreshold ? 'Add extras' : 'Change your support'}
+					</Heading>
+					{!switchContext.isFromApp && (
+						<p
+							css={css`
+								${textSans.medium()}
+								margin: 0;
+							`}
+						>
+							Change to {supporterPlusTitle} and get exclusive
+							supporter benefits
+						</p>
+					)}
+					<Card>
+						<Card.Header backgroundColor={palette.brand[500]}>
+							<div css={cardHeaderDivCss}>
+								<h3 css={productTitleCss}>
+									{supporterPlusTitle}
+								</h3>
+								{!aboveThreshold && (
+									<p css={productSubtitleCss}>
+										{mainPlan.currency}
+										{threshold}/{mainPlan.billingPeriod}
+									</p>
+								)}
+							</div>
+						</Card.Header>
+						<Card.Section>
+							<SupporterPlusBenefitsSection />
+						</Card.Section>
+					</Card>
+				</Stack>
 			</section>
 
 			<section

--- a/client/components/mma/switch/SwitchOptions.tsx
+++ b/client/components/mma/switch/SwitchOptions.tsx
@@ -15,7 +15,11 @@ import { Heading } from '../shared/Heading';
 import { SupporterPlusBenefitsSection } from '../shared/SupporterPlusBenefits';
 import type { SwitchContextInterface } from './SwitchContainer';
 import { SwitchContext } from './SwitchContainer';
-import { productTitleCss, smallPrintCss } from './SwitchStyles';
+import {
+	buttonCentredCss,
+	productTitleCss,
+	smallPrintCss,
+} from './SwitchStyles';
 
 const cardHeaderDivCss = css`
 	display: flex;
@@ -202,9 +206,7 @@ export const SwitchOptions = () => {
 				<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
 					<Button
 						size="small"
-						cssOverrides={css`
-							justify-content: center;
-						`}
+						cssOverrides={buttonCentredCss}
 						onClick={() => navigate(`/switch/review`)}
 					>
 						{aboveThreshold

--- a/client/components/mma/switch/SwitchOptions.tsx
+++ b/client/components/mma/switch/SwitchOptions.tsx
@@ -1,12 +1,5 @@
 import { css, ThemeProvider } from '@emotion/react';
-import {
-	from,
-	headline,
-	palette,
-	space,
-	textSans,
-	until,
-} from '@guardian/source-foundations';
+import { palette, space, textSans, until } from '@guardian/source-foundations';
 import {
 	Button,
 	buttonThemeReaderRevenueBrand,
@@ -22,21 +15,12 @@ import { Heading } from '../shared/Heading';
 import { SupporterPlusBenefitsSection } from '../shared/SupporterPlusBenefits';
 import type { SwitchContextInterface } from './SwitchContainer';
 import { SwitchContext } from './SwitchContainer';
+import { productTitleCss } from './SwitchStyles';
 
 const cardHeaderDivCss = css`
 	display: flex;
 	justify-content: space-between;
 	align-items: flex-end;
-`;
-
-const productTitleCss = css`
-	${headline.xsmall({ fontWeight: 'bold' })};
-	color: ${palette.neutral[100]};
-	margin: 0;
-	max-width: 20ch;
-	${from.tablet} {
-		${headline.small({ fontWeight: 'bold' })};
-	}
 `;
 
 const productSubtitleCss = css`

--- a/client/components/mma/switch/SwitchOptions.tsx
+++ b/client/components/mma/switch/SwitchOptions.tsx
@@ -10,7 +10,6 @@ import { useNavigate } from 'react-router';
 import type { PaidSubscriptionPlan } from '../../../../shared/productResponse';
 import { getMainPlan } from '../../../../shared/productResponse';
 import { calculateMonthlyOrAnnualFromBillingPeriod } from '../../../../shared/productTypes';
-import { sectionSpacing } from '../../../styles/spacing';
 import { Card } from '../shared/Card';
 import { Heading } from '../shared/Heading';
 import { SupporterPlusBenefitsSection } from '../shared/SupporterPlusBenefits';
@@ -19,6 +18,7 @@ import { SwitchContext } from './SwitchContainer';
 import {
 	buttonCentredCss,
 	productTitleCss,
+	sectionSpacing,
 	smallPrintCss,
 } from './SwitchStyles';
 

--- a/client/components/mma/switch/SwitchOptions.tsx
+++ b/client/components/mma/switch/SwitchOptions.tsx
@@ -15,7 +15,7 @@ import { Heading } from '../shared/Heading';
 import { SupporterPlusBenefitsSection } from '../shared/SupporterPlusBenefits';
 import type { SwitchContextInterface } from './SwitchContainer';
 import { SwitchContext } from './SwitchContainer';
-import { productTitleCss } from './SwitchStyles';
+import { productTitleCss, smallPrintCss } from './SwitchStyles';
 
 const cardHeaderDivCss = css`
 	display: flex;
@@ -215,17 +215,15 @@ export const SwitchOptions = () => {
 			</section>
 
 			{aboveThreshold && (
-				<p
-					css={css`
-						color: ${palette.neutral[46]};
-					`}
-				>
-					Exclusive supporter extras are unlocked for any monthly
-					support of {mainPlan.currency}
-					{monthlyThreshold} or above and any annual support of{' '}
-					{mainPlan.currency}
-					{annualThreshold} or above.
-				</p>
+				<section>
+					<p css={smallPrintCss}>
+						Exclusive supporter extras are unlocked for any monthly
+						support of {mainPlan.currency}
+						{monthlyThreshold} or above and any annual support of{' '}
+						{mainPlan.currency}
+						{annualThreshold} or above.
+					</p>
+				</section>
 			)}
 		</>
 	);

--- a/client/components/mma/switch/SwitchReview.tsx
+++ b/client/components/mma/switch/SwitchReview.tsx
@@ -18,7 +18,6 @@ import {
 import type { PaidSubscriptionPlan } from '../../../../shared/productResponse';
 import { getMainPlan } from '../../../../shared/productResponse';
 import { calculateMonthlyOrAnnualFromBillingPeriod } from '../../../../shared/productTypes';
-import { sectionSpacing } from '../../../styles/spacing';
 import {
 	LoadingState,
 	useAsyncLoader,
@@ -42,6 +41,7 @@ import {
 	iconListCss,
 	listWithDividersCss,
 	productTitleCss,
+	sectionSpacing,
 	smallPrintCss,
 } from './SwitchStyles';
 

--- a/client/components/mma/switch/SwitchReview.tsx
+++ b/client/components/mma/switch/SwitchReview.tsx
@@ -37,6 +37,8 @@ import { SupporterPlusBenefitsToggle } from '../shared/SupporterPlusBenefits';
 import type { SwitchContextInterface } from './SwitchContainer';
 import { SwitchContext } from './SwitchContainer';
 import {
+	buttonCentredCss,
+	buttonMutedCss,
 	iconListCss,
 	listWithDividersCss,
 	productTitleCss,
@@ -295,9 +297,7 @@ export const SwitchReview = () => {
 				<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
 					<Button
 						isLoading={isSwitching}
-						cssOverrides={css`
-							justify-content: center;
-						`}
+						cssOverrides={buttonCentredCss}
 						onClick={() =>
 							confirmSwitch(previewResponse.amountPayableToday)
 						}
@@ -307,9 +307,7 @@ export const SwitchReview = () => {
 				</ThemeProvider>
 				<Button
 					priority="tertiary"
-					cssOverrides={css`
-						justify-content: center;
-					`}
+					cssOverrides={[buttonCentredCss, buttonMutedCss]}
 					onClick={() => navigate('..')}
 				>
 					Back

--- a/client/components/mma/switch/SwitchReview.tsx
+++ b/client/components/mma/switch/SwitchReview.tsx
@@ -36,7 +36,11 @@ import { SepaDisplay } from '../shared/SepaDisplay';
 import { SupporterPlusBenefitsToggle } from '../shared/SupporterPlusBenefits';
 import type { SwitchContextInterface } from './SwitchContainer';
 import { SwitchContext } from './SwitchContainer';
-import { iconListCss, productTitleCss } from './SwitchStyles';
+import {
+	iconListCss,
+	listWithDividersCss,
+	productTitleCss,
+} from './SwitchStyles';
 
 const newAmountCss = css`
 	${textSans.medium({ fontWeight: 'bold' })};
@@ -44,23 +48,6 @@ const newAmountCss = css`
 	margin-top: ${space[4]}px;
 	margin-bottom: 0;
 	border-top: 1px solid ${palette.neutral[86]};
-`;
-
-const whatHappensNextCss = css`
-	margin-top: ${space[4]}px;
-
-	li + li {
-		margin-top: ${space[3]}px;
-
-		> svg {
-			padding-top: ${space[3]}px;
-		}
-
-		> span {
-			padding-top: ${space[3]}px;
-			border-top: 1px solid ${palette.neutral[86]};
-		}
-	}
 `;
 
 const buttonLayoutCss = css`
@@ -232,80 +219,90 @@ export const SwitchReview = () => {
 				</Stack>
 			</section>
 			<section css={sectionSpacing}>
-				<Heading sansSerif>What happens next?</Heading>
-				<ul css={[iconListCss, whatHappensNextCss]}>
-					<li>
-						<SvgClock size="medium" />
-						<span>
-							<strong>This change will happen today</strong>
-							Dive in and start enjoying your exclusive extras
-							straight away.
-						</span>
-					</li>
-					<li
-						css={css`
-							color: ${palette.success[400]};
-						`}
-					>
-						<SwitchOffsetPaymentIcon size="medium" />
-						<span>
-							<strong>
-								Your first payment will be just{' '}
-								{mainPlan.currency}
-								{previewResponse.amountPayableToday}
-							</strong>
-							We will charge you a smaller amount today, to offset
-							the payment you've already given us for the rest of
-							the month. After this, from {nextPayment}, your new{' '}
-							{monthlyOrAnnual.toLocaleLowerCase()} payment will
-							be {mainPlan.currency}
-							{previewResponse.supporterPlusPurchaseAmount}
-						</span>
-					</li>
-					<li>
-						<SvgCreditCard size="medium" />
-						<span>
-							<strong>No payment changes are needed</strong>
-							We will take payment as before, from
-							{productDetail.subscription.card && (
-								<CardDisplay
-									inline
-									cssOverrides={css`
-										margin: 0;
-									`}
-									{...productDetail.subscription.card}
-								/>
-							)}
-							{productDetail.subscription.payPalEmail && (
-								<PaypalDisplay
-									inline
-									payPalId={
-										productDetail.subscription.payPalEmail
-									}
-								/>
-							)}
-							{productDetail.subscription.sepaMandate && (
-								<SepaDisplay
-									inline
-									accountName={
-										productDetail.subscription.sepaMandate
-											.accountName
-									}
-									iban={
-										productDetail.subscription.sepaMandate
-											.iban
-									}
-								/>
-							)}
-							{productDetail.subscription.mandate && (
-								<DirectDebitDisplay
-									inline
-									{...productDetail.subscription.mandate}
-								/>
-							)}
-						</span>
-					</li>
-				</ul>
+				<Stack space={4}>
+					<Heading sansSerif>What happens next?</Heading>
+					<ul css={[iconListCss, listWithDividersCss]}>
+						<li>
+							<SvgClock size="medium" />
+							<span>
+								<strong>This change will happen today</strong>
+								<br />
+								Dive in and start enjoying your exclusive extras
+								straight away.
+							</span>
+						</li>
+						<li
+							css={css`
+								color: ${palette.success[400]};
+							`}
+						>
+							<SwitchOffsetPaymentIcon size="medium" />
+							<span>
+								<strong>
+									Your first payment will be just{' '}
+									{mainPlan.currency}
+									{previewResponse.amountPayableToday}
+								</strong>
+								<br />
+								We will charge you a smaller amount today, to
+								offset the payment you've already given us for
+								the rest of the month. After this, from{' '}
+								{nextPayment}, your new{' '}
+								{monthlyOrAnnual.toLocaleLowerCase()} payment
+								will be {mainPlan.currency}
+								{previewResponse.supporterPlusPurchaseAmount}
+							</span>
+						</li>
+						<li>
+							<SvgCreditCard size="medium" />
+							<span>
+								<strong>No payment changes are needed</strong>
+								<br />
+								We will take payment as before, from
+								<strong>
+									{productDetail.subscription.card && (
+										<CardDisplay
+											inline
+											cssOverrides={css`
+												margin: 0;
+											`}
+											{...productDetail.subscription.card}
+										/>
+									)}
+									{productDetail.subscription.payPalEmail && (
+										<PaypalDisplay
+											inline
+											payPalId={
+												productDetail.subscription
+													.payPalEmail
+											}
+										/>
+									)}
+									{productDetail.subscription.sepaMandate && (
+										<SepaDisplay
+											inline
+											accountName={
+												productDetail.subscription
+													.sepaMandate.accountName
+											}
+											iban={
+												productDetail.subscription
+													.sepaMandate.iban
+											}
+										/>
+									)}
+									{productDetail.subscription.mandate && (
+										<DirectDebitDisplay
+											inline
+											{...productDetail.subscription
+												.mandate}
+										/>
+									)}
+								</strong>
+							</span>
+						</li>
+					</ul>
+				</Stack>
 			</section>
 			<section css={buttonLayoutCss}>
 				<ThemeProvider theme={buttonThemeReaderRevenueBrand}>

--- a/client/components/mma/switch/SwitchReview.tsx
+++ b/client/components/mma/switch/SwitchReview.tsx
@@ -40,6 +40,7 @@ import {
 	iconListCss,
 	listWithDividersCss,
 	productTitleCss,
+	smallPrintCss,
 } from './SwitchStyles';
 
 const newAmountCss = css`
@@ -65,20 +66,6 @@ const buttonLayoutCss = css`
 			margin-top: 0;
 			margin-left: ${space[3]}px;
 		}
-	}
-`;
-
-const smallPrintCss = css`
-	${textSans.xxsmall()};
-	margin-top: 0;
-	margin-bottom: 0;
-	color: #606060;
-	> a {
-		color: inherit;
-		text-decoration: underline;
-	}
-	& + & {
-		margin-top: ${space[1]}px;
 	}
 `;
 

--- a/client/components/mma/switch/SwitchReview.tsx
+++ b/client/components/mma/switch/SwitchReview.tsx
@@ -1,11 +1,5 @@
 import { css, ThemeProvider } from '@emotion/react';
-import {
-	from,
-	headline,
-	palette,
-	space,
-	textSans,
-} from '@guardian/source-foundations';
+import { from, palette, space, textSans } from '@guardian/source-foundations';
 import {
 	Button,
 	buttonThemeReaderRevenueBrand,
@@ -42,21 +36,31 @@ import { SepaDisplay } from '../shared/SepaDisplay';
 import { SupporterPlusBenefitsToggle } from '../shared/SupporterPlusBenefits';
 import type { SwitchContextInterface } from './SwitchContainer';
 import { SwitchContext } from './SwitchContainer';
+import { iconListCss, productTitleCss } from './SwitchStyles';
 
-// TODO: this is copied from SwitchOptions, share it
-const productTitleCss = css`
-	${headline.xsmall({ fontWeight: 'bold' })};
-	color: ${palette.neutral[100]};
-	margin: 0;
-	max-width: 20ch;
-	${from.tablet} {
-		${headline.small({ fontWeight: 'bold' })};
-	}
+const newAmountCss = css`
+	${textSans.medium({ fontWeight: 'bold' })};
+	padding-top: ${space[3]}px;
+	margin-top: ${space[4]}px;
+	margin-bottom: 0;
+	border-top: 1px solid ${palette.neutral[86]};
 `;
 
-const whatHappensNextTextCss = css`
-	margin-left: 0.75rem;
-	width: 100%;
+const whatHappensNextCss = css`
+	margin-top: ${space[4]}px;
+
+	li + li {
+		margin-top: ${space[3]}px;
+
+		> svg {
+			padding-top: ${space[3]}px;
+		}
+
+		> span {
+			padding-top: ${space[3]}px;
+			border-top: 1px solid ${palette.neutral[86]};
+		}
+	}
 `;
 
 const buttonLayoutCss = css`
@@ -187,19 +191,21 @@ export const SwitchReview = () => {
 		<>
 			<section css={sectionSpacing}>
 				<Stack space={3}>
-					<section>
-						<Heading sansSerif>Review change</Heading>
-						<p
-							css={css`
-								${textSans.medium()};
-							`}
-						>
-							You will now support us with {mainPlan.currency}
-							{newAmount} every {mainPlan.billingPeriod}, giving
-							you exclusive supporter extras, including unlimited
-							reading in our news app
-						</p>
-					</section>
+					<Heading sansSerif>Review change</Heading>
+					<p
+						css={css`
+							${textSans.medium()};
+						`}
+					>
+						You will now support us with {mainPlan.currency}
+						{newAmount} every {mainPlan.billingPeriod}, giving you
+						exclusive supporter extras, including unlimited reading
+						in our news app
+					</p>
+				</Stack>
+			</section>
+			<section css={sectionSpacing}>
+				<Stack space={3}>
 					<Heading sansSerif>Your new support</Heading>
 					<Card>
 						<Card.Header backgroundColor={palette.brand[500]}>
@@ -217,181 +223,89 @@ export const SwitchReview = () => {
 								including unlimited access to the App
 							</p>
 							<SupporterPlusBenefitsToggle />
-							<p
-								css={css`
-									${textSans.medium({ fontWeight: 'bold' })};
-									padding-top: ${space[3]}px;
-									margin-top: ${space[4]}px;
-									margin-bottom: 0;
-									border-top: 1px solid ${palette.neutral[86]};
-								`}
-							>
+							<p css={newAmountCss}>
 								{mainPlan.currency}
 								{newAmount}/{mainPlan.billingPeriod}
 							</p>
 						</Card.Section>
-					</Card>{' '}
+					</Card>
 				</Stack>
-				<section css={sectionSpacing}>
-					<Stack>
-						<Heading sansSerif>What happens next?</Heading>
-						<div
-							css={css`
-								display: flex;
-								align-items: start;
-							`}
-						>
-							<SvgClock size="medium" />
-							<div css={whatHappensNextTextCss}>
-								<p
-									css={css`
-										${textSans.medium({
-											fontWeight: 'bold',
-										})};
-										margin-bottom: 0;
+			</section>
+			<section css={sectionSpacing}>
+				<Heading sansSerif>What happens next?</Heading>
+				<ul css={[iconListCss, whatHappensNextCss]}>
+					<li>
+						<SvgClock size="medium" />
+						<span>
+							<strong>This change will happen today</strong>
+							Dive in and start enjoying your exclusive extras
+							straight away.
+						</span>
+					</li>
+					<li
+						css={css`
+							color: ${palette.success[400]};
+						`}
+					>
+						<SwitchOffsetPaymentIcon size="medium" />
+						<span>
+							<strong>
+								Your first payment will be just{' '}
+								{mainPlan.currency}
+								{previewResponse.amountPayableToday}
+							</strong>
+							We will charge you a smaller amount today, to offset
+							the payment you've already given us for the rest of
+							the month. After this, from {nextPayment}, your new{' '}
+							{monthlyOrAnnual.toLocaleLowerCase()} payment will
+							be {mainPlan.currency}
+							{previewResponse.supporterPlusPurchaseAmount}
+						</span>
+					</li>
+					<li>
+						<SvgCreditCard size="medium" />
+						<span>
+							<strong>No payment changes are needed</strong>
+							We will take payment as before, from
+							{productDetail.subscription.card && (
+								<CardDisplay
+									inline
+									cssOverrides={css`
+										margin: 0;
 									`}
-								>
-									This change will happen today
-								</p>
-								<p
-									css={css`
-										${textSans.medium()}
-										margin-top: 0;
-									`}
-								>
-									Dive in and start enjoying your exclusive
-									extras straight away.
-								</p>
-							</div>
-						</div>
-						<div
-							css={css`
-								display: flex;
-								align-items: start;
-								svg {
-									flex-shrink: 0;
-									fill: ${palette.success[400]};
-								}
-							`}
-						>
-							<SwitchOffsetPaymentIcon size="medium" />
-							<div css={whatHappensNextTextCss}>
-								<p
-									css={css`
-										${textSans.medium({
-											fontWeight: 'bold',
-										})};
-										color: ${palette.success[400]};
-										margin-bottom: 0;
-										border-top: 1px solid
-											${palette.neutral[86]};
-									`}
-								>
-									Your first payment will be just{' '}
-									{mainPlan.currency}
-									{previewResponse.amountPayableToday}
-								</p>
-								<p
-									css={css`
-										${textSans.medium()};
-										color: ${palette.success[400]};
-										margin-top: 0;
-									`}
-								>
-									We will charge you a smaller amount today,
-									to offset the payment you've already given
-									us for the rest of the month. After this,
-									from {nextPayment}, your new{' '}
-									{monthlyOrAnnual.toLocaleLowerCase()}{' '}
-									payment will be {mainPlan.currency}
-									{
-										previewResponse.supporterPlusPurchaseAmount
+									{...productDetail.subscription.card}
+								/>
+							)}
+							{productDetail.subscription.payPalEmail && (
+								<PaypalDisplay
+									inline
+									payPalId={
+										productDetail.subscription.payPalEmail
 									}
-								</p>
-							</div>
-						</div>
-						<div
-							css={css`
-								display: flex;
-								align-items: start;
-							`}
-						>
-							<SvgCreditCard size="medium" />
-							<div css={whatHappensNextTextCss}>
-								<p
-									css={css`
-										${textSans.medium({
-											fontWeight: 'bold',
-										})};
-										margin-bottom: 0;
-										border-top: 1px solid
-											${palette.neutral[86]};
-									`}
-								>
-									No payment changes are needed
-								</p>
-								<div
-									css={css`
-										${from.tablet} {
-											display: flex;
-										}
-										${textSans.medium()}
-										margin-top: 0;
-									`}
-								>
-									<p
-										css={css`
-											margin-bottom: 0;
-											margin-right: ${space[1]}px;
-										`}
-									>
-										We will take payment as before, from
-									</p>
-									{productDetail.subscription.card && (
-										<b>
-											<CardDisplay
-												cssOverrides={css`
-													margin: 0;
-												`}
-												{...productDetail.subscription
-													.card}
-											/>
-										</b>
-									)}
-									{productDetail.subscription.payPalEmail && (
-										<PaypalDisplay
-											inline
-											payPalId={
-												productDetail.subscription
-													.payPalEmail
-											}
-										/>
-									)}
-									{productDetail.subscription.sepaMandate && (
-										<SepaDisplay
-											inline
-											accountName={
-												productDetail.subscription
-													.sepaMandate.accountName
-											}
-											iban={
-												productDetail.subscription
-													.sepaMandate.iban
-											}
-										/>
-									)}
-									{productDetail.subscription.mandate && (
-										<DirectDebitDisplay
-											inline
-											{...productDetail.subscription
-												.mandate}
-										/>
-									)}
-								</div>
-							</div>
-						</div>
-					</Stack>
-				</section>
+								/>
+							)}
+							{productDetail.subscription.sepaMandate && (
+								<SepaDisplay
+									inline
+									accountName={
+										productDetail.subscription.sepaMandate
+											.accountName
+									}
+									iban={
+										productDetail.subscription.sepaMandate
+											.iban
+									}
+								/>
+							)}
+							{productDetail.subscription.mandate && (
+								<DirectDebitDisplay
+									inline
+									{...productDetail.subscription.mandate}
+								/>
+							)}
+						</span>
+					</li>
+				</ul>
 			</section>
 			<section css={buttonLayoutCss}>
 				<ThemeProvider theme={buttonThemeReaderRevenueBrand}>

--- a/client/components/mma/switch/SwitchStyles.ts
+++ b/client/components/mma/switch/SwitchStyles.ts
@@ -20,25 +20,44 @@ export const productTitleCss = css`
 export const iconListCss = css`
 	${textSans.medium()};
 	list-style: none;
-	margin: 0 0 0 -${space[1]}px;
 	padding: 0;
+	margin-bottom: 0;
 
-	> li {
+	li + li {
+		margin-top: ${space[2]}px;
+		${from.tablet} {
+			margin-top: ${space[3]}px;
+		}
+	}
+
+	li {
 		display: flex;
+		margin-left: -4px;
 		align-items: flex-start;
 
 		> svg {
 			flex-shrink: 0;
-			margin-right: ${space[2]}px;
+			margin-right: 8px;
 			fill: currentColor;
 		}
-
-		> span strong {
-			display: block;
-		}
 	}
+`;
 
-	> li + li {
-		margin-top: ${space[2]}px;
+export const listWithDividersCss = css`
+	li + li {
+		> svg {
+			padding-top: ${space[2]}px;
+			${from.tablet} {
+				padding-top: ${space[3]}px;
+			}
+		}
+		> span {
+			flex-grow: 1;
+			padding-top: ${space[2]}px;
+			border-top: 1px solid ${palette.neutral[86]};
+			${from.tablet} {
+				padding-top: ${space[3]}px;
+			}
+		}
 	}
 `;

--- a/client/components/mma/switch/SwitchStyles.ts
+++ b/client/components/mma/switch/SwitchStyles.ts
@@ -5,6 +5,7 @@ import {
 	palette,
 	space,
 	textSans,
+	until,
 } from '@guardian/source-foundations';
 
 export const productTitleCss = css`
@@ -73,5 +74,15 @@ export const listWithDividersCss = css`
 				padding-top: ${space[3]}px;
 			}
 		}
+	}
+`;
+
+export const buttonCentredCss = css`
+	justify-content: center;
+`;
+
+export const buttonMutedCss = css`
+	${until.tablet} {
+		border: none;
 	}
 `;

--- a/client/components/mma/switch/SwitchStyles.ts
+++ b/client/components/mma/switch/SwitchStyles.ts
@@ -1,0 +1,44 @@
+import { css } from '@emotion/react';
+import {
+	from,
+	headline,
+	palette,
+	space,
+	textSans,
+} from '@guardian/source-foundations';
+
+export const productTitleCss = css`
+	${headline.xsmall({ fontWeight: 'bold' })};
+	color: ${palette.neutral[100]};
+	margin: 0;
+	max-width: 20ch;
+	${from.tablet} {
+		${headline.small({ fontWeight: 'bold' })};
+	}
+`;
+
+export const iconListCss = css`
+	${textSans.medium()};
+	list-style: none;
+	margin: 0 0 0 -${space[1]}px;
+	padding: 0;
+
+	> li {
+		display: flex;
+		align-items: flex-start;
+
+		> svg {
+			flex-shrink: 0;
+			margin-right: ${space[2]}px;
+			fill: currentColor;
+		}
+
+		> span strong {
+			display: block;
+		}
+	}
+
+	> li + li {
+		margin-top: ${space[2]}px;
+	}
+`;

--- a/client/components/mma/switch/SwitchStyles.ts
+++ b/client/components/mma/switch/SwitchStyles.ts
@@ -8,6 +8,13 @@ import {
 	until,
 } from '@guardian/source-foundations';
 
+export const sectionSpacing = css`
+	margin-top: ${space[6]}px;
+	${from.tablet} {
+		margin-top: ${space[9]}px;
+	}
+`;
+
 export const productTitleCss = css`
 	${headline.xsmall({ fontWeight: 'bold' })};
 	color: ${palette.neutral[100]};

--- a/client/components/mma/switch/SwitchStyles.ts
+++ b/client/components/mma/switch/SwitchStyles.ts
@@ -17,6 +17,20 @@ export const productTitleCss = css`
 	}
 `;
 
+export const smallPrintCss = css`
+	${textSans.xxsmall()};
+	margin-top: 0;
+	margin-bottom: 0;
+	color: #606060;
+	> a {
+		color: inherit;
+		text-decoration: underline;
+	}
+	& + & {
+		margin-top: ${space[1]}px;
+	}
+`;
+
 export const iconListCss = css`
 	${textSans.medium()};
 	list-style: none;

--- a/client/styles/spacing.ts
+++ b/client/styles/spacing.ts
@@ -1,9 +1,0 @@
-import { css } from '@emotion/react';
-import { from, space } from '@guardian/source-foundations';
-
-export const sectionSpacing = css`
-	margin-top: ${space[6]}px;
-	${from.tablet} {
-		margin-top: ${space[9]}px;
-	}
-`;


### PR DESCRIPTION
## What does this change?

Refactors product switching pages to extract common styles to `SwitchStyles.ts`. This also introduces new icon list styles and applies these to the two 'what happens next' sections, fixing spacing issues identified during the design review.

This also tackles some other small, post design review updates:

- Hides 'Change to [product]' copy on first page when coming via the app
- Removes border from back button on mobile
- Updates style of small print at bottom of first page to match subsequent pages

## Images

<img width="826" alt="Screenshot 2023-02-02 at 13 54 47" src="https://user-images.githubusercontent.com/1166188/216346418-b6630465-dd32-490f-b485-c9f3bbefd097.png">

<img width="438" alt="Screenshot 2023-02-02 at 13 55 02" src="https://user-images.githubusercontent.com/1166188/216346465-ec957a0e-d808-4c7d-ad09-e79754ea4960.png">

<img width="683" alt="Screenshot 2023-02-02 at 13 54 31" src="https://user-images.githubusercontent.com/1166188/216346436-1a111855-c74a-4931-93dc-f180bb3fd743.png">
