### PR TITLE
Use React Router for local links in dropdown nav

### DIFF
--- a/client/components/shared/nav/DropdownNav.tsx
+++ b/client/components/shared/nav/DropdownNav.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { brand, from, neutral, space } from '@guardian/source-foundations';
 import { useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { gridItemPlacement } from '../../../styles/grid';
 import { ProfileIcon } from '../../mma/shared/assets/ProfileIcon';
 import { expanderButtonCss } from '../ExpanderButton';
@@ -95,6 +96,43 @@ const dropdownNavItemCss = css({
 		},
 	},
 });
+
+const DropdownNavItem = ({ navItem }: { navItem: MenuSpecificNavItem }) => (
+	<>
+		{navItem.icon && (
+			<div
+				css={{
+					...(!navItem.isDropDownExclusive && {
+						[from.desktop]: {
+							display: 'none',
+						},
+					}),
+					position: 'absolute',
+					left: `${space[3]}px`,
+				}}
+			>
+				<navItem.icon
+					overrideFillColor={neutral[100]}
+					overrideWidthAtDesktop={12}
+				/>
+			</div>
+		)}
+		<span
+			css={{
+				lineHeight: '33px',
+				[from.desktop]: {
+					lineHeight: 'normal',
+					marginLeft:
+						navItem.isDropDownExclusive && navItem.icon
+							? `${space[5]}px`
+							: 0,
+				},
+			}}
+		>
+			{navItem.title}
+		</span>
+	</>
+);
 
 export const DropdownNav = () => {
 	const [showMenu, setShowMenu] = useState(false);
@@ -203,41 +241,19 @@ export const DropdownNav = () => {
 				{Object.values(NAV_LINKS).map(
 					(navItem: MenuSpecificNavItem) => (
 						<li key={navItem.title}>
-							<a href={navItem.link} css={dropdownNavItemCss}>
-								{navItem.icon && (
-									<div
-										css={{
-											...(!navItem.isDropDownExclusive && {
-												[from.desktop]: {
-													display: 'none',
-												},
-											}),
-											position: 'absolute',
-											left: `${space[3]}px`,
-										}}
-									>
-										<navItem.icon
-											overrideFillColor={neutral[100]}
-											overrideWidthAtDesktop={12}
-										/>
-									</div>
-								)}
-								<span
-									css={{
-										lineHeight: '33px',
-										[from.desktop]: {
-											lineHeight: 'normal',
-											marginLeft:
-												navItem.isDropDownExclusive &&
-												navItem.icon
-													? `${space[5]}px`
-													: 0,
-										},
-									}}
+							{navItem.local ? (
+								<Link
+									to={navItem.link}
+									css={dropdownNavItemCss}
+									onClick={() => setShowMenu(false)}
 								>
-									{navItem.title}
-								</span>
-							</a>
+									<DropdownNavItem navItem={navItem} />
+								</Link>
+							) : (
+								<a href={navItem.link} css={dropdownNavItemCss}>
+									<DropdownNavItem navItem={navItem} />
+								</a>
+							)}
 						</li>
 					),
 				)}


### PR DESCRIPTION
## What does this change?

Updates the dropdown navigation component to use React Router `<Link>` elements so that client-side routing is used. (External links continue to use regular anchor elements.)

The dropdown navigation is the only navigation available on mobile devices so mobile users are unnecessarily seeing full page refreshes as they navigate around the site.

## Images

<img width="378" alt="Screenshot 2023-03-24 at 11 12 45" src="https://user-images.githubusercontent.com/1166188/227506630-cf138e3d-5b11-4c86-920e-ec39bb431cdc.png">
