### PR TITLE
Improve Cypress cancellation spec reliability

### DIFF
--- a/cypress/integration/parallel-2/cancelContribution.spec.ts
+++ b/cypress/integration/parallel-2/cancelContribution.spec.ts
@@ -106,7 +106,9 @@ describe('Cancel contribution', () => {
 		}).as('get_case');
 
 		setupCancellation();
-		cy.findAllByRole('radio').eq(0).click();
+		cy.findAllByRole('radio', {
+			name: 'I am unhappy with some editorial decisions',
+		}).click();
 		cy.findByRole('button', { name: 'Continue' }).click();
 
 		cy.wait('@get_case').its('response.statusCode').should('equal', 500);
@@ -116,7 +118,9 @@ describe('Cancel contribution', () => {
 
 	it('cancels contribution with custom save body component (reason: I can no longer afford to support you)', () => {
 		setupCancellation();
-		cy.findAllByRole('radio').eq(2).click();
+		cy.findByRole('radio', {
+			name: 'I can no longer afford to support you',
+		}).click();
 		cy.findByRole('button', { name: 'Continue' }).click();
 
 		cy.wait('@get_case');
@@ -170,7 +174,9 @@ describe('Cancel contribution', () => {
 		});
 
 		setupCancellation();
-		cy.findAllByRole('radio').eq(2).click();
+		cy.findAllByRole('radio', {
+			name: 'I can no longer afford to support you',
+		}).click();
 		cy.findByRole('button', { name: 'Continue' }).click();
 
 		cy.wait('@get_case');
@@ -190,7 +196,9 @@ describe('Cancel contribution', () => {
 
 		setSignInStatus();
 
-		cy.findAllByRole('radio').eq(0).click();
+		cy.findAllByRole('radio', {
+			name: 'I am unhappy with some editorial decisions',
+		}).click();
 		cy.findByRole('button', { name: 'Continue' }).click();
 
 		cy.wait('@get_case');

--- a/cypress/integration/parallel-2/cancelSupporterPlus.spec.ts
+++ b/cypress/integration/parallel-2/cancelSupporterPlus.spec.ts
@@ -68,7 +68,9 @@ describe('Cancel Supporter Plus', () => {
 	it('allows self-service cancellation of Supporter Plus', () => {
 		setupCancellation();
 
-		cy.findAllByRole('radio').eq(0).click();
+		cy.findByRole('radio', {
+			name: 'I am unhappy with some editorial decisions',
+		}).click();
 		cy.findByRole('button', { name: 'Continue' }).click();
 
 		cy.wait('@get_case');


### PR DESCRIPTION
## What does this change?

Updates cancellation tests to reference radio buttons by name rather than index to improve reliability.

Cancellation reasons are now randomised so if the reason radio button is selected by index a different reason will be selected for each test run. Not all tests are explicitly testing specific cancellation reasons, but the ones that are will randomly fail due to an incorrect option being selected. (Some cancellation reasons add additional steps or UI elements, changing the flow through the cancellation process.)

This change has previously been made to _some_ tests, but not all. This PR updates the remaining tests to ensure consistent test runs.

Selecting radio buttons by index:

```js
cy.findAllByRole('radio').eq(2).click();
```

Selecting radio buttons by name:

```js
cy.findAllByRole('radio', {
    name: 'I am unhappy with some editorial decisions',
}).click();
```
