### PR TITLE
Return to app banner

### DIFF
--- a/client/components/mma/switch/SwitchComplete.tsx
+++ b/client/components/mma/switch/SwitchComplete.tsx
@@ -5,6 +5,7 @@ import {
 	palette,
 	space,
 	textSans,
+	until,
 } from '@guardian/source-foundations';
 import {
 	Button,
@@ -111,35 +112,42 @@ const thankYouBannerCss = css`
 	}
 `;
 
-const thankYouButtonCss = css`
-	display: flex;
-	flex-direction: column;
+const thankYouBannerHeadingCss = css`
+	${headline.xsmall({ fontWeight: 'bold' })}
+	margin-top: 0;
+	margin-bottom: ${space[5]}px;
+	max-width: 35ch;
+`;
+
+const thankYouBannerSubheadingCss = css`
+	${textSans.large({ fontWeight: 'bold' })};
+	margin: 0;
+	border-top: 1px solid rgba(255, 255, 255, 0.6);
+`;
+
+const thankYouBannerCopyCss = css`
+	${textSans.medium()};
+	margin: 0;
+	max-width: 45ch;
+`;
+
+const thankYouBannerButtonCss = css`
 	margin-top: ${space[6]}px;
 	margin-bottom: ${space[5]}px;
+	${until.tablet} {
+		display: flex;
+		flex-direction: column;
+	}
 `;
 
 const ThankYouBanner = () => {
 	return (
 		<section css={thankYouBannerCss}>
-			<h2
-				css={css`
-					margin-top: 0;
-					margin-bottom: ${space[5]}px;
-					${headline.xsmall({ fontWeight: 'bold' })}
-				`}
-			>
-				Thank you for upgrading to
+			<h2 css={thankYouBannerHeadingCss}>
+				Thank you for upgrading to £10 monthly support + extras
 			</h2>
-			<p
-				css={css`
-					${textSans.large({ fontWeight: 'bold' })};
-					margin: 0;
-					border-top: 1px solid rgba(255, 255, 255, 0.6);
-				`}
-			>
-				One last step ...
-			</p>
-			<div css={thankYouButtonCss}>
+			<p css={thankYouBannerSubheadingCss}>One last step ...</p>
+			<div css={thankYouBannerButtonCss}>
 				<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
 					<Button
 						cssOverrides={buttonCentredCss}
@@ -149,12 +157,7 @@ const ThankYouBanner = () => {
 					</Button>
 				</ThemeProvider>
 			</div>
-			<p
-				css={css`
-					${textSans.medium()};
-					margin: 0;
-				`}
-			>
+			<p css={thankYouBannerCopyCss}>
 				If you don’t complete this step, you may be unable to access the
 				app in full for up to one hour.
 			</p>

--- a/client/components/mma/switch/SwitchComplete.tsx
+++ b/client/components/mma/switch/SwitchComplete.tsx
@@ -1,12 +1,10 @@
 import { css, ThemeProvider } from '@emotion/react';
 import {
-	brand,
 	from,
 	headline,
 	palette,
 	space,
 	textSans,
-	until,
 } from '@guardian/source-foundations';
 import {
 	Button,
@@ -59,7 +57,7 @@ export const SwitchComplete = () => {
 
 	return (
 		<>
-			{switchContext.isFromApp && <AppOnlyThankYou />}
+			{switchContext.isFromApp && <ThankYouBanner />}
 			{!switchContext.isFromApp && (
 				<section css={sectionSpacing}>
 					<ThankYouMessaging
@@ -91,32 +89,38 @@ export const SwitchComplete = () => {
 	);
 };
 
-const buttonContainerCss = css`
-	margin-top: ${space[1]}px;
-	padding: ${space[5]}px 0;
-	${until.tablet} {
-		display: flex;
-		flex-direction: column;
-	}
-`;
-
-const appThankYouCss = css`
-	background-color: ${brand[500]};
+const thankYouBannerCss = css`
+	margin-top: -1px;
+	margin-left: -${space[3]}px;
+	margin-right: -${space[3]}px;
+	padding: ${space[6]}px ${space[3]}px;
 	color: ${palette.neutral[100]};
+	background-color: ${palette.brand[500]};
 
-	${until.tablet} {
-		margin-left: -${space[3]}px;
-		margin-right: -${space[3]}px;
-		padding-left: ${space[3]}px;
-		padding-right: ${space[3]}px;
-		padding-top: ${space[6]}px;
-		padding-bottom: ${space[6]}px;
+	${from.tablet} {
+		margin-left: -${space[5]}px;
+		margin-right: -${space[5]}px;
+	}
+
+	${from.desktop} {
+		margin-top: ${space[9]}px;
+		margin-left: 0;
+		margin-right: 0;
+		padding-left: ${space[4]}px;
+		padding-right: ${space[4]}px;
 	}
 `;
 
-const AppOnlyThankYou = () => {
+const thankYouButtonCss = css`
+	display: flex;
+	flex-direction: column;
+	margin-top: ${space[6]}px;
+	margin-bottom: ${space[5]}px;
+`;
+
+const ThankYouBanner = () => {
 	return (
-		<div css={appThankYouCss}>
+		<section css={thankYouBannerCss}>
 			<h2
 				css={css`
 					margin-top: 0;
@@ -135,7 +139,7 @@ const AppOnlyThankYou = () => {
 			>
 				One last step ...
 			</p>
-			<section css={buttonContainerCss}>
+			<div css={thankYouButtonCss}>
 				<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
 					<Button
 						cssOverrides={buttonCentredCss}
@@ -144,7 +148,7 @@ const AppOnlyThankYou = () => {
 						Activate full app access now
 					</Button>
 				</ThemeProvider>
-			</section>
+			</div>
 			<p
 				css={css`
 					${textSans.medium()};
@@ -154,13 +158,13 @@ const AppOnlyThankYou = () => {
 				If you don’t complete this step, you may be unable to access the
 				app in full for up to one hour.
 			</p>
-		</div>
+		</section>
 	);
 };
 
 const whatHappensNextCss = css`
 	li > svg {
-		fill: ${brand[500]};
+		fill: ${palette.brand[500]};
 	}
 `;
 

--- a/client/components/mma/switch/SwitchComplete.tsx
+++ b/client/components/mma/switch/SwitchComplete.tsx
@@ -47,6 +47,7 @@ export const SwitchComplete = () => {
 		monthlyOrAnnual == 'Monthly' ? monthlyThreshold : annualThreshold;
 	const newAmount = Math.max(threshold, mainPlan.price / 100);
 	const newAmountAndCurrency = `${mainPlan.currency}${newAmount}`;
+	const isUpgrading = mainPlan.price >= threshold * 100;
 
 	const location = useLocation();
 	const routerState = location.state as SwitchRouterState;
@@ -62,6 +63,7 @@ export const SwitchComplete = () => {
 				<ThankYouBanner
 					newAmount={newAmountAndCurrency}
 					newProduct={supporterPlusTitle.toLowerCase()}
+					isUpgrading={isUpgrading}
 				/>
 			) : (
 				<section css={sectionSpacing}>
@@ -143,11 +145,16 @@ const thankYouBannerButtonCss = css`
 	}
 `;
 
-const ThankYouBanner = (props: { newAmount: string; newProduct: string }) => {
+const ThankYouBanner = (props: {
+	newAmount: string;
+	newProduct: string;
+	isUpgrading: boolean;
+}) => {
 	return (
 		<section css={thankYouBannerCss}>
 			<h2 css={thankYouBannerHeadingCss}>
-				Thank you for upgrading to {props.newAmount} {props.newProduct}.
+				Thank you for {props.isUpgrading ? 'upgrading' : 'changing'} to{' '}
+				{props.newAmount} {props.newProduct}.
 			</h2>
 			<p css={thankYouBannerSubheadingCss}>One last step ...</p>
 			<div css={thankYouBannerButtonCss}>

--- a/client/components/mma/switch/SwitchComplete.tsx
+++ b/client/components/mma/switch/SwitchComplete.tsx
@@ -8,7 +8,6 @@ import {
 	until,
 } from '@guardian/source-foundations';
 import {
-	Button,
 	buttonThemeReaderRevenueBrand,
 	LinkButton,
 	Stack,
@@ -43,10 +42,11 @@ export const SwitchComplete = () => {
 	const monthlyOrAnnual = calculateMonthlyOrAnnualFromBillingPeriod(
 		mainPlan.billingPeriod,
 	);
-
+	const supporterPlusTitle = `${monthlyOrAnnual} + extras`;
 	const threshold =
 		monthlyOrAnnual == 'Monthly' ? monthlyThreshold : annualThreshold;
 	const newAmount = Math.max(threshold, mainPlan.price / 100);
+	const newAmountAndCurrency = `${mainPlan.currency}${newAmount}`;
 
 	const location = useLocation();
 	const routerState = location.state as SwitchRouterState;
@@ -58,8 +58,12 @@ export const SwitchComplete = () => {
 
 	return (
 		<>
-			{switchContext.isFromApp && <ThankYouBanner />}
-			{!switchContext.isFromApp && (
+			{switchContext.isFromApp ? (
+				<ThankYouBanner
+					newAmount={newAmountAndCurrency}
+					newProduct={supporterPlusTitle.toLowerCase()}
+				/>
+			) : (
 				<section css={sectionSpacing}>
 					<ThankYouMessaging
 						mainPlan={mainPlan}
@@ -107,8 +111,7 @@ const thankYouBannerCss = css`
 		margin-top: ${space[9]}px;
 		margin-left: 0;
 		margin-right: 0;
-		padding-left: ${space[4]}px;
-		padding-right: ${space[4]}px;
+		padding: ${space[4]}px ${space[4]}px;
 	}
 `;
 
@@ -116,7 +119,7 @@ const thankYouBannerHeadingCss = css`
 	${headline.xsmall({ fontWeight: 'bold' })}
 	margin-top: 0;
 	margin-bottom: ${space[5]}px;
-	max-width: 35ch;
+	max-width: 30ch;
 `;
 
 const thankYouBannerSubheadingCss = css`
@@ -140,21 +143,21 @@ const thankYouBannerButtonCss = css`
 	}
 `;
 
-const ThankYouBanner = () => {
+const ThankYouBanner = (props: { newAmount: string; newProduct: string }) => {
 	return (
 		<section css={thankYouBannerCss}>
 			<h2 css={thankYouBannerHeadingCss}>
-				Thank you for upgrading to £10 monthly support + extras
+				Thank you for upgrading to {props.newAmount} {props.newProduct}.
 			</h2>
 			<p css={thankYouBannerSubheadingCss}>One last step ...</p>
 			<div css={thankYouBannerButtonCss}>
 				<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
-					<Button
+					<LinkButton
+						href="x-gu://mma/success"
 						cssOverrides={buttonCentredCss}
-						onClick={() => alert('app')}
 					>
 						Activate full app access now
-					</Button>
+					</LinkButton>
 				</ThemeProvider>
 			</div>
 			<p css={thankYouBannerCopyCss}>

--- a/client/components/mma/switch/SwitchComplete.tsx
+++ b/client/components/mma/switch/SwitchComplete.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/react';
+import { css, ThemeProvider } from '@emotion/react';
 import {
 	brand,
 	from,
@@ -6,8 +6,11 @@ import {
 	palette,
 	space,
 	textSans,
+	until,
 } from '@guardian/source-foundations';
 import {
+	Button,
+	buttonThemeReaderRevenueBrand,
 	LinkButton,
 	Stack,
 	SvgClock,
@@ -26,7 +29,7 @@ import type {
 } from './SwitchContainer';
 import { SwitchContext } from './SwitchContainer';
 import { SwitchSignInImage } from './SwitchSignInImage';
-import { iconListCss, sectionSpacing } from './SwitchStyles';
+import { buttonCentredCss, iconListCss, sectionSpacing } from './SwitchStyles';
 
 export const SwitchComplete = () => {
 	const switchContext = useContext(SwitchContext) as SwitchContextInterface;
@@ -51,21 +54,20 @@ export const SwitchComplete = () => {
 	const amountPayableToday = routerState?.amountPayableToday;
 
 	if (!amountPayableToday) {
-		return <Navigate to="/switch" />;
+		return <Navigate to=".." />;
 	}
 
 	return (
 		<>
-			<section css={sectionSpacing}>
-				<Stack space={3}>
-					{!switchContext.isFromApp && (
-						<ThankYouMessaging
-							mainPlan={mainPlan}
-							newAmount={newAmount}
-						/>
-					)}
-				</Stack>
-			</section>
+			{switchContext.isFromApp && <AppOnlyThankYou />}
+			{!switchContext.isFromApp && (
+				<section css={sectionSpacing}>
+					<ThankYouMessaging
+						mainPlan={mainPlan}
+						newAmount={newAmount}
+					/>
+				</section>
+			)}
 			<section css={sectionSpacing}>
 				<WhatHappensNext
 					currency={mainPlan.currency}
@@ -86,6 +88,73 @@ export const SwitchComplete = () => {
 				</section>
 			)}
 		</>
+	);
+};
+
+const buttonContainerCss = css`
+	margin-top: ${space[1]}px;
+	padding: ${space[5]}px 0;
+	${until.tablet} {
+		display: flex;
+		flex-direction: column;
+	}
+`;
+
+const appThankYouCss = css`
+	background-color: ${brand[500]};
+	color: ${palette.neutral[100]};
+
+	${until.tablet} {
+		margin-left: -${space[3]}px;
+		margin-right: -${space[3]}px;
+		padding-left: ${space[3]}px;
+		padding-right: ${space[3]}px;
+		padding-top: ${space[6]}px;
+		padding-bottom: ${space[6]}px;
+	}
+`;
+
+const AppOnlyThankYou = () => {
+	return (
+		<div css={appThankYouCss}>
+			<h2
+				css={css`
+					margin-top: 0;
+					margin-bottom: ${space[5]}px;
+					${headline.xsmall({ fontWeight: 'bold' })}
+				`}
+			>
+				Thank you for upgrading to
+			</h2>
+			<p
+				css={css`
+					${textSans.large({ fontWeight: 'bold' })};
+					margin: 0;
+					border-top: 1px solid rgba(255, 255, 255, 0.6);
+				`}
+			>
+				One last step ...
+			</p>
+			<section css={buttonContainerCss}>
+				<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
+					<Button
+						cssOverrides={buttonCentredCss}
+						onClick={() => alert('app')}
+					>
+						Activate full app access now
+					</Button>
+				</ThemeProvider>
+			</section>
+			<p
+				css={css`
+					${textSans.medium()};
+					margin: 0;
+				`}
+			>
+				If you don’t complete this step, you may be unable to access the
+				app in full for up to one hour.
+			</p>
+		</div>
 	);
 };
 
@@ -181,12 +250,12 @@ const signInContentContainerCss = css`
 `;
 
 const signInHeadingCss = css`
-	${textSans.medium({ fontWeight: 'bold', lineHeight: 'regular' })};
+	${textSans.medium({ fontWeight: 'bold' })};
 	margin: 0;
 `;
 
 const signInParaCss = css`
-	${textSans.medium({ lineHeight: 'regular' })};
+	${textSans.medium()};
 	margin: 0;
 	max-width: 64%;
 `;


### PR DESCRIPTION
## What does this change?

Adds a 'thank you' banner specifically for users who began the switching journey in the app. The banner includes a CTA to return users to the app so they can continue reading.

This is primarily for mobile users, although users on tablets may also go through the same switching journey via the app so this includes an interim desktop design which may be refined later.

## How to test

Start a switching journey from `/app/switch`. The banner will appear at the top of the final page.

## Images

<img width="320" alt="Screenshot 2023-02-07 at 10 18 59" src="https://user-images.githubusercontent.com/1166188/217219570-b0ebe615-058e-4e96-869e-166325f8ae2c.png">

<img width="802" alt="Screenshot 2023-02-07 at 10 19 14" src="https://user-images.githubusercontent.com/1166188/217219582-e02646ae-d207-4cf5-8917-e86064405f88.png">

<img width="1241" alt="Screenshot 2023-02-07 at 10 19 27" src="https://user-images.githubusercontent.com/1166188/217219601-b8857183-0c06-47e1-985a-7c2ebafb5d92.png">
