### PR TITLE
Update copy on help centre for reopened services

### DIFF
--- a/client/__tests__/components/helpCentre/__snapshots__/helpCentreContactOptions.test.tsx.snap
+++ b/client/__tests__/components/helpCentre/__snapshots__/helpCentreContactOptions.test.tsx.snap
@@ -199,7 +199,7 @@ Array [
   font-weight: normal;
 }
 
-.emotion-24 {
+.emotion-36 {
   font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
   font-size: 1.0625rem;
   line-height: 1.5;
@@ -207,7 +207,7 @@ Array [
   margin-bottom: 0;
 }
 
-.emotion-24+p {
+.emotion-36+p {
   margin-top: 16px;
 }
 
@@ -254,7 +254,7 @@ Array [
             <span
               className="emotion-9"
             >
-              +44 (0) 330 333 6790
+              +44 (0) 330 333 6767
             </span>
             <span
               className="emotion-10"
@@ -331,11 +331,6 @@ Array [
               9am - 5pm Monday - Friday (AEDT)
             </span>
           </p>
-          <p
-            className="emotion-24"
-          >
-            Phonelines for this region are temporarily down
-          </p>
         </div>
       </div>
       <div>
@@ -401,7 +396,7 @@ Array [
             </span>
           </p>
           <p
-            className="emotion-24"
+            className="emotion-36"
           >
             Phonelines for this region are temporarily down
           </p>
@@ -611,7 +606,7 @@ Array [
   font-weight: normal;
 }
 
-.emotion-24 {
+.emotion-36 {
   font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
   font-size: 1.0625rem;
   line-height: 1.5;
@@ -619,7 +614,7 @@ Array [
   margin-bottom: 0;
 }
 
-.emotion-24+p {
+.emotion-36+p {
   margin-top: 16px;
 }
 
@@ -666,7 +661,7 @@ Array [
             <span
               className="emotion-9"
             >
-              +44 (0) 330 333 6790
+              +44 (0) 330 333 6767
             </span>
             <span
               className="emotion-10"
@@ -743,11 +738,6 @@ Array [
               9am - 5pm Monday - Friday (AEDT)
             </span>
           </p>
-          <p
-            className="emotion-24"
-          >
-            Phonelines for this region are temporarily down
-          </p>
         </div>
       </div>
       <div>
@@ -813,7 +803,7 @@ Array [
             </span>
           </p>
           <p
-            className="emotion-24"
+            className="emotion-36"
           >
             Phonelines for this region are temporarily down
           </p>
@@ -1296,7 +1286,7 @@ html:not(.src-focus-disabled) .emotion-7:focus {
   font-weight: normal;
 }
 
-.emotion-36 {
+.emotion-45 {
   font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
   font-size: 1.0625rem;
   line-height: 1.5;
@@ -1304,23 +1294,23 @@ html:not(.src-focus-disabled) .emotion-7:focus {
   margin-bottom: 0;
 }
 
-.emotion-36+p {
+.emotion-45+p {
   margin-top: 16px;
 }
 
-.emotion-47 {
+.emotion-46 {
   margin-top: 36px;
   padding: 12px;
   background-color: #ecf3fe;
 }
 
 @media (min-width: 980px) {
-  .emotion-47 {
+  .emotion-46 {
     padding: 24px;
   }
 }
 
-.emotion-48 {
+.emotion-47 {
   margin: 0;
   font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
   font-size: 0.9375rem;
@@ -1328,7 +1318,7 @@ html:not(.src-focus-disabled) .emotion-7:focus {
   font-weight: 700;
 }
 
-.emotion-49 {
+.emotion-48 {
   font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
   font-size: 0.9375rem;
   line-height: 1.5;
@@ -1337,7 +1327,7 @@ html:not(.src-focus-disabled) .emotion-7:focus {
   margin: 0;
 }
 
-.emotion-49 a {
+.emotion-48 a {
   color: #0077B6;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -1573,7 +1563,7 @@ html:not(.src-focus-disabled) .emotion-7:focus {
               <span
                 className="emotion-24"
               >
-                +44 (0) 330 333 6790
+                +44 (0) 330 333 6767
               </span>
               <span
                 className="emotion-25"
@@ -1635,11 +1625,6 @@ html:not(.src-focus-disabled) .emotion-7:focus {
                 9am - 5pm Monday - Friday (AEDT)
               </span>
             </p>
-            <p
-              className="emotion-36"
-            >
-              Phonelines for this region are temporarily down
-            </p>
           </div>
         </div>
         <div>
@@ -1690,7 +1675,7 @@ html:not(.src-focus-disabled) .emotion-7:focus {
               </span>
             </p>
             <p
-              className="emotion-36"
+              className="emotion-45"
             >
               Phonelines for this region are temporarily down
             </p>
@@ -1699,16 +1684,16 @@ html:not(.src-focus-disabled) .emotion-7:focus {
       </div>
     </div>
     <div
-      className="emotion-47"
+      className="emotion-46"
       id="livechatPrivacyNotice"
     >
       <h2
-        className="emotion-48"
+        className="emotion-47"
       >
         Data privacy notice
       </h2>
       <p
-        className="emotion-49"
+        className="emotion-48"
       >
         We use a type of cookie technology called an SDK (Software Development Kit) to ensure that our live chat services work correctly and meet your expectations. It cannot be switched off but it is removed at the end of the chat. If you do not wish for this cookie to be dropped on your device, please email or phone us instead. Live chats and phone calls will be recorded for monitoring and training purposes. Please do not disclose personal data of a sensitive nature in the live chat, such as health or financial information. A copy of the chat transcript will be emailed to you unless the chat contains payment card information, in which case no transcript will be sent. Click to find out more in our
          

--- a/client/components/helpCentre/HelpCentrePage.tsx
+++ b/client/components/helpCentre/HelpCentrePage.tsx
@@ -75,7 +75,7 @@ const HelpCentreRouter = () => {
 		{
 			date: '3 Jan 2023 17:00',
 			message:
-				'Due to operational challenges caused by the ransomware attack on the Guardian, Customer Service phonelines in the US & Australia are currently not available. Live chat, email and UK phonelines remain unaffected.',
+				'Due to operational challenges caused by the ransomware attack on the Guardian, Customer Service phonelines in the US are currently not available. Live chat, email and UK and Australia phonelines remain unaffected.',
 			link: 'https://www.theguardian.com/media/2022/dec/21/guardian-hit-by-serious-it-incident-believed-to-be-ransomware-attack',
 		},
 	];

--- a/client/components/shared/CallCenterEmailAndNumbers.tsx
+++ b/client/components/shared/CallCenterEmailAndNumbers.tsx
@@ -37,7 +37,7 @@ const PHONE_DATA: PhoneRegion[] = [
 		],
 		phoneNumbers: [
 			{
-				phoneNumber: '+44 (0) 330 333 6790',
+				phoneNumber: '+44 (0) 330 333 6767',
 			},
 		],
 	},
@@ -45,8 +45,6 @@ const PHONE_DATA: PhoneRegion[] = [
 		key: 'AUS',
 		title: 'Australia, New Zealand, and Asia Pacific',
 		openingHours: ['9am - 5pm Monday - Friday (AEDT)'],
-		additionalOpeningHoursInfo:
-			'Phonelines for this region are temporarily down',
 		phoneNumbers: [
 			{
 				phoneNumber: '1800 773 766',


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We are now able to reopen some of our services since the ransomware attack and can update the copy in the help centre banner. Some other changes have been requested too to keep our help centre up to date.

1) Banner.
Due to operational challenges caused by the ransomware attack on the Guardian, Customer Service phonelines in the US are currently not available. Live chat, email and UK and Australia phonelines remain unaffected. Click here for more information (to be hyperlinked to https://www.theguardian.com/media/2022/dec/21/guardian-hit-by-serious-it-incident-believed-to-be-ransomware-attack)

2) Phonelines.
Remove "Phonelines for this region are temporarily down" from the Australia phonelines section

3) UK Phone number.

Update UK phone number to  +44 (0) 330 333 6767

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Visit `/help-centre/` and see changes 1), 2) and 3).

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://user-images.githubusercontent.com/114918544/229482872-14ce30f8-edb0-4ecb-8025-e0ae77fbc843.png)
![image](https://user-images.githubusercontent.com/114918544/229482928-0a708207-e25a-4305-8925-4e9df8ad3739.png)
![image](https://user-images.githubusercontent.com/114918544/229482958-fb68a24a-da7a-475b-bd01-83bdf1a10eff.png)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
