### PR TITLE
Membership Saves - Cancellation Reasons Page 

### DIFF
--- a/client/components/mma/cancel/CancellationReasonSelection.tsx
+++ b/client/components/mma/cancel/CancellationReasonSelection.tsx
@@ -119,13 +119,8 @@ const ReasonPicker = ({
 							padding: ${space[5]}px;
 						`}
 					>
-						{productType.cancellation.reasons
-							.filter((reason: CancellationReason) =>
-								reason.shouldShow
-									? reason.shouldShow(productDetail)
-									: true,
-							)
-							.map((reason: CancellationReason) => (
+						{productType.cancellation.reasons.map(
+							(reason: CancellationReason) => (
 								<Radio
 									key={reason.reasonId}
 									name="cancellation-reason"
@@ -139,7 +134,8 @@ const ReasonPicker = ({
 										}
 									`}
 								/>
-							))}
+							),
+						)}
 					</RadioGroup>
 				</fieldset>
 				{inValidationErrorState && !selectedReasonId.length && (

--- a/client/components/mma/cancel/cancellationReason.ts
+++ b/client/components/mma/cancel/cancellationReason.ts
@@ -1,4 +1,3 @@
-import type { ProductDetail } from '../../../../shared/productResponse';
 import type { SavedBodyProps } from './stages/SavedCancellation';
 
 export interface SaveBodyProps {
@@ -19,7 +18,6 @@ export interface CancellationReason {
 	hideContactUs?: boolean;
 	skipFeedback?: boolean;
 	savedBody?: React.FC<SavedBodyProps>;
-	shouldShow?: (productDetail: ProductDetail) => boolean;
 }
 
 export type CancellationReasonId =

--- a/client/components/mma/cancel/cancellationSaves/CancellationSaves.stories.tsx
+++ b/client/components/mma/cancel/cancellationSaves/CancellationSaves.stories.tsx
@@ -5,8 +5,8 @@ import { membership } from '../../../../fixtures/productDetail';
 import { CancellationContainer } from '../CancellationContainer';
 import { MembershipCancellationLanding } from './MembershipCancellationLanding';
 import { MembershipSwitch } from './MembershipSwitch';
-import { SwitchingOptions } from './SwitchingOptions';
 import { SelectReason } from './SelectReason';
+import { SwitchingOptions } from './SwitchingOptions';
 import { ValueOfSupport } from './ValueOfSupport';
 
 export default {
@@ -39,7 +39,7 @@ export const LandingPage: ComponentStory<
 };
 
 export const SwitchOptions: ComponentStory<typeof SwitchingOptions> = () => {
-	return <SwitchingOptions/>;
+	return <SwitchingOptions />;
 };
 
 export const Reasons: ComponentStory<typeof SelectReason> = () => {

--- a/client/components/mma/cancel/cancellationSaves/CancellationSaves.stories.tsx
+++ b/client/components/mma/cancel/cancellationSaves/CancellationSaves.stories.tsx
@@ -6,6 +6,7 @@ import { CancellationContainer } from '../CancellationContainer';
 import { MembershipCancellationLanding } from './MembershipCancellationLanding';
 import { MembershipSwitch } from './MembershipSwitch';
 import { SwitchingOptions } from './SwitchingOptions';
+import { SelectReason } from './SelectReason';
 import { ValueOfSupport } from './ValueOfSupport';
 
 export default {
@@ -38,5 +39,9 @@ export const LandingPage: ComponentStory<
 };
 
 export const SwitchOptions: ComponentStory<typeof SwitchingOptions> = () => {
-	return <SwitchingOptions />;
+	return <SwitchingOptions/>;
+};
+
+export const Reasons: ComponentStory<typeof SelectReason> = () => {
+	return <SelectReason />;
 };

--- a/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
@@ -1,5 +1,3 @@
-import { css } from '@emotion/react';
-import { from, headline, palette } from '@guardian/source-foundations';
 import {
 	Button,
 	Stack,
@@ -8,21 +6,7 @@ import {
 import { CallCentreEmailAndNumbers } from '../../../shared/CallCenterEmailAndNumbers';
 import { Heading } from '../../shared/Heading';
 import { sectionSpacing } from '../../switch/SwitchStyles';
-import { buttonLayoutCss } from './SaveStyles';
-
-const headingCss = css`
-	${headline.xsmall({ fontWeight: 'bold' })};
-	margin-top: 0;
-	margin-bottom: 0;
-
-	${from.tablet} {
-		${headline.small({ fontWeight: 'bold' })};
-		span {
-			display: block;
-			color: ${palette.brand['500']};
-		}
-	}
-`;
+import { buttonLayoutCss, headingCss } from './SaveStyles';
 
 export const MembershipCancellationLanding = () => {
 	return (

--- a/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
+++ b/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
@@ -114,3 +114,17 @@ export const cardHeaderDivCss = css`
 	justify-content: space-between;
 	align-items: flex-end;
 `;
+
+export const headingCss = css`
+	${headline.xsmall({ fontWeight: 'bold' })};
+	margin-top: 0;
+	margin-bottom: 0;
+
+	${from.tablet} {
+		${headline.small({ fontWeight: 'bold' })};
+		span {
+			display: block;
+			color: ${palette.brand['500']};
+		}
+	}
+`;

--- a/client/components/mma/cancel/cancellationSaves/SelectReason.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SelectReason.tsx
@@ -1,0 +1,161 @@
+import { css } from '@emotion/react';
+import { from, palette, space, textSans } from '@guardian/source-foundations';
+import {
+	Button,
+	Radio,
+	RadioGroup,
+	Stack,
+	SvgCalendar,
+	SvgEnvelope,
+} from '@guardian/source-react-components';
+import { useNavigate } from 'react-router';
+import { ProgressIndicator } from '../../shared/ProgressIndicator';
+import type { CancellationReason } from '../cancellationReason';
+import { membershipCancellationReasons } from '../membership/MembershipCancellationReasons';
+import {
+	buttonCentredCss,
+	buttonLayoutCss,
+	headingCss,
+	sectionSpacing,
+} from './SaveStyles';
+
+const infoCss = css`
+	${textSans.medium()}
+	display: flex;
+	> svg {
+		flex-shrink: 0;
+		margin-right: 8px;
+		fill: currentColor;
+	}
+	> span {
+		padding-top: ${space[1]}px;
+	}
+`;
+
+const CancellationInfo = () => (
+	<ul
+		css={css`
+			padding-inline-start: 0;
+		`}
+	>
+		<Stack space={1}>
+			<li css={infoCss}>
+				<SvgCalendar size="medium" />
+				<span>
+					You'll continue to have access to your Membership benefits
+					until xx
+				</span>
+			</li>
+			<li css={infoCss}>
+				<SvgEnvelope size="medium" />
+				<span>We will send you a confirmation email at xx.com</span>
+			</li>
+		</Stack>
+	</ul>
+);
+
+const ReasonSelection = () => {
+	return (
+		<fieldset
+			// onChange={(event: FormEvent<HTMLFieldSetElement>) => {
+			// 	const target: HTMLInputElement =
+			// 		event.target as HTMLInputElement;
+			// 	setSelectedReasonId(target.value);
+			// }}
+			css={css`
+				border: 1px solid ${palette.neutral[86]};
+				margin: 0 0 ${space[5]}px;
+				padding: 0;
+			`}
+		>
+			<legend
+				css={css`
+					display: block;
+					width: 100%;
+					margin: 0;
+					padding: ${space[3]}px;
+					float: left;
+					background-color: ${palette.neutral[97]};
+					border-bottom: 1px solid ${palette.neutral[86]};
+					${textSans.medium({ fontWeight: 'bold' })};
+					${from.tablet} {
+						padding: ${space[3]}px ${space[5]}px;
+					}
+				`}
+			>
+				Why did you cancel your Membership with us today?
+			</legend>
+			<RadioGroup
+				name="issue_type"
+				orientation="vertical"
+				css={css`
+					display: block;
+					padding: ${space[5]}px;
+				`}
+			>
+				{membershipCancellationReasons.map(
+					(reason: CancellationReason) => (
+						<Radio
+							key={reason.reasonId}
+							name="cancellation-reason"
+							value={reason.reasonId}
+							label={reason.linkLabel}
+							css={css`
+								vertical-align: top;
+								text-transform: lowercase;
+								:checked + div label:first-of-type {
+									font-weight: bold;
+								}
+							`}
+						/>
+					),
+				)}
+			</RadioGroup>
+		</fieldset>
+	);
+};
+
+export const SelectReason = () => {
+	const navigate = useNavigate();
+
+	return (
+		<>
+			<ProgressIndicator
+				steps={[
+					{ title: '' },
+					{ title: '' },
+					{ title: 'Confirmation', isCurrentStep: true },
+				]}
+				additionalCSS={css`
+					margin: ${space[5]}px 0 ${space[12]}px;
+				`}
+			/>
+			<h2 css={headingCss}>Your Membership is cancelled</h2>
+			<CancellationInfo />
+			<p
+				css={css`
+					${textSans.medium()}
+					border-top: 1px solid ${palette.neutral[86]};
+					padding-top: ${space[5]}px;
+				`}
+			>
+				We're always trying to improve our offering and welcome any
+				feedback. If you can, please take a moment to tell us why you've
+				cancelled your Membership.
+			</p>
+			<ReasonSelection />
+			<section
+				css={[sectionSpacing, buttonLayoutCss, { textAlign: 'right' }]}
+			>
+				<Button
+					priority="tertiary"
+					cssOverrides={[buttonCentredCss]}
+					onClick={() => navigate('..')}
+				>
+					Skip
+				</Button>
+				<Button cssOverrides={buttonCentredCss}>Submit</Button>
+			</section>
+		</>
+	);
+};

--- a/client/components/mma/cancel/cancellationSaves/ValueOfSupport.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ValueOfSupport.tsx
@@ -12,13 +12,7 @@ import { Heading } from '../../shared/Heading';
 import { ProgressIndicator } from '../../shared/ProgressIndicator';
 import type { CancellationContextInterface } from '../CancellationContainer';
 import { CancellationContext } from '../CancellationContainer';
-
-const buttonLayoutCss = css`
-	text-align: right;
-	> * + * {
-		margin-left: ${space[3]}px;
-	}
-`;
+import { buttonLayoutCss } from './SaveStyles';
 
 export const ValueOfSupport = () => {
 	const navigate = useNavigate();
@@ -63,7 +57,7 @@ export const ValueOfSupport = () => {
 				</p>
 			</Stack>
 			<div>Image placeholder</div>
-			<div css={buttonLayoutCss}>
+			<div css={[buttonLayoutCss, { textAlign: 'right' }]}>
 				<Button priority="tertiary" onClick={() => navigate('/')}>
 					Back
 				</Button>


### PR DESCRIPTION

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Create Cancellation Reasons page, using the old cancellation reasons for membership. This PR also removes an unused property from the CancellationReason type. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

New item in storybook.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
![image](https://user-images.githubusercontent.com/114918544/233420011-37f024ba-bce9-4a28-8dab-821d9b18bc34.png)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
