### PR TITLE
Merge app subscriptions into other 'Subscriptions' category

### DIFF
--- a/client/components/mma/accountoverview/AccountOverview.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.tsx
@@ -112,6 +112,14 @@ const AccountOverviewPage = () => {
 	);
 
 	if (
+		featureSwitches.appSubscriptions &&
+		appSubscriptions.length > 0 &&
+		!productCategories.includes('subscriptions')
+	) {
+		productCategories.push('subscriptions');
+	}
+
+	if (
 		(allActiveProductDetails.length === 0 &&
 			appSubscriptions.length === 0) ||
 		(allActiveProductDetails.length === 0 &&
@@ -231,23 +239,19 @@ const AccountOverviewPage = () => {
 										/>
 									</div>
 								)}
+							{featureSwitches.appSubscriptions &&
+								appSubscriptions.length > 0 &&
+								category == 'subscriptions' &&
+								appSubscriptions.map((subscription) => (
+									<InAppPurchaseCard
+										key={subscription.subscriptionId}
+										subscription={subscription}
+									/>
+								))}
 						</Stack>
 					</Fragment>
 				);
 			})}
-			{featureSwitches.appSubscriptions && appSubscriptions.length > 0 && (
-				<>
-					<h2 css={subHeadingCss}>Subscriptions</h2>
-					<Stack space={6}>
-						{appSubscriptions.map((subscription) => (
-							<InAppPurchaseCard
-								key={subscription.subscriptionId}
-								subscription={subscription}
-							/>
-						))}
-					</Stack>
-				</>
-			)}
 		</>
 	);
 };

--- a/client/components/mma/accountoverview/AccountOverview.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.tsx
@@ -241,7 +241,7 @@ const AccountOverviewPage = () => {
 								)}
 							{featureSwitches.appSubscriptions &&
 								appSubscriptions.length > 0 &&
-								category == 'subscriptions' &&
+								category === 'subscriptions' &&
 								appSubscriptions.map((subscription) => (
 									<InAppPurchaseCard
 										key={subscription.subscriptionId}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Merges App subscriptions from a separate category with heading 'Subscriptions' into the same section as other Subscriptions (which come from a different data source).

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

See [this PR](https://github.com/guardian/manage-frontend/pull/1037)

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://user-images.githubusercontent.com/114918544/232455882-b9093bc3-4ac6-47fe-853c-91c82ce3283a.png)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
