### PR TITLE
Refactored KnownIssues to take in the members data api object not Pro…

### DIFF
--- a/client/components/helpCentre/KnownIssues.tsx
+++ b/client/components/helpCentre/KnownIssues.tsx
@@ -7,7 +7,8 @@ import {
 	textSans,
 } from '@guardian/source-foundations';
 import { useEffect, useState } from 'react';
-import type { ProductDetail } from '../../../shared/productResponse';
+import type { MembersDataApiResponse } from '../../../shared/productResponse';
+import { isProduct } from '../../../shared/productResponse';
 import { gridBase, gridItemPlacement } from '../../styles/grid';
 import { allProductsDetailFetcher } from '../../utilities/productUtils';
 import { ErrorIcon } from '../mma/shared/assets/ErrorIcon';
@@ -30,11 +31,11 @@ export interface KnownIssueObj {
 	affectedProducts?: string[]; // maps to productDetail.tier property
 }
 
-interface KownIssuesProp {
+interface KnownIssuesProp {
 	issues: KnownIssueObj[];
 }
 
-export const KnownIssues = (props: KownIssuesProp) => {
+export const KnownIssues = (props: KnownIssuesProp) => {
 	const [issuesData, setIssuesData] = useState<KnownIssueObj[]>([]);
 	useEffect(() => {
 		(async () => {
@@ -66,11 +67,11 @@ export const KnownIssues = (props: KownIssuesProp) => {
 				if (signInStatus === 'signedInRecently') {
 					const productDetailsResponse =
 						await allProductsDetailFetcher();
-					const productDetails: ProductDetail[] =
+					const mdapiResponse: MembersDataApiResponse =
 						await productDetailsResponse.json();
-					const userProductNames = productDetails.map(
-						(productDetail) => productDetail.tier,
-					);
+					const userProductNames = mdapiResponse.products
+						.filter(isProduct)
+						.map((productDetail) => productDetail.tier);
 
 					const productIssues = unfilteredDateSortedIssues.filter(
 						(issue) =>


### PR DESCRIPTION
## What does this change?
Refactored KnownIssues to take in the members data api object not ProductDetails. KnownIssues calls out to MDAPI to determine whether a user should see the banner depending on whether they have a product which is part of the affected products field.

## For Background
 It was discovered during testing for product switching cancellation that when a user cancels after product switching, the frontend succeeds (which is why we thought it worked), but the backend has failed to cancel the switch. This is due to the subsequent MDAPI call succeeding in the cancellation flow( related Trello card attached).

It was uncovered during the debugging of the above issue that there was an issue on the client side which meant that the part of the code which handled this journey was expecting a ProductDetails[] instead of the mdapiResponse object. 

This has flagged that we need to have a thorough check and refactor of any other places in the codebase that this occurs to avoid any further issue.

## How to test
Locally I changed the hard coded known issues banner in HelpCenterPage.tsx and set the affected product field to 'Supporter Plus' which my account has. This resulted in the banner being shown
![image](https://user-images.githubusercontent.com/115992455/223507150-26ee695b-9432-4cc2-94b0-79a1989097d8.png)

When the same field was changed to a different product tier like 'Contributor' the banner was not displayed.

