### PR TITLE
Remove product switch code from main bundle

### DIFF
--- a/client/components/mma/MMAPage.tsx
+++ b/client/components/mma/MMAPage.tsx
@@ -39,10 +39,6 @@ import { Main } from '../shared/Main';
 import { DeliveryAddressUpdate } from './delivery/address/DeliveryAddressForm';
 import { Maintenance } from './maintenance/Maintenance';
 import { MMAPageSkeleton } from './MMAPageSkeleton';
-import { SwitchComplete } from './switch/complete/SwitchComplete';
-import { SwitchOptions } from './switch/options/SwitchOptions';
-import { SwitchReview } from './switch/review/SwitchReview';
-import { SwitchContainer } from './switch/SwitchContainer';
 
 const record = (event: any) => {
 	if (window.guardian?.ophan?.record) {
@@ -233,6 +229,38 @@ const DeliveryRecordsProblemConfirmation = lazy(() =>
 		/* webpackChunkName: "DeliveryRecords" */ './delivery/records/DeliveryRecordsProblemConfirmation'
 	).then(({ DeliveryRecordsProblemConfirmation }) => ({
 		default: DeliveryRecordsProblemConfirmation,
+	})),
+);
+
+const SwitchContainer = lazy(() =>
+	import(/* webpackChunkName: "Switch" */ './switch/SwitchContainer').then(
+		({ SwitchContainer }) => ({
+			default: SwitchContainer,
+		}),
+	),
+);
+
+const SwitchOptions = lazy(() =>
+	import(
+		/* webpackChunkName: "Switch" */ './switch/options/SwitchOptions'
+	).then(({ SwitchOptions }) => ({
+		default: SwitchOptions,
+	})),
+);
+
+const SwitchReview = lazy(() =>
+	import(
+		/* webpackChunkName: "Switch" */ './switch/review/SwitchReview'
+	).then(({ SwitchReview }) => ({
+		default: SwitchReview,
+	})),
+);
+
+const SwitchComplete = lazy(() =>
+	import(
+		/* webpackChunkName: "Switch" */ './switch/complete/SwitchComplete'
+	).then(({ SwitchComplete }) => ({
+		default: SwitchComplete,
 	})),
 );
 


### PR DESCRIPTION
## What does this change?

Adds code splitting for product switch pages so they are dynamically imported as needed and not included in the main bundle. This matches the other sections of the site and ensure users are not downloading code that they do not need. This is especially important at the moment as product switching is only partially rolled out for beta app users, but all visitors to the site are having to download the code for this feature.

|Before|Before (gzip)|After|After (gzip)|
|---|---|---|---|
|818.32KB|243.23 KB|737.6 KB|213.78 KB|

## How to test

Manually navigate to the product switch page at `/switch` with dev tools open and you will see the product switch bundle being dynamically loaded.

<img width="667" alt="Screenshot 2023-02-21 at 16 53 41" src="https://user-images.githubusercontent.com/1166188/220419730-8ecb5369-de3c-4b6d-81e8-4009e1490755.png">
