### PR TITLE
Membership Saves - Create Switching Page [Initial design]

### DIFF
--- a/client/components/mma/cancel/cancellationSaves/CancellationSaves.stories.tsx
+++ b/client/components/mma/cancel/cancellationSaves/CancellationSaves.stories.tsx
@@ -3,6 +3,7 @@ import { ReactRouterDecorator } from '../../../../../.storybook/ReactRouterDecor
 import { PRODUCT_TYPES } from '../../../../../shared/productTypes';
 import { membership } from '../../../../fixtures/productDetail';
 import { CancellationContainer } from '../CancellationContainer';
+import { MembershipSwitch } from './MembershipSwitch';
 import { ValueOfSupport } from './ValueOfSupport';
 
 export default {
@@ -20,6 +21,10 @@ export default {
 	},
 } as ComponentMeta<typeof CancellationContainer>;
 
-export const Default: ComponentStory<typeof ValueOfSupport> = () => {
+export const ValueOfSupportPage: ComponentStory<typeof ValueOfSupport> = () => {
 	return <ValueOfSupport />;
+};
+
+export const Switch: ComponentStory<typeof MembershipSwitch> = () => {
+	return <MembershipSwitch />;
 };

--- a/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
@@ -1,0 +1,165 @@
+import { css, ThemeProvider } from '@emotion/react';
+import { palette, space, textSans } from '@guardian/source-foundations';
+import {
+	Button,
+	buttonThemeReaderRevenueBrand,
+	Stack,
+	SvgClock,
+	SvgCreditCard,
+} from '@guardian/source-react-components';
+import { useNavigate } from 'react-router';
+import { Card } from '../../shared/Card';
+import { Heading } from '../../shared/Heading';
+import {
+	buttonCentredCss,
+	buttonLayoutCss,
+	iconListCss,
+	listWithDividersCss,
+	newAmountCss,
+	productTitleCss,
+	sectionSpacing,
+	smallPrintCss,
+} from './SaveStyles';
+
+const YourNewSupport = () => (
+	<section css={sectionSpacing}>
+		<Heading
+			sansSerif
+			cssOverrides={css`
+				margin-bottom: ${space[3]}px;
+			`}
+		>
+			Your new support
+		</Heading>
+		<Card>
+			<Card.Header backgroundColor={palette.brand[500]}>
+				<h3 css={productTitleCss}>Monthly</h3>
+			</Card.Header>
+			<Card.Section>
+				<p
+					css={css`
+						${textSans.medium()};
+						margin: 0;
+					`}
+				>
+					Monthly support with supporter newsletter and fewer asks for
+					support
+				</p>
+				<p css={newAmountCss}>XY/month</p>
+			</Card.Section>
+		</Card>
+	</section>
+);
+
+const WhatHappensNext = () => (
+	<section css={sectionSpacing}>
+		<Stack space={4}>
+			<Heading sansSerif>What happens next?</Heading>
+			<ul css={[iconListCss, listWithDividersCss]}>
+				<li>
+					<SvgClock size="medium" />
+					<span>
+						<strong>
+							Your new support will start at the end of your
+							billing period
+						</strong>
+						<br />
+						You will be charged XY from the XX month. From that
+						date, you will continue to receive the supporter
+						newsletter and see fewer support asks but you will lose
+						access to premium features in the App and ad-free
+						reading.
+					</span>
+				</li>
+				<li>
+					<SvgCreditCard size="medium" />
+					<span>
+						<strong>Your payment method</strong>
+						<br />
+						The payment will be taken from{' '}
+						{/* <PaymentDetails
+            subscription={
+                contributionToSwitch.subscription
+            }
+        /> */}
+					</span>
+				</li>
+			</ul>
+		</Stack>
+	</section>
+);
+
+const TsAndCs = () => (
+	<section css={sectionSpacing}>
+		<p css={smallPrintCss}>
+			This subscription auto-renews and you will be charged the applicable
+			monthly amount each time it renews unless you cancel. You can change
+			how much you pay at any time but
+		</p>
+		<p css={smallPrintCss}>
+			By proceeding, you are agreeing to our{' '}
+			<a href="https://www.theguardian.com/info/2022/oct/28/the-guardian-supporter-plus-terms-and-conditions">
+				Terms and Conditions
+			</a>
+			.
+		</p>
+		<p css={smallPrintCss}>
+			To find out what personal data we collect and how we use it, please
+			visit our{' '}
+			<a href="https://www.theguardian.com/help/privacy-policy">
+				Privacy Policy
+			</a>
+			.
+		</p>
+	</section>
+);
+
+export const MembershipSwitch = () => {
+	const navigate = useNavigate();
+
+	return (
+		<>
+			<section css={sectionSpacing}>
+				<Heading sansSerif>Review change</Heading>
+				<p
+					css={css`
+						${textSans.medium()}
+						margin: 0;
+					`}
+				>
+					You are changing your current membership for a XY Monthly.
+				</p>
+			</section>
+			<YourNewSupport />
+			<WhatHappensNext />
+			<section css={sectionSpacing}>
+				<p
+					css={css`
+						${textSans.medium()}
+						border-top: 1px solid ${palette.neutral[86]};
+						padding-top: ${space[5]}px;
+					`}
+				>
+					Please note that, once the change is done, you will not be
+					able to have the full set of benefits for £7 again (full
+					price is now £10).
+				</p>
+			</section>
+			<section css={[sectionSpacing, buttonLayoutCss]}>
+				<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
+					<Button cssOverrides={buttonCentredCss}>
+						Confirm change
+					</Button>
+				</ThemeProvider>
+				<Button
+					priority="tertiary"
+					cssOverrides={[buttonCentredCss]}
+					onClick={() => navigate('..')}
+				>
+					Back
+				</Button>
+			</section>
+			<TsAndCs />
+		</>
+	);
+};

--- a/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
@@ -7,9 +7,21 @@ import {
 	SvgClock,
 	SvgCreditCard,
 } from '@guardian/source-react-components';
-import { useNavigate } from 'react-router';
+import { useContext } from 'react';
+import { Navigate, useNavigate } from 'react-router';
+import { dateString } from '../../../../../shared/dates';
+import type {
+	PaidSubscriptionPlan} from '../../../../../shared/productResponse';
+import {
+	getMainPlan
+} from '../../../../../shared/productResponse';
 import { Card } from '../../shared/Card';
 import { Heading } from '../../shared/Heading';
+import type {
+	CancellationContextInterface} from '../CancellationContainer';
+import {
+	CancellationContext
+} from '../CancellationContainer';
 import {
 	buttonCentredCss,
 	buttonLayoutCss,
@@ -21,73 +33,82 @@ import {
 	smallPrintCss,
 } from './SaveStyles';
 
-const YourNewSupport = () => (
-	<section css={sectionSpacing}>
-		<Heading
-			sansSerif
-			cssOverrides={css`
-				margin-bottom: ${space[3]}px;
-			`}
-		>
-			Your new support
-		</Heading>
-		<Card>
-			<Card.Header backgroundColor={palette.brand[500]}>
-				<h3 css={productTitleCss}>Monthly</h3>
-			</Card.Header>
-			<Card.Section>
-				<p
-					css={css`
-						${textSans.medium()};
-						margin: 0;
-					`}
-				>
-					Monthly support with supporter newsletter and fewer asks for
-					support
-				</p>
-				<p css={newAmountCss}>XY/month</p>
-			</Card.Section>
-		</Card>
-	</section>
-);
+const YourNewSupport = (props: { billingPeriod: string }) => {
+	const monthlyOrAnnual = getMonthlyOrAnnual(props.billingPeriod);
+	return (
+		<section css={sectionSpacing}>
+			<Heading
+				sansSerif
+				cssOverrides={css`
+					margin-bottom: ${space[3]}px;
+				`}
+			>
+				Your new support
+			</Heading>
+			<Card>
+				<Card.Header backgroundColor={palette.brand[500]}>
+					<h3 css={productTitleCss}>{monthlyOrAnnual}</h3>
+				</Card.Header>
+				<Card.Section>
+					<p
+						css={css`
+							${textSans.medium()};
+							margin: 0;
+						`}
+					>
+						{monthlyOrAnnual} support with supporter newsletter and
+						fewer asks for support
+					</p>
+					<p css={newAmountCss}>XY/{props.billingPeriod}</p>
+				</Card.Section>
+			</Card>
+		</section>
+	);
+};
 
-const WhatHappensNext = () => (
-	<section css={sectionSpacing}>
-		<Stack space={4}>
-			<Heading sansSerif>What happens next?</Heading>
-			<ul css={[iconListCss, listWithDividersCss]}>
-				<li>
-					<SvgClock size="medium" />
-					<span>
-						<strong>
-							Your new support will start at the end of your
-							billing period
-						</strong>
-						<br />
-						You will be charged XY from the XX month. From that
-						date, you will continue to receive the supporter
-						newsletter and see fewer support asks but you will lose
-						access to premium features in the App and ad-free
-						reading.
-					</span>
-				</li>
-				<li>
-					<SvgCreditCard size="medium" />
-					<span>
-						<strong>Your payment method</strong>
-						<br />
-						The payment will be taken from{' '}
-						{/* <PaymentDetails
+const WhatHappensNext = (props: { nextBillingDate: string }) => {
+	const nextPaymentDate = dateString(
+		new Date(props.nextBillingDate),
+		'd MMMM',
+	);
+	return (
+		<section css={sectionSpacing}>
+			<Stack space={4}>
+				<Heading sansSerif>What happens next?</Heading>
+				<ul css={[iconListCss, listWithDividersCss]}>
+					<li>
+						<SvgClock size="medium" />
+						<span>
+							<strong>
+								Your new support will start at the end of your
+								billing period
+							</strong>
+							<br />
+							You will be charged XY from the {nextPaymentDate}.
+							From that date, you will continue to receive the
+							supporter newsletter and see fewer support asks but
+							you will lose access to premium features in the App
+							and ad-free reading.
+						</span>
+					</li>
+					<li>
+						<SvgCreditCard size="medium" />
+						<span>
+							<strong>Your payment method</strong>
+							<br />
+							The payment will be taken from{' '}
+							{/* <PaymentDetails
             subscription={
                 contributionToSwitch.subscription
             }
         /> */}
-					</span>
-				</li>
-			</ul>
-		</Stack>
-	</section>
-);
+						</span>
+					</li>
+				</ul>
+			</Stack>
+		</section>
+	);
+};
 
 const TsAndCs = () => (
 	<section css={sectionSpacing}>
@@ -116,6 +137,21 @@ const TsAndCs = () => (
 
 export const MembershipSwitch = () => {
 	const navigate = useNavigate();
+	const cancellationContext = useContext(
+		CancellationContext,
+	) as CancellationContextInterface;
+	const membership = cancellationContext.productDetail;
+
+	if (!membership) {
+		return <Navigate to="/" />;
+	}
+	const mainPlan = getMainPlan(
+		membership.subscription,
+	) as PaidSubscriptionPlan;
+
+	const currentPrice = membership.subscription.plan?.price;
+	const billingPeriod = membership.subscription.plan?.billingPeriod ?? '';
+	const monthlyOrAnnual = getMonthlyOrAnnual(billingPeriod);
 
 	return (
 		<>
@@ -127,11 +163,15 @@ export const MembershipSwitch = () => {
 						margin: 0;
 					`}
 				>
-					You are changing your current membership for a XY Monthly.
+					You are changing your current membership for a{' '}
+					{mainPlan.currency}
+					{currentPrice} {monthlyOrAnnual}.
 				</p>
 			</section>
-			<YourNewSupport />
-			<WhatHappensNext />
+			<YourNewSupport billingPeriod={billingPeriod} />
+			<WhatHappensNext
+				nextBillingDate={membership.subscription.plan?.end ?? ''}
+			/>
 			<section css={sectionSpacing}>
 				<p
 					css={css`
@@ -163,3 +203,6 @@ export const MembershipSwitch = () => {
 		</>
 	);
 };
+function getMonthlyOrAnnual(billingPeriod: string | undefined) {
+	return billingPeriod === 'year' ? 'Annual' : 'Monthly';
+}

--- a/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
+++ b/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
@@ -1,0 +1,103 @@
+import { css } from '@emotion/react';
+import {
+	from,
+	headline,
+	palette,
+	space,
+	textSans,
+} from '@guardian/source-foundations';
+
+export const sectionSpacing = css`
+	margin-top: ${space[6]}px;
+	${from.tablet} {
+		margin-top: ${space[9]}px;
+	}
+`;
+
+export const productTitleCss = css`
+	${headline.xsmall({ fontWeight: 'bold' })};
+	color: ${palette.neutral[100]};
+	margin: 0;
+	max-width: 20ch;
+	${from.tablet} {
+		${headline.small({ fontWeight: 'bold' })};
+	}
+`;
+
+export const newAmountCss = css`
+	${textSans.medium({ fontWeight: 'bold' })};
+	padding-top: ${space[3]}px;
+	margin-top: ${space[4]}px;
+	margin-bottom: 0;
+	border-top: 1px solid ${palette.neutral[86]};
+`;
+
+export const iconListCss = css`
+	${textSans.medium()};
+	list-style: none;
+	padding: 0;
+	margin-bottom: 0;
+
+	li + li {
+		margin-top: ${space[2]}px;
+		${from.tablet} {
+			margin-top: ${space[3]}px;
+		}
+	}
+
+	li {
+		display: flex;
+		margin-left: -4px;
+		align-items: flex-start;
+
+		> svg {
+			flex-shrink: 0;
+			margin-right: 8px;
+			fill: currentColor;
+		}
+	}
+`;
+
+export const listWithDividersCss = css`
+	li + li {
+		> svg {
+			padding-top: ${space[2]}px;
+			${from.tablet} {
+				padding-top: ${space[3]}px;
+			}
+		}
+		> span {
+			flex-grow: 1;
+			padding-top: ${space[2]}px;
+			border-top: 1px solid ${palette.neutral[86]};
+			min-width: 0;
+			${from.tablet} {
+				padding-top: ${space[3]}px;
+			}
+		}
+	}
+`;
+
+export const buttonCentredCss = css`
+	justify-content: center;
+`;
+
+export const buttonLayoutCss = css`
+	> * + * {
+		margin-left: ${space[3]}px;
+	}
+`;
+
+export const smallPrintCss = css`
+	${textSans.xxsmall()};
+	margin-top: 0;
+	margin-bottom: 0;
+	color: #606060;
+	> a {
+		color: inherit;
+		text-decoration: underline;
+	}
+	& + & {
+		margin-top: ${space[1]}px;
+	}
+`;

--- a/client/components/mma/cancel/cancellationSaves/ValueOfSupport.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ValueOfSupport.tsx
@@ -10,11 +10,8 @@ import { Navigate, useNavigate } from 'react-router';
 import { dateString } from '../../../../../shared/dates';
 import { Heading } from '../../shared/Heading';
 import { ProgressIndicator } from '../../shared/ProgressIndicator';
-import type {
-	CancellationContextInterface} from '../CancellationContainer';
-import {
-	CancellationContext
-} from '../CancellationContainer';
+import type { CancellationContextInterface } from '../CancellationContainer';
+import { CancellationContext } from '../CancellationContainer';
 
 const buttonLayoutCss = css`
 	text-align: right;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Create the initial design of the Switching Page in new Membership save journey.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Added to storybook, not yet hooked up to any routes.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://user-images.githubusercontent.com/114918544/233049459-e3c56c21-552f-4d03-b1b2-e61ce3e57dc4.png)


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
