### PR TITLE
Product switch payment failure and generic error messaging

### DIFF
--- a/client/components/mma/switch/SwitchOptions.tsx
+++ b/client/components/mma/switch/SwitchOptions.tsx
@@ -12,6 +12,7 @@ import { getMainPlan } from '../../../../shared/productResponse';
 import { calculateMonthlyOrAnnualFromBillingPeriod } from '../../../../shared/productTypes';
 import { getBenefitsThreshold } from '../../../utilities/benefitsThreshold';
 import type { CurrencyIso } from '../../../utilities/currencyIso';
+import { ErrorSummary } from '../paymentUpdate/Summary';
 import { Card } from '../shared/Card';
 import { Heading } from '../shared/Heading';
 import { SupporterPlusBenefitsSection } from '../shared/SupporterPlusBenefits';
@@ -19,6 +20,8 @@ import type { SwitchContextInterface } from './SwitchContainer';
 import { SwitchContext } from './SwitchContainer';
 import {
 	buttonCentredCss,
+	errorSummaryLinkCss,
+	errorSummaryOverrideCss,
 	productTitleCss,
 	sectionSpacing,
 	smallPrintCss,
@@ -122,8 +125,29 @@ export const SwitchOptions = () => {
 
 	return (
 		<>
+			{productDetail.alertText && (
+				<section css={sectionSpacing}>
+					<ErrorSummary
+						message="There is a problem with your payment"
+						context={
+							<>
+								Please click{' '}
+								<a
+									css={errorSummaryLinkCss}
+									href="/payment/contributions"
+								>
+									here
+								</a>{' '}
+								to update your payment details in order to
+								change your support.
+							</>
+						}
+						cssOverrides={errorSummaryOverrideCss}
+					/>
+				</section>
+			)}
 			{switchContext.isFromApp && (
-				<div css={sectionSpacing}>
+				<section css={sectionSpacing}>
 					<h2 css={fromAppHeadingCss}>
 						Unlock full access to our news app today
 					</h2>
@@ -136,7 +160,7 @@ export const SwitchOptions = () => {
 						If this doesn't suit you, no change is needed, but note
 						you will have limited access to our app.
 					</p>
-				</div>
+				</section>
 			)}
 			<section css={sectionSpacing}>
 				<Heading

--- a/client/components/mma/switch/SwitchOptions.tsx
+++ b/client/components/mma/switch/SwitchOptions.tsx
@@ -7,6 +7,7 @@ import {
 } from '@guardian/source-react-components';
 import { useContext, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
+import { Link } from 'react-router-dom';
 import type { PaidSubscriptionPlan } from '../../../../shared/productResponse';
 import { getMainPlan } from '../../../../shared/productResponse';
 import { calculateMonthlyOrAnnualFromBillingPeriod } from '../../../../shared/productTypes';
@@ -20,6 +21,7 @@ import type { SwitchContextInterface } from './SwitchContainer';
 import { SwitchContext } from './SwitchContainer';
 import {
 	buttonCentredCss,
+	errorSummaryBlockLinkCss,
 	errorSummaryLinkCss,
 	errorSummaryOverrideCss,
 	productTitleCss,
@@ -128,21 +130,23 @@ export const SwitchOptions = () => {
 			{productDetail.alertText && (
 				<section css={sectionSpacing}>
 					<ErrorSummary
-						message="There is a problem with your payment"
+						cssOverrides={errorSummaryOverrideCss}
+						message="There is a problem with your payment method"
 						context={
 							<>
-								Please click{' '}
-								<a
-									css={errorSummaryLinkCss}
-									href="/payment/contributions"
-								>
-									here
-								</a>{' '}
-								to update your payment details in order to
+								Please update your payment details in order to
 								change your support.
+								<Link
+									css={[
+										errorSummaryLinkCss,
+										errorSummaryBlockLinkCss,
+									]}
+									to="/payment/contributions"
+								>
+									Check your payment details
+								</Link>
 							</>
 						}
-						cssOverrides={errorSummaryOverrideCss}
 					/>
 				</section>
 			)}

--- a/client/components/mma/switch/SwitchReview.tsx
+++ b/client/components/mma/switch/SwitchReview.tsx
@@ -9,6 +9,7 @@ import {
 } from '@guardian/source-react-components';
 import { useContext, useState } from 'react';
 import { Navigate, useNavigate } from 'react-router';
+import { Link } from 'react-router-dom';
 import {
 	dateAddMonths,
 	dateAddYears,
@@ -40,6 +41,7 @@ import { SwitchContext } from './SwitchContainer';
 import {
 	buttonCentredCss,
 	buttonMutedCss,
+	errorSummaryBlockLinkCss,
 	errorSummaryLinkCss,
 	errorSummaryOverrideCss,
 	iconListCss,
@@ -52,26 +54,25 @@ import {
 const SwitchErrorContext = (props: { PaymentFailure: boolean }) =>
 	props.PaymentFailure ? (
 		<>
-			Please click{' '}
-			<a css={errorSummaryLinkCss} href="/payment/contributions">
-				here
-			</a>{' '}
-			to update your payment details in order to change your support.
+			Please update your payment details in order to change your support.
+			<Link
+				css={[errorSummaryLinkCss, errorSummaryBlockLinkCss]}
+				to="/payment/contributions"
+			>
+				Check your payment details
+			</Link>
 		</>
 	) : (
 		<>
-			Please click{' '}
-			<a css={errorSummaryLinkCss} href="/payment/contributions">
-				here
-			</a>{' '}
-			to check that your details are correct before trying again. If the
-			problem persists contact{' '}
+			Please ensure your payment details are correct. If the problem
+			persists get in touch at{' '}
 			<a
 				css={errorSummaryLinkCss}
 				href="mailto:customer.help@guardian.com"
 			>
 				customer.help@guardian.com
 			</a>
+			.
 		</>
 	);
 
@@ -356,7 +357,11 @@ export const SwitchReview = () => {
 			{switchingError && (
 				<section css={sectionSpacing}>
 					<ErrorSummary
-						message="There is a problem with your payment"
+						message={
+							inPaymentFailure
+								? 'There is a problem with your payment method'
+								: 'We were unable to change your support'
+						}
 						context={
 							<SwitchErrorContext
 								PaymentFailure={inPaymentFailure}

--- a/client/components/mma/switch/SwitchStyles.ts
+++ b/client/components/mma/switch/SwitchStyles.ts
@@ -101,6 +101,11 @@ export const errorSummaryOverrideCss = css`
 `;
 
 export const errorSummaryLinkCss = css`
-	color: ${palette.error[400]};
+	color: currentColor;
 	text-decoration: underline;
+`;
+
+export const errorSummaryBlockLinkCss = css`
+	display: block;
+	margin-top: ${space[3]}px;
 `;

--- a/client/components/mma/switch/SwitchStyles.ts
+++ b/client/components/mma/switch/SwitchStyles.ts
@@ -93,3 +93,14 @@ export const buttonMutedCss = css`
 		border: none;
 	}
 `;
+
+export const errorSummaryOverrideCss = css`
+	${until.tablet} {
+		border-radius: 6px;
+	}
+`;
+
+export const errorSummaryLinkCss = css`
+	color: ${palette.error[400]};
+	text-decoration: underline;
+`;

--- a/cypress/integration/parallel-2/productSwitch.spec.ts
+++ b/cypress/integration/parallel-2/productSwitch.spec.ts
@@ -278,12 +278,9 @@ describe('product switching', () => {
 
 			cy.findByRole('button', { name: 'Confirm change' }).click();
 
-			cy.findByText('There is a problem with your payment').should(
+			cy.findByText('We were unable to change your support').should(
 				'exist',
 			);
-			cy.findByText(
-				/check that your details are correct before trying again/,
-			).should('exist');
 		});
 
 		it('shows payment failure error message and does not call product move API again', () => {
@@ -300,12 +297,9 @@ describe('product switching', () => {
 			cy.visit('/switch');
 			setSignInStatus();
 
-			cy.findByText('There is a problem with your payment').should(
+			cy.findByText('There is a problem with your payment method').should(
 				'exist',
 			);
-			cy.findByText(
-				/update your payment details in order to change your support/,
-			).should('exist');
 
 			cy.findByRole('button', {
 				name: 'Add extras with no extra cost',
@@ -313,12 +307,9 @@ describe('product switching', () => {
 
 			cy.findByRole('button', { name: 'Confirm change' }).click();
 
-			cy.findByText('There is a problem with your payment').should(
+			cy.findByText('There is a problem with your payment method').should(
 				'exist',
 			);
-			cy.findByText(
-				/update your payment details in order to change your support/,
-			).should('exist');
 
 			cy.get('@product_move.all').should('have.length', 1);
 		});


### PR DESCRIPTION
## What does this change?

Update generic switch error message and add specific payment failure error message for switches that haven't been started from the _Account Overview_ page (where the existing eligibility check would have prevented a user from switching).

## Images

<img width="361" alt="Screenshot 2023-02-09 at 18 05 28" src="https://user-images.githubusercontent.com/1166188/217907191-987a3d95-6027-4a46-a537-92b38e671415.png">

<img width="383" alt="Screenshot 2023-02-09 at 18 11 46" src="https://user-images.githubusercontent.com/1166188/217907232-e4ba3d8e-98eb-40ae-a5ce-17287194fa9b.png">

<img width="383" alt="Screenshot 2023-02-09 at 18 12 58" src="https://user-images.githubusercontent.com/1166188/217907239-a4faf1e0-66c4-41c8-82f7-a3b5ae1157c1.png">
