### PR TITLE
Continue membership confirmation v1 

### DIFF
--- a/client/components/mma/MMAPage.tsx
+++ b/client/components/mma/MMAPage.tsx
@@ -169,6 +169,14 @@ const SelectReason = lazy(() =>
 	})),
 );
 
+const ContinueMembershipConfirmation = lazy(() =>
+	import(
+		/* webpackChunkName: "Cancellation" */ './cancel/cancellationSaves/ContinueMembershipConfirmation'
+	).then(({ ContinueMembershipConfirmation }) => ({
+		default: ContinueMembershipConfirmation,
+	})),
+);
+
 const PaymentDetailUpdateContainer = lazy(() =>
 	import(
 		/* webpackChunkName: "PaymentDetailUpdate" */ './paymentUpdate/PaymentDetailUpdateContainer'
@@ -610,7 +618,12 @@ const MMARouter = () => {
 												path="switch-offer"
 												element={<MembershipSwitch />}
 											/>
-											<Route path="thank-you" />
+											<Route
+												path="thank-you"
+												element={
+													<ContinueMembershipConfirmation />
+												}
+											/>
 											<Route path="switch-thank-you" />
 											<Route path="confirm" />
 											<Route path="reminder" />

--- a/client/components/mma/cancel/cancellationSaves/CancellationSaves.stories.tsx
+++ b/client/components/mma/cancel/cancellationSaves/CancellationSaves.stories.tsx
@@ -3,6 +3,7 @@ import { ReactRouterDecorator } from '../../../../../.storybook/ReactRouterDecor
 import { PRODUCT_TYPES } from '../../../../../shared/productTypes';
 import { membership } from '../../../../fixtures/productDetail';
 import { CancellationContainer } from '../CancellationContainer';
+import { ContinueMembershipConfirmation } from './ContinueMembershipConfirmation';
 import { MembershipCancellationLanding } from './MembershipCancellationLanding';
 import { MembershipSwitch } from './MembershipSwitch';
 import { SaveOptions } from './SaveOptions';
@@ -44,4 +45,10 @@ export const SwitchOptions: ComponentStory<typeof SaveOptions> = () => {
 
 export const Reasons: ComponentStory<typeof SelectReason> = () => {
 	return <SelectReason />;
+};
+
+export const ContinueMembership: ComponentStory<
+	typeof ContinueMembershipConfirmation
+> = () => {
+	return <ContinueMembershipConfirmation />;
 };

--- a/client/components/mma/cancel/cancellationSaves/ContinueMembershipConfirmation.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ContinueMembershipConfirmation.tsx
@@ -5,13 +5,24 @@ import {
 	Stack,
 	SvgArrowRightStraight,
 } from '@guardian/source-react-components';
+import { useContext } from 'react';
 import { useNavigate } from 'react-router';
 import { Heading } from '../../shared/Heading';
 import { ProgressIndicator } from '../../shared/ProgressIndicator';
+import type {
+	CancellationPageTitleInterface} from '../CancellationContainer';
+import {
+	CancellationPageTitleContext
+} from '../CancellationContainer';
 import { buttonLayoutCss } from './SaveStyles';
 
 export const ContinueMembershipConfirmation = () => {
 	const navigate = useNavigate();
+
+	const pageTitleContext = useContext(
+		CancellationPageTitleContext,
+	) as CancellationPageTitleInterface;
+	pageTitleContext.setPageTitle('Membership confirmation');
 
 	return (
 		<>
@@ -36,7 +47,7 @@ export const ContinueMembershipConfirmation = () => {
 				<Button
 					icon={<SvgArrowRightStraight />}
 					iconSide="right"
-					onClick={() => navigate('../')}
+					onClick={() => navigate('https://www.theguardian.com')}
 				>
 					Continue reading the Guardian
 				</Button>

--- a/client/components/mma/cancel/cancellationSaves/ContinueMembershipConfirmation.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ContinueMembershipConfirmation.tsx
@@ -1,0 +1,46 @@
+import { css } from '@emotion/react';
+import { space } from '@guardian/source-foundations';
+import {
+	Button,
+	Stack,
+	SvgArrowRightStraight,
+} from '@guardian/source-react-components';
+import { useNavigate } from 'react-router';
+import { Heading } from '../../shared/Heading';
+import { ProgressIndicator } from '../../shared/ProgressIndicator';
+import { buttonLayoutCss } from './SaveStyles';
+
+export const ContinueMembershipConfirmation = () => {
+	const navigate = useNavigate();
+
+	return (
+		<>
+			<ProgressIndicator
+				steps={[
+					{ title: '' },
+					{ title: '' },
+					{ title: 'Confirmation', isCurrentStep: true },
+				]}
+				additionalCSS={css`
+					margin: ${space[5]}px 0 ${space[12]}px;
+				`}
+			/>
+			<Stack space={4}>
+				<Heading>Thank you for continuing your membership</Heading>
+				<p>
+					No action is needed from your side. Your membership will
+					continue as normal.
+				</p>
+			</Stack>
+			<div css={[buttonLayoutCss, { textAlign: 'left' }]}>
+				<Button
+					icon={<SvgArrowRightStraight />}
+					iconSide="right"
+					onClick={() => navigate('../')}
+				>
+					Continue reading the Guardian
+				</Button>
+			</div>
+		</>
+	);
+};


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
New screen created to display at the end of the journey where a user has chosen to remain with their membership


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
New item in storybook.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
![image](https://user-images.githubusercontent.com/115992455/235111298-08f61297-2160-4cdf-9bea-d3d5b7d76244.png)


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
