### PR TITLE
Allow multiple Recurring Contributions in Product Switch Journey

### DIFF
--- a/client/components/mma/switch/SwitchContainer.tsx
+++ b/client/components/mma/switch/SwitchContainer.tsx
@@ -34,7 +34,7 @@ export interface SwitchRouterState {
 }
 
 export interface SwitchContextInterface {
-	productDetail: ProductDetail;
+	contributionToSwitch: ProductDetail;
 	isFromApp: boolean;
 	user?: MembersDataApiUser;
 	mainPlan: PaidSubscriptionPlan;
@@ -56,7 +56,7 @@ export const SwitchContext: Context<SwitchContextInterface | {}> =
 export const SwitchContainer = (props: { isFromApp?: boolean }) => {
 	const location = useLocation();
 	const routerState = location.state as SwitchRouterState;
-	const productDetail = routerState?.productDetail;
+	const contributionToSwitch = routerState?.productDetail;
 	const user = routerState?.user;
 
 	const [switchHasCompleted, setSwitchHasCompleted] =
@@ -70,13 +70,13 @@ export const SwitchContainer = (props: { isFromApp?: boolean }) => {
 		return <Navigate to="/" />;
 	}
 
-	if (!productDetail) {
+	if (!contributionToSwitch) {
 		return <AsyncLoadedSwitchContainer isFromApp={props.isFromApp} />;
 	}
 
 	return (
 		<RenderedPage
-			productDetail={productDetail}
+			contributionToSwitch={contributionToSwitch}
 			user={user}
 			isFromApp={props.isFromApp}
 		/>
@@ -124,10 +124,10 @@ const AsyncLoadedSwitchContainer = (props: { isFromApp?: boolean }) => {
 		return <Navigate to="/" />;
 	}
 
-	const productDetail = data.products.filter(isProduct)[0];
+	const contributionToSwitch = data.products.filter(isProduct)[0];
 	return (
 		<RenderedPage
-			productDetail={productDetail}
+			contributionToSwitch={contributionToSwitch}
 			user={data.user}
 			isFromApp={props.isFromApp}
 		/>
@@ -135,12 +135,12 @@ const AsyncLoadedSwitchContainer = (props: { isFromApp?: boolean }) => {
 };
 
 const RenderedPage = (props: {
-	productDetail: ProductDetail;
+	contributionToSwitch: ProductDetail;
 	user?: MembersDataApiUser;
 	isFromApp?: boolean;
 }) => {
 	const mainPlan = getMainPlan(
-		props.productDetail.subscription,
+		props.contributionToSwitch.subscription,
 	) as PaidSubscriptionPlan;
 	const monthlyOrAnnual = calculateMonthlyOrAnnualFromBillingPeriod(
 		mainPlan.billingPeriod,
@@ -150,7 +150,7 @@ const RenderedPage = (props: {
 		<SwitchPageContainer>
 			<SwitchContext.Provider
 				value={{
-					productDetail: props.productDetail,
+					contributionToSwitch: props.contributionToSwitch,
 					isFromApp: props.isFromApp,
 					user: props.user,
 					mainPlan,

--- a/client/components/mma/switch/SwitchContainer.tsx
+++ b/client/components/mma/switch/SwitchContainer.tsx
@@ -120,7 +120,7 @@ const AsyncLoadedSwitchContainer = (props: { isFromApp?: boolean }) => {
 		);
 	}
 
-	if (data == null || noSingleRecurringContribution(data)) {
+	if (data == null || data.products.length == 0) {
 		return <Navigate to="/" />;
 	}
 
@@ -170,12 +170,6 @@ const RenderedPage = (props: {
 
 function userIsNavigatingBackFromCompletePage(hasCompleted: boolean) {
 	return hasCompleted && !location.pathname.includes('complete');
-}
-
-function noSingleRecurringContribution(data: MembersDataApiResponse) {
-	return (
-		data.products.length == 0 || data.products.filter(isProduct).length > 1
-	);
 }
 
 function getThresholds(

--- a/client/components/mma/switch/options/SwitchOptions.tsx
+++ b/client/components/mma/switch/options/SwitchOptions.tsx
@@ -7,13 +7,16 @@ import {
 } from '@guardian/source-react-components';
 import { ErrorSummary } from '@guardian/source-react-components-development-kitchen';
 import { useContext, useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import { Link } from 'react-router-dom';
 import { formatAmount } from '../../../../utilities/utils';
 import { Card } from '../../shared/Card';
 import { Heading } from '../../shared/Heading';
 import { SupporterPlusBenefitsSection } from '../../shared/SupporterPlusBenefits';
-import type { SwitchContextInterface } from '.././SwitchContainer';
+import type {
+	SwitchContextInterface,
+	SwitchRouterState,
+} from '.././SwitchContainer';
 import { SwitchContext } from '.././SwitchContainer';
 import {
 	buttonCentredCss,
@@ -68,6 +71,8 @@ const fromAppHeadingCss = css`
 
 export const SwitchOptions = () => {
 	const switchContext = useContext(SwitchContext) as SwitchContextInterface;
+	const location = useLocation();
+	const routerState = location.state as SwitchRouterState;
 
 	const {
 		productDetail,
@@ -253,7 +258,11 @@ export const SwitchOptions = () => {
 					<Button
 						size="small"
 						cssOverrides={buttonCentredCss}
-						onClick={() => navigate('review')}
+						onClick={() =>
+							navigate('review', {
+								state: routerState,
+							})
+						}
 					>
 						{isAboveThreshold
 							? 'Add extras'

--- a/client/components/mma/switch/options/SwitchOptions.tsx
+++ b/client/components/mma/switch/options/SwitchOptions.tsx
@@ -75,7 +75,7 @@ export const SwitchOptions = () => {
 	const routerState = location.state as SwitchRouterState;
 
 	const {
-		productDetail,
+		contributionToSwitch,
 		mainPlan,
 		monthlyOrAnnual,
 		supporterPlusTitle,
@@ -121,7 +121,7 @@ export const SwitchOptions = () => {
 
 	return (
 		<>
-			{productDetail.alertText && (
+			{contributionToSwitch.alertText && (
 				<section css={sectionSpacing}>
 					<ErrorSummary
 						cssOverrides={errorSummaryOverrideCss}

--- a/client/components/mma/switch/review/SwitchReview.tsx
+++ b/client/components/mma/switch/review/SwitchReview.tsx
@@ -175,14 +175,14 @@ export const SwitchReview = () => {
 
 	const switchContext = useContext(SwitchContext) as SwitchContextInterface;
 	const {
-		productDetail,
+		contributionToSwitch,
 		mainPlan,
 		monthlyOrAnnual,
 		supporterPlusTitle,
 		thresholds,
 	} = switchContext;
 
-	const inPaymentFailure = !!productDetail.alertText;
+	const inPaymentFailure = !!contributionToSwitch.alertText;
 
 	const {
 		monthlyThreshold,
@@ -195,7 +195,7 @@ export const SwitchReview = () => {
 
 	const productMoveFetch = (preview: boolean) =>
 		fetch(
-			`/api/product-move/${productDetail.subscription.subscriptionId}`,
+			`/api/product-move/${contributionToSwitch.subscription.subscriptionId}`,
 			{
 				method: 'POST',
 				body: JSON.stringify({
@@ -364,7 +364,9 @@ export const SwitchReview = () => {
 								<br />
 								We will take payment as before, from{' '}
 								<PaymentDetails
-									subscription={productDetail.subscription}
+									subscription={
+										contributionToSwitch.subscription
+									}
 								/>
 							</span>
 						</li>

--- a/client/components/mma/switch/review/SwitchReview.tsx
+++ b/client/components/mma/switch/review/SwitchReview.tsx
@@ -9,7 +9,7 @@ import {
 } from '@guardian/source-react-components';
 import { ErrorSummary } from '@guardian/source-react-components-development-kitchen';
 import { useContext, useState } from 'react';
-import { Navigate, useNavigate } from 'react-router';
+import { Navigate, useLocation, useNavigate } from 'react-router';
 import { Link } from 'react-router-dom';
 import { dateString } from '../../../../../shared/dates';
 import type { Subscription } from '../../../../../shared/productResponse';
@@ -29,7 +29,10 @@ import { cardTypeToSVG } from '../../shared/CardDisplay';
 import { Heading } from '../../shared/Heading';
 import { getObfuscatedPayPalId } from '../../shared/PaypalDisplay';
 import { SupporterPlusBenefitsToggle } from '../../shared/SupporterPlusBenefits';
-import type { SwitchContextInterface } from '../SwitchContainer';
+import type {
+	SwitchContextInterface,
+	SwitchRouterState,
+} from '../SwitchContainer';
 import { SwitchContext } from '../SwitchContainer';
 import {
 	buttonCentredCss,
@@ -164,6 +167,8 @@ interface PreviewResponse {
 
 export const SwitchReview = () => {
 	const navigate = useNavigate();
+	const location = useLocation();
+	const routerState = location.state as SwitchRouterState;
 
 	const [isSwitching, setIsSwitching] = useState<boolean>(false);
 	const [switchingError, setSwitchingError] = useState<boolean>(false);
@@ -224,6 +229,7 @@ export const SwitchReview = () => {
 			} else {
 				navigate('../complete', {
 					state: {
+						...routerState,
 						amountPayableToday: amount,
 						nextPaymentDate: nextPaymentDate,
 						switchHasCompleted: true,
@@ -380,7 +386,7 @@ export const SwitchReview = () => {
 				<Button
 					priority="tertiary"
 					cssOverrides={[buttonCentredCss, buttonMutedCss]}
-					onClick={() => navigate('..')}
+					onClick={() => navigate('..', { state: routerState })}
 				>
 					Back
 				</Button>

--- a/cypress/integration/parallel-2/productSwitch.spec.ts
+++ b/cypress/integration/parallel-2/productSwitch.spec.ts
@@ -1,5 +1,6 @@
 import {
 	contributionCard,
+	contributionPayPal,
 	toMembersDataApiResponse,
 } from '../../../client/fixtures/productDetail';
 import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
@@ -35,12 +36,18 @@ if (featureSwitches.cancellationProductSwitch) {
 
 			cy.intercept('GET', '/api/me/mma?productType=Contribution', {
 				statusCode: 200,
-				body: toMembersDataApiResponse(contributionCard),
+				body: toMembersDataApiResponse(
+					contributionCard,
+					contributionPayPal,
+				),
 			});
 
 			cy.intercept('GET', '/api/me/mma', {
 				statusCode: 200,
-				body: toMembersDataApiResponse(contributionCard),
+				body: toMembersDataApiResponse(
+					contributionCard,
+					contributionPayPal,
+				),
 			});
 
 			cy.intercept('GET', '/mpapi/user/mobile-subscriptions', {
@@ -199,7 +206,7 @@ describe('product switching', () => {
 		cy.intercept('GET', '/api/me/mma?productType=Contribution', {
 			statusCode: 200,
 			body: toMembersDataApiResponse(contributionCard),
-		});
+		}).as('mdapi_get_contribution');
 
 		cy.intercept('GET', '/api/me/mma', {
 			statusCode: 200,
@@ -221,11 +228,31 @@ describe('product switching', () => {
 		featureSwitches.accountOverviewNewLayout &&
 		featureSwitches.productSwitching
 	) {
-		it('navigates to product switching page from Account Overview', () => {
+		it('successfully completes product switching page from Account Overview', () => {
 			cy.visit('/');
 			setSignInStatus();
 			cy.findByText('Change to monthly + extras').click();
 			cy.findByText('Your current support').should('exist');
+
+			cy.findByRole('button', {
+				name: 'Add extras',
+			}).click();
+
+			cy.findByRole('button', { name: 'Confirm change' }).click();
+
+			cy.intercept('POST', '/api/product-move/*', {
+				statusCode: 200,
+				body: productMoveSuccessfulResponse,
+			});
+
+			cy.findByText(/Thank you for changing your support type/).should(
+				'exist',
+			);
+			cy.findByText(
+				/Your first billing date is today and you will be charged £5/,
+			).should('exist');
+
+			cy.get('@mdapi_get_contribution.all').should('have.length', 0);
 		});
 	}
 
@@ -270,6 +297,8 @@ describe('product switching', () => {
 			cy.findByText(
 				/Your first billing date is today and you will be charged £5/,
 			).should('exist');
+
+			cy.get('@mdapi_get_contribution.all').should('have.length', 1);
 		});
 
 		it('Does not allow user to navigate back to switch review and confirmation pages after switch completion', () => {

--- a/cypress/integration/parallel-2/productSwitch.spec.ts
+++ b/cypress/integration/parallel-2/productSwitch.spec.ts
@@ -207,7 +207,10 @@ describe('product switching', () => {
 
 		cy.intercept('GET', '/api/me/mma', {
 			statusCode: 200,
-			body: toMembersDataApiResponse(contributionCard),
+			body: toMembersDataApiResponse(
+				contributionCard,
+				contributionPayPal,
+			),
 		});
 
 		cy.intercept('GET', '/api/cancelled/', {
@@ -228,13 +231,19 @@ describe('product switching', () => {
 		it('successfully completes product switching page from Account Overview', () => {
 			cy.visit('/');
 			setSignInStatus();
-			cy.findByText('Change to monthly + extras').click();
+
+			cy.findAllByText('Change to monthly + extras').should(
+				'have.length',
+				2,
+			);
+			cy.findAllByText('Change to monthly + extras').last().click();
 			cy.findByText('Your current support').should('exist');
 
 			cy.findByRole('button', {
 				name: 'Add extras',
 			}).click();
 
+			cy.findByLabelText('PayPal').should('exist');
 			cy.findByRole('button', { name: 'Confirm change' }).click();
 
 			cy.intercept('POST', '/api/product-move/*', {

--- a/cypress/integration/parallel-2/productSwitch.spec.ts
+++ b/cypress/integration/parallel-2/productSwitch.spec.ts
@@ -36,18 +36,12 @@ if (featureSwitches.cancellationProductSwitch) {
 
 			cy.intercept('GET', '/api/me/mma?productType=Contribution', {
 				statusCode: 200,
-				body: toMembersDataApiResponse(
-					contributionCard,
-					contributionPayPal,
-				),
+				body: toMembersDataApiResponse(contributionCard),
 			});
 
 			cy.intercept('GET', '/api/me/mma', {
 				statusCode: 200,
-				body: toMembersDataApiResponse(
-					contributionCard,
-					contributionPayPal,
-				),
+				body: toMembersDataApiResponse(contributionCard),
 			});
 
 			cy.intercept('GET', '/mpapi/user/mobile-subscriptions', {
@@ -205,7 +199,10 @@ describe('product switching', () => {
 
 		cy.intercept('GET', '/api/me/mma?productType=Contribution', {
 			statusCode: 200,
-			body: toMembersDataApiResponse(contributionCard),
+			body: toMembersDataApiResponse(
+				contributionCard,
+				contributionPayPal,
+			),
 		}).as('mdapi_get_contribution');
 
 		cy.intercept('GET', '/api/me/mma', {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Removes a check that a user only has one Recurring Contribution during Product Switching. There is a ticket in Conversions team to allow multiple contributions to be checked out - so we should not assume this will be the case downstream.

Also fixes an issue picked up where the RC productDetail selected for switching was not being passed through in routerState (meaning MDAPI was being called on the second step), so we are now passing through the existing state to every page.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Take out multiple RCs (under the threshold amount) and product switch one of them via the account overview - the second switch page should load and not redirect to the Account Overview. 

Cypress tests have been updated to include a check of how many times MDAPI is called, on a full switch journey when coming directly to the URL or by clicking to switch a specific contribution.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
