### PR TITLE
Membership Saves - Create Reminder screen

### DIFF
--- a/client/components/mma/MMAPage.tsx
+++ b/client/components/mma/MMAPage.tsx
@@ -185,6 +185,14 @@ const ConfirmMembershipCancellation = lazy(() =>
 	})),
 );
 
+const SupportReminder = lazy(() =>
+	import(
+		/* webpackChunkName: "Cancellation" */ './cancel/cancellationSaves/SupportReminder'
+	).then(({ SupportReminder }) => ({
+		default: SupportReminder,
+	})),
+);
+
 const PaymentDetailUpdateContainer = lazy(() =>
 	import(
 		/* webpackChunkName: "PaymentDetailUpdate" */ './paymentUpdate/PaymentDetailUpdateContainer'
@@ -639,7 +647,10 @@ const MMARouter = () => {
 													<ConfirmMembershipCancellation />
 												}
 											/>
-											<Route path="reminder" />
+											<Route
+												path="reminder"
+												element={<SupportReminder />}
+											/>
 										</>
 									)}
 								</Route>

--- a/client/components/mma/cancel/Cancellation.stories.tsx
+++ b/client/components/mma/cancel/Cancellation.stories.tsx
@@ -74,8 +74,7 @@ Review.parameters = {
 export const Confirmation: ComponentStory<
 	typeof CancellationContainer
 > = () => {
-	// @ts-expect-error set identity details email in the window
-	window.guardian = { identityDetails: { email: 'test' } };
+	window.guardian.identityDetails.email = 'test';
 
 	return getCancellationSummary(
 		PRODUCT_TYPES.contributions,

--- a/client/components/mma/cancel/Cancellation.stories.tsx
+++ b/client/components/mma/cancel/Cancellation.stories.tsx
@@ -74,7 +74,8 @@ Review.parameters = {
 export const Confirmation: ComponentStory<
 	typeof CancellationContainer
 > = () => {
-	window.guardian.identityDetails.email = 'test';
+	// @ts-expect-error set identity details email in the window
+	window.guardian = { identityDetails: { email: 'test' } };
 
 	return getCancellationSummary(
 		PRODUCT_TYPES.contributions,

--- a/client/components/mma/cancel/cancellationContributionReminder.tsx
+++ b/client/components/mma/cancel/cancellationContributionReminder.tsx
@@ -1,13 +1,9 @@
 import { css } from '@emotion/react';
 import { space } from '@guardian/source-foundations';
-import {
-	Button,
-	Radio,
-	RadioGroup,
-	SvgArrowRightStraight,
-} from '@guardian/source-react-components';
+import { Button, Radio, RadioGroup } from '@guardian/source-react-components';
 import { useEffect, useState } from 'react';
 import type * as React from 'react';
+import { useNavigate } from 'react-router';
 import { trackEventInOphanOnly } from '../../../utilities/analytics';
 import { getGeoLocation } from '../../../utilities/geolocation';
 
@@ -24,6 +20,12 @@ const setReminderContainerStyles = css`
 const formContainerStyles = css`
 	& > * + * {
 		margin-top: ${space[6]}px;
+	}
+`;
+
+const buttonLayoutCss = css`
+	> * + * {
+		margin-left: ${space[3]}px;
 	}
 `;
 
@@ -92,6 +94,8 @@ const getDefaultReminderChoices = (): ReminderChoice[] => [
 export const CancellationContributionReminder: React.FC = () => {
 	const [selectedChoiceIndex, setSelectedChoiceIndex] = useState(0);
 	const [hasSetReminder, setHasSetReminder] = useState(false);
+
+	const navigate = useNavigate();
 
 	const email = window.guardian.identityDetails.email;
 	const reminderChoices = getDefaultReminderChoices();
@@ -163,14 +167,15 @@ export const CancellationContributionReminder: React.FC = () => {
 								/>
 							))}
 						</RadioGroup>
-
-						<Button
-							onClick={onSubmit}
-							icon={<SvgArrowRightStraight />}
-							iconSide="right"
-						>
-							Set my reminder
-						</Button>
+						<div css={buttonLayoutCss}>
+							<Button onClick={onSubmit}>Set my reminder</Button>
+							<Button
+								priority="tertiary"
+								onClick={() => navigate('/')}
+							>
+								Back to your account
+							</Button>
+						</div>
 					</div>
 				</div>
 			)}

--- a/client/components/mma/cancel/cancellationSaves/CancellationSaves.stories.tsx
+++ b/client/components/mma/cancel/cancellationSaves/CancellationSaves.stories.tsx
@@ -14,7 +14,6 @@ import { MembershipSwitch } from './MembershipSwitch';
 import { SaveOptions } from './SaveOptions';
 import { SelectReason } from './SelectReason';
 import { SupportReminder } from './SupportReminder';
-import { SwitchThankYou } from './SwitchThankYou';
 import { ValueOfSupport } from './ValueOfSupport';
 
 export default {
@@ -75,13 +74,8 @@ export const ConfirmCancellation: ComponentStory<
 };
 
 export const Reminder: ComponentStory<typeof SupportReminder> = () => {
-	window.guardian.identityDetails.email = 'test';
+	// @ts-expect-error set identity details email in the window
+	window.guardian = { identityDetails: { email: 'test' } };
 
 	return <SupportReminder />;
-};
-
-export const SwitchCompleteThankYou: ComponentStory<
-	typeof SwitchThankYou
-> = () => {
-	return <SwitchThankYou />;
 };

--- a/client/components/mma/cancel/cancellationSaves/CancellationSaves.stories.tsx
+++ b/client/components/mma/cancel/cancellationSaves/CancellationSaves.stories.tsx
@@ -13,6 +13,7 @@ import { MembershipCancellationLanding } from './MembershipCancellationLanding';
 import { MembershipSwitch } from './MembershipSwitch';
 import { SaveOptions } from './SaveOptions';
 import { SelectReason } from './SelectReason';
+import { SupportReminder } from './SupportReminder';
 import { ValueOfSupport } from './ValueOfSupport';
 
 export default {
@@ -70,4 +71,11 @@ export const ConfirmCancellation: ComponentStory<
 	typeof ConfirmMembershipCancellation
 > = () => {
 	return <ConfirmMembershipCancellation />;
+};
+
+export const Reminder: ComponentStory<typeof SupportReminder> = () => {
+	// @ts-expect-error set identity details email in the window
+	window.guardian = { identityDetails: { email: 'test' } };
+
+	return <SupportReminder />;
 };

--- a/client/components/mma/cancel/cancellationSaves/CancellationSaves.stories.tsx
+++ b/client/components/mma/cancel/cancellationSaves/CancellationSaves.stories.tsx
@@ -14,6 +14,7 @@ import { MembershipSwitch } from './MembershipSwitch';
 import { SaveOptions } from './SaveOptions';
 import { SelectReason } from './SelectReason';
 import { SupportReminder } from './SupportReminder';
+import { SwitchThankYou } from './SwitchThankYou';
 import { ValueOfSupport } from './ValueOfSupport';
 
 export default {
@@ -71,6 +72,12 @@ export const ConfirmCancellation: ComponentStory<
 	typeof ConfirmMembershipCancellation
 > = () => {
 	return <ConfirmMembershipCancellation />;
+};
+
+export const SwitchCompleteThankYou: ComponentStory<
+	typeof SwitchThankYou
+> = () => {
+	return <SwitchThankYou />;
 };
 
 export const Reminder: ComponentStory<typeof SupportReminder> = () => {

--- a/client/components/mma/cancel/cancellationSaves/CancellationSaves.stories.tsx
+++ b/client/components/mma/cancel/cancellationSaves/CancellationSaves.stories.tsx
@@ -74,8 +74,7 @@ export const ConfirmCancellation: ComponentStory<
 };
 
 export const Reminder: ComponentStory<typeof SupportReminder> = () => {
-	// @ts-expect-error set identity details email in the window
-	window.guardian = { identityDetails: { email: 'test' } };
+	window.guardian.identityDetails.email = 'test';
 
 	return <SupportReminder />;
 };

--- a/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
@@ -189,6 +189,7 @@ export const MembershipSwitch = () => {
 		</>
 	);
 };
+
 function getMonthlyOrAnnual(billingPeriod: string | undefined) {
 	return billingPeriod === 'year' ? 'Annual' : 'Monthly';
 }

--- a/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
+++ b/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
@@ -124,7 +124,6 @@ export const headingCss = css`
 		${headline.small({ fontWeight: 'bold' })};
 		span {
 			display: block;
-			color: ${palette.brand['500']};
 		}
 	}
 `;

--- a/client/components/mma/cancel/cancellationSaves/SupportReminder.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SupportReminder.tsx
@@ -1,0 +1,16 @@
+import { CancellationContributionReminder } from '../cancellationContributionReminder';
+import { headingCss, sectionSpacing } from './SaveStyles';
+
+export const SupportReminder = () => {
+	return (
+		<section css={sectionSpacing}>
+			<h2 css={headingCss}>
+				We're sorry to see you go today.
+				<span css={{ display: 'block' }}>
+					You can support us again any time.
+				</span>
+			</h2>
+			<CancellationContributionReminder />
+		</section>
+	);
+};

--- a/cypress/integration/parallel-2/cancelContribution.spec.ts
+++ b/cypress/integration/parallel-2/cancelContribution.spec.ts
@@ -7,7 +7,6 @@ import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
 describe('Cancel contribution', () => {
 	const setSignInStatus = () => {
 		cy.window().then((window) => {
-			// @ts-ignore
 			window.guardian.identityDetails = {
 				signInStatus: 'signedInRecently',
 				userId: '200006712',

--- a/cypress/integration/parallel-2/cancelContribution.spec.ts
+++ b/cypress/integration/parallel-2/cancelContribution.spec.ts
@@ -9,7 +9,7 @@ describe('Cancel contribution', () => {
 		cy.window().then((window) => {
 			window.guardian.identityDetails = {
 				signInStatus: 'signedInRecently',
-				userId: '200006712',
+				userId: '1',
 				displayName: 'user',
 				email: 'example@example.com',
 			};

--- a/cypress/integration/parallel-2/membershipSave.spec.ts
+++ b/cypress/integration/parallel-2/membershipSave.spec.ts
@@ -13,7 +13,7 @@ if (featureSwitches.membershipSave) {
 			cy.window().then((window) => {
 				window.guardian.identityDetails = {
 					signInStatus: 'signedInRecently',
-					userId: '200006712',
+					userId: '1',
 					displayName: 'user',
 					email: 'example@example.com',
 				};

--- a/cypress/integration/parallel-2/membershipSave.spec.ts
+++ b/cypress/integration/parallel-2/membershipSave.spec.ts
@@ -9,6 +9,18 @@ import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
 
 if (featureSwitches.membershipSave) {
 	describe('Cancel membership saves', () => {
+		const setSignInStatus = () => {
+			cy.window().then((window) => {
+				// @ts-ignore
+				window.guardian.identityDetails = {
+					signInStatus: 'signedInRecently',
+					userId: '200006712',
+					displayName: 'user',
+					email: 'example@example.com',
+				};
+			});
+		};
+
 		beforeEach(() => {
 			signInAndAcceptCookies();
 			console.log('beforeEach');
@@ -31,6 +43,17 @@ if (featureSwitches.membershipSave) {
 				statusCode: 200,
 				body: [],
 			}).as('cancelled');
+
+			cy.intercept('POST', '/api/case', {
+				statusCode: 200,
+				body: {
+					id: 'caseId',
+				},
+			}).as('get_case');
+
+			cy.intercept('POST', '/api/reminders', {
+				statusCode: 200,
+			}).as('set_reminder');
 		});
 
 		it('switches to recurring contribution', () => {
@@ -63,6 +86,8 @@ if (featureSwitches.membershipSave) {
 
 		it('cancels membership', () => {
 			cy.visit('/');
+			setSignInStatus();
+
 			cy.get(`[data-cy="Manage membership"]`).click();
 
 			cy.findByText(/Cancel/).click();
@@ -86,7 +111,36 @@ if (featureSwitches.membershipSave) {
 				name: 'Cancel membership',
 			}).click();
 
-			cy.findByText(/Your Membership is cancelled/).should('exist');
+			cy.findByText(/Are you sure/).should('exist');
+			cy.findByRole('button', {
+				name: 'Confirm Cancellation',
+			}).click();
+
+			cy.findByRole('button', {
+				name: 'Submit',
+			}).click();
+			cy.findByText(/Please select a reason/).should('exist');
+
+			cy.findAllByRole('radio', {
+				name: 'Other',
+			}).click();
+
+			cy.findByRole('button', {
+				name: 'Submit',
+			}).click();
+
+			cy.wait('@get_case');
+
+			cy.findByText(/You can support us again any time/).should('exist');
+			cy.findByRole('button', {
+				name: 'Set my reminder',
+			}).click();
+
+			cy.wait('@set_reminder');
+
+			cy.findByText(/Thank you for setting up support reminder/).should(
+				'exist',
+			);
 		});
 
 		it('retains membership', () => {

--- a/cypress/integration/parallel-2/membershipSave.spec.ts
+++ b/cypress/integration/parallel-2/membershipSave.spec.ts
@@ -11,7 +11,6 @@ if (featureSwitches.membershipSave) {
 	describe('Cancel membership saves', () => {
 		const setSignInStatus = () => {
 			cy.window().then((window) => {
-				// @ts-ignore
 				window.guardian.identityDetails = {
 					signInStatus: 'signedInRecently',
 					userId: '200006712',

--- a/cypress/integration/parallel-2/productSwitch.spec.ts
+++ b/cypress/integration/parallel-2/productSwitch.spec.ts
@@ -17,7 +17,6 @@ import { ProductDetail } from '../../../shared/productResponse';
 
 const setSignInStatus = () => {
 	cy.window().then((window) => {
-		// @ts-ignore
 		window.guardian.identityDetails = {
 			signInStatus: 'signedInRecently',
 			userId: '200006712',
@@ -74,7 +73,6 @@ if (featureSwitches.cancellationProductSwitch) {
 			cy.visit('/');
 
 			cy.window().then((window) => {
-				// @ts-ignore
 				window.guardian.identityDetails = {
 					signInStatus: 'signedInRecently',
 					userId: '200006712',
@@ -106,7 +104,6 @@ if (featureSwitches.cancellationProductSwitch) {
 			cy.visit('/');
 
 			cy.window().then((window) => {
-				// @ts-ignore
 				window.guardian.identityDetails = {
 					signInStatus: 'signedInRecently',
 					userId: '200006712',
@@ -158,7 +155,6 @@ if (featureSwitches.cancellationProductSwitch) {
 			cy.visit('/');
 
 			cy.window().then((window) => {
-				// @ts-ignore
 				window.guardian.identityDetails = {
 					signInStatus: 'signedInRecently',
 					userId: '200006712',

--- a/cypress/integration/parallel-2/productSwitch.spec.ts
+++ b/cypress/integration/parallel-2/productSwitch.spec.ts
@@ -19,7 +19,7 @@ const setSignInStatus = () => {
 	cy.window().then((window) => {
 		window.guardian.identityDetails = {
 			signInStatus: 'signedInRecently',
-			userId: '200006712',
+			userId: '1',
 			displayName: 'user',
 			email: 'example@example.com',
 		};
@@ -106,7 +106,7 @@ if (featureSwitches.cancellationProductSwitch) {
 			cy.window().then((window) => {
 				window.guardian.identityDetails = {
 					signInStatus: 'signedInRecently',
-					userId: '200006712',
+					userId: '1',
 					displayName: 'user',
 					email: 'example@example.com',
 				};

--- a/cypress/integration/parallel-2/productSwitch.spec.ts
+++ b/cypress/integration/parallel-2/productSwitch.spec.ts
@@ -75,7 +75,7 @@ if (featureSwitches.cancellationProductSwitch) {
 			cy.window().then((window) => {
 				window.guardian.identityDetails = {
 					signInStatus: 'signedInRecently',
-					userId: '200006712',
+					userId: '1',
 					displayName: 'user',
 					email: 'example@example.com',
 				};
@@ -157,7 +157,7 @@ if (featureSwitches.cancellationProductSwitch) {
 			cy.window().then((window) => {
 				window.guardian.identityDetails = {
 					signInStatus: 'signedInRecently',
-					userId: '200006712',
+					userId: '1',
 					displayName: 'user',
 					email: 'example@example.com',
 				};

--- a/cypress/integration/parallel-2/updateContributionAmount.spec.ts
+++ b/cypress/integration/parallel-2/updateContributionAmount.spec.ts
@@ -7,7 +7,6 @@ import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
 describe('Update contribution amount', () => {
 	const setSignInStatus = () => {
 		cy.window().then((window) => {
-			// @ts-ignore
 			window.guardian.identityDetails = {
 				signInStatus: 'signedInRecently',
 				userId: '200006712',

--- a/cypress/integration/parallel-2/updateContributionAmount.spec.ts
+++ b/cypress/integration/parallel-2/updateContributionAmount.spec.ts
@@ -9,7 +9,7 @@ describe('Update contribution amount', () => {
 		cy.window().then((window) => {
 			window.guardian.identityDetails = {
 				signInStatus: 'signedInRecently',
-				userId: '200006712',
+				userId: '1',
 				displayName: 'user',
 				email: 'example@example.com',
 			};

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -17,11 +17,17 @@
 import './commands';
 import 'cypress-plugin-stripe-elements';
 import { createTestUser } from './commands';
+import type { Globals } from '../../shared/globals';
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
 
 declare global {
 	namespace Cypress {
+		interface Window {
+			guardian: Globals;
+			embedded_svc: any;
+		}
+
 		interface Chainable {
 			createTestUser: typeof createTestUser;
 			resolve(name: string): Chainable<Element>;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a reminder screen and API call post cancellation in the Membership cancellation saves journey. This PR also adds in the API call to send the reason on the previous screen. Also changes the existing reminder component to add a new button.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Testing locally:
Enable feature switch and confirm a cancellation on membership save journey. Click `Set Reminder`. The `api/reminders` call does not seem to work locally at time of writing.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Validation on reasons screen
![image](https://user-images.githubusercontent.com/114918544/235722187-4ec2647f-7ac0-42aa-bb5c-ebe75a4c2a46.png)

New screen
![image](https://user-images.githubusercontent.com/114918544/235722478-2e6b326f-a1b3-4f7f-99c0-7acd4046eeae.png)

After submission
![image](https://user-images.githubusercontent.com/114918544/235722574-27a6c848-c7e0-42e8-a967-d2d162482bdc.png)

Existing reminder screen
![image](https://user-images.githubusercontent.com/114918544/235722907-d3be4973-510c-422e-adbb-c9a42cb38f53.png)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
