### PR TITLE
Enable new Account Overview layout and product switching from MMA

### DIFF
--- a/client/components/mma/accountoverview/AccountOverview.stories.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.stories.tsx
@@ -26,6 +26,8 @@ import {
 import { user } from '../../../fixtures/user';
 import { AccountOverview } from './AccountOverview';
 
+featureSwitches['appSubscriptions'] = true;
+
 export default {
 	title: 'Pages/AccountOverview',
 	component: AccountOverview,
@@ -66,11 +68,9 @@ export const WithSubscriptions: ComponentStory<typeof AccountOverview> = () => {
 	return <AccountOverview />;
 };
 
-export const WithContributionNewLayout: ComponentStory<
+export const WithContributionAndSwitchPossible: ComponentStory<
 	typeof AccountOverview
 > = () => {
-	featureSwitches['accountOverviewNewLayout'] = true;
-
 	fetchMock
 		.restore()
 		.get('/api/cancelled/', { body: [] })
@@ -84,10 +84,9 @@ export const WithContributionNewLayout: ComponentStory<
 	return <AccountOverview />;
 };
 
-export const WithContributionNewLayoutPaymentFailure: ComponentStory<
+export const WithContributionInPaymentFailure: ComponentStory<
 	typeof AccountOverview
 > = () => {
-	featureSwitches['accountOverviewNewLayout'] = true;
 	const contributionPaymentFailure = {
 		...contributionPayPal,
 		alertText: 'Your payment has failed.',
@@ -109,11 +108,9 @@ export const WithContributionNewLayoutPaymentFailure: ComponentStory<
 	return <AccountOverview />;
 };
 
-export const WithContributionNewLayoutDigisubAndContribution: ComponentStory<
+export const WithContributionAndDigisub: ComponentStory<
 	typeof AccountOverview
 > = () => {
-	featureSwitches['accountOverviewNewLayout'] = true;
-
 	fetchMock
 		.restore()
 		.get('/api/cancelled/', { body: [] })
@@ -127,11 +124,9 @@ export const WithContributionNewLayoutDigisubAndContribution: ComponentStory<
 	return <AccountOverview />;
 };
 
-export const WithCancellationsNewLayout: ComponentStory<
+export const WithCancelledSubscriptions: ComponentStory<
 	typeof AccountOverview
 > = () => {
-	featureSwitches['accountOverviewNewLayout'] = true;
-
 	fetchMock
 		.restore()
 		.get('/api/me/mma', {
@@ -151,11 +146,9 @@ export const WithCancellationsNewLayout: ComponentStory<
 	return <AccountOverview />;
 };
 
-export const WithGiftSubscriptionNewLayout: ComponentStory<
+export const WithGiftSubscriptions: ComponentStory<
 	typeof AccountOverview
 > = () => {
-	featureSwitches['accountOverviewNewLayout'] = true;
-
 	fetchMock
 		.restore()
 		.get('/api/me/mma', {
@@ -175,8 +168,6 @@ export const WithGiftSubscriptionNewLayout: ComponentStory<
 export const WithAppSubscriptions: ComponentStory<
 	typeof AccountOverview
 > = () => {
-	featureSwitches['appSubscriptions'] = true;
-
 	fetchMock
 		.restore()
 		.get('/api/cancelled/', { body: [] })

--- a/client/components/mma/accountoverview/AccountOverview.stories.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.stories.tsx
@@ -108,7 +108,7 @@ export const WithContributionInPaymentFailure: ComponentStory<
 	return <AccountOverview />;
 };
 
-export const WithContributionAndDigisub: ComponentStory<
+export const WithContributionAndSwitchNotPossible: ComponentStory<
 	typeof AccountOverview
 > = () => {
 	fetchMock

--- a/cypress/integration/parallel-3/holidayStops.spec.ts
+++ b/cypress/integration/parallel-3/holidayStops.spec.ts
@@ -228,11 +228,7 @@ describe('Holiday stops', () => {
 		cy.wait('@mobile_subscriptions');
 
 		cy.findByRole('heading', { name: 'Account overview' }).should('exist');
-		cy.findAllByRole('link', {
-			name: 'Guardian Weekly : Manage subscription',
-		})
-			.eq(0)
-			.click();
+		cy.findAllByText('Manage subscription').eq(0).click();
 
 		cy.findByText('A-S00293857').should('exist');
 
@@ -241,11 +237,7 @@ describe('Holiday stops', () => {
 		cy.wait('@cancelled');
 		cy.wait('@mobile_subscriptions');
 
-		cy.findAllByRole('link', {
-			name: 'Guardian Weekly : Manage subscription',
-		})
-			.eq(1)
-			.click();
+		cy.findAllByText('Manage subscription').eq(1).click();
 
 		cy.findByText('A-S00286635').should('exist');
 		cy.findByRole('link', { name: 'Manage suspensions' }).click();

--- a/shared/featureSwitches.ts
+++ b/shared/featureSwitches.ts
@@ -25,7 +25,7 @@ export const initFeatureSwitchUrlParamOverride = () => {
 export const featureSwitches: Record<string, boolean> = {
 	exampleFeature: false,
 	cancellationProductSwitch: false,
-	accountOverviewNewLayout: false,
+	accountOverviewNewLayout: true,
 	productSwitching: true,
 	appSubscriptions: false,
 };


### PR DESCRIPTION
## What does this change?

Enables the new Account Overview layout and allows product switches to be initiated from MMA.

## How to test

When signed in with an active recurring contribution, but no digital subscription, you should should see a _Change to monthly + extras_ button in the product card. (_annual_ if an annual contribution.)

All other subscription information shown in the old layout should be displayed in the new product cards, and it should be possible to manage each subscription and update payment details as before.

## How can we measure success?

Apart from the addition of the _Change to monthly + extras_ button and a new look and feel, users should experience no change in functionality so we should not expect any additional contact with customer support as a result of this change. We should also monitor Sentry and ensure there are no new errors being logged.

## Images

## Before

![manage thegulocal com_ (3)](https://user-images.githubusercontent.com/1166188/226988239-530aea9b-7a40-4615-ac28-9208a8952b6b.png)

![manage thegulocal com_ (2)](https://user-images.githubusercontent.com/1166188/226988255-1136108c-dcf9-4800-ac59-71e7d3c62877.png)

## After

![manage thegulocal com_ (4)](https://user-images.githubusercontent.com/1166188/226988286-70166db7-1839-4885-8395-1e232990afa1.png)

![manage thegulocal com_](https://user-images.githubusercontent.com/1166188/226988297-48ceb9bd-e52e-4d6d-a4fa-ff60731eefdd.png)

 