### PR TITLE
Product switch copy updates

### DIFF
--- a/client/components/mma/switch/SwitchComplete.tsx
+++ b/client/components/mma/switch/SwitchComplete.tsx
@@ -88,6 +88,7 @@ export const SwitchComplete = () => {
 					nextPaymentAmount={newAmount}
 					billingPeriod={monthlyOrAnnual.toLowerCase()}
 					email={switchContext.user?.email ?? ''}
+					isFromApp={switchContext.isFromApp}
 				/>
 			</section>
 			{!switchContext.isFromApp && (
@@ -178,8 +179,8 @@ const ThankYouBanner = (props: {
 				</ThemeProvider>
 			</div>
 			<p css={thankYouBannerCopyCss}>
-				Your new support plan starts today. It may take up to an hour
-				for your full app access to become available
+				If you don’t complete this step, you may be unable to access the
+				app in full for up to one hour.
 			</p>
 		</section>
 	);
@@ -197,6 +198,7 @@ const WhatHappensNext = (props: {
 	nextPaymentAmount: number;
 	billingPeriod: string;
 	email: string;
+	isFromApp: boolean;
 }) => {
 	// ToDo: the API could return the next payment date
 	const nextPaymentDate = dateString(
@@ -227,13 +229,15 @@ const WhatHappensNext = (props: {
 						{props.nextPaymentAmount}
 					</span>
 				</li>
-				<li>
-					<InverseStarIcon size="medium" />
-					<span>
-						Your new support will start today. It can take up to an
-						hour for your support to be activated.
-					</span>
-				</li>
+				{!props.isFromApp && (
+					<li>
+						<InverseStarIcon size="medium" />
+						<span>
+							Your new support will start today. It can take up to
+							an hour for your support to be activated.
+						</span>
+					</li>
+				)}
 			</ul>
 		</Stack>
 	);

--- a/client/components/mma/switch/SwitchComplete.tsx
+++ b/client/components/mma/switch/SwitchComplete.tsx
@@ -16,6 +16,11 @@ import {
 } from '@guardian/source-react-components';
 import { useContext } from 'react';
 import { Navigate, useLocation } from 'react-router';
+import {
+	dateAddMonths,
+	dateAddYears,
+	dateString,
+} from '../../../../shared/dates';
 import type { PaidSubscriptionPlan } from '../../../../shared/productResponse';
 import { getMainPlan } from '../../../../shared/productResponse';
 import { calculateMonthlyOrAnnualFromBillingPeriod } from '../../../../shared/productTypes';
@@ -49,7 +54,7 @@ export const SwitchComplete = () => {
 	);
 	const newAmount = Math.max(threshold, mainPlan.price / 100);
 	const newAmountAndCurrency = `${mainPlan.currency}${newAmount}`;
-	const isUpgrading = mainPlan.price >= threshold * 100;
+	const aboveThreshold = mainPlan.price >= threshold * 100;
 
 	const location = useLocation();
 	const routerState = location.state as SwitchRouterState;
@@ -65,13 +70,14 @@ export const SwitchComplete = () => {
 				<ThankYouBanner
 					newAmount={newAmountAndCurrency}
 					newProduct={supporterPlusTitle.toLowerCase()}
-					isUpgrading={isUpgrading}
+					aboveThreshold={aboveThreshold}
 				/>
 			) : (
 				<section css={sectionSpacing}>
 					<ThankYouMessaging
 						mainPlan={mainPlan}
 						newAmount={newAmount}
+						aboveThreshold={aboveThreshold}
 					/>
 				</section>
 			)}
@@ -79,6 +85,8 @@ export const SwitchComplete = () => {
 				<WhatHappensNext
 					currency={mainPlan.currency}
 					amountPayableToday={amountPayableToday}
+					nextPaymentAmount={newAmount}
+					billingPeriod={monthlyOrAnnual.toLowerCase()}
 					email={switchContext.user?.email ?? ''}
 				/>
 			</section>
@@ -150,13 +158,13 @@ const thankYouBannerButtonCss = css`
 const ThankYouBanner = (props: {
 	newAmount: string;
 	newProduct: string;
-	isUpgrading: boolean;
+	aboveThreshold: boolean;
 }) => {
 	return (
 		<section css={thankYouBannerCss}>
 			<h2 css={thankYouBannerHeadingCss}>
-				Thank you for {props.isUpgrading ? 'upgrading' : 'changing'} to{' '}
-				{props.newAmount} {props.newProduct}.
+				Thank you for {props.aboveThreshold ? 'changing' : 'upgrading'}{' '}
+				to {props.newAmount} {props.newProduct}.
 			</h2>
 			<p css={thankYouBannerSubheadingCss}>One last step ...</p>
 			<div css={thankYouBannerButtonCss}>
@@ -170,8 +178,8 @@ const ThankYouBanner = (props: {
 				</ThemeProvider>
 			</div>
 			<p css={thankYouBannerCopyCss}>
-				If you don’t complete this step, you may be unable to access the
-				app in full for up to one hour.
+				Your new support plan starts today. It may take up to an hour
+				for your full app access to become available
 			</p>
 		</section>
 	);
@@ -186,8 +194,18 @@ const whatHappensNextCss = css`
 const WhatHappensNext = (props: {
 	currency: string;
 	amountPayableToday: number;
+	nextPaymentAmount: number;
+	billingPeriod: string;
 	email: string;
 }) => {
+	// ToDo: the API could return the next payment date
+	const nextPaymentDate = dateString(
+		props.billingPeriod == 'monthly'
+			? dateAddMonths(new Date(), 1)
+			: dateAddYears(new Date(), 1),
+		'd MMMM',
+	);
+
 	return (
 		<Stack space={4}>
 			<Heading sansSerif>What happens next?</Heading>
@@ -201,9 +219,12 @@ const WhatHappensNext = (props: {
 				<li>
 					<SvgClock size="medium" />
 					<span>
-						Your first billing date is today and you will be charge
-						a reduced rate of {props.currency}
-						{props.amountPayableToday}.
+						Your first billing date is today and you will be charged{' '}
+						{props.currency}
+						{props.amountPayableToday}. From {nextPaymentDate}, your
+						ongoing {props.billingPeriod} payment will be{' '}
+						{props.currency}
+						{props.nextPaymentAmount}
 					</span>
 				</li>
 				<li>
@@ -235,11 +256,18 @@ const thankYouCss = css`
 const ThankYouMessaging = (props: {
 	mainPlan: PaidSubscriptionPlan;
 	newAmount: number;
+	aboveThreshold: boolean;
 }) => {
 	return (
 		<h2 css={thankYouCss}>
-			Thank you for upgrading to {props.mainPlan.currency}
-			{props.newAmount} per {props.mainPlan.billingPeriod}.{' '}
+			{props.aboveThreshold ? (
+				<>Thank you for changing your support type.</>
+			) : (
+				<>
+					Thank you for upgrading to {props.mainPlan.currency}
+					{props.newAmount} per {props.mainPlan.billingPeriod}.
+				</>
+			)}
 			<span>Enjoy your exclusive extras.</span>
 		</h2>
 	);
@@ -285,8 +313,8 @@ const SignInBanner = () => (
 		<div css={signInContentContainerCss}>
 			<h2 css={signInHeadingCss}>Sign in on all your devices</h2>
 			<p css={signInParaCss}>
-				To access your extras on all your digital devices, please sign
-				in. It takes less than a minute.
+				To access your exclusive extras on our website and app, please
+				sign in. It takes less than a minute.
 			</p>
 		</div>
 	</div>

--- a/client/components/mma/switch/SwitchContainer.tsx
+++ b/client/components/mma/switch/SwitchContainer.tsx
@@ -27,7 +27,7 @@ export interface SwitchRouterState {
 
 export interface SwitchContextInterface {
 	productDetail: ProductDetail;
-	isFromApp: Boolean;
+	isFromApp: boolean;
 	user?: MembersDataApiUser;
 }
 

--- a/client/components/mma/switch/SwitchOptions.tsx
+++ b/client/components/mma/switch/SwitchOptions.tsx
@@ -152,9 +152,7 @@ export const SwitchOptions = () => {
 				<Card>
 					<Card.Header backgroundColor={palette.brand[600]}>
 						<div css={cardHeaderDivCss}>
-							<h3 css={productTitleCss}>
-								{monthlyOrAnnual} support
-							</h3>
+							<h3 css={productTitleCss}>{monthlyOrAnnual}</h3>
 							<p css={productSubtitleCss}>
 								{mainPlan.currency}
 								{currentAmount}/{mainPlan.billingPeriod}
@@ -167,10 +165,9 @@ export const SwitchOptions = () => {
 								${textSans.medium()}
 							`}
 						>
-							You're currently supporting the Guardian with a{' '}
-							{monthlyOrAnnual.toLowerCase()} contribution of{' '}
-							{mainPlan.currency}
-							{currentAmount}.
+							You pay {mainPlan.currency}
+							{currentAmount} on a recurring basis every{' '}
+							{mainPlan.billingPeriod}
 						</div>
 					</Card.Section>
 				</Card>
@@ -188,8 +185,19 @@ export const SwitchOptions = () => {
 								margin: 0;
 							`}
 						>
-							Change to {supporterPlusTitle} and get exclusive
-							supporter benefits
+							{aboveThreshold ? (
+								<>
+									Your current payment entitles you to unlock
+									exclusive supporter extras. It takes less
+									than a minute to change your support type
+									and gain access.
+								</>
+							) : (
+								<>
+									Unlock exclusive supporter extras when you
+									pay a little more
+								</>
+							)}
 						</p>
 					)}
 					<Card>
@@ -225,7 +233,7 @@ export const SwitchOptions = () => {
 					>
 						{aboveThreshold
 							? 'Add extras with no extra cost'
-							: `Change to ${monthlyOrAnnual.toLowerCase()} + extras`}
+							: 'Upgrade'}
 					</Button>
 				</ThemeProvider>
 			</section>
@@ -233,11 +241,11 @@ export const SwitchOptions = () => {
 			{aboveThreshold && (
 				<section>
 					<p css={smallPrintCss}>
-						Exclusive supporter extras are unlocked for any monthly
-						support of {mainPlan.currency}
-						{monthlyThreshold} or above and any annual support of{' '}
+						These exclusive supporter extras are unlocked for a
+						minimum monthly support of {mainPlan.currency}
+						{monthlyThreshold} and a minimum annual support of{' '}
 						{mainPlan.currency}
-						{annualThreshold} or above.
+						{annualThreshold}.
 					</p>
 				</section>
 			)}

--- a/client/components/mma/switch/SwitchOptions.tsx
+++ b/client/components/mma/switch/SwitchOptions.tsx
@@ -125,18 +125,16 @@ export const SwitchOptions = () => {
 			{switchContext.isFromApp && (
 				<div css={sectionSpacing}>
 					<h2 css={fromAppHeadingCss}>
-						Change your support to unlock unlimited reading in our
-						news app
+						Unlock full access to our news app today
 					</h2>
 					<p
 						css={css`
 							${textSans.medium()}
 						`}
 					>
-						To unlock unlimited reading in our news app, please make
-						a small change to your support type. If this doesn't
-						suit you, no change is needed, but note you will
-						continue to have limited app access.
+						It takes less than a minute to change your support type.
+						If this doesn't suit you, no change is needed, but note
+						you will have limited access to our app.
 					</p>
 				</div>
 			)}
@@ -178,26 +176,27 @@ export const SwitchOptions = () => {
 					<Heading sansSerif>
 						{aboveThreshold ? 'Add extras' : 'Change your support'}
 					</Heading>
-					{!switchContext.isFromApp && (
+					{aboveThreshold && (
 						<p
 							css={css`
 								${textSans.medium()}
 								margin: 0;
 							`}
 						>
-							{aboveThreshold ? (
-								<>
-									Your current payment entitles you to unlock
-									exclusive supporter extras. It takes less
-									than a minute to change your support type
-									and gain access.
-								</>
-							) : (
-								<>
-									Unlock exclusive supporter extras when you
-									pay a little more
-								</>
-							)}
+							Your current payment entitles you to unlock
+							exclusive supporter extras. It takes less than a
+							minute to change your support type and gain access.
+						</p>
+					)}
+					{!aboveThreshold && !switchContext.isFromApp && (
+						<p
+							css={css`
+								${textSans.medium()}
+								margin: 0;
+							`}
+						>
+							Unlock exclusive supporter extras when you pay a
+							little more
 						</p>
 					)}
 					<Card>
@@ -238,17 +237,15 @@ export const SwitchOptions = () => {
 				</ThemeProvider>
 			</section>
 
-			{aboveThreshold && (
-				<section>
-					<p css={smallPrintCss}>
-						These exclusive supporter extras are unlocked for a
-						minimum monthly support of {mainPlan.currency}
-						{monthlyThreshold} and a minimum annual support of{' '}
-						{mainPlan.currency}
-						{annualThreshold}.
-					</p>
-				</section>
-			)}
+			<section>
+				<p css={smallPrintCss}>
+					These exclusive supporter extras are unlocked for a minimum
+					monthly support of {mainPlan.currency}
+					{monthlyThreshold} and a minimum annual support of{' '}
+					{mainPlan.currency}
+					{annualThreshold}.
+				</p>
+			</section>
 		</>
 	);
 };

--- a/client/components/mma/switch/SwitchReview.tsx
+++ b/client/components/mma/switch/SwitchReview.tsx
@@ -175,19 +175,11 @@ export const SwitchReview = () => {
 							${textSans.medium()};
 						`}
 					>
-						{aboveThreshold ? (
-							<>
-								Please review your choice to unlock exclusive
-								supporter extras. You'll still pay
-							</>
-						) : (
-							<>
-								Please review your choice to unlock exclusive
-								supporter extras by paying
-							</>
-						)}{' '}
+						Please {switchContext.isFromApp ? 'confirm' : 'review'}{' '}
+						your choice to unlock exclusive supporter extras
+						{aboveThreshold ? ". You'll still pay " : ' by paying '}
 						{mainPlan.currency}
-						{newAmount} per {mainPlan.billingPeriod}
+						{newAmount} per {mainPlan.billingPeriod}.
 					</p>
 				</Stack>
 			</section>

--- a/client/components/mma/switch/SwitchReview.tsx
+++ b/client/components/mma/switch/SwitchReview.tsx
@@ -101,6 +101,7 @@ export const SwitchReview = () => {
 		mainPlan.currencyISO as CurrencyIso,
 		monthlyOrAnnual,
 	);
+	const aboveThreshold = mainPlan.price >= threshold * 100;
 	const newAmount = Math.max(threshold, mainPlan.price / 100);
 
 	// ToDo: the API could return the next payment date
@@ -174,10 +175,19 @@ export const SwitchReview = () => {
 							${textSans.medium()};
 						`}
 					>
-						You will now support us with {mainPlan.currency}
-						{newAmount} every {mainPlan.billingPeriod}, giving you
-						exclusive supporter extras, including unlimited reading
-						in our news app
+						{aboveThreshold ? (
+							<>
+								Please review your choice to unlock exclusive
+								supporter extras. You'll still pay
+							</>
+						) : (
+							<>
+								Please review your choice to unlock exclusive
+								supporter extras by paying
+							</>
+						)}{' '}
+						{mainPlan.currency}
+						{newAmount} per {mainPlan.billingPeriod}
 					</p>
 				</Stack>
 			</section>
@@ -196,8 +206,9 @@ export const SwitchReview = () => {
 									max-width: 40ch;
 								`}
 							>
-								{monthlyOrAnnual} support with exclusive extras
-								including unlimited access to the App
+								{monthlyOrAnnual} support with exclusive extras,
+								including full access to our app and ad-free
+								reading
 							</p>
 							<SupporterPlusBenefitsToggle />
 							<p css={newAmountCss}>
@@ -218,7 +229,7 @@ export const SwitchReview = () => {
 								<strong>This change will happen today</strong>
 								<br />
 								Dive in and start enjoying your exclusive extras
-								straight away.
+								straight away
 							</span>
 						</li>
 						<li
@@ -229,7 +240,8 @@ export const SwitchReview = () => {
 							<SwitchOffsetPaymentIcon size="medium" />
 							<span>
 								<strong>
-									Your first payment will be just{' '}
+									Your first payment will be{' '}
+									{aboveThreshold && 'just'}{' '}
 									{mainPlan.currency}
 									{previewResponse.amountPayableToday}
 								</strong>
@@ -238,15 +250,15 @@ export const SwitchReview = () => {
 								offset the payment you've already given us for
 								the rest of the {mainPlan.billingPeriod}. After
 								this, from {nextPayment}, your new{' '}
-								{monthlyOrAnnual.toLocaleLowerCase()} payment
-								will be {mainPlan.currency}
+								{monthlyOrAnnual.toLowerCase()} payment will be{' '}
+								{mainPlan.currency}
 								{previewResponse.supporterPlusPurchaseAmount}
 							</span>
 						</li>
 						<li>
 							<SvgCreditCard size="medium" />
 							<span>
-								<strong>No payment changes are needed</strong>
+								<strong>Your payment method</strong>
 								<br />
 								We will take payment as before, from
 								<strong>
@@ -303,7 +315,7 @@ export const SwitchReview = () => {
 							confirmSwitch(previewResponse.amountPayableToday)
 						}
 					>
-						Confirm change
+						Confirm {aboveThreshold ? 'change' : 'upgrade'}
 					</Button>
 				</ThemeProvider>
 				<Button


### PR DESCRIPTION
## What does this change?

Applies latest round of copy changes to the product switching pages. This covers contributions that are above and below the benefit threshold, and switches initiated from the Guardian news app.

## Images

<img width="365" alt="Screenshot 2023-02-09 at 17 41 30" src="https://user-images.githubusercontent.com/1166188/217895203-90f90a0f-d6cb-4211-97ad-6f79381559e2.png">
