### PR TITLE
Update product-move-api url to include switch type param

### DIFF
--- a/client/components/mma/switch/review/SwitchReview.tsx
+++ b/client/components/mma/switch/review/SwitchReview.tsx
@@ -96,7 +96,7 @@ const buttonLayoutCss = css`
 `;
 
 const productSwitchType: ProductSwitchType =
-	'RecurringContributionToSupporterPlus';
+	'recurring-contribution-to-supporter-plus';
 
 interface PreviewResponse {
 	amountPayableToday: number;

--- a/client/components/mma/switch/review/SwitchReview.tsx
+++ b/client/components/mma/switch/review/SwitchReview.tsx
@@ -12,6 +12,7 @@ import { useContext, useState } from 'react';
 import { Navigate, useLocation, useNavigate } from 'react-router';
 import { Link } from 'react-router-dom';
 import { dateString } from '../../../../../shared/dates';
+import type { ProductSwitchType } from '../../../../../shared/productSwitchTypes';
 import {
 	LoadingState,
 	useAsyncLoader,
@@ -94,6 +95,9 @@ const buttonLayoutCss = css`
 	}
 `;
 
+const productSwitchType: ProductSwitchType =
+	'RecurringContributionToSupporterPlus';
+
 interface PreviewResponse {
 	amountPayableToday: number;
 	supporterPlusPurchaseAmount: number;
@@ -130,7 +134,7 @@ export const SwitchReview = () => {
 
 	const productMoveFetch = (preview: boolean) =>
 		fetch(
-			`/api/product-move/${contributionToSwitch.subscription.subscriptionId}`,
+			`/api/product-move/${productSwitchType}/${contributionToSwitch.subscription.subscriptionId}`,
 			{
 				method: 'POST',
 				body: JSON.stringify({

--- a/cypress/integration/parallel-2/productSwitch.spec.ts
+++ b/cypress/integration/parallel-2/productSwitch.spec.ts
@@ -223,7 +223,7 @@ describe('product switching', () => {
 			body: [],
 		}).as('cancelled');
 
-		cy.intercept('POST', '/api/product-move/*', {
+		cy.intercept('POST', '/api/product-move/**', {
 			statusCode: 200,
 			body: productMovePreviewResponse,
 		}).as('product_move');
@@ -288,7 +288,7 @@ describe('product switching', () => {
 
 		cy.findByRole('button', { name: 'Confirm change' }).click();
 
-		cy.intercept('POST', '/api/product-move/*', {
+		cy.intercept('POST', '/api/product-move/**', {
 			statusCode: 200,
 			body: productMoveSuccessfulResponse,
 		});
@@ -313,7 +313,7 @@ describe('product switching', () => {
 
 		cy.findByRole('button', { name: 'Confirm change' }).click();
 
-		cy.intercept('POST', '/api/product-move/*', {
+		cy.intercept('POST', '/api/product-move/**', {
 			statusCode: 200,
 			body: productMoveSuccessfulResponse,
 		});
@@ -338,7 +338,7 @@ describe('product switching', () => {
 			name: 'Add extras',
 		}).click();
 
-		cy.intercept('POST', '/api/product-move/*', {
+		cy.intercept('POST', '/api/product-move/**', {
 			statusCode: 500,
 			body: {},
 		});

--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -165,10 +165,12 @@ router.get('/available-product-moves/:subscriptionName', (_, response) => {
 //
 
 router.post(
-	'/product-move/:subscriptionName',
-	productMoveAPI('product-move/:subscriptionName', 'MOVE_PRODUCT', [
-		'subscriptionName',
-	]),
+	'/product-move/:switchType/:subscriptionName',
+	productMoveAPI(
+		'product-move/:switchType/:subscriptionName',
+		'MOVE_PRODUCT',
+		['subscriptionName'],
+	),
 );
 
 router.get(

--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -169,7 +169,7 @@ router.post(
 	productMoveAPI(
 		'product-move/:switchType/:subscriptionName',
 		'MOVE_PRODUCT',
-		['subscriptionName'],
+		['switchType', 'subscriptionName'],
 	),
 );
 

--- a/shared/productSwitchTypes.ts
+++ b/shared/productSwitchTypes.ts
@@ -1,0 +1,3 @@
+export type ProductSwitchType =
+	| 'MembershipToRecurringContribution'
+	| 'RecurringContributionToSupporterPlus';

--- a/shared/productSwitchTypes.ts
+++ b/shared/productSwitchTypes.ts
@@ -1,3 +1,3 @@
 export type ProductSwitchType =
-	| 'MembershipToRecurringContribution'
-	| 'RecurringContributionToSupporterPlus';
+	| 'to-recurring-contribution'
+	| 'recurring-contribution-to-supporter-plus';


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a new parameter to the `product-move-api` call, depending on what the products being switched are. 

>**Note**
>This should only go in once the change has been made server side, ideally so that it supports both versions.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Complete an RC to S+ product switch at `/switch`.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
