### PR TITLE
Enable `no-unnecessary-type-assertion`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,7 +37,6 @@ module.exports = {
 		'@typescript-eslint/no-floating-promises': ['off'],
 		'@typescript-eslint/no-misused-promises': ['off'],
 		'@typescript-eslint/no-unnecessary-condition': ['off'],
-		'@typescript-eslint/no-unnecessary-type-assertion': ['off'],
 		'@typescript-eslint/no-unsafe-argument': ['off'],
 		'@typescript-eslint/no-unsafe-assignment': ['off'],
 		'@typescript-eslint/no-unsafe-call': ['off'],

--- a/client/components/mma/accountoverview/AccountOverview.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.tsx
@@ -22,7 +22,6 @@ import {
 	mdapiResponseReader,
 	sortByJoinDate,
 } from '../../../../shared/productResponse';
-import type { GroupedProductTypeKeys } from '../../../../shared/productTypes';
 import {
 	GROUPED_PRODUCT_TYPES,
 	PRODUCT_TYPES,
@@ -101,8 +100,7 @@ const AccountOverviewRenderer = ([mdapiObject, cancelledProductsResponse]: [
 				productDetail={maybeFirstPaymentFailure}
 			/>
 			{productCategories.map((category) => {
-				const groupedProductType =
-					GROUPED_PRODUCT_TYPES[category as GroupedProductTypeKeys];
+				const groupedProductType = GROUPED_PRODUCT_TYPES[category];
 				const activeProductsInCategory = allActiveProductDetails.filter(
 					(activeProduct) => activeProduct.mmaCategory === category,
 				);
@@ -154,8 +152,7 @@ const AccountOverviewRenderer = ([mdapiObject, cancelledProductsResponse]: [
 									activeProductsInCategory.some(
 										(productDetail) =>
 											isCancelled(
-												(productDetail as ProductDetail)
-													.subscription,
+												productDetail.subscription,
 											),
 									)) && (
 									<div>

--- a/client/components/mma/cancel/CancellationReasonSelection.tsx
+++ b/client/components/mma/cancel/CancellationReasonSelection.tsx
@@ -322,10 +322,7 @@ export const CancellationReasonSelection = () => {
 			fetch={cancellationDateFetcher(
 				productDetail.subscription.subscriptionId,
 			)}
-			render={ReasonPickerRenderer(
-				productType as ProductTypeWithCancellationFlow,
-				productDetail,
-			)}
+			render={ReasonPickerRenderer(productType, productDetail)}
 			loadingMessage={`Checking your ${
 				productType.shortFriendlyName ||
 				productType.friendlyName(productDetail)

--- a/client/components/mma/cancel/stages/ExecuteCancellation.tsx
+++ b/client/components/mma/cancel/stages/ExecuteCancellation.tsx
@@ -150,7 +150,7 @@ export const ExecuteCancellation = () => {
 		return <Navigate to="../" />;
 	}
 
-	const caseId = routerState.caseId as string;
+	const caseId = routerState.caseId;
 
 	const { productDetail, productType } = useContext(
 		CancellationContext,


### PR DESCRIPTION
## What does this change?

Remove `no-unnecessary-type-assertion` eslint rule override and remove unnecessary type assertions.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
