### PR TITLE
Create Membership save eligibility check

### DIFF
--- a/client/components/mma/cancel/CancellationSwitchEligibilityCheck.tsx
+++ b/client/components/mma/cancel/CancellationSwitchEligibilityCheck.tsx
@@ -1,90 +1,33 @@
 import { useContext } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 import { featureSwitches } from '../../../../shared/featureSwitches';
-import { MDA_TEST_USER_HEADER } from '../../../../shared/productResponse';
-import { GROUPED_PRODUCT_TYPES } from '../../../../shared/productTypes';
-import { useFetch } from '../../../utilities/hooks/useFetch';
-import { Spinner } from '../../shared/Spinner';
-import { WithStandardTopMargin } from '../../shared/WithStandardTopMargin';
+import { CancellationContext } from './CancellationContainer';
 import type {
 	CancellationContextInterface,
-	CancellationPageTitleInterface,
 	CancellationRouterState,
 } from './CancellationContainer';
-import {
-	CancellationContext,
-	CancellationPageTitleContext,
-} from './CancellationContainer';
 import { CancellationReasonSelection } from './CancellationReasonSelection';
-import { CancellationSwitchOffer } from './productSwitch/CancellationSwitchOffer';
-import type { AvailableProductsResponse } from './productSwitch/productSwitchApi';
 
 export const CancellationSwitchEligibilityCheck = () => {
 	const location = useLocation();
 	const routerState = location.state as CancellationRouterState;
+
 	const cancellationContext = useContext(
 		CancellationContext,
 	) as CancellationContextInterface;
-	const pageTitleContext = useContext(
-		CancellationPageTitleContext,
-	) as CancellationPageTitleInterface;
 
 	const productDetail = cancellationContext.productDetail;
-
 	if (!productDetail) {
 		return <Navigate to="/" />;
 	}
 
-	const groupedProductType =
-		GROUPED_PRODUCT_TYPES[
-			cancellationContext.productType.groupedProductType
-		];
-
-	if (routerState?.dontShowOffer) {
-		pageTitleContext.setPageTitle(
-			`Cancel ${
-				groupedProductType.shortFriendlyName ||
-				groupedProductType.friendlyName()
-			}`,
-		);
-		return <CancellationReasonSelection />;
+	if (
+		featureSwitches.membershipSave &&
+		!routerState?.dontShowOffer &&
+		productDetail.mmaCategory === 'membership'
+	) {
+		return <Navigate to="./landing" />;
 	}
 
-	const cancellationProductSwitchFeatureIsOn =
-		featureSwitches.cancellationProductSwitch;
-
-	const { data, error } = useFetch<AvailableProductsResponse[]>(
-		`/api/available-product-moves/${productDetail.subscription.subscriptionId}`,
-		{
-			method: 'GET',
-			headers: {
-				[MDA_TEST_USER_HEADER]: `${productDetail.isTestUser}`,
-			},
-		},
-	);
-
-	if (error) {
-		return <CancellationReasonSelection />;
-	}
-
-	if (!data) {
-		return (
-			<WithStandardTopMargin>
-				<Spinner
-					loadingMessage={`Checking your ${
-						cancellationContext.productType.shortFriendlyName ||
-						cancellationContext.productType.friendlyName(
-							productDetail,
-						)
-					} details...`}
-				/>
-			</WithStandardTopMargin>
-		);
-	}
-
-	return cancellationProductSwitchFeatureIsOn && data.length ? (
-		<CancellationSwitchOffer availableProductsToSwitch={data} />
-	) : (
-		<CancellationReasonSelection />
-	);
+	return <CancellationReasonSelection />;
 };

--- a/client/components/mma/cancel/cancellationSaves/CancellationSaves.stories.tsx
+++ b/client/components/mma/cancel/cancellationSaves/CancellationSaves.stories.tsx
@@ -3,7 +3,7 @@ import { rest } from 'msw';
 import { ReactRouterDecorator } from '../../../../../.storybook/ReactRouterDecorator';
 import { PRODUCT_TYPES } from '../../../../../shared/productTypes';
 import {
-	membership,
+	membershipSupporter,
 	toMembersDataApiResponse,
 } from '../../../../fixtures/productDetail';
 import { CancellationContainer } from '../CancellationContainer';
@@ -20,7 +20,7 @@ export default {
 	parameters: {
 		layout: 'fullscreen',
 		reactRouter: {
-			state: { productDetail: membership },
+			state: { productDetail: membershipSupporter },
 			container: (
 				<CancellationContainer productType={PRODUCT_TYPES.membership} />
 			),
@@ -45,7 +45,7 @@ export const LandingPage: ComponentStory<
 LandingPage.parameters = {
 	msw: [
 		rest.get('/api/me/mma', (_req, res, ctx) => {
-			return res(ctx.json(toMembersDataApiResponse(membership)));
+			return res(ctx.json(toMembersDataApiResponse(membershipSupporter)));
 		}),
 	],
 };

--- a/client/components/mma/cancel/cancellationSaves/CancellationSaves.stories.tsx
+++ b/client/components/mma/cancel/cancellationSaves/CancellationSaves.stories.tsx
@@ -1,7 +1,11 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import { rest } from 'msw';
 import { ReactRouterDecorator } from '../../../../../.storybook/ReactRouterDecorator';
 import { PRODUCT_TYPES } from '../../../../../shared/productTypes';
-import { membership } from '../../../../fixtures/productDetail';
+import {
+	membership,
+	toMembersDataApiResponse,
+} from '../../../../fixtures/productDetail';
 import { CancellationContainer } from '../CancellationContainer';
 import { MembershipCancellationLanding } from './MembershipCancellationLanding';
 import { MembershipSwitch } from './MembershipSwitch';
@@ -36,6 +40,14 @@ export const LandingPage: ComponentStory<
 	typeof MembershipCancellationLanding
 > = () => {
 	return <MembershipCancellationLanding />;
+};
+
+LandingPage.parameters = {
+	msw: [
+		rest.get('/api/me/mma', (_req, res, ctx) => {
+			return res(ctx.json(toMembersDataApiResponse(membership)));
+		}),
+	],
 };
 
 export const SwitchOptions: ComponentStory<typeof SaveOptions> = () => {

--- a/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
@@ -3,14 +3,68 @@ import {
 	Stack,
 	SvgArrowRightStraight,
 } from '@guardian/source-react-components';
-import { useNavigate } from 'react-router';
+import { Navigate, useNavigate } from 'react-router';
+import { featureSwitches } from '../../../../../shared/featureSwitches';
+import type {
+	MembersDataApiResponse,
+	ProductDetail,
+} from '../../../../../shared/productResponse';
+import {
+	LoadingState,
+	useAsyncLoader,
+} from '../../../../utilities/hooks/useAsyncLoader';
+import { allProductsDetailFetcher } from '../../../../utilities/productUtils';
 import { CallCentreEmailAndNumbers } from '../../../shared/CallCenterEmailAndNumbers';
+import { GenericErrorScreen } from '../../../shared/GenericErrorScreen';
+import { JsonResponseHandler } from '../../shared/asyncComponents/DefaultApiResponseHandler';
+import { DefaultLoadingView } from '../../shared/asyncComponents/DefaultLoadingView';
 import { Heading } from '../../shared/Heading';
 import { sectionSpacing } from '../../switch/SwitchStyles';
 import { buttonLayoutCss, headingCss } from './SaveStyles';
 
+function ineligibleForSave(products: ProductDetail[]) {
+	const inPaymentFailure = products.find((product) => product.alertText);
+
+	const hasOtherProduct = products.find(
+		(product) => product.mmaCategory != 'membership',
+	);
+
+	return inPaymentFailure || hasOtherProduct;
+}
+
 export const MembershipCancellationLanding = () => {
 	const navigate = useNavigate();
+	const {
+		data,
+		loadingState,
+	}: {
+		data: MembersDataApiResponse | null;
+		loadingState: LoadingState;
+	} = useAsyncLoader(allProductsDetailFetcher, JsonResponseHandler);
+
+	if (loadingState == LoadingState.HasError) {
+		return <GenericErrorScreen />;
+	}
+	if (loadingState == LoadingState.IsLoading) {
+		return <DefaultLoadingView loadingMessage="Loading your products..." />;
+	}
+	if (data === null) {
+		return <GenericErrorScreen />;
+	}
+
+	if (
+		featureSwitches.membershipSave &&
+		ineligibleForSave(data.products as ProductDetail[])
+	) {
+		return (
+			<Navigate
+				to="../"
+				state={{
+					dontShowOffer: true,
+				}}
+			/>
+		);
+	}
 
 	return (
 		<>

--- a/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
@@ -3,6 +3,7 @@ import {
 	Stack,
 	SvgArrowRightStraight,
 } from '@guardian/source-react-components';
+import { useContext } from 'react';
 import { Navigate, useNavigate } from 'react-router';
 import { featureSwitches } from '../../../../../shared/featureSwitches';
 import type {
@@ -20,20 +21,37 @@ import { JsonResponseHandler } from '../../shared/asyncComponents/DefaultApiResp
 import { DefaultLoadingView } from '../../shared/asyncComponents/DefaultLoadingView';
 import { Heading } from '../../shared/Heading';
 import { sectionSpacing } from '../../switch/SwitchStyles';
+import type { CancellationContextInterface } from '../CancellationContainer';
+import { CancellationContext } from '../CancellationContainer';
 import { buttonLayoutCss, headingCss } from './SaveStyles';
 
-function ineligibleForSave(products: ProductDetail[]) {
+function ineligibleForSave(
+	products: ProductDetail[],
+	membershipToCancel: ProductDetail,
+) {
 	const inPaymentFailure = products.find((product) => product.alertText);
 
 	const hasOtherProduct = products.find(
 		(product) => product.mmaCategory != 'membership',
 	);
 
-	return inPaymentFailure || hasOtherProduct;
+	const membershipTierIsNotSupporter =
+		membershipToCancel.tier !== 'Supporter';
+
+	return inPaymentFailure || hasOtherProduct || membershipTierIsNotSupporter;
 }
 
 export const MembershipCancellationLanding = () => {
 	const navigate = useNavigate();
+	const cancellationContext = useContext(
+		CancellationContext,
+	) as CancellationContextInterface;
+	const membership = cancellationContext.productDetail;
+
+	if (!membership) {
+		return <Navigate to="/" />;
+	}
+
 	const {
 		data,
 		loadingState,
@@ -54,7 +72,7 @@ export const MembershipCancellationLanding = () => {
 
 	if (
 		featureSwitches.membershipSave &&
-		ineligibleForSave(data.products as ProductDetail[])
+		ineligibleForSave(data.products as ProductDetail[], membership)
 	) {
 		return (
 			<Navigate

--- a/client/fixtures/productDetail.ts
+++ b/client/fixtures/productDetail.ts
@@ -840,7 +840,7 @@ export const membership: ProductDetail = {
 	isTestUser: true,
 	isPaidTier: true,
 	selfServiceCancellation: {
-		isAllowed: false,
+		isAllowed: true,
 		shouldDisplayEmail: true,
 		phoneRegionsToDisplay: ['UK & ROW', 'US', 'AUS'],
 	},

--- a/client/fixtures/productDetail.ts
+++ b/client/fixtures/productDetail.ts
@@ -894,7 +894,7 @@ export const membershipStaff: ProductDetail = {
 	},
 };
 
-export const membership: ProductDetail = {
+export const membershipSupporter: ProductDetail = {
 	mmaCategory: 'membership',
 	tier: 'Supporter',
 	isPaidTier: true,

--- a/client/fixtures/productDetail.ts
+++ b/client/fixtures/productDetail.ts
@@ -834,7 +834,7 @@ export const contributionSepa: ProductDetail = {
 	isTestUser: false,
 };
 
-export const membership: ProductDetail = {
+export const membershipStaff: ProductDetail = {
 	mmaCategory: 'membership',
 	tier: 'Staff Membership',
 	isTestUser: true,
@@ -854,7 +854,7 @@ export const membership: ProductDetail = {
 			accountNumber: '****9911',
 			sortCode: '200000',
 		},
-		contactId: '0039E00001VVNb5QAH',
+		contactId: '1',
 		deliveryAddress: {
 			addressLine1: 'Kings Place',
 			addressLine2: '90 York Way',
@@ -890,8 +890,77 @@ export const membership: ProductDetail = {
 		currentPlans: [],
 		futurePlans: [],
 		readerType: 'Direct',
-		accountId: '8ad088718219a6b601821bbe9e6210f2',
+		accountId: '1',
 	},
+};
+
+export const membership: ProductDetail = {
+	mmaCategory: 'membership',
+	tier: 'Supporter',
+	isPaidTier: true,
+	selfServiceCancellation: {
+		isAllowed: true,
+		shouldDisplayEmail: true,
+		phoneRegionsToDisplay: ['UK & ROW', 'US', 'AUS'],
+	},
+	billingCountry: 'United Kingdom',
+	joinDate: '2023-04-26',
+	optIn: true,
+	subscription: {
+		paymentMethod: 'Card',
+		card: {
+			last4: '4242',
+			expiry: {
+				month: 4,
+				year: 2024,
+			},
+			type: 'Visa',
+			stripePublicKeyForUpdate: 'pk_test_1',
+			email: 'test@example.com',
+		},
+		contactId: '2',
+		safeToUpdatePaymentMethod: true,
+		start: '2023-04-26',
+		end: '2024-04-26',
+		nextPaymentPrice: 700,
+		nextPaymentDate: '2023-05-26',
+		lastPaymentDate: '2023-04-26',
+		chargedThroughDate: '2023-05-26',
+		renewalDate: '2024-04-26',
+		anniversaryDate: '2024-04-26',
+		cancelledAt: false,
+		subscriberId: 'A-S00538748',
+		subscriptionId: 'A-S00538748',
+		trialLength: -1,
+		autoRenew: true,
+		plan: {
+			name: 'Supporter',
+			price: 700,
+			currency: '£',
+			currencyISO: 'GBP',
+			billingPeriod: 'month',
+			start: '',
+			end: '',
+			shouldBeVisible: false,
+		},
+		currentPlans: [
+			{
+				name: null,
+				start: '2023-04-26',
+				end: '2024-04-26',
+				shouldBeVisible: true,
+				chargedThrough: '2023-05-26',
+				price: 700,
+				currency: '£',
+				currencyISO: 'GBP',
+				billingPeriod: 'month',
+			},
+		],
+		futurePlans: [],
+		readerType: 'Direct',
+		accountId: '2',
+	},
+	isTestUser: false,
 };
 
 export const patronDigitalSub: ProductDetail = {

--- a/cypress/integration/parallel-2/membershipSave.spec.ts
+++ b/cypress/integration/parallel-2/membershipSave.spec.ts
@@ -1,7 +1,7 @@
 import {
 	contributionCard,
 	guardianWeeklyExpiredCard,
-	membership,
+	membershipSupporter,
 	toMembersDataApiResponse,
 } from '../../../client/fixtures/productDetail';
 import { featureSwitches } from '../../../shared/featureSwitches';
@@ -14,12 +14,12 @@ if (featureSwitches.membershipSave) {
 			console.log('beforeEach');
 			cy.intercept('GET', '/api/me/mma?productType=Membership', {
 				statusCode: 200,
-				body: toMembersDataApiResponse(membership),
+				body: toMembersDataApiResponse(membershipSupporter),
 			});
 
 			cy.intercept('GET', '/api/me/mma', {
 				statusCode: 200,
-				body: toMembersDataApiResponse(membership),
+				body: toMembersDataApiResponse(membershipSupporter),
 			});
 
 			cy.intercept('GET', '/mpapi/user/mobile-subscriptions', {
@@ -115,7 +115,10 @@ if (featureSwitches.membershipSave) {
 		it('redirects user with other product to normal journey', () => {
 			cy.intercept('GET', '/api/me/mma', {
 				statusCode: 200,
-				body: toMembersDataApiResponse(membership, contributionCard),
+				body: toMembersDataApiResponse(
+					membershipSupporter,
+					contributionCard,
+				),
 			});
 
 			cy.visit('/cancel/membership');
@@ -127,7 +130,7 @@ if (featureSwitches.membershipSave) {
 			cy.intercept('GET', '/api/me/mma', {
 				statusCode: 200,
 				body: toMembersDataApiResponse(
-					membership,
+					membershipSupporter,
 					guardianWeeklyExpiredCard,
 				),
 			});

--- a/cypress/integration/parallel-5/membership.spec.ts
+++ b/cypress/integration/parallel-5/membership.spec.ts
@@ -35,7 +35,7 @@ describe('membership test', () => {
 		cy.wait('@product_detail');
 		cy.wait('@mobile_subscriptions');
 
-		cy.findByText('Staff Membership');
+		cy.findByText('Guardian membership');
 	});
 
 	it('membership subscription', () => {

--- a/cypress/integration/parallel-5/membership.spec.ts
+++ b/cypress/integration/parallel-5/membership.spec.ts
@@ -1,6 +1,6 @@
 import {
 	toMembersDataApiResponse,
-	membership,
+	membershipSupporter,
 } from '../../../client/fixtures/productDetail';
 import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
 
@@ -10,7 +10,7 @@ describe('membership test', () => {
 
 		cy.intercept('GET', '/api/me/mma', {
 			statusCode: 200,
-			body: toMembersDataApiResponse(membership),
+			body: toMembersDataApiResponse(membershipSupporter),
 		}).as('product_detail');
 
 		cy.intercept('GET', '/mpapi/user/mobile-subscriptions', {
@@ -20,7 +20,7 @@ describe('membership test', () => {
 
 		cy.intercept('GET', '/api/me/mma/**', {
 			statusCode: 200,
-			body: toMembersDataApiResponse(membership),
+			body: toMembersDataApiResponse(membershipSupporter),
 		}).as('refetch_subscription');
 
 		cy.intercept('GET', '/api/cancelled/', {

--- a/cypress/integration/parallel-5/membership.spec.ts
+++ b/cypress/integration/parallel-5/membership.spec.ts
@@ -43,7 +43,7 @@ describe('membership test', () => {
 
 		cy.findByText('Manage membership').click();
 
-		cy.findByText('Would you like to cancel your membership?');
+		cy.findByText('Cancel membership');
 	});
 
 	it('membership billing page', () => {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Create a check to only direct users to the new membership save journey if they are eligible. 

Criteria:
1. Not in payment failure
2. User has no Recurring Support or other products

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

(Feature switch on)
With a user with a membership + recurring contribution - go to `cancel/membership` and see the normal journey (i.e. Please select a reason)

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
