### PR TITLE
Fix Navigation on Help Centre

### DIFF
--- a/client/components/helpCentre/HelpCentrePage.tsx
+++ b/client/components/helpCentre/HelpCentrePage.tsx
@@ -81,7 +81,7 @@ const HelpCentreRouter = () => {
 	];
 
 	return (
-		<Main signInStatus={signInStatus}>
+		<Main signInStatus={signInStatus} isHelpCentrePage>
 			<Global styles={css(`${global}`)} />
 			<Global styles={css(`${fonts}`)} />
 			<HelpCenterContentWrapper knownIssues={knownIssues}>

--- a/client/components/shared/Header.tsx
+++ b/client/components/shared/Header.tsx
@@ -11,9 +11,10 @@ import { DropdownNav } from './nav/DropdownNav';
 
 export interface HeaderProps {
 	signInStatus: SignInStatus;
+	isHelpCentrePage?: boolean;
 }
 
-export const Header = (props: HeaderProps) => {
+export const Header = ({ signInStatus, isHelpCentrePage }: HeaderProps) => {
 	const headerCss = css`
 		background-color: ${palette.brand[400]};
 		min-height: 50px;
@@ -53,12 +54,14 @@ export const Header = (props: HeaderProps) => {
 	return (
 		<header css={headerCss}>
 			<div css={containerCss}>
-				{props.signInStatus === 'signedIn' && (
+				{signInStatus === 'signedIn' && (
 					<div css={divCss}>
-						<DropdownNav />
+						<DropdownNav
+							isHelpCentrePage={isHelpCentrePage ?? false}
+						/>
 					</div>
 				)}
-				{props.signInStatus === 'signedOut' && (
+				{signInStatus === 'signedOut' && (
 					<a href={'/'} css={aCss}>
 						Sign in
 					</a>

--- a/client/components/shared/Main.tsx
+++ b/client/components/shared/Main.tsx
@@ -7,9 +7,14 @@ import { Header } from './Header';
 export interface MainProps {
 	signInStatus?: SignInStatus;
 	children: JSX.Element | JSX.Element[];
+	isHelpCentrePage?: boolean;
 }
 
-export const Main = ({ signInStatus = 'init', children }: MainProps) => (
+export const Main = ({
+	signInStatus = 'init',
+	children,
+	isHelpCentrePage,
+}: MainProps) => (
 	<div
 		css={{
 			display: 'flex',
@@ -34,7 +39,10 @@ export const Main = ({ signInStatus = 'init', children }: MainProps) => (
 		>
 			Skip to main content
 		</a>
-		<Header signInStatus={signInStatus} />
+		<Header
+			signInStatus={signInStatus}
+			isHelpCentrePage={isHelpCentrePage}
+		/>
 		<div
 			css={{
 				flexGrow: 1,

--- a/client/components/shared/nav/DropdownNav.tsx
+++ b/client/components/shared/nav/DropdownNav.tsx
@@ -134,7 +134,7 @@ const DropdownNavItem = ({ navItem }: { navItem: MenuSpecificNavItem }) => (
 	</>
 );
 
-export const DropdownNav = () => {
+export const DropdownNav = (props: { isHelpCentrePage: boolean }) => {
 	const [showMenu, setShowMenu] = useState(false);
 	const wrapperRef = useRef<HTMLElement>(null);
 	const buttonRef = useRef<HTMLButtonElement>(null);
@@ -241,7 +241,7 @@ export const DropdownNav = () => {
 				{Object.values(NAV_LINKS).map(
 					(navItem: MenuSpecificNavItem) => (
 						<li key={navItem.title}>
-							{navItem.local ? (
+							{navItem.local && !props.isHelpCentrePage ? (
 								<Link
 									to={navItem.link}
 									css={dropdownNavItemCss}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR fixes a bug where navigation via the dropdown does not work on Help Centre pages. The solution is to use normal links when on a help centre page since they are part of a different react router so the `<Link>` component does not work. The bug was introduced in this PR: https://github.com/guardian/manage-frontend/pull/1033. We will still use `<Link>` for links on non-Help Centre pages since it does not refresh the page.


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Navigate to `/help-centre` and use the dropdown navigation, the links should work (and reload the page).

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

We should be aware that only links within MMA (and not Help Centre pages) can be linked to with the property `local` in the interface `NavItem`, and furthermore that we cannot navigate using React router between MMA and Help Centre.
 
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
