### PR TITLE
Change URL for app journeys to app/switch

### DIFF
--- a/client/components/mma/MMAPage.tsx
+++ b/client/components/mma/MMAPage.tsx
@@ -327,19 +327,29 @@ const MMARouter = () => {
 							path="/account-settings"
 							element={<Settings />}
 						/>
-						{featureSwitches.productSwitching && (
-							<Route path="/switch" element={<SwitchContainer />}>
-								<Route index element={<SwitchOptions />} />
+						{featureSwitches.productSwitching &&
+							[
+								{ path: '/switch', fromApp: false },
+								{ path: '/app/switch', fromApp: true },
+							].map(({ path, fromApp }) => (
 								<Route
-									path="review"
-									element={<SwitchReview />}
-								/>
-								<Route
-									path="complete"
-									element={<SwitchComplete />}
-								/>
-							</Route>
-						)}
+									key={path}
+									path={path}
+									element={
+										<SwitchContainer isFromApp={fromApp} />
+									}
+								>
+									<Route index element={<SwitchOptions />} />
+									<Route
+										path="review"
+										element={<SwitchReview />}
+									/>
+									<Route
+										path="complete"
+										element={<SwitchComplete />}
+									/>
+								</Route>
+							))}
 						{Object.values(GROUPED_PRODUCT_TYPES).map(
 							(groupedProductType: GroupedProductType) => (
 								<Route

--- a/client/components/mma/switch/SwitchContainer.tsx
+++ b/client/components/mma/switch/SwitchContainer.tsx
@@ -1,5 +1,5 @@
 import { createContext } from 'react';
-import type { Context, ReactNode  } from 'react';
+import type { Context, ReactNode } from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router';
 import type {
 	MembersDataApiResponse,
@@ -34,19 +34,23 @@ export interface SwitchContextInterface {
 export const SwitchContext: Context<SwitchContextInterface | {}> =
 	createContext({});
 
-const isFromApp = () => window?.location.hash.includes('from-app');
-
-export const SwitchContainer = () => {
+export const SwitchContainer = (props: { isFromApp?: boolean }) => {
 	const location = useLocation();
 	const routerState = location.state as SwitchRouterState;
 	const productDetail = routerState?.productDetail;
 	const user = routerState?.user;
 
 	if (!productDetail) {
-		return <AsyncLoadedSwitchContainer />;
+		return <AsyncLoadedSwitchContainer isFromApp={props.isFromApp} />;
 	}
 
-	return <RenderedPage productDetail={productDetail} user={user} />;
+	return (
+		<RenderedPage
+			productDetail={productDetail}
+			user={user}
+			isFromApp={props.isFromApp}
+		/>
+	);
 };
 
 const SwitchPageContainer = (props: { children: ReactNode }) => {
@@ -61,7 +65,7 @@ const SwitchPageContainer = (props: { children: ReactNode }) => {
 	);
 };
 
-const AsyncLoadedSwitchContainer = () => {
+const AsyncLoadedSwitchContainer = (props: { isFromApp?: boolean }) => {
 	const request = createProductDetailFetcher(
 		PRODUCT_TYPES.contributions.allProductsProductTypeFilterString,
 	);
@@ -95,19 +99,26 @@ const AsyncLoadedSwitchContainer = () => {
 	}
 
 	const productDetail = data.products.filter(isProduct)[0];
-	return <RenderedPage productDetail={productDetail} user={data.user} />;
+	return (
+		<RenderedPage
+			productDetail={productDetail}
+			user={data.user}
+			isFromApp={props.isFromApp}
+		/>
+	);
 };
 
 const RenderedPage = (props: {
 	productDetail: ProductDetail;
 	user?: MembersDataApiUser;
+	isFromApp?: boolean;
 }) => {
 	return (
 		<SwitchPageContainer>
 			<SwitchContext.Provider
 				value={{
 					productDetail: props.productDetail,
-					isFromApp: isFromApp(),
+					isFromApp: props.isFromApp,
 					user: props.user,
 				}}
 			>

--- a/client/components/mma/switch/SwitchOptions.tsx
+++ b/client/components/mma/switch/SwitchOptions.tsx
@@ -214,7 +214,7 @@ export const SwitchOptions = () => {
 					<Button
 						size="small"
 						cssOverrides={buttonCentredCss}
-						onClick={() => navigate(`/switch/review`)}
+						onClick={() => navigate('review')}
 					>
 						{aboveThreshold
 							? 'Add extras with no extra cost'

--- a/client/components/mma/switch/SwitchReview.tsx
+++ b/client/components/mma/switch/SwitchReview.tsx
@@ -135,7 +135,7 @@ export const SwitchReview = () => {
 				setIsSwitching(false);
 				setSwitchingError(true);
 			} else {
-				navigate('/switch/complete', {
+				navigate('../complete', {
 					state: { amountPayableToday: amount },
 				});
 			}


### PR DESCRIPTION
## What does this change?

Changes the url for from app journeys to be `app/switch` instead of using a hash in the name, because if you get redirected to Identity to sign in it seems to strip out any query parameters and hashes.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
