### PR TITLE
Create membership save routes

### DIFF
--- a/client/components/mma/MMAPage.tsx
+++ b/client/components/mma/MMAPage.tsx
@@ -4,6 +4,10 @@ import { breakpoints, from, space } from '@guardian/source-foundations';
 import type { ReactNode } from 'react';
 import { lazy, Suspense, useEffect, useState } from 'react';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+import {
+	featureSwitches,
+	initFeatureSwitchUrlParamOverride,
+} from '../../../shared/featureSwitches';
 import type {
 	GroupedProductType,
 	ProductType,
@@ -41,6 +45,8 @@ const record = (event: any) => {
 		window.guardian.ophan.record(event);
 	}
 };
+
+initFeatureSwitchUrlParamOverride();
 
 // The code below uses magic comments to instruct Webpack on
 // how to name the chunks these dynamic imports produce
@@ -121,6 +127,46 @@ const ExecuteCancellation = lazy(() =>
 	import(
 		/* webpackChunkName: "Cancellation" */ './cancel/stages/ExecuteCancellation'
 	).then(({ ExecuteCancellation }) => ({ default: ExecuteCancellation })),
+);
+
+const MembershipCancellationLanding = lazy(() =>
+	import(
+		/* webpackChunkName: "Cancellation" */ './cancel/cancellationSaves/MembershipCancellationLanding'
+	).then(({ MembershipCancellationLanding }) => ({
+		default: MembershipCancellationLanding,
+	})),
+);
+
+const ValueOfSupport = lazy(() =>
+	import(
+		/* webpackChunkName: "Cancellation" */ './cancel/cancellationSaves/ValueOfSupport'
+	).then(({ ValueOfSupport }) => ({
+		default: ValueOfSupport,
+	})),
+);
+
+const SaveOptions = lazy(() =>
+	import(
+		/* webpackChunkName: "Cancellation" */ './cancel/cancellationSaves/SaveOptions'
+	).then(({ SaveOptions }) => ({
+		default: SaveOptions,
+	})),
+);
+
+const MembershipSwitch = lazy(() =>
+	import(
+		/* webpackChunkName: "Cancellation" */ './cancel/cancellationSaves/MembershipSwitch'
+	).then(({ MembershipSwitch }) => ({
+		default: MembershipSwitch,
+	})),
+);
+
+const SelectReason = lazy(() =>
+	import(
+		/* webpackChunkName: "Cancellation" */ './cancel/cancellationSaves/SelectReason'
+	).then(({ SelectReason }) => ({
+		default: SelectReason,
+	})),
 );
 
 const PaymentDetailUpdateContainer = lazy(() =>
@@ -540,6 +586,32 @@ const MMARouter = () => {
 										path="confirmed"
 										element={<ExecuteCancellation />}
 									/>
+									{featureSwitches.membershipSave && (
+										<>
+											<Route
+												path="landing"
+												element={
+													<MembershipCancellationLanding />
+												}
+											/>
+											<Route
+												path="details"
+												element={<ValueOfSupport />}
+											/>
+											<Route
+												path="offers"
+												element={<SaveOptions />}
+											/>
+											<Route
+												path="reasons"
+												element={<SelectReason />}
+											/>
+											<Route
+												path="switch-offer"
+												element={<MembershipSwitch />}
+											/>
+										</>
+									)}
 								</Route>
 							),
 						)}

--- a/client/components/mma/MMAPage.tsx
+++ b/client/components/mma/MMAPage.tsx
@@ -610,6 +610,10 @@ const MMARouter = () => {
 												path="switch-offer"
 												element={<MembershipSwitch />}
 											/>
+											<Route path="thank-you" />
+											<Route path="switch-thank-you" />
+											<Route path="confirm" />
+											<Route path="reminder" />
 										</>
 									)}
 								</Route>

--- a/client/components/mma/cancel/cancellationSaves/CancellationSaves.stories.tsx
+++ b/client/components/mma/cancel/cancellationSaves/CancellationSaves.stories.tsx
@@ -5,8 +5,8 @@ import { membership } from '../../../../fixtures/productDetail';
 import { CancellationContainer } from '../CancellationContainer';
 import { MembershipCancellationLanding } from './MembershipCancellationLanding';
 import { MembershipSwitch } from './MembershipSwitch';
+import { SaveOptions } from './SaveOptions';
 import { SelectReason } from './SelectReason';
-import { SwitchingOptions } from './SwitchingOptions';
 import { ValueOfSupport } from './ValueOfSupport';
 
 export default {
@@ -38,8 +38,8 @@ export const LandingPage: ComponentStory<
 	return <MembershipCancellationLanding />;
 };
 
-export const SwitchOptions: ComponentStory<typeof SwitchingOptions> = () => {
-	return <SwitchingOptions />;
+export const SwitchOptions: ComponentStory<typeof SaveOptions> = () => {
+	return <SaveOptions />;
 };
 
 export const Reasons: ComponentStory<typeof SelectReason> = () => {

--- a/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
@@ -3,12 +3,15 @@ import {
 	Stack,
 	SvgArrowRightStraight,
 } from '@guardian/source-react-components';
+import { useNavigate } from 'react-router';
 import { CallCentreEmailAndNumbers } from '../../../shared/CallCenterEmailAndNumbers';
 import { Heading } from '../../shared/Heading';
 import { sectionSpacing } from '../../switch/SwitchStyles';
 import { buttonLayoutCss, headingCss } from './SaveStyles';
 
 export const MembershipCancellationLanding = () => {
+	const navigate = useNavigate();
+
 	return (
 		<>
 			<section css={sectionSpacing}>
@@ -54,6 +57,7 @@ export const MembershipCancellationLanding = () => {
 						<Button
 							icon={<SvgArrowRightStraight />}
 							iconSide="right"
+							onClick={() => navigate('../details')}
 						>
 							Cancel online
 						</Button>

--- a/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
@@ -188,7 +188,7 @@ export const MembershipSwitch = () => {
 				<Button
 					priority="tertiary"
 					cssOverrides={[buttonCentredCss]}
-					onClick={() => navigate('..')}
+					onClick={() => navigate('../offers')}
 				>
 					Back
 				</Button>

--- a/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
@@ -9,9 +9,7 @@ import {
 } from '@guardian/source-react-components';
 import { useContext } from 'react';
 import { Navigate, useNavigate } from 'react-router';
-import { dateString } from '../../../../../shared/dates';
-import type { PaidSubscriptionPlan } from '../../../../../shared/productResponse';
-import { getMainPlan } from '../../../../../shared/productResponse';
+import { dateString, parseDate } from '../../../../../shared/dates';
 import { Card } from '../../shared/Card';
 import { Heading } from '../../shared/Heading';
 import type { CancellationContextInterface } from '../CancellationContainer';
@@ -62,7 +60,7 @@ const YourNewSupport = (props: { billingPeriod: string }) => {
 
 const WhatHappensNext = (props: { nextBillingDate: string }) => {
 	const nextPaymentDate = dateString(
-		new Date(props.nextBillingDate),
+		parseDate(props.nextBillingDate).date,
 		'd MMMM',
 	);
 	return (
@@ -139,13 +137,11 @@ export const MembershipSwitch = () => {
 	if (!membership) {
 		return <Navigate to="/" />;
 	}
-	const mainPlan = getMainPlan(
-		membership.subscription,
-	) as PaidSubscriptionPlan;
 
 	const currentPrice = membership.subscription.plan?.price;
 	const billingPeriod = membership.subscription.plan?.billingPeriod ?? '';
 	const monthlyOrAnnual = getMonthlyOrAnnual(billingPeriod);
+	const currencySymbol = membership.subscription.plan?.currency ?? '£';
 
 	return (
 		<>
@@ -158,7 +154,7 @@ export const MembershipSwitch = () => {
 					`}
 				>
 					You are changing your current membership for a{' '}
-					{mainPlan.currency}
+					{currencySymbol}
 					{currentPrice} {monthlyOrAnnual}.
 				</p>
 			</section>

--- a/client/components/mma/cancel/cancellationSaves/SaveOptions.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SaveOptions.tsx
@@ -5,6 +5,7 @@ import {
 	Stack,
 	SvgArrowRightStraight,
 } from '@guardian/source-react-components';
+import { useNavigate } from 'react-router';
 import { Card } from '../../shared/Card';
 import { Heading } from '../../shared/Heading';
 import { MembershipBenefitsSection } from '../../shared/MembershipBenefits';
@@ -17,7 +18,9 @@ import {
 	productSubtitleCss,
 } from './SaveStyles';
 
-export const SwitchingOptions = () => {
+export const SaveOptions = () => {
+	const navigate = useNavigate();
+
 	return (
 		<>
 			<ProgressIndicator
@@ -85,6 +88,7 @@ export const SwitchingOptions = () => {
 								<Button
 									icon={<SvgArrowRightStraight />}
 									iconSide="right"
+									onClick={() => navigate('../switch-offer')}
 								>
 									Become a recurring supporter
 								</Button>
@@ -100,7 +104,11 @@ export const SwitchingOptions = () => {
 			</Stack>
 			<section css={sectionSpacing}>
 				<div css={buttonLayoutCss}>
-					<Button icon={<SvgArrowRightStraight />} iconSide="right">
+					<Button
+						icon={<SvgArrowRightStraight />}
+						iconSide="right"
+						onClick={() => navigate('../reasons')}
+					>
 						Cancel membership
 					</Button>
 				</div>

--- a/client/components/mma/cancel/cancellationSaves/ValueOfSupport.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ValueOfSupport.tsx
@@ -34,8 +34,8 @@ export const ValueOfSupport = () => {
 		<>
 			<ProgressIndicator
 				steps={[
-					{ title: '' },
 					{ title: 'Details', isCurrentStep: true },
+					{ title: '' },
 					{ title: '' },
 				]}
 				additionalCSS={css`
@@ -58,10 +58,17 @@ export const ValueOfSupport = () => {
 			</Stack>
 			<div>Image placeholder</div>
 			<div css={[buttonLayoutCss, { textAlign: 'right' }]}>
-				<Button priority="tertiary" onClick={() => navigate('/')}>
+				<Button
+					priority="tertiary"
+					onClick={() => navigate('../landing')}
+				>
 					Back
 				</Button>
-				<Button icon={<SvgArrowRightStraight />} iconSide="right">
+				<Button
+					icon={<SvgArrowRightStraight />}
+					iconSide="right"
+					onClick={() => navigate('../offers')}
+				>
 					Continue to cancellation
 				</Button>
 			</div>

--- a/cypress/integration/parallel-2/membershipSave.spec.ts
+++ b/cypress/integration/parallel-2/membershipSave.spec.ts
@@ -2,95 +2,104 @@ import {
 	membership,
 	toMembersDataApiResponse,
 } from '../../../client/fixtures/productDetail';
+import { featureSwitches } from '../../../shared/featureSwitches';
 import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
 
-describe('Cancel membership saves', () => {
-	beforeEach(() => {
-		signInAndAcceptCookies();
-		console.log('beforeEach');
-		cy.intercept('GET', '/api/me/mma?productType=Membership', {
-			statusCode: 200,
-			body: toMembersDataApiResponse(membership),
+if (featureSwitches.membershipSave) {
+	describe('Cancel membership saves', () => {
+		beforeEach(() => {
+			signInAndAcceptCookies();
+			console.log('beforeEach');
+			cy.intercept('GET', '/api/me/mma?productType=Membership', {
+				statusCode: 200,
+				body: toMembersDataApiResponse(membership),
+			});
+
+			cy.intercept('GET', '/mpapi/user/mobile-subscriptions', {
+				statusCode: 200,
+				body: { subscriptions: [] },
+			}).as('mobile_subscriptions');
+
+			cy.intercept('GET', '/api/cancelled/', {
+				statusCode: 200,
+				body: [],
+			}).as('cancelled');
 		});
 
-		cy.intercept('GET', '/mpapi/user/mobile-subscriptions', {
-			statusCode: 200,
-			body: { subscriptions: [] },
-		}).as('mobile_subscriptions');
+		it('switches to recurring contribution', () => {
+			cy.visit('/cancel/membership/landing');
 
-		cy.intercept('GET', '/api/cancelled/', {
-			statusCode: 200,
-			body: [],
-		}).as('cancelled');
+			cy.findByText(
+				/We're sorry to hear you're thinking of cancelling/,
+			).should('exist');
+			cy.findByRole('button', {
+				name: 'Cancel online',
+			}).click();
+
+			cy.findByText(/Thank you for supporting the Guardian/).should(
+				'exist',
+			);
+			cy.findByRole('button', {
+				name: 'Continue to cancellation',
+			}).click();
+
+			cy.findByText(/consider different support options/).should('exist');
+			cy.findByRole('button', {
+				name: 'Become a recurring supporter',
+			}).click();
+
+			cy.findByText(/Review change/).should('exist');
+			cy.findByRole('button', {
+				name: 'Confirm change',
+			}).click();
+		});
+
+		it('cancels membership', () => {
+			cy.visit('/cancel/membership/landing');
+
+			cy.findByText(
+				/We're sorry to hear you're thinking of cancelling/,
+			).should('exist');
+			cy.findByRole('button', {
+				name: 'Cancel online',
+			}).click();
+
+			cy.findByText(/Thank you for supporting the Guardian/).should(
+				'exist',
+			);
+			cy.findByRole('button', {
+				name: 'Continue to cancellation',
+			}).click();
+
+			cy.findByText(/consider different support options/).should('exist');
+			cy.findByRole('button', {
+				name: 'Cancel membership',
+			}).click();
+
+			cy.findByText(/Your Membership is cancelled/).should('exist');
+		});
+
+		it('retains membership', () => {
+			cy.visit('/cancel/membership/landing');
+
+			cy.findByText(
+				/We're sorry to hear you're thinking of cancelling/,
+			).should('exist');
+			cy.findByRole('button', {
+				name: 'Cancel online',
+			}).click();
+
+			cy.findByText(/Thank you for supporting the Guardian/).should(
+				'exist',
+			);
+			cy.findByRole('button', {
+				name: 'Continue to cancellation',
+			}).click();
+
+			cy.findByText(/consider different support options/).should('exist');
+			cy.findByRole('button', {
+				name: 'Continue your membership',
+			}).click();
+		});
 	});
-
-	it('switches to recurring contribution', () => {
-		cy.visit('/cancel/membership/landing');
-
-		cy.findByText(
-			/We're sorry to hear you're thinking of cancelling/,
-		).should('exist');
-		cy.findByRole('button', {
-			name: 'Cancel online',
-		}).click();
-
-		cy.findByText(/Thank you for supporting the Guardian/).should('exist');
-		cy.findByRole('button', {
-			name: 'Continue to cancellation',
-		}).click();
-
-		cy.findByText(/consider different support options/).should('exist');
-		cy.findByRole('button', {
-			name: 'Become a recurring supporter',
-		}).click();
-
-		cy.findByText(/Review change/).should('exist');
-		cy.findByRole('button', {
-			name: 'Confirm change',
-		}).click();
-	});
-
-	it('cancels membership', () => {
-		cy.visit('/cancel/membership/landing');
-
-		cy.findByText(
-			/We're sorry to hear you're thinking of cancelling/,
-		).should('exist');
-		cy.findByRole('button', {
-			name: 'Cancel online',
-		}).click();
-
-		cy.findByText(/Thank you for supporting the Guardian/).should('exist');
-		cy.findByRole('button', {
-			name: 'Continue to cancellation',
-		}).click();
-
-		cy.findByText(/consider different support options/).should('exist');
-		cy.findByRole('button', {
-			name: 'Cancel membership',
-		}).click();
-
-		cy.findByText(/Your Membership is cancelled/).should('exist');
-	});
-
-	it('retains membership', () => {
-		cy.visit('/cancel/membership/landing');
-
-		cy.findByText(
-			/We're sorry to hear you're thinking of cancelling/,
-		).should('exist');
-		cy.findByRole('button', {
-			name: 'Cancel online',
-		}).click();
-
-		cy.findByText(/Thank you for supporting the Guardian/).should('exist');
-		cy.findByRole('button', {
-			name: 'Continue to cancellation',
-		}).click();
-
-		cy.findByText(/consider different support options/).should('exist');
-		cy.findByRole('button', {
-			name: 'Continue your membership',
-		}).click();
-	});
-});
+}

--- a/cypress/integration/parallel-2/membershipSave.spec.ts
+++ b/cypress/integration/parallel-2/membershipSave.spec.ts
@@ -7,11 +7,21 @@ import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
 describe('Cancel membership saves', () => {
 	beforeEach(() => {
 		signInAndAcceptCookies();
-
+		console.log('beforeEach');
 		cy.intercept('GET', '/api/me/mma?productType=Membership', {
 			statusCode: 200,
 			body: toMembersDataApiResponse(membership),
 		});
+
+		cy.intercept('GET', '/mpapi/user/mobile-subscriptions', {
+			statusCode: 200,
+			body: { subscriptions: [] },
+		}).as('mobile_subscriptions');
+
+		cy.intercept('GET', '/api/cancelled/', {
+			statusCode: 200,
+			body: [],
+		}).as('cancelled');
 	});
 
 	it('switches to recurring contribution', () => {

--- a/cypress/integration/parallel-2/membershipSave.spec.ts
+++ b/cypress/integration/parallel-2/membershipSave.spec.ts
@@ -4,7 +4,7 @@ import {
 } from '../../../client/fixtures/productDetail';
 import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
 
-describe('Cancel guardian weekly', () => {
+describe('Cancel membership saves', () => {
 	beforeEach(() => {
 		signInAndAcceptCookies();
 

--- a/cypress/integration/parallel-2/membershipSave.spec.ts
+++ b/cypress/integration/parallel-2/membershipSave.spec.ts
@@ -1,0 +1,86 @@
+import {
+	membership,
+	toMembersDataApiResponse,
+} from '../../../client/fixtures/productDetail';
+import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
+
+describe('Cancel guardian weekly', () => {
+	beforeEach(() => {
+		signInAndAcceptCookies();
+
+		cy.intercept('GET', '/api/me/mma?productType=Membership', {
+			statusCode: 200,
+			body: toMembersDataApiResponse(membership),
+		});
+	});
+
+	it('switches to recurring contribution', () => {
+		cy.visit('/cancel/membership/landing');
+
+		cy.findByText(
+			/We're sorry to hear you're thinking of cancelling/,
+		).should('exist');
+		cy.findByRole('button', {
+			name: 'Cancel online',
+		}).click();
+
+		cy.findByText(/Thank you for supporting the Guardian/).should('exist');
+		cy.findByRole('button', {
+			name: 'Continue to cancellation',
+		}).click();
+
+		cy.findByText(/consider different support options/).should('exist');
+		cy.findByRole('button', {
+			name: 'Become a recurring supporter',
+		}).click();
+
+		cy.findByText(/Review change/).should('exist');
+		cy.findByRole('button', {
+			name: 'Confirm change',
+		}).click();
+	});
+
+	it('cancels membership', () => {
+		cy.visit('/cancel/membership/landing');
+
+		cy.findByText(
+			/We're sorry to hear you're thinking of cancelling/,
+		).should('exist');
+		cy.findByRole('button', {
+			name: 'Cancel online',
+		}).click();
+
+		cy.findByText(/Thank you for supporting the Guardian/).should('exist');
+		cy.findByRole('button', {
+			name: 'Continue to cancellation',
+		}).click();
+
+		cy.findByText(/consider different support options/).should('exist');
+		cy.findByRole('button', {
+			name: 'Cancel membership',
+		}).click();
+
+		cy.findByText(/Your Membership is cancelled/).should('exist');
+	});
+
+	it('retains membership', () => {
+		cy.visit('/cancel/membership/landing');
+
+		cy.findByText(
+			/We're sorry to hear you're thinking of cancelling/,
+		).should('exist');
+		cy.findByRole('button', {
+			name: 'Cancel online',
+		}).click();
+
+		cy.findByText(/Thank you for supporting the Guardian/).should('exist');
+		cy.findByRole('button', {
+			name: 'Continue to cancellation',
+		}).click();
+
+		cy.findByText(/consider different support options/).should('exist');
+		cy.findByRole('button', {
+			name: 'Continue your membership',
+		}).click();
+	});
+});

--- a/cypress/integration/parallel-2/productSwitch.spec.ts
+++ b/cypress/integration/parallel-2/productSwitch.spec.ts
@@ -213,6 +213,11 @@ describe('product switching', () => {
 			),
 		});
 
+		cy.intercept('GET', '/mpapi/user/mobile-subscriptions', {
+			statusCode: 200,
+			body: { subscriptions: [] },
+		}).as('mobile_subscriptions');
+
 		cy.intercept('GET', '/api/cancelled/', {
 			statusCode: 200,
 			body: [],

--- a/shared/featureSwitches.ts
+++ b/shared/featureSwitches.ts
@@ -26,4 +26,5 @@ export const featureSwitches: Record<string, boolean> = {
 	exampleFeature: false,
 	cancellationProductSwitch: false,
 	appSubscriptions: false,
+	membershipSave: false,
 };

--- a/shared/featureSwitches.ts
+++ b/shared/featureSwitches.ts
@@ -26,5 +26,5 @@ export const featureSwitches: Record<string, boolean> = {
 	exampleFeature: false,
 	cancellationProductSwitch: false,
 	appSubscriptions: false,
-	membershipSave: true,
+	membershipSave: false,
 };

--- a/shared/featureSwitches.ts
+++ b/shared/featureSwitches.ts
@@ -26,5 +26,5 @@ export const featureSwitches: Record<string, boolean> = {
 	exampleFeature: false,
 	cancellationProductSwitch: false,
 	appSubscriptions: false,
-	membershipSave: false,
+	membershipSave: true,
 };


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Creates routes for membership saves journey (behind a feature flag).  Add Cypress tests visiting the pages on the journey.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Enable the feature flag, then with a membership head to `cancel/membership/landing`

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
