### PR TITLE
unhide newsletter 6029

### DIFF
--- a/client/components/mma/identity/identity.ts
+++ b/client/components/mma/identity/identity.ts
@@ -120,11 +120,6 @@ export const ConsentOptions: ConsentOptionCollection = {
 				// Prevent trial newsletter from displaying.
 				.filter((newsletter: ConsentOption) => newsletter.id !== '6028') // identityId: 'saturday-roundup-trial'
 				// @AB_TEST: Default Onboarding Newsletter Test: END
-
-				// Temporary change - the newsletter with this number needs to be
-				// set up in advance but not rendered on MMA until the journalism
-				// it refers to is published.
-				.filter((newsletter: ConsentOption) => newsletter.id !== '6029')
 		);
 	},
 	consents(options: ConsentOption[]): ConsentOption[] {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Reverses the change on https://github.com/guardian/manage-frontend/pull/1032. Not to be merged until after the journalism the newsletter related to has been announced.


## How to test

There will not be any visible change on this branch until newsletter 6029 is created. After that has happened and the newsletter data from identity has updated: 
 - on this branch: newsletter 6029 will be visible
 - on main:  newsletter 6029 will be hidden

## How can we measure success?

Newsletter 6029 will be visible on MMA shortly after the announcement.

## Have we considered potential risks?

There may be a brief period after the newsletter goes live (ie possible to subscribe) and this PR taking effect (
