### PR TITLE
Get nextPaymentDate from preview API response

### DIFF
--- a/client/components/mma/switch/SwitchComplete.stories.tsx
+++ b/client/components/mma/switch/SwitchComplete.stories.tsx
@@ -15,6 +15,7 @@ export default {
 				productDetail: contribution,
 				user: { email: 'test@theguardian.com' },
 				amountPayableToday: 5.9,
+				nextPaymentDate: '20 March',
 			},
 			container: <SwitchContainer />,
 		},

--- a/client/components/mma/switch/SwitchComplete.tsx
+++ b/client/components/mma/switch/SwitchComplete.tsx
@@ -16,11 +16,6 @@ import {
 } from '@guardian/source-react-components';
 import { useContext } from 'react';
 import { Navigate, useLocation } from 'react-router';
-import {
-	dateAddMonths,
-	dateAddYears,
-	dateString,
-} from '../../../../shared/dates';
 import type { PaidSubscriptionPlan } from '../../../../shared/productResponse';
 import { getMainPlan } from '../../../../shared/productResponse';
 import { calculateMonthlyOrAnnualFromBillingPeriod } from '../../../../shared/productTypes';
@@ -62,8 +57,9 @@ export const SwitchComplete = () => {
 	const location = useLocation();
 	const routerState = location.state as SwitchRouterState;
 	const amountPayableToday = routerState?.amountPayableToday;
+	const nextPaymentDate = routerState?.nextPaymentDate;
 
-	if (!amountPayableToday) {
+	if (!amountPayableToday || !nextPaymentDate) {
 		return <Navigate to=".." />;
 	}
 
@@ -92,6 +88,7 @@ export const SwitchComplete = () => {
 					billingPeriod={monthlyOrAnnual.toLowerCase()}
 					email={switchContext.user?.email ?? ''}
 					isFromApp={switchContext.isFromApp}
+					nextPaymentDate={nextPaymentDate}
 				/>
 			</section>
 			{!switchContext.isFromApp && (
@@ -202,15 +199,8 @@ const WhatHappensNext = (props: {
 	billingPeriod: string;
 	email: string;
 	isFromApp: boolean;
+	nextPaymentDate: string;
 }) => {
-	// ToDo: the API could return the next payment date
-	const nextPaymentDate = dateString(
-		props.billingPeriod == 'monthly'
-			? dateAddMonths(new Date(), 1)
-			: dateAddYears(new Date(), 1),
-		'd MMMM',
-	);
-
 	return (
 		<Stack space={4}>
 			<Heading sansSerif>What happens next?</Heading>
@@ -227,8 +217,8 @@ const WhatHappensNext = (props: {
 						Your first billing date is today and you will be charged{' '}
 						{props.currency}
 						{formatAmount(props.amountPayableToday)}. From{' '}
-						{nextPaymentDate}, your ongoing {props.billingPeriod}{' '}
-						payment will be {props.currency}
+						{props.nextPaymentDate}, your ongoing{' '}
+						{props.billingPeriod} payment will be {props.currency}
 						{formatAmount(props.nextPaymentAmount)}
 					</span>
 				</li>

--- a/client/components/mma/switch/SwitchContainer.tsx
+++ b/client/components/mma/switch/SwitchContainer.tsx
@@ -23,6 +23,7 @@ export interface SwitchRouterState {
 	productDetail: ProductDetail;
 	user?: MembersDataApiUser;
 	amountPayableToday: number;
+	nextPaymentDate: string;
 }
 
 export interface SwitchContextInterface {

--- a/client/fixtures/productMove.ts
+++ b/client/fixtures/productMove.ts
@@ -1,7 +1,7 @@
 export const productMovePreviewResponse = {
 	amountPayableToday: 5.0,
-	contributionRefundAmount: -5.0,
 	supporterPlusPurchaseAmount: 10.0,
+	nextPaymentDate: '2023-03-20',
 };
 
 export const productMoveSuccessfulResponse = {


### PR DESCRIPTION
## What does this change?

The next payment date shown to a user was previously calculated on the client side - for accuracy and safety we are now getting this from the product-move-api preview response.

Also removes the refund property from the preview response body - since we are not intending on using that property for now.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Start a switch on `switch` and observe the next payment date should be present on the Review and Thank You pages.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://user-images.githubusercontent.com/114918544/218449789-43d86cdf-d5f9-40f7-88d8-ce314cbdf36a.png)


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
