### PR TITLE
filter out newsletter 6029

### DIFF
--- a/client/components/mma/identity/identity.ts
+++ b/client/components/mma/identity/identity.ts
@@ -119,7 +119,12 @@ export const ConsentOptions: ConsentOptionCollection = {
 				// @AB_TEST: Default Onboarding Newsletter Test: START
 				// Prevent trial newsletter from displaying.
 				.filter((newsletter: ConsentOption) => newsletter.id !== '6028') // identityId: 'saturday-roundup-trial'
-			// @AB_TEST: Default Onboarding Newsletter Test: END
+				// @AB_TEST: Default Onboarding Newsletter Test: END
+
+				// Temporary change - the newsletter with this number needs to be
+				// set up in advance but not rendered on MMA until the journalism
+				// it refers to is published.
+				.filter((newsletter: ConsentOption) => newsletter.id !== '6029')
 		);
 	},
 	consents(options: ConsentOption[]): ConsentOption[] {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Prevents a newsletter with a specific id number being rendered on the /email-prefs page.

This is temporary change - a newsletter with this number needs to be set up in advance but not rendered on MMA until the journalism it refers to is published. At that point, this change can be reverted.

There is an equivalent change in frontend to hide the same newsletter: https://github.com/guardian/frontend/pull/26010

## How to test

There will not be any visible change on this branch currently as newsletter 6029 is not yet created (that can't happen until this change is merged).

However, you can test that the exclusion works by editing the new line to filter out an existing newsletter, IE:
`.filter((newsletter: ConsentOption) => newsletter.id !== '4222')`
would exclude "Animals Farmed"


## How can we measure success?

Allows us to prevent the MMA page pre-empting a scheduled announcement, without delaying the launch of the newsletter.

## Have we considered potential risks?

We will need to revert or overwrite this change relatively promptly after the scheduled announcement so users who subscribe the the newsletter will have the option to unsubscribe using MMA. Will put in a another PR for that.