### PR TITLE
Icons and text greyed out when benefit is unavailable

### DIFF
--- a/client/components/mma/shared/RecurringSupporterBenefits.tsx
+++ b/client/components/mma/shared/RecurringSupporterBenefits.tsx
@@ -1,7 +1,16 @@
+import { css } from '@emotion/react';
+import { palette } from '@guardian/source-foundations';
 import { SvgCrossRound, SvgTickRound } from '@guardian/source-react-components';
 import { benefitsCss, lineBreakCss } from './BenefitsStyles';
 
 export const RecurringSupporterBenefitsSection = () => {
+	const unavailableBenefits = css`
+		color: ${palette.neutral[60]};
+		svg {
+			fill: ${palette.neutral[60]};
+		}
+	`;
+
 	return (
 		<ul id="benefits" css={benefitsCss}>
 			<li>
@@ -18,15 +27,14 @@ export const RecurringSupporterBenefitsSection = () => {
 					insight on the week's top stories
 				</span>
 			</li>
-			<li>
+			<li css={unavailableBenefits}>
 				<SvgCrossRound size="small" />
 				<span>
 					<strong>Unlimited app access.</strong>
-					<br css={lineBreakCss} />
-					For the best mobile experience
+					<br css={lineBreakCss} /> For the best mobile experience
 				</span>
 			</li>
-			<li>
+			<li css={unavailableBenefits}>
 				<SvgCrossRound size="small" />
 				<span>
 					<strong>Ad-free reading.</strong>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Cross icons for when benefit are not available and the text that goes along with it has been greyed out as per the design
## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
![image](https://user-images.githubusercontent.com/115992455/233400862-23be6310-5003-41c0-925e-721096e80395.png)


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
