### PR TITLE
Make amendments to copy

### DIFF
--- a/client/components/mma/accountoverview/PersonalisedHeader.tsx
+++ b/client/components/mma/accountoverview/PersonalisedHeader.tsx
@@ -16,9 +16,8 @@ function calculateTimeOfDay() {
 	}
 	if (currentHour < 18) {
 		return 'Good afternoon';
-	} else {
-		return 'Good evening';
 	}
+	return 'Good evening';
 }
 
 export const PersonalisedHeader = ({

--- a/client/components/mma/accountoverview/PersonalisedHeader.tsx
+++ b/client/components/mma/accountoverview/PersonalisedHeader.tsx
@@ -1,10 +1,24 @@
 import { css } from '@emotion/react';
 import { headline, space } from '@guardian/source-foundations';
+import { dateString } from '../../../../shared/dates';
 import type { MembersDataApiResponse } from '../../../../shared/productResponse';
 import { isProduct, sortByJoinDate } from '../../../../shared/productResponse';
 
 interface PersonalisedHeaderProps {
 	mdapiResponse: MembersDataApiResponse;
+}
+
+function calculateTimeOfDay() {
+	const currentHour = new Date().getHours();
+
+	if (currentHour < 12) {
+		return 'Good morning';
+	}
+	if (currentHour < 18) {
+		return 'Good afternoon';
+	} else {
+		return 'Good evening';
+	}
 }
 
 export const PersonalisedHeader = ({
@@ -16,20 +30,10 @@ export const PersonalisedHeader = ({
 		.filter(isProduct)
 		.sort(sortByJoinDate);
 	const oldestProduct = productDetails[productDetails.length - 1];
-	const supportStartYear = new Date(oldestProduct.joinDate).getFullYear();
-
-	const calculatedTimeOfDay = () => {
-		const currentHour = new Date().getHours();
-
-		if (currentHour < 12) {
-			return 'Good Morning';
-		}
-		if (currentHour < 18) {
-			return 'Good Afternoon';
-		} else {
-			return 'Good Evening';
-		}
-	};
+	const supportStartYear = dateString(
+		new Date(oldestProduct.joinDate),
+		'MMMM yyyy',
+	);
 
 	return userDetails ? (
 		<hgroup
@@ -43,14 +47,14 @@ export const PersonalisedHeader = ({
 					margin-bottom: 0;
 				`}
 			>
-				{calculatedTimeOfDay()} {userDetails.firstName ?? 'Reader'}
+				{calculateTimeOfDay()}, {userDetails.firstName ?? 'supporter'}
 			</h2>
 			<p
 				css={css`
 					${headline.xxxsmall()};
 				`}
 			>
-				Thanks for supporting the Guardian since {supportStartYear}
+				Thank you for funding the Guardian since {supportStartYear}
 			</p>
 		</hgroup>
 	) : null;

--- a/client/components/mma/shared/SupporterPlusBenefits.tsx
+++ b/client/components/mma/shared/SupporterPlusBenefits.tsx
@@ -95,7 +95,7 @@ export const SupporterPlusBenefitsToggle = () => {
 				aria-controls="benefits"
 				onClick={() => setShowBenefits(!showBenefits)}
 			>
-				{showBenefits ? 'hide' : 'view'} benefits
+				{showBenefits ? 'hide' : 'view'} extras
 			</button>
 		</>
 	);

--- a/client/components/mma/switch/SwitchComplete.tsx
+++ b/client/components/mma/switch/SwitchComplete.tsx
@@ -59,14 +59,14 @@ export const SwitchComplete = () => {
 	const amountPayableToday = routerState?.amountPayableToday;
 	const nextPaymentDate = routerState?.nextPaymentDate;
 
-	if (!amountPayableToday || !nextPaymentDate) {
+	if (amountPayableToday === undefined || !nextPaymentDate) {
 		return <Navigate to=".." />;
 	}
 
 	return (
 		<>
 			{switchContext.isFromApp ? (
-				<ThankYouBanner
+				<AppThankYouBanner
 					newAmount={newAmountAndCurrency}
 					newProduct={supporterPlusTitle.toLowerCase()}
 					aboveThreshold={aboveThreshold}
@@ -156,7 +156,7 @@ const thankYouBannerButtonCss = css`
 	}
 `;
 
-const ThankYouBanner = (props: {
+const AppThankYouBanner = (props: {
 	newAmount: string;
 	newProduct: string;
 	aboveThreshold: boolean;
@@ -180,7 +180,7 @@ const ThankYouBanner = (props: {
 			</div>
 			<p css={thankYouBannerCopyCss}>
 				If you don’t complete this step, you may be unable to access the
-				app in full for up to one hour.
+				app in full for up to one hour
 			</p>
 		</section>
 	);
@@ -227,7 +227,7 @@ const WhatHappensNext = (props: {
 						<InverseStarIcon size="medium" />
 						<span>
 							Your new support will start today. It can take up to
-							an hour for your support to be activated.
+							an hour for your support to be activated
 						</span>
 					</li>
 				)}
@@ -266,7 +266,7 @@ const ThankYouMessaging = (props: {
 					{props.mainPlan.billingPeriod}.
 				</>
 			)}{' '}
-			<span>Enjoy your exclusive extras.</span>
+			<span>Enjoy your exclusive extras</span>
 		</h2>
 	);
 };

--- a/client/components/mma/switch/SwitchOptions.tsx
+++ b/client/components/mma/switch/SwitchOptions.tsx
@@ -213,9 +213,10 @@ export const SwitchOptions = () => {
 								margin: 0;
 							`}
 						>
-							Your current payment entitles you to unlock
-							exclusive supporter extras. It takes less than a
-							minute to change your support type and gain access.
+							In exchange for your current payment, you can choose
+							to receive exclusive supporter extras. It takes less
+							than a minute to change your support type and gain
+							access.
 						</p>
 					)}
 					{!aboveThreshold && !switchContext.isFromApp && (
@@ -262,19 +263,19 @@ export const SwitchOptions = () => {
 						onClick={() => navigate('review')}
 					>
 						{aboveThreshold
-							? 'Add extras with no extra cost'
-							: 'Upgrade'}
+							? 'Add extras'
+							: `Upgrade to ${mainPlan.currency}${threshold} per ${mainPlan.billingPeriod}`}
 					</Button>
 				</ThemeProvider>
 			</section>
 
 			<section>
 				<p css={smallPrintCss}>
-					These exclusive supporter extras are unlocked for a minimum
-					monthly support of {mainPlan.currency}
-					{formatAmount(monthlyThreshold)} and a minimum annual
-					support of {mainPlan.currency}
-					{formatAmount(annualThreshold)}.
+					These exclusive supporter extras are available when you pay{' '}
+					{mainPlan.currency}
+					{formatAmount(monthlyThreshold)} minimum on a monthly basis,
+					or {mainPlan.currency}
+					{formatAmount(annualThreshold)} minimum on an annual basis.
 				</p>
 			</section>
 		</>

--- a/client/components/mma/switch/SwitchReview.tsx
+++ b/client/components/mma/switch/SwitchReview.tsx
@@ -262,8 +262,8 @@ export const SwitchReview = () => {
 							<span>
 								<strong>This change will happen today</strong>
 								<br />
-								Dive in and start enjoying your exclusive extras
-								straight away
+								In just a couple of steps, you'll be able to
+								start enjoying your exclusive extras{' '}
 							</span>
 						</li>
 						<li

--- a/client/components/mma/switch/SwitchReview.tsx
+++ b/client/components/mma/switch/SwitchReview.tsx
@@ -274,18 +274,21 @@ export const SwitchReview = () => {
 							<SwitchOffsetPaymentIcon size="medium" />
 							<span>
 								<strong>
-									Your first payment will be{' '}
-									{aboveThreshold && 'just'}{' '}
-									{mainPlan.currency}
-									{formatAmount(
-										previewResponse.amountPayableToday,
-									)}
+									{previewResponse.amountPayableToday > 0 &&
+										`Your first payment will be
+									${aboveThreshold && 'just'}
+									${mainPlan.currency}${formatAmount(previewResponse.amountPayableToday)}`}
+									{previewResponse.amountPayableToday == 0 &&
+										"There's nothing extra to pay today"}
 								</strong>
 								<br />
-								We will charge you a smaller amount today, to
+								{previewResponse.amountPayableToday > 0 &&
+									`We will charge you a smaller amount today, to
 								offset the payment you've already given us for
-								the rest of the {mainPlan.billingPeriod}. After
-								this, from {nextPaymentDate}, your new{' '}
+								the rest of the ${mainPlan.billingPeriod}.`}
+								{previewResponse.amountPayableToday == 0 &&
+									`We won't charge you today, as your current payment covers you for the rest of the ${mainPlan.billingPeriod}.`}{' '}
+								After this, from {nextPaymentDate}, your new{' '}
 								{monthlyOrAnnual.toLowerCase()} payment will be{' '}
 								{mainPlan.currency}
 								{formatAmount(

--- a/cypress/integration/parallel-2/productSwitch.spec.ts
+++ b/cypress/integration/parallel-2/productSwitch.spec.ts
@@ -236,7 +236,7 @@ describe('product switching', () => {
 			setSignInStatus();
 
 			cy.findByRole('button', {
-				name: 'Add extras with no extra cost',
+				name: 'Add extras',
 			}).click();
 
 			cy.findByText('Review change').should('exist');
@@ -249,7 +249,7 @@ describe('product switching', () => {
 			setSignInStatus();
 
 			cy.findByRole('button', {
-				name: 'Add extras with no extra cost',
+				name: 'Add extras',
 			}).click();
 
 			cy.findByRole('button', { name: 'Confirm change' }).click();
@@ -272,7 +272,7 @@ describe('product switching', () => {
 			setSignInStatus();
 
 			cy.findByRole('button', {
-				name: 'Add extras with no extra cost',
+				name: 'Add extras',
 			}).click();
 
 			cy.intercept('POST', '/api/product-move/*', {
@@ -306,7 +306,7 @@ describe('product switching', () => {
 			);
 
 			cy.findByRole('button', {
-				name: 'Add extras with no extra cost',
+				name: 'Add extras',
 			}).click();
 
 			cy.findByRole('button', { name: 'Confirm change' }).click();


### PR DESCRIPTION
## What does this change?

Makes the following amendments to copy:

  | Page | Copy | Should be
-- | -- | -- | --
All scenarios | Account Overview | Good Afternoon Reader | Good afternoon, supporter
  |   | Thanks for supporting... | Thank you for funding the Guardian since [month] [year]
  | Change your support / Review change | view benefits > | View extras >
  |   | hide benefits > | Hide extras >
  |   | Dive in and start enjoying your exclusive extras straight away | In just a couple of steps, you'll be able to start enjoying your exclusive extras
  | Thank you page | Remove full stops except for the banner |  
Above Threshold Specific | Change your support / Your current support | Add extras with no extra cost | Add extras
  |   | Your current payment entitles you to | In exchange for your current payment, you can choose to receive exclusive supporter extras ...
  |   | These exclusive supporter extras are unlocked for a minimum monthly support of £10 and a minimum annual support of £95. | These exclusive supporter extras are available when you pay £10 minimum on a monthly basis, or £95 minimum on an annual basis.
Below Threshold specific | Your current support | Upgrade | Upgrade to £X per month/year



<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Navigate to each page in the above table, in the scenarios listed and witness the 'should be' copy.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Account Overview
![image](https://user-images.githubusercontent.com/114918544/219423496-0e4d2885-f7d1-40c5-a0f5-decceefd91ea.png)

Your current support
Below threshold
![image](https://user-images.githubusercontent.com/114918544/219424128-dec1c331-a3ed-4e33-81f4-a6ef1038053f.png)
Above threshold
![image](https://user-images.githubusercontent.com/114918544/219424165-15164c6a-f3d3-483b-ac62-826b877f6754.png)

£0 edgecase copy
![image](https://user-images.githubusercontent.com/114918544/219424537-8eeb9217-7362-49b7-945e-fc42ae8f43ee.png)
 
![image](https://user-images.githubusercontent.com/114918544/219424313-deb2ab97-cb10-4c27-9019-a05c9f8c90d0.png)


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
