### PR TITLE
Fix Failed Cancellation not displaying error

### DIFF
--- a/client/components/mma/cancel/stages/ExecuteCancellation.tsx
+++ b/client/components/mma/cancel/stages/ExecuteCancellation.tsx
@@ -4,7 +4,10 @@ import { Button } from '@guardian/source-react-components';
 import type { ReactNode } from 'react';
 import { useContext } from 'react';
 import { Navigate, useLocation, useNavigate } from 'react-router-dom';
-import type { ProductDetail } from '../../../../../shared/productResponse';
+import type {
+	MembersDataApiResponse,
+	ProductDetail,
+} from '../../../../../shared/productResponse';
 import { isProduct } from '../../../../../shared/productResponse';
 import type {
 	ProductType,
@@ -26,7 +29,7 @@ import type { OptionalCancellationReasonId } from '../cancellationReason';
 import { getCancellationSummary, isCancelled } from '../CancellationSummary';
 import { CaseUpdateAsyncLoader, getUpdateCasePromise } from '../caseUpdate';
 
-class PerformCancelAsyncLoader extends AsyncLoader<ProductDetail[]> {}
+class PerformCancelAsyncLoader extends AsyncLoader<MembersDataApiResponse> {}
 
 const getCancelFunc =
 	(
@@ -111,8 +114,11 @@ const getCaseUpdatingCancellationSummary =
 		productType: ProductTypeWithCancellationFlow,
 		cancelledProductDetail: ProductDetail,
 	) =>
-	(productDetails: ProductDetail[]) => {
-		const productDetail = productDetails[0] || { subscription: {} };
+	(mdapiResponse: MembersDataApiResponse) => {
+		const productDetail = (mdapiResponse.products[0] as ProductDetail) || {
+			subscription: {},
+		};
+
 		const render = getCancellationSummaryWithReturnButton(
 			getCancellationSummary(
 				productType,


### PR DESCRIPTION
## What does this change?

Show error message as expected when a cancellation fails. The code was expecting the old MDAPI response type (ProductDetail array) instead of the new object which contains `user` and `products` properties.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
