### PR TITLE
Prevent multiple calls to `product-move` API

### DIFF
--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -130,6 +130,7 @@ export const ProductCard = ({
 
 	const showSwitchButton =
 		isEligibleToSwitch &&
+		!hasCancellationPending &&
 		specificProductType.productType === 'contributions';
 
 	const productBenefits =

--- a/client/components/mma/switch/review/SwitchReview.tsx
+++ b/client/components/mma/switch/review/SwitchReview.tsx
@@ -204,6 +204,10 @@ export const SwitchReview = () => {
 		);
 
 	const confirmSwitch = async (amount: number) => {
+		if (isSwitching) {
+			return;
+		}
+
 		if (inPaymentFailure) {
 			setSwitchingError(true);
 			return;


### PR DESCRIPTION
## What does this change?

Prevents the `product-move` API being called again if the switch 'confirm' button is clicked more than once, and hides the switch button on the _Account Overview_ if the product has a pending cancellation. (This shouldn't happen in practice for a contribution, but we have a fixture that covers this scenario so this is a bit belt and braces.)

<img width="573" alt="Screenshot 2023-03-16 at 16 13 54" src="https://user-images.githubusercontent.com/1166188/225690563-2564e3b9-9a7e-44ac-aed9-3d27ad8eddd7.png">

## How to test

With the _Network_ tab in devtools open, click the 'confirm' button on the switch review page multiple times and check that the `product-move` API is only called once.