### PR TITLE
Update Layout for Data Privacy UI

### DIFF
--- a/client/components/mma/dataPrivacy/DataPrivacy.styles.ts
+++ b/client/components/mma/dataPrivacy/DataPrivacy.styles.ts
@@ -4,7 +4,10 @@ import {
 	from,
 	headline,
 	palette,
- space , textSans , until } from '@guardian/source-foundations';
+	space,
+	textSans,
+	until,
+} from '@guardian/source-foundations';
 import { gridColumns } from '../../../styles/grid';
 
 export const dataPrivacyHeadingCss = css`
@@ -120,15 +123,9 @@ export const dataPrivacyWrapper = css`
 	display: grid;
 	grid-template-columns: repeat(${gridColumns.default}, minmax(0, 1fr));
 	column-gap: ${space[5]}px;
-	margin: auto;
-	/* padding-left: ${space[3]}px;
-	padding-right: ${space[3]}px; */
 	max-width: calc(${breakpoints.wide}px + 2.5rem);
-	color: ${palette.neutral['100']};
 
 	${from.tablet} {
-		/* padding-left: ${space[5]}px;
-		padding-right: ${space[5]}px; */
 		grid-template-columns: repeat(
 			${gridColumns.tabletAndDesktop},
 			minmax(0, 1fr)

--- a/client/components/mma/dataPrivacy/DataPrivacy.styles.ts
+++ b/client/components/mma/dataPrivacy/DataPrivacy.styles.ts
@@ -1,10 +1,11 @@
 import { css } from '@emotion/react';
 import {
+	breakpoints,
+	from,
 	headline,
 	palette,
-	textSans,
-	until,
-} from '@guardian/source-foundations';
+ space , textSans , until } from '@guardian/source-foundations';
+import { gridColumns } from '../../../styles/grid';
 
 export const dataPrivacyHeadingCss = css`
 	margin: 0;
@@ -115,4 +116,26 @@ export const dataPrivacyWrapper = css`
 		outline-width: 3px;
 		outline-color: ${palette.focus[400]};
 	}
+
+	display: grid;
+	grid-template-columns: repeat(${gridColumns.default}, minmax(0, 1fr));
+	column-gap: ${space[5]}px;
+	margin: auto;
+	/* padding-left: ${space[3]}px;
+	padding-right: ${space[3]}px; */
+	max-width: calc(${breakpoints.wide}px + 2.5rem);
+	color: ${palette.neutral['100']};
+
+	${from.tablet} {
+		/* padding-left: ${space[5]}px;
+		padding-right: ${space[5]}px; */
+		grid-template-columns: repeat(
+			${gridColumns.tabletAndDesktop},
+			minmax(0, 1fr)
+		);
+	}
+
+	${from.wide} {
+		grid-template-columns: repeat(${gridColumns.wide}, minmax(0, 1fr));
+	} ;
 `;

--- a/client/components/mma/dataPrivacy/DataPrivacy.styles.ts
+++ b/client/components/mma/dataPrivacy/DataPrivacy.styles.ts
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import {
-	breakpoints,
 	from,
 	headline,
 	palette,
@@ -123,7 +122,6 @@ export const dataPrivacyWrapper = css`
 	display: grid;
 	grid-template-columns: repeat(${gridColumns.default}, minmax(0, 1fr));
 	column-gap: ${space[5]}px;
-	max-width: calc(${breakpoints.wide}px + 2.5rem);
 
 	${from.tablet} {
 		grid-template-columns: repeat(

--- a/client/components/mma/dataPrivacy/DataPrivacyPage.tsx
+++ b/client/components/mma/dataPrivacy/DataPrivacyPage.tsx
@@ -1,5 +1,7 @@
 import type { CMP } from '@guardian/consent-management-platform/dist/types';
+import { from } from '@guardian/source-foundations';
 import { useEffect, useState } from 'react';
+import { gridItemPlacement } from '../../../styles/grid';
 import { fetchWithDefaultParameters } from '../../../utilities/fetch';
 import {
 	LoadingState,
@@ -115,16 +117,34 @@ export const DataPrivacyPage = () => {
 
 	const content = () => (
 		<div css={dataPrivacyWrapper}>
-			<WithStandardTopMargin>
-				<YourDataSection
-					consents={consents}
-					toggleConsent={toggleConsentSubscription}
-				/>
-				<Lines n={1} />
-				<CookiesOnThisBrowserSection onClick={openManageCookies} />
-				<Lines n={1} />
-				<LearnMoreSection />
-			</WithStandardTopMargin>
+			<div
+				css={{
+					...gridItemPlacement(1, 12),
+
+					[from.tablet]: {
+						...gridItemPlacement(1, 12),
+					},
+
+					[from.desktop]: {
+						...gridItemPlacement(1, 10),
+					},
+
+					[from.wide]: {
+						...gridItemPlacement(1, 14),
+					},
+				}}
+			>
+				<WithStandardTopMargin>
+					<YourDataSection
+						consents={consents}
+						toggleConsent={toggleConsentSubscription}
+					/>
+					<Lines n={1} />
+					<CookiesOnThisBrowserSection onClick={openManageCookies} />
+					<Lines n={1} />
+					<LearnMoreSection />
+				</WithStandardTopMargin>
+			</div>
 		</div>
 	);
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Updating the design for the data privacy page
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
![Screenshot 2023-04-17 at 10 24 31](https://user-images.githubusercontent.com/106528085/232443012-129d9e23-7635-47a4-96f9-23a570cca382.png)
![Screenshot 2023-04-17 at 10 24 49](https://user-images.githubusercontent.com/106528085/232443033-f9f0763e-9c02-4318-a7f5-1f6284355fd4.png)
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
