### PR TITLE
Help Centre landing page updates

### DIFF
--- a/client/components/helpCentre/HelpCentreConfig.ts
+++ b/client/components/helpCentre/HelpCentreConfig.ts
@@ -70,7 +70,7 @@ export const helpCentreConfig: HelpCentreTopic[] = [
 			},
 			{
 				id: 'q5',
-				title: 'Changing my contribution amount',
+				title: 'Changing the amount of my payments',
 				link: '/help-centre/article/changing-my-contribution-amount',
 			},
 		],
@@ -233,11 +233,6 @@ export const helpCentreMoreQuestionsConfig: HelpCentreMoreQuestionsTopic[] = [
 				title: 'Device compatibility',
 				link: '/help-centre/article/what-devices-are-compatible-with-your-apps',
 			},
-			{
-				id: 'q4',
-				title: 'Getting started with your Digital Subscription',
-				link: '/help-centre/article/getting-started-with-your-digital-subscription',
-			},
 		],
 	},
 	{
@@ -299,26 +294,21 @@ export const helpCentreMoreQuestionsConfig: HelpCentreMoreQuestionsTopic[] = [
 		links: [
 			{
 				id: 'q1',
-				title: 'Gifting a Digital Subscription',
-				link: '/help-centre/article/gifting-a-digital-subscription',
-			},
-			{
-				id: 'q2',
 				title: 'Gifting the Guardian Weekly',
 				link: '/help-centre/article/gifting-the-guardian-weekly',
 			},
 			{
-				id: 'q3',
+				id: 'q2',
 				title: "My gift recipient hasn't recieved their gift",
 				link: '/help-centre/article/my-gift-recipient-hasnt-received-their-gift',
 			},
 			{
-				id: 'q4',
+				id: 'q3',
 				title: "I've accidentally entered the wrong details when gifting",
 				link: '/help-centre/article/ive-accidentally-entered-the-wrong-details',
 			},
 			{
-				id: 'q5',
+				id: 'q4',
 				title: 'The person I bought a gift for already has a subscription, can I get a refund?',
 				link: '/help-centre/article/the-person-i-bought-a-gift-for-already-has-a-subscription-can-i-get-a-refund',
 			},


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

With supporter plus/app metering having been released we need to make some small changes to the Help Centre landing page

Amendments:
1) "Changing my contribution amount" to become "Changing the amount of my payments"

To be deleted:
1) "Getting started with your Digital Subscription" (apps category)
2) "Gifting a digital subscription" (gifting category)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
