### PR TITLE
Refactor Billing page to use useAsyncLoader hook

### DIFF
--- a/client/components/mma/accountoverview/AccountOverview.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.tsx
@@ -70,7 +70,7 @@ const AccountOverviewRenderer = ([mdapiObject, cancelledProductsResponse]: [
 	}
 
 	const maybeFirstPaymentFailure = allActiveProductDetails.find(
-		(_) => _.alertText,
+		(product) => product.alertText,
 	);
 
 	const hasDigiSubAndContribution =
@@ -81,9 +81,8 @@ const AccountOverviewRenderer = ([mdapiObject, cancelledProductsResponse]: [
 			isSpecificProductType(productDetail, PRODUCT_TYPES.digipack),
 		);
 
-	const isEligibleToSwitch = !(
-		maybeFirstPaymentFailure || hasDigiSubAndContribution
-	);
+	const isEligibleToSwitch =
+		!maybeFirstPaymentFailure && !hasDigiSubAndContribution;
 
 	const subHeadingCss = css`
 		margin: ${space[12]}px 0 ${space[6]}px;
@@ -100,7 +99,7 @@ const AccountOverviewRenderer = ([mdapiObject, cancelledProductsResponse]: [
 			<PersonalisedHeader mdapiResponse={mdaResponse} />
 
 			<PaymentFailureAlertIfApplicable
-				productDetail={maybeFirstPaymentFailure}
+				productDetails={allActiveProductDetails}
 			/>
 			{productCategories.map((category) => {
 				const groupedProductType = GROUPED_PRODUCT_TYPES[category];

--- a/client/components/mma/accountoverview/ManageProduct.tsx
+++ b/client/components/mma/accountoverview/ManageProduct.tsx
@@ -99,7 +99,7 @@ const InnerContent = ({
 
 	return (
 		<>
-			<PaymentFailureAlertIfApplicable productDetail={productDetail} />
+			<PaymentFailureAlertIfApplicable productDetails={[productDetail]} />
 			<div
 				css={css`
 					${subHeadingBorderTopCss}

--- a/client/components/mma/billing/Billing.stories.tsx
+++ b/client/components/mma/billing/Billing.stories.tsx
@@ -1,6 +1,7 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 import fetchMock from 'fetch-mock';
 import { ReactRouterDecorator } from '../../../../.storybook/ReactRouterDecorator';
+import { guardianWeeklyCardInvoice } from '../../../fixtures/invoices';
 import {
 	digitalDD,
 	guardianWeeklyCard,
@@ -39,7 +40,9 @@ export const WithSubscriptions: ComponentStory<typeof Billing> = () => {
 				newspaperVoucherPaypal,
 			),
 		})
-		.get('/api/invoices', { body: { invoices: [] } });
+		.get('/api/invoices', {
+			body: { invoices: [guardianWeeklyCardInvoice] },
+		});
 
 	return <Billing />;
 };

--- a/client/components/mma/billing/Billing.tsx
+++ b/client/components/mma/billing/Billing.tsx
@@ -105,9 +105,6 @@ const BillingRenderer = () => {
 	const mmaCategoryToProductDetails =
 		organiseProductsIntoCategory(allProductDetails);
 
-	const hasPaymentFailure = (product: ProductDetail) => !!product.alertText;
-	const maybeFirstPaymentFailure = allProductDetails.find(hasPaymentFailure);
-
 	if (allProductDetails.length === 0) {
 		return <EmptyAccountOverview />;
 	}
@@ -115,7 +112,7 @@ const BillingRenderer = () => {
 	return (
 		<>
 			<PaymentFailureAlertIfApplicable
-				productDetail={maybeFirstPaymentFailure}
+				productDetails={allProductDetails}
 			/>
 			{Object.entries(mmaCategoryToProductDetails).map(
 				([mmaCategory, productDetails]) => {

--- a/client/components/mma/shared/AsyncLoader.tsx
+++ b/client/components/mma/shared/AsyncLoader.tsx
@@ -89,7 +89,7 @@ export class AsyncLoader<
 		} else if (this.props.errorRender) {
 			return this.props.errorRender();
 		}
-		return <GenericErrorScreen loggingMessage={false} />;
+		return <GenericErrorScreen />;
 	}
 
 	private processResponse = (

--- a/client/components/mma/shared/PaymentFailureAlertIfApplicable.tsx
+++ b/client/components/mma/shared/PaymentFailureAlertIfApplicable.tsx
@@ -4,13 +4,24 @@ import { GROUPED_PRODUCT_TYPES } from '../../../../shared/productTypes';
 import { ProblemAlert } from './ProblemAlert';
 
 interface PaymentFailureAlertIfApplicableProps {
-	productDetail: ProductDetail | undefined;
+	productDetails: ProductDetail[];
+}
+
+function findPaymentFailureProduct(allProductDetails: ProductDetail[]) {
+	const hasPaymentFailure = (product: ProductDetail) => !!product.alertText;
+	return allProductDetails.find(hasPaymentFailure);
 }
 
 export const PaymentFailureAlertIfApplicable = ({
-	productDetail,
-}: PaymentFailureAlertIfApplicableProps) =>
-	productDetail?.alertText ? (
+	productDetails,
+}: PaymentFailureAlertIfApplicableProps) => {
+	const productDetail = findPaymentFailureProduct(productDetails);
+
+	if (!productDetail || !productDetail.alertText) {
+		return null;
+	}
+
+	return (
 		<ProblemAlert
 			title="A payment needs your attention"
 			message={augmentPaymentFailureAlertText(productDetail.alertText)}
@@ -27,7 +38,8 @@ export const PaymentFailureAlertIfApplicable = ({
 				margin-top: 30px;
 			`}
 		/>
-	) : null;
+	);
+};
 
 export const augmentPaymentFailureAlertText = (alertText: string) =>
 	`${alertText} Please check that the payment details shown are up to date.`;

--- a/client/components/mma/shared/asyncComponents/DefaultErrorView.tsx
+++ b/client/components/mma/shared/asyncComponents/DefaultErrorView.tsx
@@ -1,5 +1,5 @@
 import { GenericErrorScreen } from '../../../shared/GenericErrorScreen';
 
 export function DefaultErrorView() {
-	return <GenericErrorScreen loggingMessage={false} />;
+	return <GenericErrorScreen />;
 }

--- a/client/components/mma/shared/asyncComponents/DefaultLoadingView.tsx
+++ b/client/components/mma/shared/asyncComponents/DefaultLoadingView.tsx
@@ -1,10 +1,10 @@
 import { Spinner } from '../../../shared/Spinner';
 import { WithStandardTopMargin } from '../../../shared/WithStandardTopMargin';
 
-export function DefaultLoadingView() {
+export function DefaultLoadingView(props?: { loadingMessage?: string }) {
 	return (
 		<WithStandardTopMargin>
-			<Spinner loadingMessage="Loading" />
+			<Spinner loadingMessage={props?.loadingMessage ?? 'Loading'} />
 		</WithStandardTopMargin>
 	);
 }

--- a/client/components/mma/switch/SwitchContainer.tsx
+++ b/client/components/mma/switch/SwitchContainer.tsx
@@ -78,7 +78,7 @@ const AsyncLoadedSwitchContainer = (props: { isFromApp?: boolean }) => {
 	if (loadingState == LoadingState.HasError) {
 		return (
 			<SwitchPageContainer>
-				<GenericErrorScreen loggingMessage={false} />
+				<GenericErrorScreen />
 			</SwitchPageContainer>
 		);
 	}

--- a/client/components/mma/switch/SwitchReview.tsx
+++ b/client/components/mma/switch/SwitchReview.tsx
@@ -154,7 +154,7 @@ export const SwitchReview = () => {
 	} = useAsyncLoader(() => productMoveFetch(true), JsonResponseHandler);
 
 	if (loadingState == LoadingState.HasError) {
-		return <GenericErrorScreen loggingMessage={false} />;
+		return <GenericErrorScreen />;
 	}
 	if (loadingState == LoadingState.IsLoading) {
 		return <DefaultLoadingView />;

--- a/client/components/shared/GenericErrorScreen.tsx
+++ b/client/components/shared/GenericErrorScreen.tsx
@@ -4,7 +4,7 @@ import { CallCentreNumbers } from './CallCentreNumbers';
 import { WithStandardTopMargin } from './WithStandardTopMargin';
 
 interface GenericErrorScreenProps {
-	loggingMessage: string | false;
+	loggingMessage?: string;
 }
 
 export const GenericErrorScreen = ({

--- a/client/fixtures/invoices.ts
+++ b/client/fixtures/invoices.ts
@@ -1,0 +1,13 @@
+import type { InvoiceDataApiItem } from '../../shared/productResponse';
+import { guardianWeeklyCard } from './productDetail';
+
+export const guardianWeeklyCardInvoice: InvoiceDataApiItem = {
+	invoiceId: '',
+	subscriptionName: guardianWeeklyCard.subscription.subscriptionId,
+	date: '2021-12-10',
+	pdfPath: '',
+	price: 135,
+	paymentMethod: 'Card',
+	last4: '4242',
+	hasMultipleSubs: false,
+};

--- a/cypress/integration/parallel-1/updatePaymentDetails.spec.ts
+++ b/cypress/integration/parallel-1/updatePaymentDetails.spec.ts
@@ -16,8 +16,8 @@ describe('Update payment details', () => {
 		signInAndAcceptCookies();
 	});
 
-	it('Complete card payment update', () => {
-		cy.intercept('GET', '/api/me/mma?productType=*', {
+	it('Complete card payment update through billing page', () => {
+		cy.intercept('GET', '/api/me/mma*', {
 			statusCode: 200,
 			body: toMembersDataApiResponse(guardianWeeklyCurrentSubscription),
 		}).as('product_detail');
@@ -26,6 +26,11 @@ describe('Update payment details', () => {
 			statusCode: 200,
 			body: toMembersDataApiResponse(guardianWeeklyCurrentSubscription),
 		}).as('refetch_subscription');
+
+		cy.intercept('GET', 'api/invoices', {
+			statusCode: 200,
+			body: { invoices: [] },
+		}).as('invoices');
 
 		cy.intercept('POST', '/api/payment/card', {
 			statusCode: 200,
@@ -47,9 +52,11 @@ describe('Update payment details', () => {
 			body: paymentMethods,
 		});
 
-		cy.visit('/payment/subscriptioncard');
-
+		cy.visit('/billing');
 		cy.wait('@product_detail');
+		cy.wait('@invoices');
+
+		cy.findByText('Update payment method').click();
 
 		cy.resolve('Stripe').should((value) => {
 			expect(value).to.be.ok;


### PR DESCRIPTION
- refactor default loading view and error screen

## What does this change?

Refactors the Billing page to use the useAsyncLoader hook pattern. Also refactors the page to join invoices to product details before the display logic. Adds a loading message to the defaultLoadingView.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Go to billing, the page should load the same as before these changes.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
