### PR TITLE
Account Overview product banners

### DIFF
--- a/client/components/mma/accountoverview/AccountOverview.stories.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.stories.tsx
@@ -38,6 +38,7 @@ export const WithSubscriptions: ComponentStory<typeof AccountOverview> = () => {
 		.get('/api/cancelled/', { body: [] })
 		.get('/api/me/mma', {
 			body: toMembersDataApiResponse(
+				supporterPlus,
 				guardianWeeklyCard,
 				digitalDD,
 				newspaperVoucherPaypal,

--- a/client/components/mma/accountoverview/AccountOverviewCardV2.tsx
+++ b/client/components/mma/accountoverview/AccountOverviewCardV2.tsx
@@ -47,32 +47,31 @@ const productCardConfiguration: {
 	},
 	supporterplus: {
 		headerColor: palette.brand[500],
-		headerImageId: 'digitalSubPackshot',
 		showBenefitsSection: true,
 	},
 	digipack: {
-		headerColor: palette.brand[500],
+		headerColor: '#ff663d',
 	},
 	digitalvoucher: {
-		headerColor: '#ff5943',
+		headerColor: palette.sport[500],
 	},
 	newspaper: {
-		headerColor: '#ff5943',
+		headerColor: palette.sport[500],
 	},
 	homedelivery: {
-		headerColor: '#ff5943',
+		headerColor: palette.sport[500],
 	},
 	voucher: {
-		headerColor: '#ff5943',
+		headerColor: palette.sport[500],
 	},
 	guardianweekly: {
 		headerColor: '#5f8085',
 	},
 	membership: {
-		headerColor: palette.brand[500],
+		headerColor: palette.lifestyle[300],
 	},
 	guardianpatron: {
-		headerColor: palette.brand[500],
+		headerColor: palette.sport[300],
 	},
 };
 

--- a/client/components/mma/accountoverview/AccountOverviewCardV2.tsx
+++ b/client/components/mma/accountoverview/AccountOverviewCardV2.tsx
@@ -24,7 +24,6 @@ import { ErrorIcon } from '../shared/assets/ErrorIcon';
 import { Card } from '../shared/Card';
 import { CardDisplay } from '../shared/CardDisplay';
 import { DirectDebitDisplay } from '../shared/DirectDebitDisplay';
-import { GridPicture } from '../shared/images/GridPicture';
 import {
 	getNextPaymentDetails,
 	NewPaymentPriceAlert,
@@ -33,9 +32,31 @@ import { PaypalDisplay } from '../shared/PaypalDisplay';
 import { SepaDisplay } from '../shared/SepaDisplay';
 import { SupporterPlusBenefitsToggle } from '../shared/SupporterPlusBenefits';
 
+const gridImageCatalogue = {
+	PrintPackshot: '34edb8f20fe4f9e847ea63967b202b52a6891c16/0_0_520_312',
+	GuardianWeeklyPackshot:
+		'0ed355937481e005eb1ffecacddbb592d450e8e8/0_0_591_355',
+	SupporterPlusPackshot:
+		'956d120bc2a924d214908e5d9e3a1e39be156666/0_0_643_300',
+};
+
+type GridImageId = keyof typeof gridImageCatalogue;
+
+enum ImageType {
+	JPG = 'jpg',
+	PNG = 'png',
+}
+
+const gridUrl = (
+	gridId: GridImageId,
+	size: number = 500,
+	imageType: ImageType = ImageType.PNG,
+): string =>
+	`https://media.guim.co.uk/${gridImageCatalogue[gridId]}/${size}.${imageType}`;
+
 interface ProductCardConfiguration {
 	headerColor: string;
-	headerImageId?: string;
+	headerImageId?: GridImageId;
 	showBenefitsSection?: boolean;
 }
 
@@ -47,6 +68,7 @@ const productCardConfiguration: {
 	},
 	supporterplus: {
 		headerColor: palette.brand[500],
+		headerImageId: 'SupporterPlusPackshot',
 		showBenefitsSection: true,
 	},
 	digipack: {
@@ -54,18 +76,23 @@ const productCardConfiguration: {
 	},
 	digitalvoucher: {
 		headerColor: palette.sport[500],
+		headerImageId: 'PrintPackshot',
 	},
 	newspaper: {
 		headerColor: palette.sport[500],
+		headerImageId: 'PrintPackshot',
 	},
 	homedelivery: {
 		headerColor: palette.sport[500],
+		headerImageId: 'PrintPackshot',
 	},
 	voucher: {
 		headerColor: palette.sport[500],
+		headerImageId: 'PrintPackshot',
 	},
 	guardianweekly: {
 		headerColor: '#5f8085',
+		headerImageId: 'GuardianWeeklyPackshot',
 	},
 	membership: {
 		headerColor: palette.lifestyle[300],
@@ -208,28 +235,12 @@ export const AccountOverviewCardV2 = ({
 				>
 					<h3 css={productTitleCss}>{productTitle}</h3>
 					{cardConfig.headerImageId && (
-						<GridPicture
-							cssOverrides={css`
-								margin-top: -${space[3] + 16}px;
-								margin-bottom: -${space[3]}px;
-								max-height: 80px;
-								${from.tablet} {
-									max-height: 144px;
-								}
+						<img
+							src={gridUrl(cardConfig.headerImageId)}
+							alt=""
+							css={css`
+								width: 295px;
 							`}
-							sources={[
-								{
-									gridId: cardConfig.headerImageId,
-									srcSizes: [497, 285],
-									imgType: 'png',
-									sizes: '100vw',
-									media: '(max-width: 220px)',
-								},
-							]}
-							fallback={cardConfig.headerImageId}
-							fallbackSize={497}
-							altText=""
-							fallbackImgType="png"
 						/>
 					)}
 				</div>

--- a/client/components/mma/accountoverview/AccountOverviewCardV2.tsx
+++ b/client/components/mma/accountoverview/AccountOverviewCardV2.tsx
@@ -56,8 +56,12 @@ const gridUrl = (
 
 interface ProductCardConfiguration {
 	headerColor: string;
-	headerImageId?: GridImageId;
 	showBenefitsSection?: boolean;
+	headerImage?: {
+		gridId: GridImageId;
+		width: number;
+		offset: number;
+	};
 }
 
 const productCardConfiguration: {
@@ -68,31 +72,55 @@ const productCardConfiguration: {
 	},
 	supporterplus: {
 		headerColor: palette.brand[500],
-		headerImageId: 'SupporterPlusPackshot',
 		showBenefitsSection: true,
+		headerImage: {
+			gridId: 'SupporterPlusPackshot',
+			width: 320,
+			offset: 38,
+		},
 	},
 	digipack: {
 		headerColor: '#ff663d',
 	},
 	digitalvoucher: {
 		headerColor: palette.sport[500],
-		headerImageId: 'PrintPackshot',
+		headerImage: {
+			gridId: 'PrintPackshot',
+			width: 260,
+			offset: 88,
+		},
 	},
 	newspaper: {
 		headerColor: palette.sport[500],
-		headerImageId: 'PrintPackshot',
+		headerImage: {
+			gridId: 'PrintPackshot',
+			width: 260,
+			offset: 88,
+		},
 	},
 	homedelivery: {
 		headerColor: palette.sport[500],
-		headerImageId: 'PrintPackshot',
+		headerImage: {
+			gridId: 'PrintPackshot',
+			width: 260,
+			offset: 88,
+		},
 	},
 	voucher: {
 		headerColor: palette.sport[500],
-		headerImageId: 'PrintPackshot',
+		headerImage: {
+			gridId: 'PrintPackshot',
+			width: 260,
+			offset: 88,
+		},
 	},
 	guardianweekly: {
 		headerColor: '#5f8085',
-		headerImageId: 'GuardianWeeklyPackshot',
+		headerImage: {
+			gridId: 'GuardianWeeklyPackshot',
+			width: 295,
+			offset: 52,
+		},
 	},
 	membership: {
 		headerColor: palette.lifestyle[300],
@@ -173,6 +201,20 @@ export const AccountOverviewCardV2 = ({
 		}
 	`;
 
+	const productPackshotCss = css`
+		display: none;
+		position: absolute;
+		bottom: 0;
+		${from.tablet} {
+			display: block;
+		}
+	`;
+
+	const productPackshotAlignmentCss = (width: number, offset: number) => css`
+		width: ${width}px;
+		right: ${offset}px;
+	`;
+
 	const productDetailLayoutCss = css`
 		> * + * {
 			margin-top: ${space[5]}px;
@@ -227,23 +269,20 @@ export const AccountOverviewCardV2 = ({
 				backgroundColor={cardConfig.headerColor}
 				minHeightTablet
 			>
-				<div
-					css={css`
-						display: flex;
-						justify-content: space-between;
-					`}
-				>
-					<h3 css={productTitleCss}>{productTitle}</h3>
-					{cardConfig.headerImageId && (
-						<img
-							src={gridUrl(cardConfig.headerImageId)}
-							alt=""
-							css={css`
-								width: 295px;
-							`}
-						/>
-					)}
-				</div>
+				<h3 css={productTitleCss}>{productTitle}</h3>
+				{cardConfig.headerImage && (
+					<img
+						alt=""
+						src={gridUrl(cardConfig.headerImage.gridId)}
+						css={[
+							productPackshotCss,
+							productPackshotAlignmentCss(
+								cardConfig.headerImage.width,
+								cardConfig.headerImage.offset,
+							),
+						]}
+					/>
+				)}
 			</Card.Header>
 
 			{cardConfig.showBenefitsSection && nextPaymentDetails && (

--- a/client/components/mma/shared/Card.tsx
+++ b/client/components/mma/shared/Card.tsx
@@ -12,6 +12,7 @@ Card.Header = (props: {
 	minHeightTablet?: boolean;
 }) => {
 	const headerCss = css`
+		position: relative;
 		padding: ${space[3]}px ${space[4]}px;
 		min-height: 64px;
 		background-color: ${props.backgroundColor ?? palette.neutral[97]};


### PR DESCRIPTION
## What does this change?

Adds support for product banners on the _Account Overview_ page. The images themselves are hosted on Grid so this PR is relatively small. The codebase already includes some Grid image components borrowed from [`support-frontend`](https://github.com/guardian/support-frontend), but for the sake of simplicity these have not been used here as we don't require responsive image support. (It should be noted that these components are not used in any public facing features so could potentially be removed.)

_Note:_ this is a draft PR as designs for the banner images are still being finalised

## Images

<img width="740" alt="Screenshot 2023-02-28 at 15 52 00" src="https://user-images.githubusercontent.com/1166188/221906352-44f58fa8-9310-44b2-b0ed-af34800738c1.png">
