### PR TITLE
Inline 'price rise' alert and dynamic product name on switch button

### DIFF
--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -4,6 +4,7 @@ import {
 	Button,
 	buttonThemeReaderRevenueBrand,
 	Stack,
+	SvgInfoRound,
 } from '@guardian/source-react-components';
 import { useNavigate } from 'react-router';
 import {
@@ -28,10 +29,7 @@ import { ErrorIcon } from '../shared/assets/ErrorIcon';
 import { Card } from '../shared/Card';
 import { CardDisplay } from '../shared/CardDisplay';
 import { DirectDebitDisplay } from '../shared/DirectDebitDisplay';
-import {
-	getNextPaymentDetails,
-	NewPaymentPriceAlert,
-} from '../shared/NextPaymentDetails';
+import { getNextPaymentDetails } from '../shared/NextPaymentDetails';
 import { PaypalDisplay } from '../shared/PaypalDisplay';
 import { SepaDisplay } from '../shared/SepaDisplay';
 import { SupporterPlusBenefitsToggle } from '../shared/SupporterPlusBenefits';
@@ -84,6 +82,24 @@ const PaymentMethod = ({
 		)}
 	</div>
 );
+
+const NewPriceAlert = () => {
+	const iconCss = css`
+		svg {
+			position: relative;
+			top: 7px;
+			margin-left: -4px;
+			fill: ${palette.brand[500]};
+		}
+	`;
+
+	return (
+		<span css={iconCss}>
+			<SvgInfoRound size="small" />
+			New price |{' '}
+		</span>
+	);
+};
 
 export const ProductCard = ({
 	productDetail,
@@ -284,7 +300,7 @@ export const ProductCard = ({
 											</dt>
 											<dd>
 												{nextPaymentDetails.isNewPaymentValue && (
-													<NewPaymentPriceAlert />
+													<NewPriceAlert />
 												)}
 												{
 													nextPaymentDetails.paymentValue

--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -13,11 +13,15 @@ import {
 } from '../../../../shared/dates';
 import type {
 	MembersDataApiUser,
+	PaidSubscriptionPlan,
 	ProductDetail,
 	Subscription,
 } from '../../../../shared/productResponse';
 import { getMainPlan, isGift } from '../../../../shared/productResponse';
-import { GROUPED_PRODUCT_TYPES } from '../../../../shared/productTypes';
+import {
+	calculateSupporterPlusTitle,
+	GROUPED_PRODUCT_TYPES,
+} from '../../../../shared/productTypes';
 import { trackEvent } from '../../../utilities/analytics';
 import { InfoSummary } from '../paymentUpdate/Summary';
 import { ErrorIcon } from '../shared/assets/ErrorIcon';
@@ -345,7 +349,11 @@ export const ProductCard = ({
 											})
 										}
 									>
-										Change to monthly + extras
+										Change to{' '}
+										{calculateSupporterPlusTitle(
+											(mainPlan as PaidSubscriptionPlan)
+												.billingPeriod,
+										)}
 									</Button>
 								</ThemeProvider>
 							)}

--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -233,7 +233,7 @@ const calculateProductTitle =
 	(baseProductTitle: string) => (mainPlan?: SubscriptionPlan) =>
 		baseProductTitle + (mainPlan?.name ? ` - ${mainPlan.name}` : '');
 
-const calculateSupporterPlusTitle = (billingPeriod: string) =>
+export const calculateSupporterPlusTitle = (billingPeriod: string) =>
 	billingPeriod === 'month' ? 'monthly + extras' : 'annual + extras';
 
 export const calculateMonthlyOrAnnualFromBillingPeriod = (


### PR DESCRIPTION
## What does this change?

A couple of small tweaks and fixes ahead of enabling the new Account Overview layout: the existing price rise alert component has been replaced as it breaks the layout and now appears inline with the price, and the 'Change to x' button has been updated so that the product name is dynamic rather than hardcoded as 'monthly + extras'.

## Images

<img width="819" alt="Screenshot 2023-03-17 at 17 54 57" src="https://user-images.githubusercontent.com/1166188/226310545-c917f122-56e4-465a-a9ce-58461847308b.png">
