### PR TITLE
Check if app subscription is iOS or Android from productId

### DIFF
--- a/client/components/mma/billing/Billing.stories.tsx
+++ b/client/components/mma/billing/Billing.stories.tsx
@@ -2,7 +2,11 @@ import type { ComponentMeta, ComponentStory } from '@storybook/react';
 import fetchMock from 'fetch-mock';
 import { ReactRouterDecorator } from '../../../../.storybook/ReactRouterDecorator';
 import { featureSwitches } from '../../../../shared/featureSwitches';
-import { InAppPurchase } from '../../../fixtures/inAppPurchase';
+import {
+	InAppPurchase,
+	InAppPurchaseAndroid,
+	InAppPurchaseIos,
+} from '../../../fixtures/inAppPurchase';
 import { guardianWeeklyCardInvoice } from '../../../fixtures/invoices';
 import {
 	digitalDD,
@@ -48,7 +52,13 @@ export const WithSubscriptions: ComponentStory<typeof Billing> = () => {
 			),
 		})
 		.get('/mpapi/user/mobile-subscriptions', {
-			body: { subscriptions: [InAppPurchase] },
+			body: {
+				subscriptions: [
+					InAppPurchase,
+					InAppPurchaseIos,
+					InAppPurchaseAndroid,
+				],
+			},
 		})
 		.get('/api/invoices', {
 			body: { invoices: [guardianWeeklyCardInvoice] },

--- a/client/components/mma/billing/Billing.tsx
+++ b/client/components/mma/billing/Billing.tsx
@@ -15,7 +15,11 @@ import type {
 	AppSubscription,
 	MPAPIResponse,
 } from '../../../../shared/mpapiResponse';
-import { isValidAppSubscription } from '../../../../shared/mpapiResponse';
+import {
+	AppStore,
+	determineAppStore,
+	isValidAppSubscription,
+} from '../../../../shared/mpapiResponse';
 import type {
 	InvoiceDataApiItem,
 	MembersDataApiItem,
@@ -304,9 +308,25 @@ function renderProductBillingInfo([mmaCategory, productDetails]: [
 	);
 }
 
-function renderInAppPurchase(value: AppSubscription) {
+function getAppStoreMessage(subscription: AppSubscription) {
+	const iosMessage = 'Apple (for iOS)';
+	const androidMessage = 'Google (for Android)';
+
+	const appStore = determineAppStore(subscription);
+
+	switch (appStore) {
+		case AppStore.IOS:
+			return iosMessage;
+		case AppStore.ANDROID:
+			return androidMessage;
+		default:
+			return `${iosMessage}, or ${androidMessage}`;
+	}
+}
+
+function renderInAppPurchase(subscription: AppSubscription) {
 	return (
-		<div css={subHeadingBorderTopCss} key={value.subscriptionId}>
+		<div css={subHeadingBorderTopCss} key={subscription.subscriptionId}>
 			<h2
 				css={css`
 					${subHeadingTitleCss}
@@ -323,8 +343,8 @@ function renderInAppPurchase(value: AppSubscription) {
 					padding: ${space[3]}px;
 				`}
 			>
-				To change your payment setup, please contact Apple (for iOS), or
-				Google (for Android).
+				To change your payment setup, please contact{' '}
+				{getAppStoreMessage(subscription)}.
 			</div>
 		</div>
 	);

--- a/client/fixtures/inAppPurchase.ts
+++ b/client/fixtures/inAppPurchase.ts
@@ -4,6 +4,7 @@ export const InAppPurchase: AppSubscription = {
 	subscriptionId: '1',
 	valid: true,
 	from: '2023-01-11T11:05:20.000Z',
+	productId: '',
 };
 
 export const CancelledInAppPurchase: AppSubscription = {
@@ -11,4 +12,19 @@ export const CancelledInAppPurchase: AppSubscription = {
 	subscriptionId: '2',
 	valid: true,
 	from: '2023-01-11T11:05:20.000Z',
+	productId: '',
+};
+
+export const InAppPurchaseIos: AppSubscription = {
+	subscriptionId: '3',
+	valid: true,
+	from: '2023-01-11T11:05:20.000Z',
+	productId: 'uk.co.guardian.gia.1month',
+};
+
+export const InAppPurchaseAndroid: AppSubscription = {
+	subscriptionId: '4',
+	valid: true,
+	from: '2023-01-11T11:05:20.000Z',
+	productId: 'com.guardian.subscription.annual.metered',
 };

--- a/shared/mpapiResponse.ts
+++ b/shared/mpapiResponse.ts
@@ -5,6 +5,7 @@ export interface AppSubscription {
 	cancellationTimestamp?: string;
 	from: string;
 	valid: boolean;
+	productId: string;
 }
 
 export interface MPAPIResponse {
@@ -20,3 +21,22 @@ export const AppSubscriptionSoftOptInIds: string[] = [
 	SoftOptInIDs.SimilarProducts,
 	SoftOptInIDs.SupporterNewsletter,
 ];
+
+export enum AppStore {
+	IOS,
+	ANDROID,
+	UNKNOWN,
+}
+
+export function determineAppStore(subscription: AppSubscription) {
+	if (subscription.productId.includes('guardian.subscription')) {
+		return AppStore.ANDROID;
+	} else if (
+		subscription.productId.includes('guardian.gia') ||
+		subscription.productId.includes('guardian.gla')
+	) {
+		return AppStore.IOS;
+	} else {
+		return AppStore.UNKNOWN;
+	}
+}


### PR DESCRIPTION
## What does this change?

Adds a function to determine if an app subscription is Android or iOS based on rules from a mapping table (found [here](https://docs.google.com/spreadsheets/d/1I8XZnirRkIQ1RDAq9iSqVC5B9UzFqV4iJnC_dTfydfE/edit#gid=796953305)). Shows different copy on the Billing page depending on which app store the subscription comes from. If it is a puzzle subscription it falls back to default.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

See the Billing storybook or visit the Billing page with an in app subscription.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

The naming convention of the productIds may change at some point - though not for a while. There is a fallback in place if we can not determine the origin from productId.

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://user-images.githubusercontent.com/114918544/224074168-78f5e09f-d30d-4963-9a0e-c1476f9cf0d1.png)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
