### PR TITLE
Update Design Layout

### DIFF
--- a/client/components/mma/Page.tsx
+++ b/client/components/mma/Page.tsx
@@ -174,11 +174,11 @@ const PageNavAndContentContainer = (props: PageNavAndContentContainerProps) => (
 				},
 
 				[from.desktop]: {
-					...gridItemPlacement(5, 8),
+					...gridItemPlacement(5, 6),
 				},
 
 				[from.wide]: {
-					...gridItemPlacement(6, 10),
+					...gridItemPlacement(6, 8),
 				},
 			}}
 		>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
- Changes the design layout for all pages. 
- Ana Ferreira and Dom Whooley from design updated the page design layout by updating the column layout for the Data Privacy page. 
- This [design update](https://www.figma.com/file/WOztYf2GIbvowlvJeB3vmH/Identity---MMA?node-id=926-31345&t=3ic0vidrvFdClGaO-0)  should be reflected across the site. 
- Alls team need to review the updated design on their pages.
  
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
BEFORE
![Screenshot 2023-04-12 at 11 39 39](https://user-images.githubusercontent.com/106528085/231434168-eed0338c-170e-4710-ab5e-5f0475ea764e.png)
![Screenshot 2023-04-12 at 11 40 09](https://user-images.githubusercontent.com/106528085/231434188-7805e05e-cf08-4814-b096-0df18bf118fb.png)
![Screenshot 2023-04-12 at 11 40 36](https://user-images.githubusercontent.com/106528085/231434206-fb0bc19f-4109-451a-a183-7659ff48cdcd.png)



AFTER
![Screenshot 2023-04-12 at 11 28 30](https://user-images.githubusercontent.com/106528085/231431531-472dd6ae-9ddf-45a9-b39d-3eaa7a714e3a.png)
![Screenshot 2023-04-12 at 11 28 55](https://user-images.githubusercontent.com/106528085/231431585-744afa90-ab51-44f8-a8ed-01fb1e0dbc73.png)
![Screenshot 2023-04-12 at 11 29 11](https://user-images.githubusercontent.com/106528085/231431630-d6220851-d03b-4e30-9ca8-22a99ae67c68.png)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
