### PR TITLE
Create a test page for apps team to test Return button

### DIFF
--- a/client/components/mma/MMAPage.tsx
+++ b/client/components/mma/MMAPage.tsx
@@ -36,6 +36,7 @@ import { isSignedIn } from '../../utilities/signInStatus';
 import { ErrorBoundary } from '../shared/ErrorBoundary';
 import { GenericErrorScreen } from '../shared/GenericErrorScreen';
 import { Main } from '../shared/Main';
+import { TestReturnToApp } from './appsTest/TestReturnToApp';
 import { DeliveryAddressUpdate } from './delivery/address/DeliveryAddressForm';
 import { Maintenance } from './maintenance/Maintenance';
 import { MMAPageSkeleton } from './MMAPageSkeleton';
@@ -594,6 +595,10 @@ const MMARouter = () => {
 						/>
 						<Route path="/maintenance" element={<Maintenance />} />
 						<Route path="*" element={<Navigate to="/" />} />
+						<Route
+							path="/return-to-app-test"
+							element={<TestReturnToApp />}
+						/>
 					</Routes>
 				</ErrorBoundary>
 			</Suspense>

--- a/client/components/mma/appsTest/TestReturnToApp.tsx
+++ b/client/components/mma/appsTest/TestReturnToApp.tsx
@@ -1,0 +1,15 @@
+import { ThemeProvider } from '@emotion/react';
+import {
+	buttonThemeReaderRevenueBrand,
+	LinkButton,
+} from '@guardian/source-react-components';
+
+export const TestReturnToApp = () => {
+	return (
+		<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
+			<LinkButton href="x-gu://mma/success">
+				Activate full app access now
+			</LinkButton>
+		</ThemeProvider>
+	);
+};

--- a/shared/featureSwitches.ts
+++ b/shared/featureSwitches.ts
@@ -25,6 +25,6 @@ export const initFeatureSwitchUrlParamOverride = () => {
 export const featureSwitches: Record<string, boolean> = {
 	exampleFeature: false,
 	cancellationProductSwitch: false,
-	accountOverviewNewLayout: false,
+	accountOverviewNewLayout: true,
 	productSwitching: true,
 };


### PR DESCRIPTION
## What does this change?

Apps team asked if it would be possible to get a button somewhere that does the return to app journey, so they don't have to go through the sign up and switch process every time.

This PR creates a test page with that button to test it.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Got to `/return-to-app-test`

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
