### PR TITLE
Add explicit override for testing the feature switch

### DIFF
--- a/client/components/shared/nav/NavConfig.tsx
+++ b/client/components/shared/nav/NavConfig.tsx
@@ -1,5 +1,8 @@
 import { conf } from '../../../../server/config';
-import { featureSwitches } from '../../../../shared/featureSwitches';
+import {
+	featureSwitches,
+	initFeatureSwitchUrlParamOverride,
+} from '../../../../shared/featureSwitches';
 import { AccountOverviewIcon } from '../../mma/shared/assets/AccountOverviewIcon';
 import { CreditCardIcon } from '../../mma/shared/assets/CreditCardIcon';
 import { EmailPrefsIcon } from '../../mma/shared/assets/EmailPrefIcon';
@@ -38,6 +41,10 @@ interface NavLinks {
 
 let domain: string;
 if (typeof window !== 'undefined' && window.guardian) {
+	// Window need to be defined in order to call this method.
+	// This method is necessary to called so that when we read
+	// the feature switch, it will respect the URL override
+	initFeatureSwitchUrlParamOverride();
 	domain = window.guardian.domain;
 } else {
 	domain = conf.DOMAIN;

--- a/cypress/integration/parallel-6/savedArticles.spec.ts
+++ b/cypress/integration/parallel-6/savedArticles.spec.ts
@@ -23,8 +23,9 @@ describe('Saved Articles', () => {
 	describe('Feature Switch ON:', () => {
 		it('displays Saved Article page', () => {
 			cy.visit('/saved-articles?withFeature=savedArticles');
-
-			cy.findAllByText('Saved articles').should('have.length.above', 0);
+			// We should see this text in the nav on the LH side
+			// and as a title on the page
+			cy.findAllByText('Saved articles').should('have.length', 2);
 		});
 	});
 });

--- a/cypress/integration/parallel-6/savedArticles.spec.ts
+++ b/cypress/integration/parallel-6/savedArticles.spec.ts
@@ -1,13 +1,12 @@
-import { featureSwitches } from '../../../shared/featureSwitches';
-
-if (!featureSwitches.savedArticles) {
-	describe('Feature Switch OFF: Saved Articles', () => {
-		beforeEach(() => {
-			cy.session('auth', () => {
-				cy.setCookie('gu-cmp-disabled', 'true');
-			});
+describe('Saved Articles', () => {
+	beforeEach(() => {
+		cy.session('auth', () => {
+			cy.setCookie('gu-cmp-disabled', 'true');
 		});
+	});
 
+	// TODO - add an explicit mechanism for overriding the switch to false, for when we turn this on by default?
+	describe('Feature Switch OFF', () => {
 		it('redirects to account overview homepage from /saved-articles route ', () => {
 			cy.visit('/saved-articles');
 
@@ -21,20 +20,11 @@ if (!featureSwitches.savedArticles) {
 			cy.findAllByText('Saved articles').should('have.length', 0);
 		});
 	});
-}
-
-if (featureSwitches.savedArticles) {
-	describe('Feature Switch ON: Saved Article', () => {
-		beforeEach(() => {
-			cy.session('auth', () => {
-				cy.setCookie('gu-cmp-disabled', 'true');
-			});
-		});
-
+	describe('Feature Switch ON:', () => {
 		it('displays Saved Article page', () => {
-			cy.visit('/saved-articles');
+			cy.visit('/saved-articles?withFeature=savedArticles');
 
-			cy.findAllByText('Saved articles').should('have.length', 2);
+			cy.findAllByText('Saved articles').should('have.length.above', 0);
 		});
 	});
-}
+});


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
