### PR TITLE
Create Minimal Footer for use on Switch pages

### DIFF
--- a/.storybook/FooterContextDecorator.tsx
+++ b/.storybook/FooterContextDecorator.tsx
@@ -1,0 +1,13 @@
+import { DecoratorFn } from '@storybook/react';
+import { HasMinimalFooterContext } from '../client/components/shared/Main';
+import { useState } from 'react';
+
+export const FooterContextDecorator: DecoratorFn = (Story, context) => {
+	const [_, setHasMinimalFooter] = useState<boolean>(false);
+
+	return (
+		<HasMinimalFooterContext.Provider value={{ setHasMinimalFooter }}>
+			<Story />
+		</HasMinimalFooterContext.Provider>
+	);
+};

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -5,6 +5,7 @@ import { viewport } from './viewport';
 import { initialize, mswDecorator } from 'msw-storybook-addon';
 import isChromatic from 'chromatic/isChromatic';
 import MockDate from 'mockdate';
+import { FooterContextDecorator } from './FooterContextDecorator';
 
 // Initialize MSW
 initialize();
@@ -15,6 +16,7 @@ if (isChromatic()) {
 
 export const decorators = [
 	mswDecorator,
+	FooterContextDecorator,
 	(Story) => (
 		<>
 			<Global styles={css(`${global}`)} />

--- a/client/__tests__/__snapshots__/main.test.tsx.snap
+++ b/client/__tests__/__snapshots__/main.test.tsx.snap
@@ -835,7 +835,7 @@ html:not(.src-focus-disabled) .emotion-60:focus {
             >
               © 
               2022
-               Guardian News and Media Limited or its affiliated companies. All rights reserved.
+               Guardian News & Media Limited or its affiliated companies. All rights reserved.
             </div>
           </div>
         </div>

--- a/client/components/mma/Page.tsx
+++ b/client/components/mma/Page.tsx
@@ -7,8 +7,14 @@ import {
 	space,
 	textSans,
 } from '@guardian/source-foundations';
-import type { ReactElement } from 'react';
+import type { ReactElement} from 'react';
+import { useContext, useEffect } from 'react';
 import { gridBase, gridColumns, gridItemPlacement } from '../../styles/grid';
+import type {
+	HasMinimalFooterInterface} from '../shared/Main';
+import {
+	HasMinimalFooterContext
+} from '../shared/Main';
 import type { LeftSideNavProps } from '../shared/nav/LeftSideNav';
 import { LeftSideNav } from '../shared/nav/LeftSideNav';
 import type { NavItem } from '../shared/nav/NavConfig';
@@ -18,20 +24,33 @@ export interface PageContainerProps {
 	selectedNavItem: NavItem;
 	pageTitle: string | ReactElement;
 	compactTitle?: boolean;
+	minimalFooter?: boolean;
 }
 
-export const PageContainer = (props: PageContainerProps) => (
-	<>
-		<PageHeaderContainer
-			selectedNavItem={props.selectedNavItem}
-			title={props.pageTitle}
-			compactTitle={props.compactTitle}
-		/>
-		<PageNavAndContentContainer selectedNavItem={props.selectedNavItem}>
-			{props.children}
-		</PageNavAndContentContainer>
-	</>
-);
+export const PageContainer = (props: PageContainerProps) => {
+	const hasMinimalFooterContext = useContext(
+		HasMinimalFooterContext,
+	) as HasMinimalFooterInterface;
+
+	useEffect(() => {
+		hasMinimalFooterContext.setHasMinimalFooter(
+			props.minimalFooter ?? false,
+		);
+	});
+
+	return (
+		<>
+			<PageHeaderContainer
+				selectedNavItem={props.selectedNavItem}
+				title={props.pageTitle}
+				compactTitle={props.compactTitle}
+			/>
+			<PageNavAndContentContainer selectedNavItem={props.selectedNavItem}>
+				{props.children}
+			</PageNavAndContentContainer>
+		</>
+	);
+};
 
 interface PageHeaderContainerProps extends LeftSideNavProps {
 	title: string | ReactElement;

--- a/client/components/mma/switch/SwitchContainer.tsx
+++ b/client/components/mma/switch/SwitchContainer.tsx
@@ -89,6 +89,7 @@ const SwitchPageContainer = (props: { children: ReactNode }) => {
 			selectedNavItem={NAV_LINKS.accountOverview}
 			pageTitle={'Change your support'}
 			compactTitle
+			minimalFooter
 		>
 			{props.children}
 		</PageContainer>

--- a/client/components/shared/Main.tsx
+++ b/client/components/shared/Main.tsx
@@ -1,7 +1,16 @@
 import { palette, textSansSizes } from '@guardian/source-foundations';
+import type {
+	Context,
+	Dispatch,
+	SetStateAction} from 'react';
+import {
+	createContext,
+	useState,
+} from 'react';
 import { serif } from '../../styles/fonts';
 import type { SignInStatus } from '../../utilities/signInStatus';
 import { Footer } from './footer/Footer';
+import { MinimalFooter } from './footer/MinimalFooter';
 import { Header } from './Header';
 
 export interface MainProps {
@@ -10,57 +19,67 @@ export interface MainProps {
 	isHelpCentrePage?: boolean;
 }
 
+export interface HasMinimalFooterInterface {
+	setHasMinimalFooter: Dispatch<SetStateAction<boolean>>;
+}
+
+export const HasMinimalFooterContext: Context<HasMinimalFooterInterface | {}> =
+	createContext({});
+
 export const Main = ({
 	signInStatus = 'init',
 	children,
 	isHelpCentrePage,
-}: MainProps) => (
-	<div
-		css={{
-			display: 'flex',
-			flexDirection: 'column',
-			height: '100vh',
-			alignItems: 'stretch',
-			width: '100%',
-			color: palette.neutral[20],
-		}}
-	>
-		<a
-			css={{
-				color: palette.brand[400],
-				position: 'absolute',
-				textAlign: 'center',
-				fontSize: `${textSansSizes.xxsmall}px`,
-				':focus': {
-					position: 'static',
-				},
-			}}
-			href="#maincontent"
-		>
-			Skip to main content
-		</a>
-		<Header
-			signInStatus={signInStatus}
-			isHelpCentrePage={isHelpCentrePage}
-		/>
-		<div
-			css={{
-				flexGrow: 1,
-				flexShrink: 0,
-				display: 'flex',
-				flexDirection: 'column',
-			}}
-		>
-			<main
+}: MainProps)  => {
+	const [hasMinimalFooter, setHasMinimalFooter] = useState<boolean>(false);
+
+	return (
+		<HasMinimalFooterContext.Provider value={{ setHasMinimalFooter }}>
+			<div
 				css={{
-					fontFamily: serif,
-					flexGrow: 1,
-					flexShrink: 0,
+					display: 'flex',
+					flexDirection: 'column',
+					height: '100vh',
+					alignItems: 'stretch',
+					width: '100%',
+					color: palette.neutral[20],
 				}}
 			>
-				{children}
-			</main>
-		</div>
-		<Footer />
-	</div>
-);
+				<a
+					css={{
+						color: palette.brand[400],
+						position: 'absolute',
+						textAlign: 'center',
+						fontSize: `${textSansSizes.xxsmall}px`,
+						':focus': {
+							position: 'static',
+						},
+					}}
+					href="#maincontent"
+				>
+					Skip to main content
+				</a>
+				<Header signInStatus={signInStatus} isHelpCentrePage={isHelpCentrePage} />
+				<div
+					css={{
+						flexGrow: 1,
+						flexShrink: 0,
+						display: 'flex',
+						flexDirection: 'column',
+					}}
+				>
+					<main
+						css={{
+							fontFamily: serif,
+							flexGrow: 1,
+							flexShrink: 0,
+						}}
+					>
+						{children}
+					</main>
+				</div>
+				{hasMinimalFooter ? <MinimalFooter /> : <Footer />}
+			</div>
+		</HasMinimalFooterContext.Provider>
+	);
+};

--- a/client/components/shared/footer/Footer.stories.tsx
+++ b/client/components/shared/footer/Footer.stories.tsx
@@ -1,5 +1,6 @@
 import type { ComponentStory, Meta } from '@storybook/react';
 import { Footer } from './Footer';
+import { MinimalFooter } from './MinimalFooter';
 
 export default {
 	title: 'Components/Footer',
@@ -13,3 +14,7 @@ export default {
 } as Meta;
 
 export const Default: ComponentStory<typeof Footer> = () => <Footer />;
+
+export const Minimal: ComponentStory<typeof MinimalFooter> = () => (
+	<MinimalFooter />
+);

--- a/client/components/shared/footer/Footer.tsx
+++ b/client/components/shared/footer/Footer.tsx
@@ -316,7 +316,7 @@ export const Footer = () => {
 								</span>
 							</a>
 							<div css={copyrightTextStyles}>
-								© {TODAY.getFullYear()} Guardian News and Media
+								© {TODAY.getFullYear()} Guardian News & Media
 								Limited or its affiliated companies.
 								All&nbsp;rights&nbsp;reserved.
 							</div>

--- a/client/components/shared/footer/Footerlinks.tsx
+++ b/client/components/shared/footer/Footerlinks.tsx
@@ -103,3 +103,24 @@ export const footerlinks: FooterLink[][] = [
 		},
 	],
 ];
+
+export const minimalFooterLinks: FooterLink[][] = [
+	[
+		{
+			title: 'Privacy policy',
+			link: `https://${domain}/info/privacy`,
+		},
+	],
+	[
+		{
+			title: 'Contact us',
+			link: `https://${domain}/help/contact-us`,
+		},
+	],
+	[
+		{
+			title: 'Help centre',
+			link: `https://www.${domain}/help`,
+		},
+	],
+];

--- a/client/components/shared/footer/MinimalFooter.tsx
+++ b/client/components/shared/footer/MinimalFooter.tsx
@@ -1,0 +1,141 @@
+import { css } from '@emotion/react';
+import { from, palette, until } from '@guardian/source-foundations';
+import { minimalFooterLinks } from './Footerlinks';
+
+const footerColourStyles = css`
+	background-color: ${palette.brand[400]};
+	color: ${palette.neutral[100]};
+`;
+
+const footerSizeStyles = css`
+	max-width: 1300px;
+	margin: auto;
+`;
+
+const footerContentStyles = css`
+	padding: 10px 0px;
+	border: 1px solid rgba(255, 255, 255, 0.3);
+	border-top: 0;
+
+	${until.tablet} {
+		border-left: 0;
+		border-right: 0;
+	}
+
+	${from.tablet} {
+		padding: 10px;
+	}
+
+	${from.desktop} {
+		padding: 0;
+	}
+
+	${from.leftCol} {
+		display: flex;
+	}
+`;
+
+const footerMenuStyles = css`
+	font-feature-settings: kern;
+	font-size: 16px;
+	line-height: 16px;
+	display: flex;
+	flex-direction: row;
+	padding-bottom: 18px;
+	border-top: 1px solid rgba(255, 255, 255, 0.3);
+	${from.wide} {
+		border-top: 0;
+	}
+`;
+
+const footerMenuUlStyles = css`
+	line-height: 19.2px;
+	width: calc(50% - 1.25rem - 1px);
+	list-style: none;
+	position: relative;
+	padding: 0 10px;
+	margin: 0;
+
+	&:not(:first-of-type) {
+		border-left: 1px solid rgba(255, 255, 255, 0.3);
+	}
+
+	${from.tablet} {
+		width: 161px;
+		flex: 1 0 0;
+	}
+`;
+
+const footerMenuLiStyles = css`
+	list-style: none;
+`;
+
+const footerLinkStyles = css`
+	display: inline-block;
+	padding: 6px 0;
+	color: ${palette.neutral[100]};
+	:hover {
+		color: ${palette.brandAlt[400]};
+		cursor: pointer;
+	}
+`;
+
+const copyrightStyles = css`
+	padding-bottom: 24px;
+	padding-left: 20px;
+	padding-right: 20px;
+	position: relative;
+`;
+
+const copyrightTextStyles = css`
+	${from.tablet} {
+		padding-top: 6px;
+	}
+	padding-top: 26px;
+	font-size: 12px;
+`;
+
+export const MinimalFooter = () => {
+	const TODAY = new Date(Date.now());
+
+	return (
+		<footer>
+			<div>
+				<div css={footerColourStyles}>
+					<div css={footerSizeStyles}>
+						<div css={footerContentStyles}>
+							<div css={footerMenuStyles}>
+								{minimalFooterLinks.map((linkList, i) => (
+									<ul key={i} css={footerMenuUlStyles}>
+										{linkList.map(({ title, link }) => {
+											return (
+												<li
+													key={title}
+													css={footerMenuLiStyles}
+												>
+													<a
+														href={link}
+														css={footerLinkStyles}
+													>
+														{title}
+													</a>
+												</li>
+											);
+										})}
+									</ul>
+								))}
+							</div>
+						</div>
+						<div css={copyrightStyles}>
+							<div css={copyrightTextStyles}>
+								© {TODAY.getFullYear()} Guardian News & Media
+								Limited or its affiliated companies.
+								All&nbsp;rights&nbsp;reserved.
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</footer>
+	);
+};


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR creates a new minimal footer (similar to the one found on Support site) for use on Product Switching pages. This serves to reduce the risk associated from Apple legal reviews of the app switch journey by removing Support buttons. It is also a less cluttered footer. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Go to any page on MMA and there should be no changes, go to `switch` and witness the new footer.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Switch page
![image](https://user-images.githubusercontent.com/114918544/236433456-b517b8ef-1cec-4312-b027-5f4e6bf86d9b.png)

Desktop
![image](https://user-images.githubusercontent.com/114918544/236433597-313ea660-7e1f-4363-87b5-5387acc69a70.png)

Tablet
![image](https://user-images.githubusercontent.com/114918544/236433701-c73e40fc-661c-42ea-a1e9-eb6c1abcd496.png)

Mobile
![image](https://user-images.githubusercontent.com/114918544/236433787-9a99989c-deef-42e4-95f4-4d49a2efd64d.png)


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
