### PR TITLE
Fix product switching Cypress spec

### DIFF
--- a/cypress/integration/parallel-2/productSwitch.spec.ts
+++ b/cypress/integration/parallel-2/productSwitch.spec.ts
@@ -259,8 +259,12 @@ describe('product switching', () => {
 				body: productMoveSuccessfulResponse,
 			});
 
-			cy.findByText(/Thank you/).should('exist');
-			cy.findByText(/reduced rate of £5/).should('exist');
+			cy.findByText(/Thank you for changing your support type/).should(
+				'exist',
+			);
+			cy.findByText(
+				/Your first billing date is today and you will be charged £5/,
+			).should('exist');
 		});
 
 		it('shows an error message if switch fails', () => {


### PR DESCRIPTION
## What does this change?

Updates Cypress spec to reflect latest copy changes. This was missed as the tests are only run when the feature switch is enabled.