### PR TITLE
Add threshold per currency config and use new config in Switch pages

### DIFF
--- a/client/components/mma/accountoverview/ContributionUpdateAmountForm.tsx
+++ b/client/components/mma/accountoverview/ContributionUpdateAmountForm.tsx
@@ -17,6 +17,11 @@ import type { PaidSubscriptionPlan } from '../../../../shared/productResponse';
 import { augmentBillingPeriod } from '../../../../shared/productResponse';
 import type { ProductType } from '../../../../shared/productTypes';
 import { trackEvent } from '../../../utilities/analytics';
+import type {
+	ContributionInterval} from '../../../utilities/contributionsAmount';
+import {
+	contributionAmountsLookup
+} from '../../../utilities/contributionsAmount';
 import { fetchWithDefaultParameters } from '../../../utilities/fetch';
 import { AsyncLoader } from '../shared/AsyncLoader';
 import { Button } from '../shared/Buttons';
@@ -34,126 +39,7 @@ interface ContributionUpdateAmountFormProps {
 	onUpdateConfirmed: (updatedAmount: number) => void;
 }
 
-export type ContributionInterval = 'month' | 'year';
-
-interface ContributionAmountOptions {
-	amounts: number[];
-	otherDefaultAmount: number;
-	minAmount: number;
-	maxAmount: number;
-}
-
-type ContributionAmountsLookup = Record<
-	string,
-	{
-		month: ContributionAmountOptions;
-		year: ContributionAmountOptions;
-	}
->;
-
 class UpdateAmountLoader extends AsyncLoader<string> {}
-
-// TODO: make this dynamic (i.e. looks up api/config file agreed/shared by contributions team)
-export const contributionAmountsLookup: ContributionAmountsLookup = {
-	GBP: {
-		month: {
-			amounts: [3, 7, 12],
-			otherDefaultAmount: 2,
-			minAmount: 2,
-			maxAmount: 166,
-		},
-		year: {
-			amounts: [60, 120, 240, 480],
-			otherDefaultAmount: 10,
-			minAmount: 10,
-			maxAmount: 2000,
-		},
-	},
-	USD: {
-		month: {
-			amounts: [5, 10, 20],
-			otherDefaultAmount: 2,
-			minAmount: 2,
-			maxAmount: 800,
-		},
-		year: {
-			amounts: [50, 100, 250, 500],
-			otherDefaultAmount: 20,
-			minAmount: 10,
-			maxAmount: 10000,
-		},
-	},
-	EUR: {
-		month: {
-			amounts: [6, 10, 20],
-			otherDefaultAmount: 2,
-			minAmount: 2,
-			maxAmount: 166,
-		},
-		year: {
-			amounts: [50, 100, 250, 500],
-			otherDefaultAmount: 10,
-			minAmount: 10,
-			maxAmount: 2000,
-		},
-	},
-	AUD: {
-		month: {
-			amounts: [10, 20, 40],
-			otherDefaultAmount: 10,
-			minAmount: 10,
-			maxAmount: 200,
-		},
-		year: {
-			amounts: [80, 250, 500, 750],
-			otherDefaultAmount: 10,
-			minAmount: 10,
-			maxAmount: 2000,
-		},
-	},
-	NZD: {
-		month: {
-			amounts: [10, 20, 50],
-			otherDefaultAmount: 10,
-			minAmount: 10,
-			maxAmount: 200,
-		},
-		year: {
-			amounts: [50, 100, 250, 500],
-			otherDefaultAmount: 10,
-			minAmount: 10,
-			maxAmount: 2000,
-		},
-	},
-	CAD: {
-		month: {
-			amounts: [5, 10, 20],
-			otherDefaultAmount: 5,
-			minAmount: 5,
-			maxAmount: 166,
-		},
-		year: {
-			amounts: [60, 100, 250, 500],
-			otherDefaultAmount: 10,
-			minAmount: 10,
-			maxAmount: 2000,
-		},
-	},
-	international: {
-		month: {
-			amounts: [5, 10, 20],
-			otherDefaultAmount: 5,
-			minAmount: 5,
-			maxAmount: 166,
-		},
-		year: {
-			amounts: [60, 100, 250, 500],
-			otherDefaultAmount: 10,
-			minAmount: 10,
-			maxAmount: 2000,
-		},
-	},
-};
 
 export const ContributionUpdateAmountForm = (
 	props: ContributionUpdateAmountFormProps,

--- a/client/components/mma/cancel/contributions/utils.ts
+++ b/client/components/mma/cancel/contributions/utils.ts
@@ -1,6 +1,9 @@
 import type { PaidSubscriptionPlan } from '../../../../../shared/productResponse';
-import type { ContributionInterval } from '../../accountoverview/ContributionUpdateAmountForm';
-import { contributionAmountsLookup } from '../../accountoverview/ContributionUpdateAmountForm';
+import type {
+	ContributionInterval} from '../../../../utilities/contributionsAmount';
+import {
+	contributionAmountsLookup
+} from '../../../../utilities/contributionsAmount';
 
 export const getIsPayingMinAmount = (mainPlan: PaidSubscriptionPlan) => {
 	const currentContributionOptions = (contributionAmountsLookup[

--- a/client/components/mma/switch/SwitchComplete.stories.tsx
+++ b/client/components/mma/switch/SwitchComplete.stories.tsx
@@ -24,3 +24,20 @@ export default {
 export const Default: ComponentStory<typeof SwitchComplete> = () => (
 	<SwitchComplete />
 );
+
+export const YearlyOtherCurrency: ComponentStory<
+	typeof SwitchComplete
+> = () => <SwitchComplete />;
+
+const contributionBelowThreshold = JSON.parse(JSON.stringify(contribution));
+const plan = contributionBelowThreshold.subscription.currentPlans[0];
+plan.price = 300;
+plan.currency = '$';
+plan.billingPeriod = 'year';
+plan.currencyISO = 'NZD';
+
+YearlyOtherCurrency.parameters = {
+	reactRouter: {
+		state: { productDetail: contributionBelowThreshold },
+	},
+};

--- a/client/components/mma/switch/SwitchComplete.tsx
+++ b/client/components/mma/switch/SwitchComplete.tsx
@@ -19,6 +19,8 @@ import { Navigate, useLocation } from 'react-router';
 import type { PaidSubscriptionPlan } from '../../../../shared/productResponse';
 import { getMainPlan } from '../../../../shared/productResponse';
 import { calculateMonthlyOrAnnualFromBillingPeriod } from '../../../../shared/productTypes';
+import { getBenefitsThreshold } from '../../../utilities/benefitsThreshold';
+import type { CurrencyIso } from '../../../utilities/currencyIso';
 import { InverseStarIcon } from '../shared/assets/InverseStarIcon';
 import { Heading } from '../shared/Heading';
 import type {
@@ -36,15 +38,15 @@ export const SwitchComplete = () => {
 		productDetail.subscription,
 	) as PaidSubscriptionPlan;
 
-	// ToDo: hardcoding this for now; need to find out where to get this from for each currency
-	const monthlyThreshold = 10;
-	const annualThreshold = 95;
 	const monthlyOrAnnual = calculateMonthlyOrAnnualFromBillingPeriod(
 		mainPlan.billingPeriod,
 	);
 	const supporterPlusTitle = `${monthlyOrAnnual} + extras`;
-	const threshold =
-		monthlyOrAnnual == 'Monthly' ? monthlyThreshold : annualThreshold;
+
+	const threshold = getBenefitsThreshold(
+		mainPlan.currencyISO as CurrencyIso,
+		monthlyOrAnnual,
+	);
 	const newAmount = Math.max(threshold, mainPlan.price / 100);
 	const newAmountAndCurrency = `${mainPlan.currency}${newAmount}`;
 	const isUpgrading = mainPlan.price >= threshold * 100;

--- a/client/components/mma/switch/SwitchOptions.tsx
+++ b/client/components/mma/switch/SwitchOptions.tsx
@@ -10,6 +10,8 @@ import { useNavigate } from 'react-router';
 import type { PaidSubscriptionPlan } from '../../../../shared/productResponse';
 import { getMainPlan } from '../../../../shared/productResponse';
 import { calculateMonthlyOrAnnualFromBillingPeriod } from '../../../../shared/productTypes';
+import { getBenefitsThreshold } from '../../../utilities/benefitsThreshold';
+import type { CurrencyIso } from '../../../utilities/currencyIso';
 import { Card } from '../shared/Card';
 import { Heading } from '../shared/Heading';
 import { SupporterPlusBenefitsSection } from '../shared/SupporterPlusBenefits';
@@ -76,9 +78,14 @@ export const SwitchOptions = () => {
 	);
 	const supporterPlusTitle = `${monthlyOrAnnual} + extras`;
 
-	// ToDo: hardcoding this for now; need to find out where to get this from for each currency
-	const monthlyThreshold = 10;
-	const annualThreshold = 95;
+	const monthlyThreshold = getBenefitsThreshold(
+		mainPlan.currencyISO as CurrencyIso,
+		'Monthly',
+	);
+	const annualThreshold = getBenefitsThreshold(
+		mainPlan.currencyISO as CurrencyIso,
+		'Annual',
+	);
 
 	const threshold =
 		monthlyOrAnnual == 'Monthly' ? monthlyThreshold : annualThreshold;
@@ -218,7 +225,7 @@ export const SwitchOptions = () => {
 					>
 						{aboveThreshold
 							? 'Add extras with no extra cost'
-							: 'Change to monthly + extras'}
+							: `Change to ${monthlyOrAnnual.toLowerCase()} + extras`}
 					</Button>
 				</ThemeProvider>
 			</section>

--- a/client/components/mma/switch/SwitchReview.stories.tsx
+++ b/client/components/mma/switch/SwitchReview.stories.tsx
@@ -27,3 +27,20 @@ export default {
 export const Default: ComponentStory<typeof SwitchReview> = () => (
 	<SwitchReview />
 );
+
+export const YearlyOtherCurrency: ComponentStory<typeof SwitchReview> = () => (
+	<SwitchReview />
+);
+
+const contributionBelowThreshold = JSON.parse(JSON.stringify(contribution));
+const plan = contributionBelowThreshold.subscription.currentPlans[0];
+plan.price = 300;
+plan.currency = '$';
+plan.billingPeriod = 'year';
+plan.currencyISO = 'NZD';
+
+YearlyOtherCurrency.parameters = {
+	reactRouter: {
+		state: { productDetail: contributionBelowThreshold },
+	},
+};

--- a/client/components/mma/switch/SwitchReview.tsx
+++ b/client/components/mma/switch/SwitchReview.tsx
@@ -18,6 +18,8 @@ import {
 import type { PaidSubscriptionPlan } from '../../../../shared/productResponse';
 import { getMainPlan } from '../../../../shared/productResponse';
 import { calculateMonthlyOrAnnualFromBillingPeriod } from '../../../../shared/productTypes';
+import { getBenefitsThreshold } from '../../../utilities/benefitsThreshold';
+import type { CurrencyIso } from '../../../utilities/currencyIso';
 import {
 	LoadingState,
 	useAsyncLoader,
@@ -94,12 +96,11 @@ export const SwitchReview = () => {
 		mainPlan.billingPeriod,
 	);
 	const supporterPlusTitle = `${monthlyOrAnnual} + extras`;
-	// ToDo: hardcoding this for now; need to find out where to get this from for each currency
-	const monthlyThreshold = 10;
-	const annualThreshold = 95;
 
-	const threshold =
-		monthlyOrAnnual == 'Monthly' ? monthlyThreshold : annualThreshold;
+	const threshold = getBenefitsThreshold(
+		mainPlan.currencyISO as CurrencyIso,
+		monthlyOrAnnual,
+	);
 	const newAmount = Math.max(threshold, mainPlan.price / 100);
 
 	// ToDo: the API could return the next payment date
@@ -235,8 +236,8 @@ export const SwitchReview = () => {
 								<br />
 								We will charge you a smaller amount today, to
 								offset the payment you've already given us for
-								the rest of the month. After this, from{' '}
-								{nextPayment}, your new{' '}
+								the rest of the {mainPlan.billingPeriod}. After
+								this, from {nextPayment}, your new{' '}
 								{monthlyOrAnnual.toLocaleLowerCase()} payment
 								will be {mainPlan.currency}
 								{previewResponse.supporterPlusPurchaseAmount}

--- a/client/utilities/benefitsThreshold.ts
+++ b/client/utilities/benefitsThreshold.ts
@@ -1,0 +1,45 @@
+import type { CurrencyIso } from './currencyIso';
+
+export const benefitsThresholdsByCountryGroup: Record<
+	CurrencyIso | 'international',
+	Record<string, number>
+> = {
+	GBP: {
+		Monthly: 10,
+		Annual: 95,
+	},
+	USD: {
+		Monthly: 13,
+		Annual: 120,
+	},
+	EUR: {
+		Monthly: 10,
+		Annual: 95,
+	},
+	AUD: {
+		Monthly: 17,
+		Annual: 160,
+	},
+	NZD: {
+		Monthly: 17,
+		Annual: 160,
+	},
+	CAD: {
+		Monthly: 13,
+		Annual: 120,
+	},
+	international: {
+		Monthly: 13,
+		Annual: 120,
+	},
+};
+
+export function getBenefitsThreshold(
+	currency: CurrencyIso,
+	billingPeriod: 'Monthly' | 'Annual',
+): number {
+	const region =
+		benefitsThresholdsByCountryGroup[currency] ??
+		benefitsThresholdsByCountryGroup['international'];
+	return region[billingPeriod];
+}

--- a/client/utilities/contributionsAmount.ts
+++ b/client/utilities/contributionsAmount.ts
@@ -1,0 +1,117 @@
+export type ContributionInterval = 'month' | 'year';
+
+interface ContributionAmountOptions {
+	amounts: number[];
+	otherDefaultAmount: number;
+	minAmount: number;
+	maxAmount: number;
+}
+
+type ContributionAmountsLookup = Record<
+	string,
+	{
+		month: ContributionAmountOptions;
+		year: ContributionAmountOptions;
+	}
+>;
+
+export const contributionAmountsLookup: ContributionAmountsLookup = {
+	GBP: {
+		month: {
+			amounts: [3, 7, 12],
+			otherDefaultAmount: 2,
+			minAmount: 2,
+			maxAmount: 166,
+		},
+		year: {
+			amounts: [60, 120, 240, 480],
+			otherDefaultAmount: 10,
+			minAmount: 10,
+			maxAmount: 2000,
+		},
+	},
+	USD: {
+		month: {
+			amounts: [5, 10, 20],
+			otherDefaultAmount: 2,
+			minAmount: 2,
+			maxAmount: 800,
+		},
+		year: {
+			amounts: [50, 100, 250, 500],
+			otherDefaultAmount: 20,
+			minAmount: 10,
+			maxAmount: 10000,
+		},
+	},
+	EUR: {
+		month: {
+			amounts: [6, 10, 20],
+			otherDefaultAmount: 2,
+			minAmount: 2,
+			maxAmount: 166,
+		},
+		year: {
+			amounts: [50, 100, 250, 500],
+			otherDefaultAmount: 10,
+			minAmount: 10,
+			maxAmount: 2000,
+		},
+	},
+	AUD: {
+		month: {
+			amounts: [10, 20, 40],
+			otherDefaultAmount: 10,
+			minAmount: 10,
+			maxAmount: 200,
+		},
+		year: {
+			amounts: [80, 250, 500, 750],
+			otherDefaultAmount: 10,
+			minAmount: 10,
+			maxAmount: 2000,
+		},
+	},
+	NZD: {
+		month: {
+			amounts: [10, 20, 50],
+			otherDefaultAmount: 10,
+			minAmount: 10,
+			maxAmount: 200,
+		},
+		year: {
+			amounts: [50, 100, 250, 500],
+			otherDefaultAmount: 10,
+			minAmount: 10,
+			maxAmount: 2000,
+		},
+	},
+	CAD: {
+		month: {
+			amounts: [5, 10, 20],
+			otherDefaultAmount: 5,
+			minAmount: 5,
+			maxAmount: 166,
+		},
+		year: {
+			amounts: [60, 100, 250, 500],
+			otherDefaultAmount: 10,
+			minAmount: 10,
+			maxAmount: 2000,
+		},
+	},
+	international: {
+		month: {
+			amounts: [5, 10, 20],
+			otherDefaultAmount: 5,
+			minAmount: 5,
+			maxAmount: 166,
+		},
+		year: {
+			amounts: [60, 100, 250, 500],
+			otherDefaultAmount: 10,
+			minAmount: 10,
+			maxAmount: 2000,
+		},
+	},
+};

--- a/client/utilities/currencyIso.ts
+++ b/client/utilities/currencyIso.ts
@@ -1,0 +1,1 @@
+export type CurrencyIso = 'GBP' | 'USD' | 'AUD' | 'EUR' | 'NZD' | 'CAD';


### PR DESCRIPTION
- refactor contributionsAmount since it is similar
- add Storybooks for variations

## What does this change?

Adds a config file for Supporter Plus benefit thresholds and uses it in switch pages. Also refactor ContributionsAmountOptions (similar config) to sit in the same folder. Fixes some errors where the pages were not using dynamic monthly/annual copy and adds storybooks with currency and yearly config to catch any regressions.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Go to `/switch` with a contribution using a currency other than GBP and observe a different price point.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
