### PR TITLE
Only call the `get-cancellation-date` API endpoint when necessary

### DIFF
--- a/client/components/mma/cancel/CancellationReasonSelection.tsx
+++ b/client/components/mma/cancel/CancellationReasonSelection.tsx
@@ -329,17 +329,10 @@ const ReasonPickerWithCancellationDate = ({
 		return <GenericErrorScreen />;
 	}
 
-	// offer choice if not trial period or lead time, and startPageOfferEffectiveDateOptions config set to true
-	const shouldOfferEffectiveDateOptions =
-		!isNaN(
-			Date.parse(cancellationDateResponse.cancellationEffectiveDate),
-		) && productType.cancellation.startPageOfferEffectiveDateOptions;
-
-	const chargedThroughDateStr = shouldOfferEffectiveDateOptions
-		? parseDate(cancellationDateResponse.cancellationEffectiveDate).dateStr(
-				DATE_FNS_LONG_OUTPUT_FORMAT,
-		  )
-		: undefined;
+	// offer choice if not trial period or lead time
+	const chargedThroughDateStr = parseDate(
+		cancellationDateResponse.cancellationEffectiveDate,
+	).dateStr(DATE_FNS_LONG_OUTPUT_FORMAT);
 
 	return (
 		<ReasonPicker

--- a/client/components/mma/cancel/CancellationReasonSelection.tsx
+++ b/client/components/mma/cancel/CancellationReasonSelection.tsx
@@ -329,7 +329,6 @@ const ReasonPickerWithCancellationDate = ({
 		return <GenericErrorScreen />;
 	}
 
-	// offer choice if not trial period or lead time
 	const chargedThroughDateStr = parseDate(
 		cancellationDateResponse.cancellationEffectiveDate,
 	).dateStr(DATE_FNS_LONG_OUTPUT_FORMAT);

--- a/client/components/mma/cancel/CancellationReasonSelection.tsx
+++ b/client/components/mma/cancel/CancellationReasonSelection.tsx
@@ -335,17 +335,17 @@ const ReasonPickerWithCancellationDate = ({
 			Date.parse(cancellationDateResponse.cancellationEffectiveDate),
 		) && productType.cancellation.startPageOfferEffectiveDateOptions;
 
-	const chargedThroughDateStr =
-		shouldOfferEffectiveDateOptions &&
-		parseDate(cancellationDateResponse.cancellationEffectiveDate).dateStr(
-			DATE_FNS_LONG_OUTPUT_FORMAT,
-		);
+	const chargedThroughDateStr = shouldOfferEffectiveDateOptions
+		? parseDate(cancellationDateResponse.cancellationEffectiveDate).dateStr(
+				DATE_FNS_LONG_OUTPUT_FORMAT,
+		  )
+		: undefined;
 
 	return (
 		<ReasonPicker
 			productType={productType}
 			productDetail={productDetail}
-			chargedThroughDateStr={chargedThroughDateStr || undefined}
+			chargedThroughDateStr={chargedThroughDateStr}
 		/>
 	);
 };

--- a/cypress/integration/parallel-2/cancelContribution.spec.ts
+++ b/cypress/integration/parallel-2/cancelContribution.spec.ts
@@ -70,7 +70,7 @@ describe('Cancel contribution', () => {
 		cy.intercept('GET', 'api/cancellation-date/**', {
 			statusCode: 200,
 			body: { cancellationEffectiveDate: '2022-02-05' },
-		});
+		}).as('get_cancellation_date');
 
 		cy.intercept('POST', 'api/cancel/**', {
 			statusCode: 200,
@@ -98,6 +98,7 @@ describe('Cancel contribution', () => {
 
 		cy.get('@create_case_in_salesforce.all').should('have.length', 1);
 		cy.get('@cancel_contribution.all').should('have.length', 1);
+		cy.get('@get_cancellation_date.all').should('have.length', 0);
 	});
 
 	it('does not cancel contribution, case api call returns 500', () => {
@@ -114,6 +115,8 @@ describe('Cancel contribution', () => {
 		cy.wait('@get_case').its('response.statusCode').should('equal', 500);
 
 		cy.findByText('Oops!').should('exist');
+
+		cy.get('@get_cancellation_date.all').should('have.length', 0);
 	});
 
 	it('cancels contribution with custom save body component (reason: I can no longer afford to support you)', () => {
@@ -139,6 +142,7 @@ describe('Cancel contribution', () => {
 
 		cy.get('@create_case_in_salesforce.all').should('have.length', 1);
 		cy.get('@cancel_contribution.all').should('have.length', 1);
+		cy.get('@get_cancellation_date.all').should('have.length', 0);
 	});
 
 	it('cancels contribution with save body string (reason: I’d like to get something in return for my support)', () => {
@@ -165,6 +169,7 @@ describe('Cancel contribution', () => {
 
 		cy.get('@create_case_in_salesforce.all').should('have.length', 1);
 		cy.get('@cancel_contribution.all').should('have.length', 1);
+		cy.get('@get_cancellation_date.all').should('have.length', 0);
 	});
 
 	it('save journey completed contribution not cancelled, amount reduced', () => {
@@ -189,6 +194,8 @@ describe('Cancel contribution', () => {
 		cy.findByText(
 			'We have successfully updated the amount of your contribution. New amount, £80.00, will be taken on 5 Feb 2022. Thank you for supporting the Guardian.',
 		).should('exist');
+
+		cy.get('@get_cancellation_date.all').should('have.length', 0);
 	});
 
 	it('allows cancellation when visiting cancellation page directly', () => {
@@ -212,5 +219,7 @@ describe('Cancel contribution', () => {
 		cy.findByRole('heading', {
 			name: 'Your recurring contribution is cancelled',
 		});
+
+		cy.get('@get_cancellation_date.all').should('have.length', 0);
 	});
 });

--- a/cypress/integration/parallel-2/cancelGW.spec.ts
+++ b/cypress/integration/parallel-2/cancelGW.spec.ts
@@ -48,7 +48,7 @@ describe('Cancel guardian weekly', () => {
 		cy.intercept('GET', 'api/cancellation-date/**', {
 			statusCode: 200,
 			body: { cancellationEffectiveDate: '2022-02-05' },
-		});
+		}).as('get_cancellation_date');
 
 		cy.intercept('POST', 'api/cancel/**', {
 			statusCode: 200,
@@ -92,6 +92,8 @@ describe('Cancel guardian weekly', () => {
 		cy.findByText(
 			'Your cancellation request has been successfully submitted. Our customer service team will try their best to contact you as soon as possible to confirm the cancellation and refund any credit you are owed.',
 		).should('exist');
+
+		cy.get('@get_cancellation_date.all').should('have.length', 1);
 	});
 
 	it('cancels Guardian Weekly (reason: I dont have time to use my subscription, effective: next billing date)', () => {
@@ -120,5 +122,7 @@ describe('Cancel guardian weekly', () => {
 		cy.findByText('Your Guardian Weekly subscription is cancelled').should(
 			'exist',
 		);
+
+		cy.get('@get_cancellation_date.all').should('have.length', 1);
 	});
 });

--- a/cypress/integration/parallel-2/cancelSupporterPlus.spec.ts
+++ b/cypress/integration/parallel-2/cancelSupporterPlus.spec.ts
@@ -58,7 +58,7 @@ describe('Cancel Supporter Plus', () => {
 		cy.intercept('GET', 'api/cancellation-date/**', {
 			statusCode: 200,
 			body: { cancellationEffectiveDate: '2022-02-05' },
-		});
+		}).as('get_cancellation_date');
 
 		cy.intercept('POST', '/api/supporter-plus-cancel/**', {
 			statusCode: 200,
@@ -84,5 +84,7 @@ describe('Cancel Supporter Plus', () => {
 		cy.findByRole('heading', {
 			name: 'Monthly support + extras cancelled',
 		});
+
+		cy.get('@get_cancellation_date.all').should('have.length', 0);
 	});
 });


### PR DESCRIPTION
## What does this change?

 As part of the process to cancel a subscription, we make an API call to get a preview of the cancellation date. This is intended to provide the customer with an estimated timeframe for when their subscription will end, but it is only applicable for Guardian Weekly and Voucher products. We do not use this date for any other product in the cancellation process. This PR makes this API call conditionally based on the `startPageOfferEffectiveDateOptions `.

 Cypress tests have been amended to check the API is called (or not called) as expected.

Tested in DEV.