### PR TITLE
Fix dropdownNav at desktop smaller sizes

### DIFF
--- a/client/components/shared/nav/DropdownNav.tsx
+++ b/client/components/shared/nav/DropdownNav.tsx
@@ -7,7 +7,7 @@ import { expanderButtonCss } from '../ExpanderButton';
 import type { MenuSpecificNavItem } from './NavConfig';
 import { NAV_LINKS } from './NavConfig';
 
-const dropdownNavCss = (showMenu: boolean, isHelpCentre: boolean) =>
+const dropdownNavCss = (showMenu: boolean) =>
 	css({
 		display: `${showMenu ? 'block' : 'none'}`,
 		background: brand[400],
@@ -33,7 +33,6 @@ const dropdownNavCss = (showMenu: boolean, isHelpCentre: boolean) =>
 			maxWidth: 'none',
 			top: `${space[9]}px`,
 			left: 'auto',
-			right: `${isHelpCentre ? '' : '16px'}`,
 			marginRight: '-32px',
 			bottom: 'auto',
 			borderTop: 'none',
@@ -47,7 +46,7 @@ const dropdownNavCss = (showMenu: boolean, isHelpCentre: boolean) =>
 				height: 0,
 				position: 'absolute',
 				top: `-${space[2]}px`,
-				right: `${isHelpCentre ? '85' : space[3]}px`,
+				right: '85px',
 				borderLeft: `${space[2]}px solid transparent`,
 				borderRight: `${space[2]}px solid transparent`,
 				borderBottom: `${space[2]}px solid ${neutral['100']}`,
@@ -108,8 +107,6 @@ export const DropdownNav = () => {
 			removeListeners();
 		};
 	});
-
-	const isHelpCentre = window.location.pathname.startsWith('/help-centre');
 
 	const handleKeyDown = (event: KeyboardEvent) => {
 		if (event.code === 'Escape' && showMenu) {
@@ -202,7 +199,7 @@ export const DropdownNav = () => {
 				My account
 			</button>
 
-			<ul css={dropdownNavCss(showMenu, isHelpCentre)}>
+			<ul css={dropdownNavCss(showMenu)}>
 				{Object.values(NAV_LINKS).map(
 					(navItem: MenuSpecificNavItem) => (
 						<li key={navItem.title}>


### PR DESCRIPTION
## What does this change?

Fix the dropdown nav being cut off at smaller desktop sizes on mma by removing an unnecessary check to see if it was a help centre page or not (since mma and help-centre now use the same header).

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Before fix:
![image](https://user-images.githubusercontent.com/114918544/220708618-2d0558ed-f541-4f82-9074-bac969066927.png)
After
![image](https://user-images.githubusercontent.com/114918544/220708671-d9448fa9-4347-4f41-9e3c-268182b0ed05.png)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
