### PR TITLE
Fix copy bug with interpolated string that had "false" in the text

### DIFF
--- a/client/components/mma/switch/SwitchReview.tsx
+++ b/client/components/mma/switch/SwitchReview.tsx
@@ -340,7 +340,7 @@ export const SwitchReview = () => {
 								<strong>
 									{previewResponse.amountPayableToday > 0 &&
 										`Your first payment will be
-									${aboveThreshold && 'just'}
+									${aboveThreshold ? 'just' : ''}
 									${mainPlan.currency}${formatAmount(previewResponse.amountPayableToday)}`}
 									{previewResponse.amountPayableToday == 0 &&
 										"There's nothing extra to pay today"}


### PR DESCRIPTION
## What does this change?

Fix a bug introduced in copy amendments - a boolean was included in an interpolated string because of the `&&` operator.

![image](https://user-images.githubusercontent.com/114918544/220082107-9992ea7c-d6b7-42e5-b32b-3a1ef2b07963.png)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Visit the `review` page with a RC that is under the threshold - copy should not include the word 'false'.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
