### PR TITLE
Show cancelled products on new Account Overview layout

### DIFF
--- a/client/components/mma/accountoverview/AccountOverview.stories.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.stories.tsx
@@ -18,6 +18,7 @@ import {
 	guardianWeeklyCard,
 	newspaperVoucherPaypal,
 	supporterPlus,
+	supporterPlusCancelled,
 	toMembersDataApiResponse,
 } from '../../../fixtures/productDetail';
 import { user } from '../../../fixtures/user';
@@ -131,11 +132,15 @@ export const WithCancellationsNewLayout: ComponentStory<
 
 	fetchMock
 		.restore()
+		.get('/api/me/mma', {
+			body: [
+				contributionCancelled,
+				guardianWeeklyCancelled,
+				supporterPlusCancelled,
+			],
+		})
 		.get('/api/cancelled/', {
 			body: [cancelledContribution, cancelledGuardianWeekly],
-		})
-		.get('/api/me/mma', {
-			body: [contributionCancelled, guardianWeeklyCancelled],
 		})
 		.get('/mpapi/user/mobile-subscriptions', {
 			body: { subscriptions: [] },

--- a/client/components/mma/accountoverview/AccountOverview.stories.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.stories.tsx
@@ -3,12 +3,18 @@ import fetchMock from 'fetch-mock';
 import { ReactRouterDecorator } from '../../../../.storybook/ReactRouterDecorator';
 import { featureSwitches } from '../../../../shared/featureSwitches';
 import {
+	cancelledContribution,
+	cancelledGuardianWeekly,
+} from '../../../fixtures/cancelledProductDetail';
+import {
 	CancelledInAppPurchase,
 	InAppPurchase,
 } from '../../../fixtures/inAppPurchase';
 import {
+	contributionCancelled,
 	contributionPayPal,
 	digitalDD,
+	guardianWeeklyCancelled,
 	guardianWeeklyCard,
 	newspaperVoucherPaypal,
 	supporterPlus,
@@ -113,6 +119,26 @@ export const WithContributionNewLayoutDigisubAndContribution: ComponentStory<
 		})
 		.get('/api/me/mma', {
 			body: [contributionPayPal, digitalDD],
+		});
+
+	return <AccountOverview />;
+};
+
+export const WithCancellationsNewLayout: ComponentStory<
+	typeof AccountOverview
+> = () => {
+	featureSwitches['accountOverviewNewLayout'] = true;
+
+	fetchMock
+		.restore()
+		.get('/api/cancelled/', {
+			body: [cancelledContribution, cancelledGuardianWeekly],
+		})
+		.get('/api/me/mma', {
+			body: [contributionCancelled, guardianWeeklyCancelled],
+		})
+		.get('/mpapi/user/mobile-subscriptions', {
+			body: { subscriptions: [] },
 		});
 
 	return <AccountOverview />;

--- a/client/components/mma/accountoverview/AccountOverview.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.tsx
@@ -38,10 +38,10 @@ import { AsyncLoader } from '../shared/AsyncLoader';
 import { PaymentFailureAlertIfApplicable } from '../shared/PaymentFailureAlertIfApplicable';
 import { AccountOverviewCancelledCard } from './AccountOverviewCancelledCard';
 import { AccountOverviewCard } from './AccountOverviewCard';
-import { AccountOverviewCardV2 } from './AccountOverviewCardV2';
 import { EmptyAccountOverview } from './EmptyAccountOverview';
 import { InAppPurchaseCard } from './InAppPurchaseCard';
 import { PersonalisedHeader } from './PersonalisedHeader';
+import { ProductCard } from './ProductCard';
 
 const subHeadingCss = css`
 	margin: ${space[12]}px 0 ${space[6]}px;
@@ -151,7 +151,7 @@ const AccountOverviewRenderer = ([
 						<Stack space={6}>
 							{activeProductsInCategory.map((productDetail) =>
 								featureSwitches.accountOverviewNewLayout ? (
-									<AccountOverviewCardV2
+									<ProductCard
 										key={
 											productDetail.subscription
 												.subscriptionId

--- a/client/components/mma/accountoverview/AccountOverview.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.tsx
@@ -38,6 +38,7 @@ import { AsyncLoader } from '../shared/AsyncLoader';
 import { PaymentFailureAlertIfApplicable } from '../shared/PaymentFailureAlertIfApplicable';
 import { AccountOverviewCancelledCard } from './AccountOverviewCancelledCard';
 import { AccountOverviewCard } from './AccountOverviewCard';
+import { CancelledProductCard } from './CancelledProductCard';
 import { EmptyAccountOverview } from './EmptyAccountOverview';
 import { InAppPurchaseCard } from './InAppPurchaseCard';
 import { PersonalisedHeader } from './PersonalisedHeader';
@@ -171,15 +172,26 @@ const AccountOverviewRenderer = ([
 								),
 							)}
 							{cancelledProductsInCategory.map(
-								(cancelledProductDetail) => (
-									<AccountOverviewCancelledCard
-										key={
-											cancelledProductDetail.subscription
-												.subscriptionId
-										}
-										product={cancelledProductDetail}
-									/>
-								),
+								(cancelledProductDetail) =>
+									featureSwitches.accountOverviewNewLayout ? (
+										<CancelledProductCard
+											key={
+												cancelledProductDetail
+													.subscription.subscriptionId
+											}
+											productDetail={
+												cancelledProductDetail
+											}
+										/>
+									) : (
+										<AccountOverviewCancelledCard
+											key={
+												cancelledProductDetail
+													.subscription.subscriptionId
+											}
+											product={cancelledProductDetail}
+										/>
+									),
 							)}
 							{groupedProductType.supportTheGuardianSectionProps &&
 								(cancelledProductsInCategory.length > 0 ||

--- a/client/components/mma/accountoverview/AccountOverviewCardV2.tsx
+++ b/client/components/mma/accountoverview/AccountOverviewCardV2.tsx
@@ -24,7 +24,6 @@ import { ErrorIcon } from '../shared/assets/ErrorIcon';
 import { Card } from '../shared/Card';
 import { CardDisplay } from '../shared/CardDisplay';
 import { DirectDebitDisplay } from '../shared/DirectDebitDisplay';
-import { GridPicture } from '../shared/images/GridPicture';
 import {
 	getNextPaymentDetails,
 	NewPaymentPriceAlert,
@@ -35,7 +34,6 @@ import { SupporterPlusBenefitsToggle } from '../shared/SupporterPlusBenefits';
 
 interface ProductCardConfiguration {
 	headerColor: string;
-	headerImageId?: string;
 	showBenefitsSection?: boolean;
 }
 
@@ -47,7 +45,6 @@ const productCardConfiguration: {
 	},
 	supporterplus: {
 		headerColor: palette.brand[500],
-		headerImageId: 'digitalSubPackshot',
 		showBenefitsSection: true,
 	},
 	digipack: {
@@ -201,39 +198,7 @@ export const AccountOverviewCardV2 = ({
 				backgroundColor={cardConfig.headerColor}
 				minHeightTablet
 			>
-				<div
-					css={css`
-						display: flex;
-						justify-content: space-between;
-					`}
-				>
-					<h3 css={productTitleCss}>{productTitle}</h3>
-					{cardConfig.headerImageId && (
-						<GridPicture
-							cssOverrides={css`
-								margin-top: -${space[3] + 16}px;
-								margin-bottom: -${space[3]}px;
-								max-height: 80px;
-								${from.tablet} {
-									max-height: 144px;
-								}
-							`}
-							sources={[
-								{
-									gridId: cardConfig.headerImageId,
-									srcSizes: [497, 285],
-									imgType: 'png',
-									sizes: '100vw',
-									media: '(max-width: 220px)',
-								},
-							]}
-							fallback={cardConfig.headerImageId}
-							fallbackSize={497}
-							altText=""
-							fallbackImgType="png"
-						/>
-					)}
-				</div>
+				<h3 css={productTitleCss}>{productTitle}</h3>
 			</Card.Header>
 
 			{cardConfig.showBenefitsSection && nextPaymentDetails && (

--- a/client/components/mma/accountoverview/AccountOverviewCardV2.tsx
+++ b/client/components/mma/accountoverview/AccountOverviewCardV2.tsx
@@ -12,7 +12,7 @@ import {
 	Stack,
 } from '@guardian/source-react-components';
 import { useNavigate } from 'react-router';
-import { parseDate } from '../../../../shared/dates';
+import { cancellationFormatDate, parseDate } from '../../../../shared/dates';
 import type {
 	MembersDataApiUser,
 	ProductDetail,
@@ -111,8 +111,6 @@ export const AccountOverviewCardV2 = ({
 	const subscriptionStartDate = productDetail.subscription.start;
 	const subscriptionEndDate = productDetail.subscription.end;
 	const hasCancellationPending = productDetail.subscription.cancelledAt;
-	const cancelledCopy =
-		specificProductType.cancelledCopy || groupedProductType.cancelledCopy;
 
 	const isSafeToUpdatePaymentMethod =
 		productDetail.subscription.safeToUpdatePaymentMethod;
@@ -204,9 +202,23 @@ export const AccountOverviewCardV2 = ({
 
 	return (
 		<Stack space={4}>
-			{hasCancellationPending &&
-				productDetail.subscription.end &&
-				cancelledCopy && <InfoSummary message={cancelledCopy} />}
+			{hasCancellationPending && productDetail.subscription.end && (
+				<InfoSummary
+					message={`Your ${groupedProductType.friendlyName()} has been cancelled`}
+					context={
+						<>
+							You are able to access your{' '}
+							{groupedProductType.friendlyName()} until{' '}
+							<strong>
+								{cancellationFormatDate(
+									productDetail.subscription
+										.cancellationEffectiveDate,
+								)}
+							</strong>
+						</>
+					}
+				/>
+			)}
 			<Card>
 				<Card.Header
 					backgroundColor={cardConfig.headerColor}

--- a/client/components/mma/accountoverview/CancelledProductCard.tsx
+++ b/client/components/mma/accountoverview/CancelledProductCard.tsx
@@ -6,10 +6,11 @@ import {
 	space,
 	textSans,
 } from '@guardian/source-foundations';
-import { Stack } from '@guardian/source-react-components';
+import { LinkButton, Stack } from '@guardian/source-react-components';
 import { parseDate } from '../../../../shared/dates';
 import type { CancelledProductDetail } from '../../../../shared/productResponse';
 import { GROUPED_PRODUCT_TYPES } from '../../../../shared/productTypes';
+import { trackEvent } from '../../../utilities/analytics';
 import { InfoSummary } from '../paymentUpdate/Summary';
 import { Card } from '../shared/Card';
 import { productCardConfiguration } from './ProductCardConfiguration';
@@ -25,6 +26,10 @@ export const CancelledProductCard = ({
 
 	const cardConfig =
 		productCardConfiguration[specificProductType.productType];
+
+	const showSubscribeAgainButton =
+		productDetail.mmaCategory !== 'membership' &&
+		productDetail.mmaCategory !== 'recurringSupport';
 
 	const sectionHeadingCss = css`
 		${textSans.medium({ fontWeight: 'bold' })};
@@ -156,7 +161,25 @@ export const CancelledProductCard = ({
 							</dl>
 						</div>
 						<div css={buttonLayoutCss}>
-							{/* TODO: Resubscribe button */}
+							{showSubscribeAgainButton && (
+								<LinkButton
+									href="https://support.theguardian.com/uk/subscribe"
+									size="small"
+									cssOverrides={css`
+										justify-content: center;
+									`}
+									priority="primary"
+									onClick={() => {
+										trackEvent({
+											eventCategory: 'href',
+											eventAction: 'click',
+											eventLabel: 'subscribe_again',
+										});
+									}}
+								>
+									Subscribe again
+								</LinkButton>
+							)}
 						</div>
 					</div>
 				</Card.Section>

--- a/client/components/mma/accountoverview/CancelledProductCard.tsx
+++ b/client/components/mma/accountoverview/CancelledProductCard.tsx
@@ -1,0 +1,166 @@
+import { css } from '@emotion/react';
+import {
+	from,
+	headline,
+	palette,
+	space,
+	textSans,
+} from '@guardian/source-foundations';
+import { Stack } from '@guardian/source-react-components';
+import { parseDate } from '../../../../shared/dates';
+import type { CancelledProductDetail } from '../../../../shared/productResponse';
+import { GROUPED_PRODUCT_TYPES } from '../../../../shared/productTypes';
+import { InfoSummary } from '../paymentUpdate/Summary';
+import { Card } from '../shared/Card';
+import { productCardConfiguration } from './ProductCardConfiguration';
+
+export const CancelledProductCard = ({
+	productDetail,
+}: {
+	productDetail: CancelledProductDetail;
+}) => {
+	const groupedProductType = GROUPED_PRODUCT_TYPES[productDetail.mmaCategory];
+	const specificProductType =
+		groupedProductType.mapGroupedToSpecific(productDetail);
+
+	const cardConfig =
+		productCardConfiguration[specificProductType.productType];
+
+	const sectionHeadingCss = css`
+		${textSans.medium({ fontWeight: 'bold' })};
+		margin-top: 0;
+		margin-bottom: ${space[2]}px;
+	`;
+
+	const productTitleCss = css`
+		${headline.xxsmall({ fontWeight: 'bold' })};
+		color: ${palette.neutral[100]};
+		margin: 0;
+		max-width: 20ch;
+
+		${from.tablet} {
+			${headline.small({ fontWeight: 'bold' })};
+		}
+	`;
+
+	const productDetailLayoutCss = css`
+		> * + * {
+			margin-top: ${space[5]}px;
+		}
+
+		${from.tablet} {
+			display: flex;
+			flex-direction: row;
+			> * + * {
+				margin-top: 0;
+				margin-left: auto;
+				padding-left: ${space[4]}px;
+			}
+		}
+	`;
+
+	const keyValueCss = css`
+		${textSans.medium()};
+		margin: 0;
+
+		div + div {
+			margin-top: ${space[1]}px;
+		}
+
+		dt {
+			display: inline-block;
+			margin-right: 0.5ch;
+			:after {
+				content: ':';
+			}
+		}
+
+		dd {
+			display: inline-block;
+			margin-left: 0;
+		}
+	`;
+
+	const buttonLayoutCss = css`
+		display: flex;
+		flex-direction: column;
+		justify-content: flex-end;
+
+		> * + * {
+			margin-top: ${space[3]}px;
+		}
+	`;
+
+	return (
+		<Stack space={4}>
+			<InfoSummary
+				message={`Your ${groupedProductType.friendlyName()} has been cancelled`}
+			/>
+			<Card>
+				<Card.Header
+					backgroundColor={cardConfig.headerColor}
+					minHeightTablet
+				>
+					<h3 css={productTitleCss}>
+						{specificProductType.productTitle()}
+					</h3>
+				</Card.Header>
+				<Card.Section>
+					<div css={productDetailLayoutCss}>
+						<div>
+							<h4 css={sectionHeadingCss}>Billing and payment</h4>
+							<dl css={keyValueCss}>
+								<div>
+									<dt>
+										{groupedProductType.showSupporterId
+											? 'Supporter ID'
+											: 'Subscription ID'}
+									</dt>
+									<dd>
+										{
+											productDetail.subscription
+												.subscriptionId
+										}
+									</dd>
+								</div>
+								{groupedProductType.tierLabel && (
+									<div>
+										<dt>{groupedProductType.tierLabel}</dt>
+										<dd>{productDetail.tier}</dd>
+									</div>
+								)}
+								{productDetail.subscription.start && (
+									<div>
+										<dt>
+											{groupedProductType.shouldShowJoinDateNotStartDate
+												? 'Join'
+												: 'Start'}{' '}
+											date
+										</dt>
+										<dd>
+											{parseDate(
+												productDetail.subscription
+													.start,
+											).dateStr()}
+										</dd>
+									</div>
+								)}
+								<div>
+									<dt>End date</dt>
+									<dd>
+										{parseDate(
+											productDetail.subscription.end,
+										).dateStr()}
+									</dd>
+								</div>
+							</dl>
+						</div>
+						<div css={buttonLayoutCss}>
+							{/* TODO: Resubscribe button */}
+						</div>
+					</div>
+				</Card.Section>
+			</Card>
+		</Stack>
+	);
+};

--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -75,7 +75,7 @@ const PaymentMethod = ({
 	</div>
 );
 
-export const AccountOverviewCardV2 = ({
+export const ProductCard = ({
 	productDetail,
 	isEligibleToSwitch,
 	user,

--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -12,7 +12,11 @@ import {
 	Stack,
 } from '@guardian/source-react-components';
 import { useNavigate } from 'react-router';
-import { cancellationFormatDate, parseDate } from '../../../../shared/dates';
+import {
+	cancellationFormatDate,
+	DATE_FNS_LONG_OUTPUT_FORMAT,
+	parseDate,
+} from '../../../../shared/dates';
 import type {
 	MembersDataApiUser,
 	ProductDetail,
@@ -217,6 +221,7 @@ export const ProductCard = ({
 								{cancellationFormatDate(
 									productDetail.subscription
 										.cancellationEffectiveDate,
+									DATE_FNS_LONG_OUTPUT_FORMAT,
 								)}
 							</strong>
 						</>

--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -126,6 +126,11 @@ export const ProductCard = ({
 		isEligibleToSwitch &&
 		specificProductType.productType === 'contributions';
 
+	const productBenefits =
+		specificProductType.productType === 'supporterplus'
+			? 'supporter benefits'
+			: groupedProductType.friendlyName();
+
 	const cardConfig =
 		productCardConfiguration[specificProductType.productType];
 
@@ -207,8 +212,7 @@ export const ProductCard = ({
 					message={`Your ${groupedProductType.friendlyName()} has been cancelled`}
 					context={
 						<>
-							You are able to access your{' '}
-							{groupedProductType.friendlyName()} until{' '}
+							You are able to access your {productBenefits} until{' '}
 							<strong>
 								{cancellationFormatDate(
 									productDetail.subscription

--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -88,7 +88,7 @@ export const ProductCard = ({
 
 	const mainPlan = getMainPlan(productDetail.subscription);
 	if (!mainPlan) {
-		throw new Error('mainPlan does not exist in accountOverviewCard');
+		throw new Error('mainPlan does not exist in ProductCard');
 	}
 
 	const groupedProductType = GROUPED_PRODUCT_TYPES[productDetail.mmaCategory];

--- a/client/components/mma/accountoverview/ProductCardConfiguration.ts
+++ b/client/components/mma/accountoverview/ProductCardConfiguration.ts
@@ -1,0 +1,43 @@
+import { palette } from '@guardian/source-foundations';
+import type { ProductTypeKeys } from '../../../../shared/productTypes';
+
+interface ProductCardConfiguration {
+	headerColor: string;
+	showBenefitsSection?: boolean;
+}
+
+export const productCardConfiguration: {
+	[productType in ProductTypeKeys]: ProductCardConfiguration;
+} = {
+	contributions: {
+		headerColor: palette.brand[600],
+	},
+	supporterplus: {
+		headerColor: palette.brand[500],
+		showBenefitsSection: true,
+	},
+	digipack: {
+		headerColor: palette.brand[500],
+	},
+	digitalvoucher: {
+		headerColor: '#ff5943',
+	},
+	newspaper: {
+		headerColor: '#ff5943',
+	},
+	homedelivery: {
+		headerColor: '#ff5943',
+	},
+	voucher: {
+		headerColor: '#ff5943',
+	},
+	guardianweekly: {
+		headerColor: '#5f8085',
+	},
+	membership: {
+		headerColor: palette.brand[500],
+	},
+	guardianpatron: {
+		headerColor: palette.brand[500],
+	},
+};

--- a/client/components/mma/cancel/Cancellation.stories.tsx
+++ b/client/components/mma/cancel/Cancellation.stories.tsx
@@ -3,7 +3,7 @@ import fetchMock from 'fetch-mock';
 import { ReactRouterDecorator } from '../../../../.storybook/ReactRouterDecorator';
 import { PRODUCT_TYPES } from '../../../../shared/productTypes';
 import {
-	cancelledContribution,
+	contributionCancelled,
 	contributionPayPal,
 	guardianWeeklyCard,
 } from '../../../fixtures/productDetail';
@@ -79,6 +79,6 @@ export const Confirmation: ComponentStory<
 
 	return getCancellationSummary(
 		PRODUCT_TYPES.contributions,
-		cancelledContribution,
-	)(cancelledContribution);
+		contributionCancelled,
+	)(contributionCancelled);
 };

--- a/client/fixtures/cancelledProductDetail.ts
+++ b/client/fixtures/cancelledProductDetail.ts
@@ -1,0 +1,29 @@
+import type { CancelledProductDetail } from '../../shared/productResponse';
+
+export const cancelledContribution: CancelledProductDetail = {
+	mmaCategory: 'recurringSupport',
+	tier: 'Contributor',
+	joinDate: '2022-01-05',
+	subscription: {
+		subscriptionId: 'A-S00303370',
+		cancellationEffectiveDate: '2023-03-20',
+		start: '2021-12-10',
+		end: '2022-11-29',
+		readerType: 'Direct',
+		accountId: '8ad09f8a7e25bda3017e296317464818',
+	},
+};
+
+export const cancelledGuardianWeekly: CancelledProductDetail = {
+	mmaCategory: 'subscriptions',
+	tier: 'Guardian Weekly - Domestic',
+	joinDate: '2022-01-05',
+	subscription: {
+		subscriptionId: 'A-S00499483',
+		cancellationEffectiveDate: '2023-02-28',
+		start: '2023-03-10',
+		end: '2023-03-10',
+		readerType: 'Direct',
+		accountId: '8ad09ea08683666d0186991883c55333',
+	},
+};

--- a/client/fixtures/cancelledProductDetail.ts
+++ b/client/fixtures/cancelledProductDetail.ts
@@ -5,12 +5,12 @@ export const cancelledContribution: CancelledProductDetail = {
 	tier: 'Contributor',
 	joinDate: '2022-01-05',
 	subscription: {
-		subscriptionId: 'A-S00303370',
+		subscriptionId: 'A-S00000000',
 		cancellationEffectiveDate: '2023-03-20',
 		start: '2021-12-10',
 		end: '2022-11-29',
 		readerType: 'Direct',
-		accountId: '8ad09f8a7e25bda3017e296317464818',
+		accountId: '00000000',
 	},
 };
 
@@ -19,11 +19,11 @@ export const cancelledGuardianWeekly: CancelledProductDetail = {
 	tier: 'Guardian Weekly - Domestic',
 	joinDate: '2022-01-05',
 	subscription: {
-		subscriptionId: 'A-S00499483',
+		subscriptionId: 'A-S00000000',
 		cancellationEffectiveDate: '2023-02-28',
 		start: '2023-03-10',
 		end: '2023-03-10',
 		readerType: 'Direct',
-		accountId: '8ad09ea08683666d0186991883c55333',
+		accountId: '00000000',
 	},
 };

--- a/client/fixtures/productDetail.ts
+++ b/client/fixtures/productDetail.ts
@@ -137,6 +137,74 @@ export const guardianWeeklyExpiredCard: ProductDetail = {
 	isTestUser: false,
 };
 
+export const guardianWeeklyCancelled: ProductDetail = {
+	mmaCategory: 'subscriptions',
+	tier: 'Guardian Weekly - Domestic',
+	isPaidTier: true,
+	selfServiceCancellation: {
+		isAllowed: false,
+		shouldDisplayEmail: false,
+		phoneRegionsToDisplay: ['UK & ROW'],
+	},
+	joinDate: '2021-11-29',
+	optIn: true,
+	subscription: {
+		paymentMethod: 'Card',
+		card: {
+			last4: '4242',
+			expiry: {
+				month: 4,
+				year: 2024,
+			},
+			type: 'Visa',
+			stripePublicKeyForUpdate: 'pk_test_123',
+			email: 'test.user@example.com',
+		},
+		contactId: '0039E00001KA26BQAT',
+		deliveryAddress: {
+			addressLine1: 'Kings Place',
+			addressLine2: '90 York Way',
+			town: 'London',
+			postcode: 'N1 9GU',
+			country: 'United Kingdom',
+		},
+		safeToUpdatePaymentMethod: true,
+		start: '2021-12-10',
+		end: '2022-11-29',
+		nextPaymentPrice: 13500,
+		nextPaymentDate: '2021-12-10',
+		lastPaymentDate: null,
+		chargedThroughDate: null,
+		renewalDate: '2022-11-29',
+		anniversaryDate: '2022-12-10',
+		cancelledAt: true,
+		subscriberId: 'A-S00286635',
+		subscriptionId: 'A-S00286635',
+		trialLength: 9,
+		autoRenew: true,
+		currentPlans: [],
+		futurePlans: [
+			{
+				name: null,
+				start: '2021-12-10',
+				end: '2022-11-29',
+				shouldBeVisible: true,
+				chargedThrough: null,
+				price: 15000,
+				currency: '£',
+				currencyISO: 'GBP',
+				billingPeriod: 'year',
+			},
+		],
+		readerType: 'Direct',
+		accountId: '8ad0965d7d585497017d6ce786026089',
+		cancellationEffectiveDate: '2023-03-20',
+		deliveryAddressChangeEffectiveDate: '2021-12-10',
+	},
+	isTestUser: false,
+	key: '1638374153759',
+};
+
 export const digitalDD: ProductDetail = {
 	mmaCategory: 'subscriptions',
 	tier: 'Digital Pack',
@@ -822,7 +890,7 @@ export const supporterPlus: ProductDetail = {
 	},
 };
 
-export const cancelledContribution: ProductDetail = {
+export const contributionCancelled: ProductDetail = {
 	mmaCategory: 'recurringSupport',
 	tier: 'Contributor',
 	isPaidTier: true,

--- a/client/fixtures/productDetail.ts
+++ b/client/fixtures/productDetail.ts
@@ -890,6 +890,65 @@ export const supporterPlus: ProductDetail = {
 	},
 };
 
+export const supporterPlusCancelled: ProductDetail = {
+	mmaCategory: 'recurringSupport',
+	tier: 'Supporter Plus',
+	isPaidTier: true,
+	isTestUser: false,
+	selfServiceCancellation: {
+		isAllowed: false,
+		shouldDisplayEmail: false,
+		phoneRegionsToDisplay: ['UK & ROW'],
+	},
+	joinDate: '2022-07-20',
+	optIn: true,
+	subscription: {
+		paymentMethod: 'Card',
+		card: {
+			last4: '4242',
+			expiry: {
+				month: 2,
+				year: 2027,
+			},
+			type: 'Visa',
+			stripePublicKeyForUpdate: 'pk_test_123',
+			email: 'test.user@example.com',
+		},
+		contactId: '0039E00001VVNb5QAH',
+		safeToUpdatePaymentMethod: true,
+		start: '2022-07-20',
+		end: '2022-08-20',
+		nextPaymentPrice: 1000,
+		nextPaymentDate: '2022-08-20',
+		lastPaymentDate: '2022-07-20',
+		chargedThroughDate: '2022-08-20',
+		renewalDate: '2023-07-20',
+		anniversaryDate: '2023-07-20',
+		cancelledAt: true,
+		subscriberId: 'A-S00393340',
+		subscriptionId: 'A-S00393340',
+		trialLength: -2,
+		autoRenew: true,
+		currentPlans: [
+			{
+				name: null,
+				start: '2022-07-20',
+				end: '2023-07-20',
+				shouldBeVisible: true,
+				chargedThrough: '2022-08-20',
+				price: 1000,
+				currency: '£',
+				currencyISO: 'GBP',
+				billingPeriod: 'month',
+			},
+		],
+		futurePlans: [],
+		readerType: 'Direct',
+		accountId: '8ad088718219a6b601821bbe9e6210f2',
+		cancellationEffectiveDate: '2023-04-07',
+	},
+};
+
 export const contributionCancelled: ProductDetail = {
 	mmaCategory: 'recurringSupport',
 	tier: 'Contributor',

--- a/shared/dates.ts
+++ b/shared/dates.ts
@@ -5,10 +5,13 @@ export const DATE_FNS_INPUT_FORMAT = 'yyyy-MM-dd'; // example: 1969-07-16
 export const DATE_FNS_LONG_OUTPUT_FORMAT = 'd MMMM yyyy'; // example: 1 July 2021
 export const DATE_FNS_SHORT_OUTPUT_FORMAT = 'd MMM yyyy'; // example: 5 Jan 2019
 
-export const cancellationFormatDate = (cancellationEffectiveDate?: string) => {
+export const cancellationFormatDate = (
+	cancellationEffectiveDate?: string,
+	outputFormat: string = DATE_FNS_SHORT_OUTPUT_FORMAT,
+) => {
 	return cancellationEffectiveDate === undefined
 		? 'today'
-		: parseDate(cancellationEffectiveDate).dateStr();
+		: parseDate(cancellationEffectiveDate).dateStr(outputFormat);
 };
 
 export interface ParsedDate {


### PR DESCRIPTION
## What does this change?

Adds cancellation detail summaries to the existing product cards (to cover products which are within the cancellation period and still accessible) as well as a redesigned cancelled product card that matches the new Account Overview card design.

The product details card has been renamed from `AccountOverviewCardV2` to `ProductCard` to match the naming of the other new product card components and to reflect that it will be the canonical product details card component when this feature is released.

The placeholder banner image code and styles have been removed. A simplified implementation is covered by #1010 which is awaiting final designs.

## How to test

With the `accountOverviewNewLayout` feature flag enabled, log into an account that has cancelled products. A cancellation detail summary should be shown above the cancelled product card as per the screenshots below. Storybook has also been updated with example of cancelled products.

## Images

<img width="826" alt="Screenshot 2023-03-07 at 16 33 17" src="https://user-images.githubusercontent.com/1166188/223495334-f0bfa982-bd85-44d2-b11c-61f9534167d3.png">

<img width="823" alt="Screenshot 2023-03-07 at 16 34 04" src="https://user-images.githubusercontent.com/1166188/223495356-ed4d0033-5f5c-45a7-94e1-1d65a0c596ff.png">

<img width="823" alt="Screenshot 2023-03-07 at 16 34 13" src="https://user-images.githubusercontent.com/1166188/223495379-2a335372-154d-418c-b6b4-495c21431746.png">

<img width="821" alt="Screenshot 2023-03-07 at 16 34 24" src="https://user-images.githubusercontent.com/1166188/223495399-58432a40-8fc4-4a64-ac8f-7504630d5fdc.png">
