### PR TITLE
WIP: Create IAP ProductType and create new Product Card holding

### DIFF
--- a/client/components/mma/accountoverview/AccountOverview.stories.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.stories.tsx
@@ -6,6 +6,7 @@ import {
 	contributionPayPal,
 	digitalDD,
 	guardianWeeklyCard,
+	inAppPurchase,
 	newspaperVoucherPaypal,
 	supporterPlus,
 	toMembersDataApiResponse,
@@ -94,6 +95,32 @@ export const WithContributionNewLayoutDigisubAndContribution: ComponentStory<
 		.get('/api/cancelled/', { body: [] })
 		.get('/api/me/mma', {
 			body: [contributionPayPal, digitalDD],
+		});
+
+	return <AccountOverview />;
+};
+
+export const WithInAppPurchase: ComponentStory<typeof AccountOverview> = () => {
+	fetchMock
+		.restore()
+		.get('/api/cancelled/', { body: [] })
+		.get('/api/me/mma', {
+			body: toMembersDataApiResponse(inAppPurchase),
+		});
+
+	return <AccountOverview />;
+};
+
+export const WithInAppPurchaseNewLayout: ComponentStory<
+	typeof AccountOverview
+> = () => {
+	featureSwitches['accountOverviewNewLayout'] = true;
+
+	fetchMock
+		.restore()
+		.get('/api/cancelled/', { body: [] })
+		.get('/api/me/mma', {
+			body: toMembersDataApiResponse(inAppPurchase),
 		});
 
 	return <AccountOverview />;

--- a/client/components/mma/accountoverview/AccountOverview.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.tsx
@@ -119,7 +119,8 @@ const AccountOverviewRenderer = ([mdapiObject, cancelledProductsResponse]: [
 						</h2>
 						<Stack space={6}>
 							{activeProductsInCategory.map((productDetail) =>
-								featureSwitches.accountOverviewNewLayout ? (
+								featureSwitches.accountOverviewNewLayout ||
+								productDetail.tier === 'IAP' ? ( // ToDo: remove this check when moving to V2
 									<AccountOverviewCardV2
 										key={
 											productDetail.subscription

--- a/client/components/mma/accountoverview/AccountOverviewCardV2.tsx
+++ b/client/components/mma/accountoverview/AccountOverviewCardV2.tsx
@@ -74,7 +74,74 @@ const productCardConfiguration: {
 	guardianpatron: {
 		headerColor: palette.brand[500],
 	},
+	iap: {
+		headerColor: palette.brand[500],
+	},
 };
+const sectionHeadingCss = css`
+	${textSans.medium({ fontWeight: 'bold' })};
+	margin-top: 0;
+	margin-bottom: ${space[2]}px;
+`;
+
+const productTitleCss = css`
+	${headline.xxsmall({ fontWeight: 'bold' })};
+	color: ${palette.neutral[100]};
+	margin: 0;
+	max-width: 20ch;
+
+	${from.tablet} {
+		${headline.small({ fontWeight: 'bold' })};
+	}
+`;
+
+const productDetailLayoutCss = css`
+	> * + * {
+		margin-top: ${space[5]}px;
+	}
+
+	${from.tablet} {
+		display: flex;
+		flex-direction: row;
+		> * + * {
+			margin-top: 0;
+			margin-left: auto;
+			padding-left: ${space[4]}px;
+		}
+	}
+`;
+
+const keyValueCss = css`
+	${textSans.medium()};
+	margin: 0;
+
+	div + div {
+		margin-top: ${space[1]}px;
+	}
+
+	dt {
+		display: inline-block;
+		margin-right: 0.5ch;
+		:after {
+			content: ':';
+		}
+	}
+
+	dd {
+		display: inline-block;
+		margin-left: 0;
+	}
+`;
+
+const buttonLayoutCss = css`
+	display: flex;
+	flex-direction: column;
+	justify-content: flex-end;
+
+	> * + * {
+		margin-top: ${space[3]}px;
+	}
+`;
 
 export const AccountOverviewCardV2 = ({
 	productDetail,
@@ -130,70 +197,7 @@ export const AccountOverviewCardV2 = ({
 	const cardConfig =
 		productCardConfiguration[specificProductType.productType];
 
-	const sectionHeadingCss = css`
-		${textSans.medium({ fontWeight: 'bold' })};
-		margin-top: 0;
-		margin-bottom: ${space[2]}px;
-	`;
-
-	const productTitleCss = css`
-		${headline.xxsmall({ fontWeight: 'bold' })};
-		color: ${palette.neutral[100]};
-		margin: 0;
-		max-width: 20ch;
-
-		${from.tablet} {
-			${headline.small({ fontWeight: 'bold' })};
-		}
-	`;
-
-	const productDetailLayoutCss = css`
-		> * + * {
-			margin-top: ${space[5]}px;
-		}
-
-		${from.tablet} {
-			display: flex;
-			flex-direction: row;
-			> * + * {
-				margin-top: 0;
-				margin-left: auto;
-				padding-left: ${space[4]}px;
-			}
-		}
-	`;
-
-	const keyValueCss = css`
-		${textSans.medium()};
-		margin: 0;
-
-		div + div {
-			margin-top: ${space[1]}px;
-		}
-
-		dt {
-			display: inline-block;
-			margin-right: 0.5ch;
-			:after {
-				content: ':';
-			}
-		}
-
-		dd {
-			display: inline-block;
-			margin-left: 0;
-		}
-	`;
-
-	const buttonLayoutCss = css`
-		display: flex;
-		flex-direction: column;
-		justify-content: flex-end;
-
-		> * + * {
-			margin-top: ${space[3]}px;
-		}
-	`;
+	const isInAppPurchase = productDetail.tier === 'IAP';
 
 	return (
 		<Card>
@@ -253,156 +257,174 @@ export const AccountOverviewCardV2 = ({
 					<SupporterPlusBenefitsToggle />
 				</Card.Section>
 			)}
-			<Card.Section>
-				<div css={productDetailLayoutCss}>
-					<div>
-						<h4 css={sectionHeadingCss}>Billing and payment</h4>
-						<dl css={keyValueCss}>
-							<div>
-								<dt>
-									{groupedProductType.showSupporterId
-										? 'Supporter ID'
-										: 'Subscription ID'}
-								</dt>
-								<dd>
-									{productDetail.subscription.subscriptionId}
-								</dd>
-							</div>
-							{groupedProductType.tierLabel && (
+			{!isInAppPurchase && (
+				<Card.Section>
+					<div css={productDetailLayoutCss}>
+						<div>
+							<h4 css={sectionHeadingCss}>Billing and payment</h4>
+							<dl css={keyValueCss}>
 								<div>
-									<dt>{groupedProductType.tierLabel}</dt>
-									<dd>{productDetail.tier}</dd>
-								</div>
-							)}
-							{subscriptionStartDate && shouldShowStartDate && (
-								<div>
-									<dt>Start date</dt>
+									<dt>
+										{groupedProductType.showSupporterId
+											? 'Supporter ID'
+											: 'Subscription ID'}
+									</dt>
 									<dd>
-										{parseDate(
-											subscriptionStartDate,
-										).dateStr()}
+										{
+											productDetail.subscription
+												.subscriptionId
+										}
 									</dd>
 								</div>
-							)}
-							{shouldShowJoinDateNotStartDate && (
-								<div>
-									<dt>Join date</dt>
-									<dd>
-										{parseDate(
-											productDetail.joinDate,
-										).dateStr()}
-									</dd>
-								</div>
-							)}
-							{userIsGifter && giftPurchaseDate && (
-								<div>
-									<dt>Purchase date</dt>
-									<dd>
-										{parseDate(giftPurchaseDate).dateStr()}
-									</dd>
-								</div>
-							)}
-							{specificProductType.showTrialRemainingIfApplicable &&
-								productDetail.subscription.trialLength > 0 &&
-								!isGifted &&
-								productDetail.subscription.readerType !==
-									'Patron' && (
+								{groupedProductType.tierLabel && (
 									<div>
-										<dt>Trial remaining</dt>
+										<dt>{groupedProductType.tierLabel}</dt>
+										<dd>{productDetail.tier}</dd>
+									</div>
+								)}
+								{subscriptionStartDate && shouldShowStartDate && (
+									<div>
+										<dt>Start date</dt>
 										<dd>
-											{
-												productDetail.subscription
-													.trialLength
-											}{' '}
-											{productDetail.subscription
-												.trialLength !== 1
-												? 'days'
-												: 'day'}
+											{parseDate(
+												subscriptionStartDate,
+											).dateStr()}
 										</dd>
 									</div>
 								)}
-							{isGifted && !userIsGifter && (
-								<div>
-									<dt>End date</dt>
-									<dd>
-										{parseDate(
-											subscriptionEndDate,
-										).dateStr()}
-									</dd>
-								</div>
-							)}
-							{nextPaymentDetails &&
-								productDetail.subscription.autoRenew &&
-								!hasCancellationPending && (
+								{shouldShowJoinDateNotStartDate && (
 									<div>
-										<dt>{nextPaymentDetails.paymentKey}</dt>
+										<dt>Join date</dt>
 										<dd>
-											{nextPaymentDetails.isNewPaymentValue && (
-												<NewPaymentPriceAlert />
-											)}
-											{nextPaymentDetails.paymentValue}
-											{nextPaymentDetails.nextPaymentDateValue &&
-												productDetail.subscription
-													.readerType !== 'Patron' &&
-												` on ${nextPaymentDetails.nextPaymentDateValue}`}
+											{parseDate(
+												productDetail.joinDate,
+											).dateStr()}
 										</dd>
 									</div>
 								)}
-						</dl>
-					</div>
-					<div css={buttonLayoutCss}>
-						{!isGifted && (
-							<Button
-								aria-label={`${specificProductType.productTitle(
-									mainPlan,
-								)} : Manage ${groupedProductType.friendlyName()}`}
-								data-cy={`Manage ${groupedProductType.friendlyName()}`}
-								size="small"
-								cssOverrides={css`
-									justify-content: center;
-								`}
-								onClick={() => {
-									trackEvent({
-										eventCategory: 'account_overview',
-										eventAction: 'click',
-										eventLabel: `manage_${groupedProductType.urlPart}`,
-									});
-									navigate(`/${groupedProductType.urlPart}`, {
-										state: {
-											productDetail: productDetail,
-										},
-									});
-								}}
-							>
-								{`Manage ${groupedProductType.friendlyName()}`}
-							</Button>
-						)}
-						{showSwitchButton && (
-							<ThemeProvider
-								theme={buttonThemeReaderRevenueBrand}
-							>
+								{userIsGifter && giftPurchaseDate && (
+									<div>
+										<dt>Purchase date</dt>
+										<dd>
+											{parseDate(
+												giftPurchaseDate,
+											).dateStr()}
+										</dd>
+									</div>
+								)}
+								{specificProductType.showTrialRemainingIfApplicable &&
+									productDetail.subscription.trialLength >
+										0 &&
+									!isGifted &&
+									productDetail.subscription.readerType !==
+										'Patron' && (
+										<div>
+											<dt>Trial remaining</dt>
+											<dd>
+												{
+													productDetail.subscription
+														.trialLength
+												}{' '}
+												{productDetail.subscription
+													.trialLength !== 1
+													? 'days'
+													: 'day'}
+											</dd>
+										</div>
+									)}
+								{isGifted && !userIsGifter && (
+									<div>
+										<dt>End date</dt>
+										<dd>
+											{parseDate(
+												subscriptionEndDate,
+											).dateStr()}
+										</dd>
+									</div>
+								)}
+								{nextPaymentDetails &&
+									productDetail.subscription.autoRenew &&
+									!hasCancellationPending && (
+										<div>
+											<dt>
+												{nextPaymentDetails.paymentKey}
+											</dt>
+											<dd>
+												{nextPaymentDetails.isNewPaymentValue && (
+													<NewPaymentPriceAlert />
+												)}
+												{
+													nextPaymentDetails.paymentValue
+												}
+												{nextPaymentDetails.nextPaymentDateValue &&
+													productDetail.subscription
+														.readerType !==
+														'Patron' &&
+													` on ${nextPaymentDetails.nextPaymentDateValue}`}
+											</dd>
+										</div>
+									)}
+							</dl>
+						</div>
+						<div css={buttonLayoutCss}>
+							{!isGifted && (
 								<Button
+									aria-label={`${specificProductType.productTitle(
+										mainPlan,
+									)} : Manage ${groupedProductType.friendlyName()}`}
+									data-cy={`Manage ${groupedProductType.friendlyName()}`}
 									size="small"
 									cssOverrides={css`
 										justify-content: center;
 									`}
-									onClick={() =>
-										navigate(`/switch`, {
-											state: {
-												productDetail: productDetail,
-												user: user,
+									onClick={() => {
+										trackEvent({
+											eventCategory: 'account_overview',
+											eventAction: 'click',
+											eventLabel: `manage_${groupedProductType.urlPart}`,
+										});
+										navigate(
+											`/${groupedProductType.urlPart}`,
+											{
+												state: {
+													productDetail:
+														productDetail,
+												},
 											},
-										})
-									}
+										);
+									}}
 								>
-									Change to monthly + extras
+									{`Manage ${groupedProductType.friendlyName()}`}
 								</Button>
-							</ThemeProvider>
-						)}
+							)}
+							{showSwitchButton && (
+								<ThemeProvider
+									theme={buttonThemeReaderRevenueBrand}
+								>
+									<Button
+										size="small"
+										cssOverrides={css`
+											justify-content: center;
+										`}
+										onClick={() =>
+											navigate(`/switch`, {
+												state: {
+													productDetail:
+														productDetail,
+													user: user,
+												},
+											})
+										}
+									>
+										Change to monthly + extras
+									</Button>
+								</ThemeProvider>
+							)}
+						</div>
 					</div>
-				</div>
-			</Card.Section>
-			{productDetail.isPaidTier && (
+				</Card.Section>
+			)}
+			{productDetail.isPaidTier && !isInAppPurchase && (
 				<Card.Section>
 					<div css={productDetailLayoutCss}>
 						<div>
@@ -494,6 +516,7 @@ export const AccountOverviewCardV2 = ({
 					</div>
 				</Card.Section>
 			)}
+			{isInAppPurchase && <Card.Section>In App Purchase</Card.Section>}
 		</Card>
 	);
 };

--- a/client/fixtures/productDetail.ts
+++ b/client/fixtures/productDetail.ts
@@ -879,6 +879,36 @@ export const cancelledContribution: ProductDetail = {
 	isTestUser: false,
 };
 
+export const inAppPurchase: ProductDetail = {
+	isTestUser: false,
+	isPaidTier: true,
+	tier: 'IAP',
+	mmaCategory: 'recurringSupport',
+	joinDate: '2020-02-02',
+	selfServiceCancellation: {
+		isAllowed: false,
+		shouldDisplayEmail: false,
+		phoneRegionsToDisplay: [],
+	},
+	subscription: {
+		subscriptionId: '',
+		end: '',
+		renewalDate: '',
+		anniversaryDate: '',
+		cancelledAt: false,
+		safeToUpdatePaymentMethod: false,
+		autoRenew: false,
+		trialLength: 0,
+		readerType: 'Direct',
+		nextPaymentDate: null,
+		nextPaymentPrice: null,
+		lastPaymentDate: null,
+		chargedThroughDate: null,
+		currentPlans: [],
+		futurePlans: [],
+	},
+};
+
 export const toMembersDataApiResponse = (
 	...productDetails: ProductDetail[]
 ): MembersDataApiResponse => {

--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -43,7 +43,8 @@ type ProductFriendlyName =
 	| 'Guardian Weekly subscription'
 	| 'subscription'
 	| 'recurring support'
-	| 'guardian patron';
+	| 'guardian patron'
+	| 'in app purchase';
 type ProductUrlPart =
 	| 'membership'
 	| 'contributions'
@@ -56,7 +57,8 @@ type ProductUrlPart =
 	| 'guardianweekly'
 	| 'subscriptions'
 	| 'recurringsupport'
-	| 'guardianpatron';
+	| 'guardianpatron'
+	| 'iap';
 type SfCaseProduct =
 	| 'Membership'
 	| 'Recurring - Contributions'
@@ -77,7 +79,8 @@ export type AllProductsProductTypeFilterString =
 	| 'SupporterPlus'
 	| 'ContentSubscription'
 	| 'GuardianPatron'
-	| 'RecurringSupport';
+	| 'RecurringSupport'
+	| 'IAP';
 
 interface CancellationFlowProperties {
 	reasons: CancellationReason[];
@@ -259,7 +262,8 @@ export type ProductTypeKeys =
 	| 'guardianweekly'
 	| 'digipack'
 	| 'supporterplus'
-	| 'guardianpatron';
+	| 'guardianpatron'
+	| 'iap';
 
 /*
  * TODO: remove 'contributions' from the following list once MDAPI has been changed to return 'recurringSupport' instead
@@ -673,6 +677,21 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 			SoftOptInIDs.SupporterNewsletter,
 		],
 	},
+	iap: {
+		productTitle: () => 'In App Purchase',
+		friendlyName: () => 'in app purchase',
+		productType: 'iap',
+		groupedProductType: 'recurringSupport',
+		allProductsProductTypeFilterString: 'IAP',
+		urlPart: 'iap',
+		legacyUrlPart: 'iap',
+		softOptInIDs: [
+			SoftOptInIDs.SupportOnboarding,
+			SoftOptInIDs.SimilarProducts,
+			SoftOptInIDs.SupporterNewsletter,
+			SoftOptInIDs.DigitalSubscriberPreview,
+		],
+	},
 };
 
 export const GROUPED_PRODUCT_TYPES: {
@@ -711,6 +730,8 @@ export const GROUPED_PRODUCT_TYPES: {
 				return PRODUCT_TYPES.supporterplus;
 			} else if (productDetail.tier === 'Contributor') {
 				return PRODUCT_TYPES.contributions;
+			} else if (productDetail.tier === 'IAP') {
+				return PRODUCT_TYPES.iap;
 			}
 			throw `Specific product type for tier '${productDetail.tier}' not found.`;
 		},


### PR DESCRIPTION
## What does this change?

Add a new Product Type for In App Purchases with tier 'iap' under the recurring support category. Create an account overview card (using the new layout only) with some placeholder text.
 
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

MDAPI does not currently return IAPs in the product holding, so there is no way to test in an environment. 

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
