### PR TITLE
Switch thank you V1

### DIFF
--- a/client/components/mma/MMAPage.tsx
+++ b/client/components/mma/MMAPage.tsx
@@ -177,6 +177,14 @@ const ContinueMembershipConfirmation = lazy(() =>
 	})),
 );
 
+const SwitchMembershipThankYou = lazy(() =>
+	import(
+		/* webpackChunkName: "Cancellation" */ './cancel/cancellationSaves/SwitchThankYou'
+	).then(({ SwitchThankYou }) => ({
+		default: SwitchThankYou,
+	})),
+);
+
 const PaymentDetailUpdateContainer = lazy(() =>
 	import(
 		/* webpackChunkName: "PaymentDetailUpdate" */ './paymentUpdate/PaymentDetailUpdateContainer'
@@ -624,7 +632,12 @@ const MMARouter = () => {
 													<ContinueMembershipConfirmation />
 												}
 											/>
-											<Route path="switch-thank-you" />
+											<Route
+												path="switch-thank-you"
+												element={
+													<SwitchMembershipThankYou />
+												}
+											/>
 											<Route path="confirm" />
 											<Route path="reminder" />
 										</>

--- a/client/components/mma/MMAPage.tsx
+++ b/client/components/mma/MMAPage.tsx
@@ -640,7 +640,6 @@ const MMARouter = () => {
 													<ContinueMembershipConfirmation />
 												}
 											/>
-											<Route path="switch-thank-you" />
 											<Route
 												path="confirm"
 												element={

--- a/client/components/mma/MMAPage.tsx
+++ b/client/components/mma/MMAPage.tsx
@@ -177,7 +177,7 @@ const ContinueMembershipConfirmation = lazy(() =>
 	})),
 );
 
-const SwitchCompleteThankYou = lazy(() =>
+const SwitchThankYou = lazy(() =>
 	import(
 		/* webpackChunkName: "Cancellation" */ './cancel/cancellationSaves/SwitchThankYou'
 	).then(({ SwitchThankYou }) => ({
@@ -634,9 +634,7 @@ const MMARouter = () => {
 											/>
 											<Route
 												path="switch-thank-you"
-												element={
-													<SwitchCompleteThankYou />
-												}
+												element={<SwitchThankYou />}
 											/>
 											<Route path="confirm" />
 											<Route path="reminder" />

--- a/client/components/mma/MMAPage.tsx
+++ b/client/components/mma/MMAPage.tsx
@@ -177,7 +177,7 @@ const ContinueMembershipConfirmation = lazy(() =>
 	})),
 );
 
-const SwitchMembershipThankYou = lazy(() =>
+const SwitchCompleteThankYou = lazy(() =>
 	import(
 		/* webpackChunkName: "Cancellation" */ './cancel/cancellationSaves/SwitchThankYou'
 	).then(({ SwitchThankYou }) => ({
@@ -635,7 +635,7 @@ const MMARouter = () => {
 											<Route
 												path="switch-thank-you"
 												element={
-													<SwitchMembershipThankYou />
+													<SwitchCompleteThankYou />
 												}
 											/>
 											<Route path="confirm" />

--- a/client/components/mma/cancel/cancellationSaves/CancellationSaves.stories.tsx
+++ b/client/components/mma/cancel/cancellationSaves/CancellationSaves.stories.tsx
@@ -12,6 +12,7 @@ import { MembershipCancellationLanding } from './MembershipCancellationLanding';
 import { MembershipSwitch } from './MembershipSwitch';
 import { SaveOptions } from './SaveOptions';
 import { SelectReason } from './SelectReason';
+import { SwitchThankYou } from './SwitchThankYou';
 import { ValueOfSupport } from './ValueOfSupport';
 
 export default {
@@ -63,4 +64,10 @@ export const ContinueMembership: ComponentStory<
 	typeof ContinueMembershipConfirmation
 > = () => {
 	return <ContinueMembershipConfirmation />;
+};
+
+export const SwitchCompleteThankYou: ComponentStory<
+	typeof SwitchThankYou
+> = () => {
+	return <SwitchThankYou />;
 };

--- a/client/components/mma/cancel/cancellationSaves/SwitchThankYou.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SwitchThankYou.tsx
@@ -1,0 +1,69 @@
+import {
+	Button,
+	Stack,
+	SvgArrowRightStraight,
+	SvgCalendar,
+	SvgEnvelope,
+} from '@guardian/source-react-components';
+import { useContext } from 'react';
+import { useNavigate } from 'react-router';
+import { Heading } from '../../shared/Heading';
+import { iconListCss, sectionSpacing } from '../../switch/SwitchStyles';
+import type { CancellationPageTitleInterface } from '../CancellationContainer';
+import { CancellationPageTitleContext } from '../CancellationContainer';
+import { buttonLayoutCss } from './SaveStyles';
+
+export const SwitchThankYou = () => {
+	const navigate = useNavigate();
+
+	const pageTitleContext = useContext(
+		CancellationPageTitleContext,
+	) as CancellationPageTitleInterface;
+	pageTitleContext.setPageTitle('Change your membership');
+
+	return (
+		<>
+			<section css={sectionSpacing}>
+				<Stack space={4}>
+					<Heading>
+						Thank you for continuing to support Guardian journalism
+						every month
+					</Heading>
+				</Stack>
+			</section>
+			<section css={sectionSpacing}>
+				<Stack space={4}>
+					<Heading sansSerif>What happens next?</Heading>
+					<ul css={[iconListCss]}>
+						<li>
+							<SvgEnvelope size="medium" />
+							<span data-qm-masking="blocklist">
+								We will send you a confirmation email to
+								email@email.com
+							</span>
+						</li>
+						<li>
+							<SvgCalendar size="medium" />
+							<span>
+								This change will happen on your next billing
+								date of XYZ. Until then, you have access to all
+								of your current supporter extras
+							</span>
+						</li>
+					</ul>
+				</Stack>
+			</section>
+			<section css={sectionSpacing}>
+				<div css={[buttonLayoutCss, { textAlign: 'left' }]}>
+					<Button
+						icon={<SvgArrowRightStraight />}
+						iconSide="right"
+						onClick={() => navigate('/')}
+					>
+						Back to your account
+					</Button>
+				</div>
+			</section>
+		</>
+	);
+};


### PR DESCRIPTION
New thank you screen which is part of the user journey where a user changes from a membership to a recurring contributor

Added to storybook

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Storybook or (on local) switch the feature flag off and head to cancel/membership/switch-thank-you

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
![image](https://user-images.githubusercontent.com/115992455/235200472-305fcaed-07f2-46d3-94f8-603ca2a2eb0f.png)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
