### PR TITLE
Membership Cancel save offers v1 

### DIFF
--- a/client/components/mma/cancel/cancellationSaves/MembershipCancellationSaves.stories.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipCancellationSaves.stories.tsx
@@ -3,6 +3,7 @@ import { ReactRouterDecorator } from '../../../../../.storybook/ReactRouterDecor
 import { PRODUCT_TYPES } from '../../../../../shared/productTypes';
 import { membership } from '../../../../fixtures/productDetail';
 import { CancellationContainer } from '../CancellationContainer';
+import { SwitchingOptions } from './SwitchingOptions';
 import { ValueOfSupport } from './ValueOfSupport';
 
 export default {
@@ -20,6 +21,12 @@ export default {
 	},
 } as ComponentMeta<typeof CancellationContainer>;
 
-export const Default: ComponentStory<typeof ValueOfSupport> = () => {
+export const ValueOfSupportPage: ComponentStory<typeof ValueOfSupport> = () => {
 	return <ValueOfSupport />;
+};
+
+export const SwitchOptionsPage: ComponentStory<
+	typeof SwitchingOptions
+> = () => {
+	return <SwitchingOptions />;
 };

--- a/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
+++ b/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
@@ -101,3 +101,16 @@ export const smallPrintCss = css`
 		margin-top: ${space[1]}px;
 	}
 `;
+
+export const productSubtitleCss = css`
+	${textSans.medium({ fontWeight: 'bold' })};
+	color: ${palette.neutral[100]};
+	margin: 0;
+	max-width: 20ch;
+`;
+
+export const cardHeaderDivCss = css`
+	display: flex;
+	justify-content: space-between;
+	align-items: flex-end;
+`;

--- a/client/components/mma/cancel/cancellationSaves/SwitchingOptions.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SwitchingOptions.tsx
@@ -1,0 +1,106 @@
+import { css } from '@emotion/react';
+import { palette, space, textSans } from '@guardian/source-foundations';
+import {
+	Button,
+	Stack,
+	SvgArrowRightStraight,
+} from '@guardian/source-react-components';
+import { formatAmount } from '../../../../utilities/utils';
+import { Card } from '../../shared/Card';
+import { Heading } from '../../shared/Heading';
+import { MembershipBenefitsSection } from '../../shared/MembershipBenefits';
+import { ProgressIndicator } from '../../shared/ProgressIndicator';
+/*import { useContext } from 'react';
+import {
+	SwitchContext,
+	SwitchContextInterface,
+} from '../../switch/SwitchContainer';*/
+import { RecurringSupporterBenefitsSection } from '../../shared/RecurringSupporterBenefits';
+import { productTitleCss } from '../../switch/SwitchStyles';
+
+export const SwitchingOptions = () => {
+	/*const switchContext = useContext(SwitchContext) as SwitchContextInterface;
+	const { mainPlan } = switchContext;*/
+
+	const cardHeaderDivCss = css`
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-end;
+	`;
+	const productSubtitleCss = css`
+		${textSans.medium({ fontWeight: 'bold' })};
+		color: ${palette.neutral[100]};
+		margin: 0;
+		max-width: 20ch;
+	`;
+
+	const buttonLayoutCss = css`
+		text-align: right;
+		> * + * {
+			margin-left: ${space[3]}px;
+		}
+	`;
+
+	return (
+		<>
+			<ProgressIndicator
+				steps={[
+					{ title: '' },
+					{ title: 'Offer', isCurrentStep: true },
+					{ title: '' },
+				]}
+				additionalCSS={css`
+					margin: ${space[5]}px 0 ${space[12]}px;
+				`}
+			/>
+			<Stack space={4}>
+				<Heading>
+					Before you go, would you consider different support options
+				</Heading>
+				<Heading sansSerif>
+					Continue your membership at £7 per month
+				</Heading>
+				You will keep your current set of benefits
+				<Card>
+					<Card.Header backgroundColor={palette.brand[600]}>
+						<div css={cardHeaderDivCss}>
+							<h3 css={productTitleCss}>Membership</h3>
+							<p css={productSubtitleCss}>
+								£{formatAmount(7)}/month
+							</p>
+						</div>
+					</Card.Header>
+					<Card.Section>
+						<MembershipBenefitsSection />
+					</Card.Section>
+				</Card>
+				<Heading sansSerif>
+					Continue your membership at £5 per month
+				</Heading>
+				You will still be able to enjoy uninterrupted reading and
+				receive the supporter newsletter.
+				<Card>
+					<Card.Header backgroundColor={palette.brand[600]}>
+						<div css={cardHeaderDivCss}>
+							<h3 css={productTitleCss}>Recurring supporter</h3>
+							<p css={productSubtitleCss}>
+								£{formatAmount(5)}/month
+							</p>
+						</div>
+					</Card.Header>
+					<Card.Section>
+						<RecurringSupporterBenefitsSection />
+					</Card.Section>
+				</Card>
+				<Heading sansSerif>Cancel your membership</Heading>
+				Copy to say that you cannot become a member again once you have
+				cancelled.
+			</Stack>
+			<div css={buttonLayoutCss}>
+				<Button icon={<SvgArrowRightStraight />} iconSide="right">
+					Cancel membership
+				</Button>
+			</div>
+		</>
+	);
+};

--- a/client/components/mma/cancel/cancellationSaves/SwitchingOptions.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SwitchingOptions.tsx
@@ -5,23 +5,15 @@ import {
 	Stack,
 	SvgArrowRightStraight,
 } from '@guardian/source-react-components';
-import { formatAmount } from '../../../../utilities/utils';
 import { Card } from '../../shared/Card';
 import { Heading } from '../../shared/Heading';
 import { MembershipBenefitsSection } from '../../shared/MembershipBenefits';
 import { ProgressIndicator } from '../../shared/ProgressIndicator';
-/*import { useContext } from 'react';
-import {
-	SwitchContext,
-	SwitchContextInterface,
-} from '../../switch/SwitchContainer';*/
 import { RecurringSupporterBenefitsSection } from '../../shared/RecurringSupporterBenefits';
-import { productTitleCss } from '../../switch/SwitchStyles';
+import { productTitleCss, sectionSpacing } from '../../switch/SwitchStyles';
+import { buttonLayoutCss } from './SaveStyles';
 
 export const SwitchingOptions = () => {
-	/*const switchContext = useContext(SwitchContext) as SwitchContextInterface;
-	const { mainPlan } = switchContext;*/
-
 	const cardHeaderDivCss = css`
 		display: flex;
 		justify-content: space-between;
@@ -32,13 +24,6 @@ export const SwitchingOptions = () => {
 		color: ${palette.neutral[100]};
 		margin: 0;
 		max-width: 20ch;
-	`;
-
-	const buttonLayoutCss = css`
-		text-align: right;
-		> * + * {
-			margin-left: ${space[3]}px;
-		}
 	`;
 
 	return (
@@ -54,53 +39,80 @@ export const SwitchingOptions = () => {
 				`}
 			/>
 			<Stack space={4}>
-				<Heading>
-					Before you go, would you consider different support options
-				</Heading>
-				<Heading sansSerif>
-					Continue your membership at £7 per month
-				</Heading>
+				<section css={sectionSpacing}>
+					<Heading>
+						Before you go, would you consider different support
+						options
+					</Heading>
+				</section>
+				<section css={sectionSpacing}>
+					<Heading sansSerif>
+						Continue your membership at X per month
+					</Heading>
+				</section>
 				You will keep your current set of benefits
 				<Card>
 					<Card.Header backgroundColor={palette.brand[600]}>
 						<div css={cardHeaderDivCss}>
 							<h3 css={productTitleCss}>Membership</h3>
-							<p css={productSubtitleCss}>
-								£{formatAmount(7)}/month
-							</p>
+							<p css={productSubtitleCss}>XY/Z</p>
 						</div>
 					</Card.Header>
 					<Card.Section>
 						<MembershipBenefitsSection />
+						<section css={sectionSpacing}>
+							<div css={buttonLayoutCss}>
+								<Button
+									icon={<SvgArrowRightStraight />}
+									iconSide="right"
+								>
+									Continue your membership
+								</Button>
+							</div>
+						</section>
 					</Card.Section>
 				</Card>
-				<Heading sansSerif>
-					Continue your membership at £5 per month
-				</Heading>
+				<section css={sectionSpacing}>
+					<Heading sansSerif>
+						Continue your membership at X per month
+					</Heading>
+				</section>
 				You will still be able to enjoy uninterrupted reading and
 				receive the supporter newsletter.
 				<Card>
 					<Card.Header backgroundColor={palette.brand[600]}>
 						<div css={cardHeaderDivCss}>
 							<h3 css={productTitleCss}>Recurring supporter</h3>
-							<p css={productSubtitleCss}>
-								£{formatAmount(5)}/month
-							</p>
+							<p css={productSubtitleCss}>XY/Z</p>
 						</div>
 					</Card.Header>
 					<Card.Section>
 						<RecurringSupporterBenefitsSection />
+						<section css={sectionSpacing}>
+							<div css={buttonLayoutCss}>
+								<Button
+									icon={<SvgArrowRightStraight />}
+									iconSide="right"
+								>
+									Become a recurring supporter
+								</Button>
+							</div>
+						</section>
 					</Card.Section>
 				</Card>
-				<Heading sansSerif>Cancel your membership</Heading>
-				Copy to say that you cannot become a member again once you have
-				cancelled.
+				<section css={sectionSpacing}>
+					<Heading sansSerif>Cancel your membership</Heading>
+					Copy to say that you cannot become a member again once you
+					have cancelled.
+				</section>
 			</Stack>
-			<div css={buttonLayoutCss}>
-				<Button icon={<SvgArrowRightStraight />} iconSide="right">
-					Cancel membership
-				</Button>
-			</div>
+			<section css={sectionSpacing}>
+				<div css={buttonLayoutCss}>
+					<Button icon={<SvgArrowRightStraight />} iconSide="right">
+						Cancel membership
+					</Button>
+				</div>
+			</section>
 		</>
 	);
 };

--- a/client/components/mma/cancel/cancellationSaves/SwitchingOptions.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SwitchingOptions.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { palette, space, textSans } from '@guardian/source-foundations';
+import { palette, space } from '@guardian/source-foundations';
 import {
 	Button,
 	Stack,
@@ -11,21 +11,13 @@ import { MembershipBenefitsSection } from '../../shared/MembershipBenefits';
 import { ProgressIndicator } from '../../shared/ProgressIndicator';
 import { RecurringSupporterBenefitsSection } from '../../shared/RecurringSupporterBenefits';
 import { productTitleCss, sectionSpacing } from '../../switch/SwitchStyles';
-import { buttonLayoutCss } from './SaveStyles';
+import {
+	buttonLayoutCss,
+	cardHeaderDivCss,
+	productSubtitleCss,
+} from './SaveStyles';
 
 export const SwitchingOptions = () => {
-	const cardHeaderDivCss = css`
-		display: flex;
-		justify-content: space-between;
-		align-items: flex-end;
-	`;
-	const productSubtitleCss = css`
-		${textSans.medium({ fontWeight: 'bold' })};
-		color: ${palette.neutral[100]};
-		margin: 0;
-		max-width: 20ch;
-	`;
-
 	return (
 		<>
 			<ProgressIndicator

--- a/client/components/mma/shared/BenefitsStyles.tsx
+++ b/client/components/mma/shared/BenefitsStyles.tsx
@@ -1,0 +1,38 @@
+import { css } from '@emotion/react';
+import { from, palette, space, textSans } from '@guardian/source-foundations';
+
+export const benefitsCss = css`
+	${textSans.medium()};
+	list-style: none;
+	margin: 0 0 0 -4px;
+	padding: 0;
+
+	li + li {
+		margin-top: ${space[2]}px;
+	}
+
+	li {
+		display: flex;
+		align-items: flex-start;
+	}
+
+	svg {
+		flex-shrink: 0;
+		margin-right: ${space[2]}px;
+		fill: ${palette.brand[500]};
+	}
+`;
+
+export const lineBreakCss = css`
+	${from.tablet} {
+		display: none;
+	}
+`;
+
+export const benefitsButtonCss = css`
+	${textSans.small()}
+	margin-top: ${space[1]}px;
+	padding: 0;
+	color: ${palette.brand[500]};
+	border-bottom: 1px solid ${palette.brand[500]};
+`;

--- a/client/components/mma/shared/MembershipBenefits.tsx
+++ b/client/components/mma/shared/MembershipBenefits.tsx
@@ -1,36 +1,7 @@
-import { css } from '@emotion/react';
-import { from, palette, space, textSans } from '@guardian/source-foundations';
 import { SvgTickRound } from '@guardian/source-react-components';
+import { benefitsCss, lineBreakCss } from './BenefitsStyles';
 
 export const MembershipBenefitsSection = () => {
-	const benefitsCss = css`
-		${textSans.medium()};
-		list-style: none;
-		margin: 0 0 0 -4px;
-		padding: 0;
-
-		li + li {
-			margin-top: ${space[2]}px;
-		}
-
-		li {
-			display: flex;
-			align-items: flex-start;
-		}
-
-		svg {
-			flex-shrink: 0;
-			margin-right: ${space[2]}px;
-			fill: ${palette.brand[500]};
-		}
-	`;
-
-	const lineBreakCss = css`
-		${from.tablet} {
-			display: none;
-		}
-	`;
-
 	return (
 		<ul id="benefits" css={benefitsCss}>
 			<li>

--- a/client/components/mma/shared/MembershipBenefits.tsx
+++ b/client/components/mma/shared/MembershipBenefits.tsx
@@ -1,16 +1,6 @@
 import { css } from '@emotion/react';
 import { from, palette, space, textSans } from '@guardian/source-foundations';
 import { SvgTickRound } from '@guardian/source-react-components';
-import { useState } from 'react';
-import { expanderButtonCss } from '../../shared/ExpanderButton';
-
-const benefitsButtonCss = css`
-	${textSans.small()}
-	margin-top: ${space[1]}px;
-	padding: 0;
-	color: ${palette.brand[500]};
-	border-bottom: 1px solid ${palette.brand[500]};
-`;
 
 export const MembershipBenefitsSection = () => {
 	const benefitsCss = css`
@@ -67,36 +57,10 @@ export const MembershipBenefitsSection = () => {
 			<li>
 				<SvgTickRound size="small" />
 				<span>
-					<strong>A regular supporter newsletter.</strong> Giving you
-					editorial insight on the week's top stories
+					<strong>Supporter newsletter.</strong> Giving you editorial
+					insight on the week's top stories
 				</span>
 			</li>
 		</ul>
-	);
-};
-
-export const MembershipBenefitsToggle = () => {
-	const [showBenefits, setShowBenefits] = useState<boolean>(false);
-
-	return (
-		<>
-			<div
-				css={css`
-					margin: ${space[5]}px 0 ${space[4]}px 0;
-				`}
-				hidden={!showBenefits}
-			>
-				<MembershipBenefitsSection />
-			</div>
-			<button
-				css={[expanderButtonCss()(showBenefits), benefitsButtonCss]}
-				type="button"
-				aria-expanded={showBenefits}
-				aria-controls="benefits"
-				onClick={() => setShowBenefits(!showBenefits)}
-			>
-				{showBenefits ? 'hide' : 'view'} extras
-			</button>
-		</>
 	);
 };

--- a/client/components/mma/shared/MembershipBenefits.tsx
+++ b/client/components/mma/shared/MembershipBenefits.tsx
@@ -1,0 +1,102 @@
+import { css } from '@emotion/react';
+import { from, palette, space, textSans } from '@guardian/source-foundations';
+import { SvgTickRound } from '@guardian/source-react-components';
+import { useState } from 'react';
+import { expanderButtonCss } from '../../shared/ExpanderButton';
+
+const benefitsButtonCss = css`
+	${textSans.small()}
+	margin-top: ${space[1]}px;
+	padding: 0;
+	color: ${palette.brand[500]};
+	border-bottom: 1px solid ${palette.brand[500]};
+`;
+
+export const MembershipBenefitsSection = () => {
+	const benefitsCss = css`
+		${textSans.medium()};
+		list-style: none;
+		margin: 0 0 0 -4px;
+		padding: 0;
+
+		li + li {
+			margin-top: ${space[2]}px;
+		}
+
+		li {
+			display: flex;
+			align-items: flex-start;
+		}
+
+		svg {
+			flex-shrink: 0;
+			margin-right: ${space[2]}px;
+			fill: ${palette.brand[500]};
+		}
+	`;
+
+	const lineBreakCss = css`
+		${from.tablet} {
+			display: none;
+		}
+	`;
+
+	return (
+		<ul id="benefits" css={benefitsCss}>
+			<li>
+				<SvgTickRound size="small" />
+				<span>
+					<strong>Unlimited app access.</strong>
+					<br css={lineBreakCss} /> For the best mobile experience
+				</span>
+			</li>
+			<li>
+				<SvgTickRound size="small" />
+				<span>
+					<strong>Ad-free reading.</strong>
+					<br css={lineBreakCss} /> On any device when signed in
+				</span>
+			</li>
+			<li>
+				<SvgTickRound size="small" />
+				<span>
+					<strong>Uninterrupted reading.</strong>
+					<br css={lineBreakCss} /> No more yellow banners
+				</span>
+			</li>
+			<li>
+				<SvgTickRound size="small" />
+				<span>
+					<strong>A regular supporter newsletter.</strong> Giving you
+					editorial insight on the week's top stories
+				</span>
+			</li>
+		</ul>
+	);
+};
+
+export const MembershipBenefitsToggle = () => {
+	const [showBenefits, setShowBenefits] = useState<boolean>(false);
+
+	return (
+		<>
+			<div
+				css={css`
+					margin: ${space[5]}px 0 ${space[4]}px 0;
+				`}
+				hidden={!showBenefits}
+			>
+				<MembershipBenefitsSection />
+			</div>
+			<button
+				css={[expanderButtonCss()(showBenefits), benefitsButtonCss]}
+				type="button"
+				aria-expanded={showBenefits}
+				aria-controls="benefits"
+				onClick={() => setShowBenefits(!showBenefits)}
+			>
+				{showBenefits ? 'hide' : 'view'} extras
+			</button>
+		</>
+	);
+};

--- a/client/components/mma/shared/RecurringSupporterBenefits.tsx
+++ b/client/components/mma/shared/RecurringSupporterBenefits.tsx
@@ -1,0 +1,103 @@
+import { css } from '@emotion/react';
+import { from, palette, space, textSans } from '@guardian/source-foundations';
+import { SvgCrossRound, SvgTickRound } from '@guardian/source-react-components';
+import { useState } from 'react';
+import { expanderButtonCss } from '../../shared/ExpanderButton';
+
+const benefitsButtonCss = css`
+	${textSans.small()}
+	margin-top: ${space[1]}px;
+	padding: 0;
+	color: ${palette.brand[500]};
+	border-bottom: 1px solid ${palette.brand[500]};
+`;
+
+export const RecurringSupporterBenefitsSection = () => {
+	const benefitsCss = css`
+		${textSans.medium()};
+		list-style: none;
+		margin: 0 0 0 -4px;
+		padding: 0;
+
+		li + li {
+			margin-top: ${space[2]}px;
+		}
+
+		li {
+			display: flex;
+			align-items: flex-start;
+		}
+
+		svg {
+			flex-shrink: 0;
+			margin-right: ${space[2]}px;
+			fill: ${palette.brand[500]};
+		}
+	`;
+
+	const lineBreakCss = css`
+		${from.tablet} {
+			display: none;
+		}
+	`;
+
+	return (
+		<ul id="benefits" css={benefitsCss}>
+			<li>
+				<SvgTickRound size="small" />
+				<span>
+					<strong>Uninterrupted reading.</strong>
+					<br css={lineBreakCss} /> See far fewer asks for support
+				</span>
+			</li>
+			<li>
+				<SvgTickRound size="small" />
+				<span>
+					<strong>A regular supporter newsletter.</strong> Get
+					exclusive insight from our newsroom
+				</span>
+			</li>
+			<li>
+				<SvgCrossRound size="small" />
+				<span>
+					<strong>Unlimited app access.</strong>
+					<br css={lineBreakCss} />
+					Giving you editorial insight on the week's top stories
+				</span>
+			</li>
+			<li>
+				<SvgCrossRound size="small" />
+				<span>
+					<strong>Ad-free reading.</strong>
+					<br css={lineBreakCss} /> Avoid ads on all your devices
+				</span>
+			</li>
+		</ul>
+	);
+};
+
+export const RecurringSupporterBenefitsToggle = () => {
+	const [showBenefits, setShowBenefits] = useState<boolean>(false);
+
+	return (
+		<>
+			<div
+				css={css`
+					margin: ${space[5]}px 0 ${space[4]}px 0;
+				`}
+				hidden={!showBenefits}
+			>
+				<RecurringSupporterBenefitsSection />
+			</div>
+			<button
+				css={[expanderButtonCss()(showBenefits), benefitsButtonCss]}
+				type="button"
+				aria-expanded={showBenefits}
+				aria-controls="benefits"
+				onClick={() => setShowBenefits(!showBenefits)}
+			>
+				{showBenefits ? 'hide' : 'view'} extras
+			</button>
+		</>
+	);
+};

--- a/client/components/mma/shared/RecurringSupporterBenefits.tsx
+++ b/client/components/mma/shared/RecurringSupporterBenefits.tsx
@@ -1,36 +1,7 @@
-import { css } from '@emotion/react';
-import { from, palette, space, textSans } from '@guardian/source-foundations';
 import { SvgCrossRound, SvgTickRound } from '@guardian/source-react-components';
+import { benefitsCss, lineBreakCss } from './BenefitsStyles';
 
 export const RecurringSupporterBenefitsSection = () => {
-	const benefitsCss = css`
-		${textSans.medium()};
-		list-style: none;
-		margin: 0 0 0 -4px;
-		padding: 0;
-
-		li + li {
-			margin-top: ${space[2]}px;
-		}
-
-		li {
-			display: flex;
-			align-items: flex-start;
-		}
-
-		svg {
-			flex-shrink: 0;
-			margin-right: ${space[2]}px;
-			fill: ${palette.brand[500]};
-		}
-	`;
-
-	const lineBreakCss = css`
-		${from.tablet} {
-			display: none;
-		}
-	`;
-
 	return (
 		<ul id="benefits" css={benefitsCss}>
 			<li>

--- a/client/components/mma/shared/RecurringSupporterBenefits.tsx
+++ b/client/components/mma/shared/RecurringSupporterBenefits.tsx
@@ -1,16 +1,7 @@
 import { css } from '@emotion/react';
 import { from, palette, space, textSans } from '@guardian/source-foundations';
 import { SvgCrossRound, SvgTickRound } from '@guardian/source-react-components';
-import { useState } from 'react';
-import { expanderButtonCss } from '../../shared/ExpanderButton';
-
-const benefitsButtonCss = css`
-	${textSans.small()}
-	margin-top: ${space[1]}px;
-	padding: 0;
-	color: ${palette.brand[500]};
-	border-bottom: 1px solid ${palette.brand[500]};
-`;
+import { sans } from '../../../styles/fonts';
 
 export const RecurringSupporterBenefitsSection = () => {
 	const benefitsCss = css`
@@ -41,20 +32,33 @@ export const RecurringSupporterBenefitsSection = () => {
 		}
 	`;
 
+	const baseStyle = {
+		base: {
+			fontSize: '17px',
+			fontFamily: sans,
+			'::placeholder': {
+				color: '#c4c4c4',
+			},
+			':-ms-input-placeholder': {
+				color: '#c4c4c4',
+			},
+		},
+	};
+
 	return (
 		<ul id="benefits" css={benefitsCss}>
 			<li>
 				<SvgTickRound size="small" />
 				<span>
 					<strong>Uninterrupted reading.</strong>
-					<br css={lineBreakCss} /> See far fewer asks for support
+					<br css={lineBreakCss} /> No more yellow banners
 				</span>
 			</li>
 			<li>
 				<SvgTickRound size="small" />
 				<span>
-					<strong>A regular supporter newsletter.</strong> Get
-					exclusive insight from our newsroom
+					<strong>Supporter newsletter.</strong> Giving you editorial
+					insight on the week's top stories
 				</span>
 			</li>
 			<li>
@@ -62,42 +66,18 @@ export const RecurringSupporterBenefitsSection = () => {
 				<span>
 					<strong>Unlimited app access.</strong>
 					<br css={lineBreakCss} />
-					Giving you editorial insight on the week's top stories
+					For the best mobile experience
 				</span>
 			</li>
 			<li>
-				<SvgCrossRound size="small" />
-				<span>
-					<strong>Ad-free reading.</strong>
-					<br css={lineBreakCss} /> Avoid ads on all your devices
-				</span>
+				<div css={baseStyle}>
+					<SvgCrossRound size="small" />
+					<span>
+						<strong>Ad-free reading.</strong>
+						<br css={lineBreakCss} /> On any device when signed in
+					</span>
+				</div>
 			</li>
 		</ul>
-	);
-};
-
-export const RecurringSupporterBenefitsToggle = () => {
-	const [showBenefits, setShowBenefits] = useState<boolean>(false);
-
-	return (
-		<>
-			<div
-				css={css`
-					margin: ${space[5]}px 0 ${space[4]}px 0;
-				`}
-				hidden={!showBenefits}
-			>
-				<RecurringSupporterBenefitsSection />
-			</div>
-			<button
-				css={[expanderButtonCss()(showBenefits), benefitsButtonCss]}
-				type="button"
-				aria-expanded={showBenefits}
-				aria-controls="benefits"
-				onClick={() => setShowBenefits(!showBenefits)}
-			>
-				{showBenefits ? 'hide' : 'view'} extras
-			</button>
-		</>
 	);
 };

--- a/client/components/mma/shared/RecurringSupporterBenefits.tsx
+++ b/client/components/mma/shared/RecurringSupporterBenefits.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 import { from, palette, space, textSans } from '@guardian/source-foundations';
 import { SvgCrossRound, SvgTickRound } from '@guardian/source-react-components';
-import { sans } from '../../../styles/fonts';
 
 export const RecurringSupporterBenefitsSection = () => {
 	const benefitsCss = css`
@@ -32,19 +31,6 @@ export const RecurringSupporterBenefitsSection = () => {
 		}
 	`;
 
-	const baseStyle = {
-		base: {
-			fontSize: '17px',
-			fontFamily: sans,
-			'::placeholder': {
-				color: '#c4c4c4',
-			},
-			':-ms-input-placeholder': {
-				color: '#c4c4c4',
-			},
-		},
-	};
-
 	return (
 		<ul id="benefits" css={benefitsCss}>
 			<li>
@@ -70,13 +56,11 @@ export const RecurringSupporterBenefitsSection = () => {
 				</span>
 			</li>
 			<li>
-				<div css={baseStyle}>
-					<SvgCrossRound size="small" />
-					<span>
-						<strong>Ad-free reading.</strong>
-						<br css={lineBreakCss} /> On any device when signed in
-					</span>
-				</div>
+				<SvgCrossRound size="small" />
+				<span>
+					<strong>Ad-free reading.</strong>
+					<br css={lineBreakCss} /> On any device when signed in
+				</span>
 			</li>
 		</ul>
 	);

--- a/client/components/mma/shared/SupporterPlusBenefits.tsx
+++ b/client/components/mma/shared/SupporterPlusBenefits.tsx
@@ -1,46 +1,11 @@
 import { css } from '@emotion/react';
-import { from, palette, space, textSans } from '@guardian/source-foundations';
+import { space } from '@guardian/source-foundations';
 import { SvgTickRound } from '@guardian/source-react-components';
 import { useState } from 'react';
 import { expanderButtonCss } from '../../shared/ExpanderButton';
-
-const benefitsButtonCss = css`
-	${textSans.small()}
-	margin-top: ${space[1]}px;
-	padding: 0;
-	color: ${palette.brand[500]};
-	border-bottom: 1px solid ${palette.brand[500]};
-`;
+import { benefitsButtonCss, benefitsCss, lineBreakCss } from './BenefitsStyles';
 
 export const SupporterPlusBenefitsSection = () => {
-	const benefitsCss = css`
-		${textSans.medium()};
-		list-style: none;
-		margin: 0 0 0 -4px;
-		padding: 0;
-
-		li + li {
-			margin-top: ${space[2]}px;
-		}
-
-		li {
-			display: flex;
-			align-items: flex-start;
-		}
-
-		svg {
-			flex-shrink: 0;
-			margin-right: ${space[2]}px;
-			fill: ${palette.brand[500]};
-		}
-	`;
-
-	const lineBreakCss = css`
-		${from.tablet} {
-			display: none;
-		}
-	`;
-
 	return (
 		<ul id="benefits" css={benefitsCss}>
 			<li>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Creates the new switching options pages in the Membership save journey. This is the initial design so it may change and the buttons will need wired in.

Refactored benefits styles to be in one file to prevent repetition

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
New scenario added to storybook as this is not yet working

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
![image](https://user-images.githubusercontent.com/115992455/233113424-eeb21838-f84e-4a92-9431-a573afeb0cbc.png)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
