### PR TITLE
Move PaymentDetails to own component and use in new journey

### DIFF
--- a/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
@@ -10,8 +10,10 @@ import {
 import { useContext } from 'react';
 import { Navigate, useNavigate } from 'react-router';
 import { dateString, parseDate } from '../../../../../shared/dates';
+import type { Subscription } from '../../../../../shared/productResponse';
 import { Card } from '../../shared/Card';
 import { Heading } from '../../shared/Heading';
+import { PaymentDetails } from '../../shared/PaymentDetails';
 import type { CancellationContextInterface } from '../CancellationContainer';
 import { CancellationContext } from '../CancellationContainer';
 import {
@@ -58,9 +60,9 @@ const YourNewSupport = (props: { billingPeriod: string }) => {
 	);
 };
 
-const WhatHappensNext = (props: { nextBillingDate: string }) => {
+const WhatHappensNext = (props: { subscription: Subscription }) => {
 	const nextPaymentDate = dateString(
-		parseDate(props.nextBillingDate).date,
+		parseDate(props.subscription.nextPaymentDate ?? '').date,
 		'd MMMM',
 	);
 	return (
@@ -89,11 +91,7 @@ const WhatHappensNext = (props: { nextBillingDate: string }) => {
 							<strong>Your payment method</strong>
 							<br />
 							The payment will be taken from{' '}
-							{/* <PaymentDetails
-            subscription={
-                contributionToSwitch.subscription
-            }
-        /> */}
+							<PaymentDetails subscription={props.subscription} />
 						</span>
 					</li>
 				</ul>
@@ -159,9 +157,7 @@ export const MembershipSwitch = () => {
 				</p>
 			</section>
 			<YourNewSupport billingPeriod={billingPeriod} />
-			<WhatHappensNext
-				nextBillingDate={membership.subscription.plan?.end ?? ''}
-			/>
+			<WhatHappensNext subscription={membership.subscription} />
 			<section css={sectionSpacing}>
 				<p
 					css={css`

--- a/client/components/mma/shared/PaymentDetails.tsx
+++ b/client/components/mma/shared/PaymentDetails.tsx
@@ -1,0 +1,67 @@
+import { css } from '@emotion/react';
+import type { Subscription } from '../../../../shared/productResponse';
+import { DirectDebitLogo } from './assets/DirectDebitLogo';
+import { PaypalLogo } from './assets/PaypalLogo';
+import { cardTypeToSVG } from './CardDisplay';
+import { getObfuscatedPayPalId } from './PaypalDisplay';
+
+export const PaymentDetails = (props: { subscription: Subscription }) => {
+	const subscription = props.subscription;
+
+	const cardType = (type: string) => {
+		if (type !== 'MasterCard') {
+			return `${type} card`;
+		}
+		return type;
+	};
+
+	const containerCss = css`
+		display: inline-flex;
+		align-items: center;
+		font-weight: 700;
+		max-width: 100%;
+		> svg {
+			flex: 0 0 auto;
+			margin-left: 0.5ch;
+		}
+	`;
+
+	const truncateCss = css`
+		flex: 0 1 auto;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	`;
+
+	return (
+		<span css={containerCss} data-qm-masking="blocklist">
+			{subscription.card && (
+				<>
+					{cardType(subscription.card.type)} ending{' '}
+					{subscription.card.last4}
+					{cardTypeToSVG(subscription.card.type)}
+				</>
+			)}
+			{subscription.payPalEmail && (
+				<>
+					<span css={truncateCss}>
+						{getObfuscatedPayPalId(subscription.payPalEmail)}
+					</span>
+					<PaypalLogo />
+				</>
+			)}
+			{subscription.mandate && (
+				<>
+					account ending{' '}
+					{subscription.mandate.accountNumber.slice(-3)}
+					<DirectDebitLogo />
+				</>
+			)}
+			{subscription.sepaMandate && (
+				<>
+					SEPA {subscription.sepaMandate.accountName}{' '}
+					{subscription.sepaMandate.iban}
+				</>
+			)}
+		</span>
+	);
+};

--- a/client/components/mma/switch/review/SwitchReview.tsx
+++ b/client/components/mma/switch/review/SwitchReview.tsx
@@ -12,22 +12,18 @@ import { useContext, useState } from 'react';
 import { Navigate, useLocation, useNavigate } from 'react-router';
 import { Link } from 'react-router-dom';
 import { dateString } from '../../../../../shared/dates';
-import type { Subscription } from '../../../../../shared/productResponse';
 import {
 	LoadingState,
 	useAsyncLoader,
 } from '../../../../utilities/hooks/useAsyncLoader';
 import { formatAmount } from '../../../../utilities/utils';
 import { GenericErrorScreen } from '../../../shared/GenericErrorScreen';
-import { DirectDebitLogo } from '../../shared/assets/DirectDebitLogo';
-import { PaypalLogo } from '../../shared/assets/PaypalLogo';
 import { SwitchOffsetPaymentIcon } from '../../shared/assets/SwitchOffsetPaymentIcon';
 import { JsonResponseHandler } from '../../shared/asyncComponents/DefaultApiResponseHandler';
 import { DefaultLoadingView } from '../../shared/asyncComponents/DefaultLoadingView';
 import { Card } from '../../shared/Card';
-import { cardTypeToSVG } from '../../shared/CardDisplay';
 import { Heading } from '../../shared/Heading';
-import { getObfuscatedPayPalId } from '../../shared/PaypalDisplay';
+import { PaymentDetails } from '../../shared/PaymentDetails';
 import { SupporterPlusBenefitsToggle } from '../../shared/SupporterPlusBenefits';
 import type {
 	SwitchContextInterface,
@@ -46,67 +42,6 @@ import {
 	sectionSpacing,
 	smallPrintCss,
 } from '../SwitchStyles';
-
-const PaymentDetails = (props: { subscription: Subscription }) => {
-	const subscription = props.subscription;
-
-	const cardType = (type: string) => {
-		if (type !== 'MasterCard') {
-			return `${type} card`;
-		}
-		return type;
-	};
-
-	const containerCss = css`
-		display: inline-flex;
-		align-items: center;
-		font-weight: 700;
-		max-width: 100%;
-		> svg {
-			flex: 0 0 auto;
-			margin-left: 0.5ch;
-		}
-	`;
-
-	const truncateCss = css`
-		flex: 0 1 auto;
-		overflow: hidden;
-		text-overflow: ellipsis;
-	`;
-
-	return (
-		<span css={containerCss} data-qm-masking="blocklist">
-			{subscription.card && (
-				<>
-					{cardType(subscription.card.type)} ending{' '}
-					{subscription.card.last4}
-					{cardTypeToSVG(subscription.card.type)}
-				</>
-			)}
-			{subscription.payPalEmail && (
-				<>
-					<span css={truncateCss}>
-						{getObfuscatedPayPalId(subscription.payPalEmail)}
-					</span>
-					<PaypalLogo />
-				</>
-			)}
-			{subscription.mandate && (
-				<>
-					account ending{' '}
-					{subscription.mandate.accountNumber.slice(-3)}
-					<DirectDebitLogo />
-				</>
-			)}
-			{subscription.sepaMandate && (
-				<>
-					SEPA {subscription.sepaMandate.accountName}{' '}
-					{subscription.sepaMandate.iban}
-				</>
-			)}
-		</span>
-	);
-};
 
 const SwitchErrorContext = (props: { PaymentFailure: boolean }) =>
 	props.PaymentFailure ? (


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Reuse the PaymentDetails component from Product Switch journey in new Cancellation Saves journey

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://user-images.githubusercontent.com/114918544/235130383-b439be36-a512-4acb-a0e0-c5e2a019e449.png)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
