### PR TITLE
Improved Live Chat Data privacy notice wording

### DIFF
--- a/client/components/helpCentre/liveChat/LiveChatPrivacyNotice.tsx
+++ b/client/components/helpCentre/liveChat/LiveChatPrivacyNotice.tsx
@@ -35,8 +35,8 @@ export const LiveChatPrivacyNotice = () => {
 		<div css={containerCss} id="livechatPrivacyNotice">
 			<h2 css={titleCss}>Data privacy notice</h2>
 			<p css={paragraphCss}>
-				We use a type of cookie technology called an SDK (Software
-				Development Kit) to ensure that our live chat services work
+				We use an SDK (a Software Development Kit) from Salesforce which
+				uses cookies to ensure that our live chat service works
 				correctly and meet your expectations. It cannot be switched off
 				but it is removed at the end of the chat. If you do not wish for
 				this cookie to be dropped on your device, please email or phone


### PR DESCRIPTION
## What does this change?
I am suggesting this tweak to the text within the Data Privacy notice.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Deploy to CODE

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
Data Privacy team sign off on this new wording, and hopefully a quick poll of staff feel the new wording makes more sense.

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
If Legal and the survey are more happy then the risk I would say is lower than the current wording which I feel is confusing.

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
