### PR TITLE
Enable Product Switching feature flag

### DIFF
--- a/shared/featureSwitches.ts
+++ b/shared/featureSwitches.ts
@@ -26,5 +26,5 @@ export const featureSwitches: Record<string, boolean> = {
 	exampleFeature: false,
 	cancellationProductSwitch: false,
 	accountOverviewNewLayout: false,
-	productSwitching: false,
+	productSwitching: true,
 };


### PR DESCRIPTION
## What does this change?

Enables the Product Switching feature flag.

## How to test

`/switch` should be accessible on all environments, including production.

## Have we considered potential risks?

We're enabling this to allow beta testing of apps metering so the pages are not linked to from anywhere in MMA. It's possible somebody could stumble upon this URL and go through the switching journey, but this isn't a huge problem if it happens and is a risk we've accepted.