### PR TITLE
Update design of IAP cards on account-overview and billing

### DIFF
--- a/client/components/mma/accountoverview/AccountOverview.stories.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.stories.tsx
@@ -8,7 +8,9 @@ import {
 } from '../../../fixtures/cancelledProductDetail';
 import {
 	CancelledInAppPurchase,
-	InAppPurchase,
+	InAppPurchaseIos,
+	PuzzleAppPurchaseAndroid,
+	PuzzleAppPurchaseIos,
 } from '../../../fixtures/inAppPurchase';
 import {
 	contributionCancelled,
@@ -173,7 +175,12 @@ export const WithAppSubscriptions: ComponentStory<
 		.get('/api/cancelled/', { body: [] })
 		.get('/mpapi/user/mobile-subscriptions', {
 			body: {
-				subscriptions: [CancelledInAppPurchase, InAppPurchase],
+				subscriptions: [
+					CancelledInAppPurchase,
+					InAppPurchaseIos,
+					PuzzleAppPurchaseAndroid,
+					PuzzleAppPurchaseIos,
+				],
 			},
 		})
 		.get('/api/me/mma', { body: toMembersDataApiResponse() })

--- a/client/components/mma/accountoverview/AccountOverview.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.tsx
@@ -150,7 +150,7 @@ const AccountOverviewPage = () => {
 						{appSubscriptions.map((subscription) => (
 							<InAppPurchaseCard
 								key={subscription.subscriptionId}
-								inAppPurchase={subscription}
+								subscription={subscription}
 							/>
 						))}
 					</Stack>

--- a/client/components/mma/accountoverview/AccountOverview.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.tsx
@@ -137,25 +137,14 @@ const AccountOverviewPage = () => {
 
 	return (
 		<>
-			<PersonalisedHeader mdapiResponse={mdapiResponse} />
+			<PersonalisedHeader
+				mdapiResponse={mdapiResponse}
+				mpapiResponse={mpapiResponse}
+			/>
 
 			<PaymentFailureAlertIfApplicable
 				productDetails={allActiveProductDetails}
 			/>
-
-			{featureSwitches.appSubscriptions && appSubscriptions.length > 0 && (
-				<>
-					<h2 css={subHeadingCss}>App Subscriptions</h2>
-					<Stack space={6}>
-						{appSubscriptions.map((subscription) => (
-							<InAppPurchaseCard
-								key={subscription.subscriptionId}
-								subscription={subscription}
-							/>
-						))}
-					</Stack>
-				</>
-			)}
 			{productCategories.map((category) => {
 				const groupedProductType = GROUPED_PRODUCT_TYPES[category];
 				const activeProductsInCategory = allActiveProductDetails.filter(
@@ -246,6 +235,19 @@ const AccountOverviewPage = () => {
 					</Fragment>
 				);
 			})}
+			{featureSwitches.appSubscriptions && appSubscriptions.length > 0 && (
+				<>
+					<h2 css={subHeadingCss}>Subscriptions</h2>
+					<Stack space={6}>
+						{appSubscriptions.map((subscription) => (
+							<InAppPurchaseCard
+								key={subscription.subscriptionId}
+								subscription={subscription}
+							/>
+						))}
+					</Stack>
+				</>
+			)}
 		</>
 	);
 };

--- a/client/components/mma/accountoverview/InAppPurchaseCard.tsx
+++ b/client/components/mma/accountoverview/InAppPurchaseCard.tsx
@@ -3,9 +3,21 @@ import { Stack } from '@guardian/source-react-components';
 import { InfoSummary } from '@guardian/source-react-components-development-kitchen';
 import { dateString } from '../../../../shared/dates';
 import type { AppSubscription } from '../../../../shared/mpapiResponse';
+import { space } from '@guardian/source-foundations';
+import { Button, Stack } from '@guardian/source-react-components';
+import { capitalize } from 'lodash';
+import { useNavigate } from 'react-router';
+import { dateString } from '../../../../shared/dates';
+import type {
+	AppSubscription} from '../../../../shared/mpapiResponse';
+import {
+	AppStore,
+	determineAppStore,
+	isPuzzle,
+} from '../../../../shared/mpapiResponse';
 import { Card } from '../shared/Card';
 import { productColour } from './ProductCardConfiguration';
-import { productTitleCss } from './ProductCardStyles';
+import { productDetailLayoutCss, productTitleCss } from './ProductCardStyles';
 
 const summaryLinkCss = css`
 	color: currentColor;
@@ -24,29 +36,61 @@ const cancelledAppSubscriptionMessage = () => {
 };
 
 export const InAppPurchaseCard = ({
-	inAppPurchase,
+	subscription,
 }: {
-	inAppPurchase: AppSubscription;
+	subscription: AppSubscription;
 }) => {
+	const navigate = useNavigate();
+
+	const isPuzzleApp = isPuzzle(subscription);
+	const puzzleOrNews = isPuzzleApp ? 'puzzle' : 'news';
+	const appStore = determineAppStore(subscription);
 	return (
 		<Stack space={4}>
-			{inAppPurchase.cancellationTimestamp && (
+			{subscription.cancellationTimestamp && (
 				<InfoSummary
 					message={`Your app subscription was cancelled in ${dateString(
-						new Date(inAppPurchase.cancellationTimestamp),
+						new Date(subscription.cancellationTimestamp),
 						'MMMM yyyy',
 					)}.`}
 					context={cancelledAppSubscriptionMessage()}
 				/>
 			)}
 			<Card>
-				<Card.Header backgroundColor={productColour.inAppPurchase}>
-					<h3 css={productTitleCss(true)}>App Subscription</h3>
+				<Card.Header
+					backgroundColor={
+						isPuzzleApp
+							? productColour.puzzleApp
+							: productColour.inAppPurchase
+					}
+				>
+					<h3 css={productTitleCss(!isPuzzleApp)}>
+						{capitalize(puzzleOrNews)} App Subscription
+					</h3>
 				</Card.Header>
 				<Card.Section>
-					Your subscription started in{' '}
-					{dateString(new Date(inAppPurchase.from), 'MMMM yyyy')}.
-					Thank you for supporting the Guardian.
+					<div css={productDetailLayoutCss}>
+						<div>
+							You have unlimited access to the Guardian{' '}
+							{appStore === AppStore.ANDROID && 'Android'}
+							{appStore === AppStore.IOS && 'iOS'} {puzzleOrNews}{' '}
+							app.
+						</div>
+						<div
+							css={css`
+								margin-top: ${space[5]}px;
+							`}
+						>
+							<Button
+								size="small"
+								onClick={() => {
+									navigate('/email-prefs');
+								}}
+							>
+								Manage marketing preferences
+							</Button>
+						</div>
+					</div>
 				</Card.Section>
 			</Card>
 		</Stack>

--- a/client/components/mma/accountoverview/InAppPurchaseCard.tsx
+++ b/client/components/mma/accountoverview/InAppPurchaseCard.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { space } from '@guardian/source-foundations';
+import { space, textSans } from '@guardian/source-foundations';
 import { Button, Stack } from '@guardian/source-react-components';
 import { InfoSummary } from '@guardian/source-react-components-development-kitchen';
 import { capitalize } from 'lodash';
@@ -61,12 +61,23 @@ export const InAppPurchaseCard = ({
 					}
 				>
 					<h3 css={productTitleCss(!isPuzzleApp)}>
-						{capitalize(puzzleOrNews)} App Subscription
+						{capitalize(puzzleOrNews)} app
 					</h3>
 				</Card.Header>
 				<Card.Section>
-					<div css={productDetailLayoutCss}>
-						<div>
+					<div
+						css={[
+							productDetailLayoutCss,
+							css`
+								margin-top: -${space[2]}px;
+							`,
+						]}
+					>
+						<div
+							css={css`
+								${textSans.medium()};
+							`}
+						>
 							You have unlimited access to the Guardian{' '}
 							{appStore === AppStore.ANDROID && 'Android'}
 							{appStore === AppStore.IOS && 'iOS'} {puzzleOrNews}{' '}
@@ -74,7 +85,7 @@ export const InAppPurchaseCard = ({
 						</div>
 						<div
 							css={css`
-								margin-top: ${space[5]}px;
+								margin-top: ${space[9]}px;
 							`}
 						>
 							<Button

--- a/client/components/mma/accountoverview/InAppPurchaseCard.tsx
+++ b/client/components/mma/accountoverview/InAppPurchaseCard.tsx
@@ -1,15 +1,11 @@
 import { css } from '@emotion/react';
-import { Stack } from '@guardian/source-react-components';
-import { InfoSummary } from '@guardian/source-react-components-development-kitchen';
-import { dateString } from '../../../../shared/dates';
-import type { AppSubscription } from '../../../../shared/mpapiResponse';
 import { space } from '@guardian/source-foundations';
 import { Button, Stack } from '@guardian/source-react-components';
+import { InfoSummary } from '@guardian/source-react-components-development-kitchen';
 import { capitalize } from 'lodash';
 import { useNavigate } from 'react-router';
 import { dateString } from '../../../../shared/dates';
-import type {
-	AppSubscription} from '../../../../shared/mpapiResponse';
+import type { AppSubscription } from '../../../../shared/mpapiResponse';
 import {
 	AppStore,
 	determineAppStore,

--- a/client/components/mma/accountoverview/PersonalisedHeader.tsx
+++ b/client/components/mma/accountoverview/PersonalisedHeader.tsx
@@ -2,13 +2,9 @@ import { css } from '@emotion/react';
 import { headline, space } from '@guardian/source-foundations';
 import { min } from 'date-fns';
 import { dateString } from '../../../../shared/dates';
-import type {
-	MPAPIResponse} from '../../../../shared/mpapiResponse';
-import {
-	sortByFromDate,
-} from '../../../../shared/mpapiResponse';
+import type { MPAPIResponse } from '../../../../shared/mpapiResponse';
 import type { MembersDataApiResponse } from '../../../../shared/productResponse';
-import { isProduct, sortByJoinDate } from '../../../../shared/productResponse';
+import { isProduct } from '../../../../shared/productResponse';
 
 interface PersonalisedHeaderProps {
 	mdapiResponse: MembersDataApiResponse;
@@ -41,22 +37,12 @@ export const PersonalisedHeader = ({
 		return null;
 	}
 
-	const productDetails = mdapiResponse.products
-		.filter(isProduct)
-		.sort(sortByJoinDate);
-	const oldestProductDateString =
-		productDetails[productDetails.length - 1]?.joinDate;
+	const productDetails = mdapiResponse.products.filter(isProduct);
 
-	const oldestAppSubscriptionDateString =
-		mpapiResponse.subscriptions.sort(sortByFromDate)[
-			mpapiResponse.subscriptions.length - 1
-		]?.from;
-
-	const oldestDate = min(
-		[oldestProductDateString, oldestAppSubscriptionDateString].map((d) =>
-			d ? new Date(d) : new Date(),
-		),
-	);
+	const oldestDate = min([
+		...productDetails.map((p) => new Date(p.joinDate)),
+		...mpapiResponse.subscriptions.map((s) => new Date(s.from)),
+	]);
 
 	const supportStartYear = dateString(oldestDate, 'MMMM yyyy');
 

--- a/client/components/mma/accountoverview/ProductCardConfiguration.ts
+++ b/client/components/mma/accountoverview/ProductCardConfiguration.ts
@@ -20,6 +20,7 @@ export const productColour = {
 	newspaper: palette.brand[400],
 	digital: palette.sport[100],
 	guardianWeekly: '#cadbe8',
+	puzzleApp: palette.lifestyle[300],
 };
 
 interface ProductCardConfiguration {

--- a/client/components/mma/billing/Billing.stories.tsx
+++ b/client/components/mma/billing/Billing.stories.tsx
@@ -6,6 +6,7 @@ import {
 	InAppPurchase,
 	InAppPurchaseAndroid,
 	InAppPurchaseIos,
+	PuzzleAppPurchaseAndroid,
 } from '../../../fixtures/inAppPurchase';
 import { guardianWeeklyCardInvoice } from '../../../fixtures/invoices';
 import {
@@ -57,6 +58,7 @@ export const WithSubscriptions: ComponentStory<typeof Billing> = () => {
 					InAppPurchase,
 					InAppPurchaseIos,
 					InAppPurchaseAndroid,
+					PuzzleAppPurchaseAndroid,
 				],
 			},
 		})

--- a/client/components/mma/billing/Billing.tsx
+++ b/client/components/mma/billing/Billing.tsx
@@ -8,16 +8,18 @@ import {
 	textSans,
 	until,
 } from '@guardian/source-foundations';
+import { capitalize } from 'lodash';
 import { Fragment } from 'react';
 import { parseDate } from '../../../../shared/dates';
 import { featureSwitches } from '../../../../shared/featureSwitches';
 import type {
 	AppSubscription,
-	MPAPIResponse,
-} from '../../../../shared/mpapiResponse';
+	MPAPIResponse} from '../../../../shared/mpapiResponse';
 import {
 	AppStore,
+
 	determineAppStore,
+	isPuzzle,
 	isValidAppSubscription,
 } from '../../../../shared/mpapiResponse';
 import type {
@@ -335,6 +337,7 @@ function renderInAppPurchase(subscription: AppSubscription) {
 			padding: ${space[3]}px;
 		}
 	`;
+	const puzzleOrNews = isPuzzle(subscription) ? 'puzzle' : 'news';
 
 	return (
 		<div css={subHeadingBorderTopCss} key={subscription.subscriptionId}>
@@ -344,7 +347,7 @@ function renderInAppPurchase(subscription: AppSubscription) {
 					margin: 0;
 				`}
 			>
-				App Subscription
+				{capitalize(puzzleOrNews)} app
 			</h2>
 			<div
 				css={css`

--- a/client/components/mma/billing/Billing.tsx
+++ b/client/components/mma/billing/Billing.tsx
@@ -323,6 +323,19 @@ function getAppStoreMessage(subscription: AppSubscription) {
 }
 
 function renderInAppPurchase(subscription: AppSubscription) {
+	const tableHeadingCss = css`
+		width: 100%;
+		${headline.xxsmall({ fontWeight: 'bold' })};
+		margin: 0;
+		padding: ${space[3]}px ${space[5]}px;
+		background-color: ${neutral[97]};
+		${until.tablet} {
+			font-size: 1.0625rem;
+			line-height: 1.6;
+			padding: ${space[3]}px;
+		}
+	`;
+
 	return (
 		<div css={subHeadingBorderTopCss} key={subscription.subscriptionId}>
 			<h2
@@ -336,13 +349,21 @@ function renderInAppPurchase(subscription: AppSubscription) {
 			<div
 				css={css`
 					${textSans.medium()};
-					border: 1px solid ${neutral[20]};
+					border: 1px solid ${neutral[86]};
+					display: flex;
+					flex-wrap: wrap;
 					margin: ${space[5]}px 0;
-					padding: ${space[3]}px;
 				`}
 			>
-				To change your payment setup, please contact{' '}
-				{getAppStoreMessage(subscription)}.
+				<h2 css={tableHeadingCss}>Payment</h2>
+				<div
+					css={css`
+						padding: ${space[3]}px;
+					`}
+				>
+					To change your payment setup, please contact{' '}
+					{getAppStoreMessage(subscription)}.
+				</div>
 			</div>
 		</div>
 	);

--- a/client/fixtures/inAppPurchase.ts
+++ b/client/fixtures/inAppPurchase.ts
@@ -28,3 +28,17 @@ export const InAppPurchaseAndroid: AppSubscription = {
 	from: '2023-01-11T11:05:20.000Z',
 	productId: 'com.guardian.subscription.annual.metered',
 };
+
+export const PuzzleAppPurchaseAndroid: AppSubscription = {
+	subscriptionId: '5',
+	valid: true,
+	from: '2023-01-11T11:05:20.000Z',
+	productId: 'uk.co.guardian.puzzles.annual_sub',
+};
+
+export const PuzzleAppPurchaseIos: AppSubscription = {
+	subscriptionId: '6',
+	valid: true,
+	from: '2023-01-11T11:05:20.000Z',
+	productId: 'uk.co.guardian.puzzles.monthlySub',
+};

--- a/shared/mpapiResponse.ts
+++ b/shared/mpapiResponse.ts
@@ -29,14 +29,24 @@ export enum AppStore {
 }
 
 export function determineAppStore(subscription: AppSubscription) {
-	if (subscription.productId.includes('guardian.subscription')) {
+	if (
+		subscription.productId.includes('guardian.subscription') ||
+		subscription.productId.includes('puzzles.annual_sub') ||
+		subscription.productId.includes('puzzles.monthly_sub')
+	) {
 		return AppStore.ANDROID;
 	}
 	if (
 		subscription.productId.includes('guardian.gia') ||
-		subscription.productId.includes('guardian.gla')
+		subscription.productId.includes('guardian.gla') ||
+		subscription.productId.includes('puzzles.annualSub') ||
+		subscription.productId.includes('puzzles.monthlySub')
 	) {
 		return AppStore.IOS;
 	}
 	return AppStore.UNKNOWN;
+}
+
+export function isPuzzle(subscription: AppSubscription) {
+	return subscription.productId.includes('puzzles');
 }

--- a/shared/mpapiResponse.ts
+++ b/shared/mpapiResponse.ts
@@ -16,9 +16,6 @@ export function isValidAppSubscription(subscription: AppSubscription) {
 	return subscription.valid;
 }
 
-export const sortByFromDate = (a: AppSubscription, b: AppSubscription) =>
-	b.from.localeCompare(a.from);
-
 export const AppSubscriptionSoftOptInIds: string[] = [
 	SoftOptInIDs.SupportOnboarding,
 	SoftOptInIDs.SimilarProducts,

--- a/shared/mpapiResponse.ts
+++ b/shared/mpapiResponse.ts
@@ -16,6 +16,9 @@ export function isValidAppSubscription(subscription: AppSubscription) {
 	return subscription.valid;
 }
 
+export const sortByFromDate = (a: AppSubscription, b: AppSubscription) =>
+	b.from.localeCompare(a.from);
+
 export const AppSubscriptionSoftOptInIds: string[] = [
 	SoftOptInIDs.SupportOnboarding,
 	SoftOptInIDs.SimilarProducts,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR updates the copy and design of App subscriptions in the Account Overview and Billing page. Puzzle and News apps are distinguished by copy and colour styling.
 
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

With a user with an app subscription navigate to `/?withFeature=appSubscriptions` and see the product cards as seen in the images below. Then head to `Billing` and see the app subscriptions listed.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Account Overview
- one cancelled news app sub with fallback app store text
- one apple news app sub
- one android puzzle app sub
![image](https://user-images.githubusercontent.com/114918544/231991481-63ac0c58-49aa-454c-9537-655cf0480e3c.png)
Billing
- one news app sub with fallback app store text
- one apple news app sub
![image](https://user-images.githubusercontent.com/114918544/231991546-bb55c8c5-733b-45a1-a6de-0e11addd34ee.png)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
