### PR TITLE
Display IAPs in Account Overview, Billing page and Emails and Marketing consents

### DIFF
--- a/client/components/mma/accountoverview/AccountOverview.stories.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.stories.tsx
@@ -119,6 +119,8 @@ export const WithContributionNewLayoutDigisubAndContribution: ComponentStory<
 };
 
 export const WithIAP: ComponentStory<typeof AccountOverview> = () => {
+	featureSwitches['appSubscriptions'] = true;
+
 	fetchMock
 		.restore()
 		.get('/api/cancelled/', { body: [] })
@@ -132,6 +134,8 @@ export const WithIAP: ComponentStory<typeof AccountOverview> = () => {
 };
 
 export const WithCancelledIAP: ComponentStory<typeof AccountOverview> = () => {
+	featureSwitches['appSubscriptions'] = true;
+
 	fetchMock
 		.restore()
 		.get('/api/cancelled/', { body: [] })
@@ -147,6 +151,8 @@ export const WithCancelledIAP: ComponentStory<typeof AccountOverview> = () => {
 export const WithOneCancelledAndOneNotCancelledIAP: ComponentStory<
 	typeof AccountOverview
 > = () => {
+	featureSwitches['appSubscriptions'] = true;
+
 	fetchMock
 		.restore()
 		.get('/api/cancelled/', { body: [] })

--- a/client/components/mma/accountoverview/AccountOverview.stories.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.stories.tsx
@@ -118,37 +118,7 @@ export const WithContributionNewLayoutDigisubAndContribution: ComponentStory<
 	return <AccountOverview />;
 };
 
-export const WithIAP: ComponentStory<typeof AccountOverview> = () => {
-	featureSwitches['appSubscriptions'] = true;
-
-	fetchMock
-		.restore()
-		.get('/api/cancelled/', { body: [] })
-		.get('/mpapi/user/mobile-subscriptions', {
-			body: { subscriptions: [InAppPurchase] },
-		})
-		.get('/api/me/mma', { body: toMembersDataApiResponse(digitalDD) })
-		.get('/idapi/user', { body: user });
-
-	return <AccountOverview />;
-};
-
-export const WithCancelledIAP: ComponentStory<typeof AccountOverview> = () => {
-	featureSwitches['appSubscriptions'] = true;
-
-	fetchMock
-		.restore()
-		.get('/api/cancelled/', { body: [] })
-		.get('/mpapi/user/mobile-subscriptions', {
-			body: { subscriptions: [CancelledInAppPurchase] },
-		})
-		.get('/api/me/mma', { body: toMembersDataApiResponse() })
-		.get('/idapi/user', { body: user });
-
-	return <AccountOverview />;
-};
-
-export const WithOneCancelledAndOneNotCancelledIAP: ComponentStory<
+export const WithAppSubscriptions: ComponentStory<
 	typeof AccountOverview
 > = () => {
 	featureSwitches['appSubscriptions'] = true;

--- a/client/components/mma/accountoverview/ContributionUpdateAmountForm.tsx
+++ b/client/components/mma/accountoverview/ContributionUpdateAmountForm.tsx
@@ -17,11 +17,8 @@ import type { PaidSubscriptionPlan } from '../../../../shared/productResponse';
 import { augmentBillingPeriod } from '../../../../shared/productResponse';
 import type { ProductType } from '../../../../shared/productTypes';
 import { trackEvent } from '../../../utilities/analytics';
-import type {
-	ContributionInterval} from '../../../utilities/contributionsAmount';
-import {
-	contributionAmountsLookup
-} from '../../../utilities/contributionsAmount';
+import type { ContributionInterval } from '../../../utilities/contributionsAmount';
+import { contributionAmountsLookup } from '../../../utilities/contributionsAmount';
 import { fetchWithDefaultParameters } from '../../../utilities/fetch';
 import { AsyncLoader } from '../shared/AsyncLoader';
 import { Button } from '../shared/Buttons';

--- a/client/components/mma/accountoverview/InAppPurchaseCard.tsx
+++ b/client/components/mma/accountoverview/InAppPurchaseCard.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { from, headline, palette } from '@guardian/source-foundations';
 import { Stack } from '@guardian/source-react-components';
+import { dateString } from '../../../../shared/dates';
 import type { AppSubscription } from '../../../../shared/mpapiResponse';
 import { InfoSummary } from '../paymentUpdate/Summary';
 import { Card } from '../shared/Card';
@@ -16,13 +17,37 @@ const productTitleCss = css`
 	}
 `;
 
-export const InAppPurchaseCard = (props: {
+const summaryLinkCss = css`
+	color: currentColor;
+	text-decoration: underline;
+`;
+
+const cancelledAppSubscriptionMessage = (cancellationTimestamp: string) => {
+	return (
+		<>
+			Your app subscription was cancelled in{' '}
+			{dateString(new Date(cancellationTimestamp), 'MMMM yyyy')}. If you
+			would like to fund Guardian journalism again, please{' '}
+			<a css={summaryLinkCss} href="https://support.theguardian.com/">
+				support us today
+			</a>
+		</>
+	);
+};
+
+export const InAppPurchaseCard = ({
+	inAppPurchase,
+}: {
 	inAppPurchase: AppSubscription;
 }) => {
 	return (
 		<Stack space={3}>
-			{props.inAppPurchase.cancellationTimestamp && (
-				<InfoSummary message="ToDo: Your App Subscription Was cancelled" />
+			{inAppPurchase.cancellationTimestamp && (
+				<InfoSummary
+					message={cancelledAppSubscriptionMessage(
+						inAppPurchase.cancellationTimestamp,
+					)}
+				/>
 			)}
 			<Card>
 				<Card.Header
@@ -31,7 +56,11 @@ export const InAppPurchaseCard = (props: {
 				>
 					<h3 css={productTitleCss}>App Subscription</h3>
 				</Card.Header>
-				<Card.Section>ToDo: </Card.Section>
+				<Card.Section>
+					Your subscription started in{' '}
+					{dateString(new Date(inAppPurchase.from), 'MMMM yyyy')}.
+					Thank you for supporting the Guardian.
+				</Card.Section>
 			</Card>
 		</Stack>
 	);

--- a/client/components/mma/accountoverview/InAppPurchaseCard.tsx
+++ b/client/components/mma/accountoverview/InAppPurchaseCard.tsx
@@ -31,7 +31,7 @@ export const InAppPurchaseCard = (props: {
 				>
 					<h3 css={productTitleCss}>App Subscription</h3>
 				</Card.Header>
-				<Card.Section>you have it</Card.Section>
+				<Card.Section>ToDo: </Card.Section>
 			</Card>
 		</Stack>
 	);

--- a/client/components/mma/accountoverview/InAppPurchaseCard.tsx
+++ b/client/components/mma/accountoverview/InAppPurchaseCard.tsx
@@ -22,12 +22,10 @@ const summaryLinkCss = css`
 	text-decoration: underline;
 `;
 
-const cancelledAppSubscriptionMessage = (cancellationTimestamp: string) => {
+const cancelledAppSubscriptionMessage = () => {
 	return (
 		<>
-			Your app subscription was cancelled in{' '}
-			{dateString(new Date(cancellationTimestamp), 'MMMM yyyy')}. If you
-			would like to fund Guardian journalism again, please{' '}
+			If you would like to fund Guardian journalism again, please{' '}
 			<a css={summaryLinkCss} href="https://support.theguardian.com/">
 				support us today
 			</a>
@@ -44,9 +42,11 @@ export const InAppPurchaseCard = ({
 		<Stack space={3}>
 			{inAppPurchase.cancellationTimestamp && (
 				<InfoSummary
-					message={cancelledAppSubscriptionMessage(
-						inAppPurchase.cancellationTimestamp,
-					)}
+					message={`Your app subscription was cancelled in ${dateString(
+						new Date(inAppPurchase.cancellationTimestamp),
+						'MMMM yyyy',
+					)}.`}
+					context={cancelledAppSubscriptionMessage()}
 				/>
 			)}
 			<Card>

--- a/client/components/mma/billing/Billing.stories.tsx
+++ b/client/components/mma/billing/Billing.stories.tsx
@@ -1,6 +1,8 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 import fetchMock from 'fetch-mock';
 import { ReactRouterDecorator } from '../../../../.storybook/ReactRouterDecorator';
+import { featureSwitches } from '../../../../shared/featureSwitches';
+import { InAppPurchase } from '../../../fixtures/inAppPurchase';
 import { guardianWeeklyCardInvoice } from '../../../fixtures/invoices';
 import {
 	digitalDD,
@@ -34,6 +36,8 @@ export const NoSubscription: ComponentStory<typeof Billing> = () => {
 };
 
 export const WithSubscriptions: ComponentStory<typeof Billing> = () => {
+	featureSwitches['appSubscriptions'] = true;
+
 	fetchMock
 		.restore()
 		.get('/api/me/mma', {
@@ -44,7 +48,7 @@ export const WithSubscriptions: ComponentStory<typeof Billing> = () => {
 			),
 		})
 		.get('/mpapi/user/mobile-subscriptions', {
-			body: { subscriptions: [] },
+			body: { subscriptions: [InAppPurchase] },
 		})
 		.get('/api/invoices', {
 			body: { invoices: [guardianWeeklyCardInvoice] },

--- a/client/components/mma/billing/Billing.tsx
+++ b/client/components/mma/billing/Billing.tsx
@@ -13,10 +13,9 @@ import { parseDate } from '../../../../shared/dates';
 import { featureSwitches } from '../../../../shared/featureSwitches';
 import type {
 	AppSubscription,
-	MPAPIResponse} from '../../../../shared/mpapiResponse';
-import {
-	isValidAppSubscription
+	MPAPIResponse,
 } from '../../../../shared/mpapiResponse';
+import { isValidAppSubscription } from '../../../../shared/mpapiResponse';
 import type {
 	InvoiceDataApiItem,
 	MembersDataApiItem,

--- a/client/components/mma/billing/Billing.tsx
+++ b/client/components/mma/billing/Billing.tsx
@@ -76,9 +76,9 @@ ${until.tablet} {
 };
 `;
 
-const subHeadingBorderTopCss = `
-border-top: 1px solid ${neutral['86']};
-margin: 50px 0 ${space[5]}px;
+const subHeadingBorderTopCss = css`
+	border-top: 1px solid ${neutral['86']};
+	margin: ${space[12]}px 0 ${space[5]}px;
 `;
 
 function decorateProductDetailWithInvoices(
@@ -305,7 +305,31 @@ function renderProductBillingInfo([mmaCategory, productDetails]: [
 }
 
 function renderInAppPurchase(value: AppSubscription) {
-	return <div key={value.subscriptionId}>todo</div>;
+	return (
+		<div css={subHeadingBorderTopCss} key={value.subscriptionId}>
+			<h2
+				css={css`
+					${subHeadingTitleCss}
+					margin: 0;
+				`}
+			>
+				App Subscription
+			</h2>
+			<div
+				css={css`
+					${textSans.medium()};
+					border: 1px solid ${neutral[20]};
+					display: flex;
+					flex-wrap: wrap;
+					margin: ${space[5]}px 0;
+					padding: ${space[3]}px;
+				`}
+			>
+				To change your payment setup, please contact Apple (for iOS), or
+				Google (for Android).
+			</div>
+		</div>
+	);
 }
 
 function BillingDetailsComponent(props: {
@@ -350,7 +374,10 @@ const BillingPage = () => {
 	const { allProductDetails, mmaCategoryToProductDetails } =
 		joinInvoicesWithProductsInCategories(mdapiObject, invoicesResponse);
 
-	if (allProductDetails.length === 0 && appSubscriptions.length === 0) {
+	if (
+		(allProductDetails.length === 0 && appSubscriptions.length === 0) ||
+		(allProductDetails.length === 0 && !featureSwitches.appSubscriptions)
+	) {
 		return <EmptyAccountOverview />;
 	}
 

--- a/client/components/mma/billing/Billing.tsx
+++ b/client/components/mma/billing/Billing.tsx
@@ -319,8 +319,6 @@ function renderInAppPurchase(value: AppSubscription) {
 				css={css`
 					${textSans.medium()};
 					border: 1px solid ${neutral[20]};
-					display: flex;
-					flex-wrap: wrap;
 					margin: ${space[5]}px 0;
 					padding: ${space[3]}px;
 				`}

--- a/client/components/mma/identity/emailAndMarketing/EmailAndMarketing.stories.tsx
+++ b/client/components/mma/identity/emailAndMarketing/EmailAndMarketing.stories.tsx
@@ -2,6 +2,7 @@ import type { ComponentMeta, ComponentStory } from '@storybook/react';
 import fetchMock from 'fetch-mock';
 import { ReactRouterDecorator } from '../../../../../.storybook/ReactRouterDecorator';
 import { consents } from '../../../../fixtures/consents';
+import { InAppPurchase } from '../../../../fixtures/inAppPurchase';
 import { newsletters } from '../../../../fixtures/newsletters';
 import { newsletterSubscriptions } from '../../../../fixtures/newsletterSubscriptions';
 import {
@@ -36,6 +37,49 @@ export const Default: ComponentStory<typeof EmailAndMarketing> = () => {
 		.get('/idapicodeproxy/newsletters', { body: newsletters })
 		.get('/idapicodeproxy/users/me/newsletters', {
 			body: newsletterSubscriptions,
+		})
+		.get('/mpapi/user/mobile-subscriptions', {
+			body: { subscriptions: [] },
+		})
+		.get('/idapicodeproxy/consents?filter=all', { body: consents })
+		.get('/api/reminders/status', { body: { recurringStatus: 'NotSet' } });
+
+	return <EmailAndMarketing />;
+};
+
+export const WithNoProducts: ComponentStory<typeof EmailAndMarketing> = () => {
+	fetchMock
+		.restore()
+		.get('/api/me/mma', {
+			body: toMembersDataApiResponse(),
+		})
+		.get('/idapi/user', { body: user })
+		.get('/idapicodeproxy/newsletters', { body: newsletters })
+		.get('/idapicodeproxy/users/me/newsletters', {
+			body: newsletterSubscriptions,
+		})
+		.get('/mpapi/user/mobile-subscriptions', {
+			body: { subscriptions: [] },
+		})
+		.get('/idapicodeproxy/consents?filter=all', { body: consents })
+		.get('/api/reminders/status', { body: { recurringStatus: 'NotSet' } });
+
+	return <EmailAndMarketing />;
+};
+
+export const WithIAP: ComponentStory<typeof EmailAndMarketing> = () => {
+	fetchMock
+		.restore()
+		.get('/api/me/mma', {
+			body: toMembersDataApiResponse(),
+		})
+		.get('/idapi/user', { body: user })
+		.get('/idapicodeproxy/newsletters', { body: newsletters })
+		.get('/idapicodeproxy/users/me/newsletters', {
+			body: newsletterSubscriptions,
+		})
+		.get('/mpapi/user/mobile-subscriptions', {
+			body: { subscriptions: [InAppPurchase] },
 		})
 		.get('/idapicodeproxy/consents?filter=all', { body: consents })
 		.get('/api/reminders/status', { body: { recurringStatus: 'NotSet' } });

--- a/client/components/mma/identity/emailAndMarketing/EmailAndMarketing.stories.tsx
+++ b/client/components/mma/identity/emailAndMarketing/EmailAndMarketing.stories.tsx
@@ -1,6 +1,7 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 import fetchMock from 'fetch-mock';
 import { ReactRouterDecorator } from '../../../../../.storybook/ReactRouterDecorator';
+import { featureSwitches } from '../../../../../shared/featureSwitches';
 import { consents } from '../../../../fixtures/consents';
 import { InAppPurchase } from '../../../../fixtures/inAppPurchase';
 import { newsletters } from '../../../../fixtures/newsletters';
@@ -68,6 +69,8 @@ export const WithNoProducts: ComponentStory<typeof EmailAndMarketing> = () => {
 };
 
 export const WithIAP: ComponentStory<typeof EmailAndMarketing> = () => {
+	featureSwitches['appSubscriptions'] = true;
+
 	fetchMock
 		.restore()
 		.get('/api/me/mma', {

--- a/client/components/mma/identity/emailAndMarketing/EmailAndMarketing.tsx
+++ b/client/components/mma/identity/emailAndMarketing/EmailAndMarketing.tsx
@@ -1,16 +1,17 @@
 import { createRef, useEffect, useState } from 'react';
+import { featureSwitches } from '../../../../../shared/featureSwitches';
 import type {
 	AppSubscription,
-	MPAPIResponse} from '../../../../../shared/mpapiResponse';
+	MPAPIResponse,
+} from '../../../../../shared/mpapiResponse';
 import {
 	AppSubscriptionSoftOptInIds,
-	isValidAppSubscription
+	isValidAppSubscription,
 } from '../../../../../shared/mpapiResponse';
-import type {
-	ProductDetail} from '../../../../../shared/productResponse';
+import type { ProductDetail } from '../../../../../shared/productResponse';
 import {
 	isProduct,
-	mdapiResponseReader
+	mdapiResponseReader,
 } from '../../../../../shared/productResponse';
 import { GROUPED_PRODUCT_TYPES } from '../../../../../shared/productTypes';
 import { fetchWithDefaultParameters } from '../../../../utilities/fetch';
@@ -96,10 +97,11 @@ export const EmailAndMarketing = (_: { path?: string }) => {
 									productDetails,
 									consent,
 							  ) ||
-							  userHasAppSubscriptionWithConsent(
+							  (userHasAppSubscriptionWithConsent(
 									appSubscriptions,
 									consent,
-							  )
+							  ) &&
+									featureSwitches.appSubscriptions)
 							: true,
 				);
 

--- a/client/components/mma/identity/emailAndMarketing/EmailAndMarketing.tsx
+++ b/client/components/mma/identity/emailAndMarketing/EmailAndMarketing.tsx
@@ -1,9 +1,19 @@
 import { createRef, useEffect, useState } from 'react';
+import type {
+	AppSubscription,
+	MPAPIResponse} from '../../../../../shared/mpapiResponse';
+import {
+	AppSubscriptionSoftOptInIds,
+	isValidAppSubscription
+} from '../../../../../shared/mpapiResponse';
+import type {
+	ProductDetail} from '../../../../../shared/productResponse';
 import {
 	isProduct,
-	mdapiResponseReader,
+	mdapiResponseReader
 } from '../../../../../shared/productResponse';
 import { GROUPED_PRODUCT_TYPES } from '../../../../../shared/productTypes';
+import { fetchWithDefaultParameters } from '../../../../utilities/fetch';
 import { allProductsDetailFetcher } from '../../../../utilities/productUtils';
 import { NAV_LINKS } from '../../../shared/nav/NavConfig';
 import { Spinner } from '../../../shared/Spinner';
@@ -64,26 +74,32 @@ export const EmailAndMarketing = (_: { path?: string }) => {
 					return;
 				}
 				const productDetailsResponse = await allProductsDetailFetcher();
+
 				const productDetails = mdapiResponseReader(
 					await productDetailsResponse.json(),
 				).products.filter(isProduct);
+
+				const mpapiResponse = (await (
+					await fetchWithDefaultParameters(
+						'/mpapi/user/mobile-subscriptions',
+					)
+				).json()) as MPAPIResponse;
+				const appSubscriptions = mpapiResponse.subscriptions.filter(
+					isValidAppSubscription,
+				);
+
 				const consentOptions = await ConsentOptions.getAll();
 				const consentsWithFilteredSoftOptIns = consentOptions.filter(
 					(consent: ConsentOption) =>
 						consent.isProduct
-							? productDetails.some((productDetail) => {
-									const groupedProductType =
-										GROUPED_PRODUCT_TYPES[
-											productDetail.mmaCategory
-										];
-									const specificProductType =
-										groupedProductType.mapGroupedToSpecific(
-											productDetail,
-										);
-									return specificProductType.softOptInIDs.includes(
-										consent.id,
-									);
-							  })
+							? userHasProductWithConsent(
+									productDetails,
+									consent,
+							  ) ||
+							  userHasAppSubscriptionWithConsent(
+									appSubscriptions,
+									consent,
+							  )
 							: true,
 				);
 
@@ -169,3 +185,26 @@ export const EmailAndMarketing = (_: { path?: string }) => {
 		</PageContainer>
 	);
 };
+
+function userHasProductWithConsent(
+	productDetails: ProductDetail[],
+	consent: ConsentOption,
+) {
+	return productDetails.some((productDetail) => {
+		const groupedProductType =
+			GROUPED_PRODUCT_TYPES[productDetail.mmaCategory];
+		const specificProductType =
+			groupedProductType.mapGroupedToSpecific(productDetail);
+		return specificProductType.softOptInIDs.includes(consent.id);
+	});
+}
+
+function userHasAppSubscriptionWithConsent(
+	appSubscriptions: AppSubscription[],
+	consent: ConsentOption,
+) {
+	return (
+		appSubscriptions.length > 0 &&
+		AppSubscriptionSoftOptInIds.includes(consent.id)
+	);
+}

--- a/client/components/mma/paymentUpdate/Summary.tsx
+++ b/client/components/mma/paymentUpdate/Summary.tsx
@@ -12,7 +12,7 @@ interface SummaryProps {
 	 * The main message of the component
 	 * e.g. the main error message, success message etc.
 	 */
-	message: React.ReactNode;
+	message: string;
 	/**
 	 * Optional context information about the message
 	 */

--- a/client/components/mma/paymentUpdate/Summary.tsx
+++ b/client/components/mma/paymentUpdate/Summary.tsx
@@ -12,7 +12,7 @@ interface SummaryProps {
 	 * The main message of the component
 	 * e.g. the main error message, success message etc.
 	 */
-	message: string;
+	message: React.ReactNode;
 	/**
 	 * Optional context information about the message
 	 */

--- a/client/fixtures/inAppPurchase.ts
+++ b/client/fixtures/inAppPurchase.ts
@@ -3,10 +3,12 @@ import type { AppSubscription } from '../../shared/mpapiResponse';
 export const InAppPurchase: AppSubscription = {
 	subscriptionId: '1',
 	valid: true,
+	from: '2023-01-11T11:05:20.000Z',
 };
 
 export const CancelledInAppPurchase: AppSubscription = {
-	cancellationTimestamp: 'date',
+	cancellationTimestamp: '2023-01-11T11:05:20.000Z',
 	subscriptionId: '2',
 	valid: true,
+	from: '2023-01-11T11:05:20.000Z',
 };

--- a/shared/mpapiResponse.ts
+++ b/shared/mpapiResponse.ts
@@ -3,6 +3,7 @@ import { SoftOptInIDs } from './softOptInIDs';
 export interface AppSubscription {
 	subscriptionId: string;
 	cancellationTimestamp?: string;
+	from: string;
 	valid: boolean;
 }
 

--- a/shared/mpapiResponse.ts
+++ b/shared/mpapiResponse.ts
@@ -1,3 +1,5 @@
+import { SoftOptInIDs } from './softOptInIDs';
+
 export interface AppSubscription {
 	subscriptionId: string;
 	cancellationTimestamp?: string;
@@ -11,3 +13,10 @@ export interface MPAPIResponse {
 export function isValidAppSubscription(subscription: AppSubscription) {
 	return subscription.valid;
 }
+
+export const AppSubscriptionSoftOptInIds = [
+	SoftOptInIDs.SupportOnboarding,
+	SoftOptInIDs.SimilarProducts,
+	SoftOptInIDs.SupporterNewsletter,
+	SoftOptInIDs.DigitalSubscriberPreview,
+];

--- a/shared/mpapiResponse.ts
+++ b/shared/mpapiResponse.ts
@@ -14,9 +14,8 @@ export function isValidAppSubscription(subscription: AppSubscription) {
 	return subscription.valid;
 }
 
-export const AppSubscriptionSoftOptInIds = [
+export const AppSubscriptionSoftOptInIds: string[] = [
 	SoftOptInIDs.SupportOnboarding,
 	SoftOptInIDs.SimilarProducts,
 	SoftOptInIDs.SupporterNewsletter,
-	SoftOptInIDs.DigitalSubscriberPreview,
 ];

--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -29,6 +29,7 @@ import type {
 	SubscriptionWithDeliveryAddress,
 } from './productResponse';
 import { getMainPlan, isGift } from './productResponse';
+import { SoftOptInIDs } from './softOptInIDs';
 
 type ProductFriendlyName =
 	| 'membership'
@@ -240,14 +241,6 @@ export const calculateMonthlyOrAnnualFromBillingPeriod = (
 ) => (billingPeriod === 'month' ? 'Monthly' : 'Annual');
 
 const FRONT_PAGE_NEWSLETTER_ID = '6009';
-enum SoftOptInIDs {
-	SupportOnboarding = 'your_support_onboarding',
-	SimilarProducts = 'similar_guardian_products',
-	SupporterNewsletter = 'supporter_newsletter',
-	SubscriberPreview = 'subscriber_preview',
-	DigitalSubscriberPreview = 'digital_subscriber_preview',
-	GuardianWeeklyNewsletter = 'guardian_weekly_newsletter',
-}
 
 export type ProductTypeKeys =
 	| 'membership'

--- a/shared/softOptInIDs.ts
+++ b/shared/softOptInIDs.ts
@@ -1,0 +1,8 @@
+export enum SoftOptInIDs {
+	SupportOnboarding = 'your_support_onboarding',
+	SimilarProducts = 'similar_guardian_products',
+	SupporterNewsletter = 'supporter_newsletter',
+	SubscriberPreview = 'subscriber_preview',
+	DigitalSubscriberPreview = 'digital_subscriber_preview',
+	GuardianWeeklyNewsletter = 'guardian_weekly_newsletter',
+}


### PR DESCRIPTION
## What does this change?

Adjust the copy and design for IAP product holding on the account overview page and billing page. Get correct Soft Opt Ins for IAPs and refactor to show them on Email and Marketing page.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

With an IAP product associated with an account test the following:
Account Overview:
Navigate to `/?withFeature=appSubscriptions` and see the App Subscription product card.

Billing:
Go to Billing page and see the App Subscription box.

Email and Marketing:
Go to Email and Marketing and see the following 3 supporter exclusive consents:
- Your subscription/support
- Supporter newsletter
- Similar Guardian products

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<img width="893" alt="image" src="https://user-images.githubusercontent.com/114918544/223478350-c68eb351-b976-4637-940e-76a5b39c1ab5.png">

![image](https://user-images.githubusercontent.com/114918544/223160379-95bba182-0d0b-4c82-a9a5-0a77a5765bee.png)

![image](https://user-images.githubusercontent.com/114918544/223160309-32b20e6e-287a-4267-9678-1c4c7136f889.png)


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
