### PR TITLE
Update copy + design of Value of Support page

### DIFF
--- a/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
+++ b/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
@@ -124,6 +124,7 @@ export const headingCss = css`
 		${headline.small({ fontWeight: 'bold' })};
 		span {
 			display: block;
+			color: ${palette.brand['500']};
 		}
 	}
 `;

--- a/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
+++ b/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
@@ -88,6 +88,23 @@ export const buttonLayoutCss = css`
 	}
 `;
 
+export const stackedButtonLayoutCss = css`
+	display: flex;
+	flex-direction: column-reverse;
+	margin-top: ${space[5]}px;
+	padding-top: 32px;
+	> * + * {
+		margin-bottom: ${space[3]}px;
+	}
+	${from.tablet} {
+		flex-direction: row;
+		> * + * {
+			margin-top: 0;
+			margin-left: ${space[3]}px;
+		}
+	}
+`;
+
 export const smallPrintCss = css`
 	${textSans.xxsmall()};
 	margin-top: 0;
@@ -122,9 +139,10 @@ export const headingCss = css`
 
 	${from.tablet} {
 		${headline.small({ fontWeight: 'bold' })};
-		span {
-			display: block;
-			color: ${palette.brand['500']};
-		}
+	}
+
+	span {
+		display: block;
+		color: ${palette.brand['500']};
 	}
 `;

--- a/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
+++ b/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
@@ -98,6 +98,7 @@ export const stackedButtonLayoutCss = css`
 	}
 	${from.tablet} {
 		flex-direction: row;
+		justify-content: flex-end;
 		> * + * {
 			margin-top: 0;
 			margin-left: ${space[3]}px;

--- a/client/components/mma/cancel/cancellationSaves/ValueOfSupport.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ValueOfSupport.tsx
@@ -11,7 +11,11 @@ import { dateString } from '../../../../../shared/dates';
 import { ProgressIndicator } from '../../shared/ProgressIndicator';
 import type { CancellationContextInterface } from '../CancellationContainer';
 import { CancellationContext } from '../CancellationContainer';
-import { buttonLayoutCss, headingCss } from './SaveStyles';
+import {
+	buttonCentredCss,
+	headingCss,
+	stackedButtonLayoutCss,
+} from './SaveStyles';
 
 export const ValueOfSupport = () => {
 	const navigate = useNavigate();
@@ -57,9 +61,10 @@ export const ValueOfSupport = () => {
 				</p>
 			</Stack>
 			<div>Image placeholder</div>
-			<div css={[buttonLayoutCss, { textAlign: 'right' }]}>
+			<div css={[stackedButtonLayoutCss, { textAlign: 'right' }]}>
 				<Button
 					priority="tertiary"
+					cssOverrides={buttonCentredCss}
 					onClick={() => navigate('../landing')}
 				>
 					Back
@@ -67,6 +72,7 @@ export const ValueOfSupport = () => {
 				<Button
 					icon={<SvgArrowRightStraight />}
 					iconSide="right"
+					cssOverrides={buttonCentredCss}
 					onClick={() => navigate('../offers')}
 				>
 					Continue to cancellation

--- a/client/components/mma/cancel/cancellationSaves/ValueOfSupport.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ValueOfSupport.tsx
@@ -8,11 +8,10 @@ import {
 import { useContext } from 'react';
 import { Navigate, useNavigate } from 'react-router';
 import { dateString } from '../../../../../shared/dates';
-import { Heading } from '../../shared/Heading';
 import { ProgressIndicator } from '../../shared/ProgressIndicator';
 import type { CancellationContextInterface } from '../CancellationContainer';
 import { CancellationContext } from '../CancellationContainer';
-import { buttonLayoutCss } from './SaveStyles';
+import { buttonLayoutCss, headingCss } from './SaveStyles';
 
 export const ValueOfSupport = () => {
 	const navigate = useNavigate();
@@ -43,17 +42,18 @@ export const ValueOfSupport = () => {
 				`}
 			/>
 			<Stack space={4}>
-				<Heading>
+				<h2 css={headingCss}>
 					Thank you for supporting the Guardian since{' '}
 					{supportStartYear}.
-					<span css={{ display: 'block' }}>
-						Your support has made such a difference.
+					<span>
+						Your funding has played a vital role in our progress
 					</span>
-				</Heading>
+				</h2>
 				<p>
-					Here comes ... Before you go, please consider adapting your
-					membership to a monthly support or a Monthly + Extra
-					support.
+					Since you first joined as a Guardian Member, we've lived
+					through some of the most important news events of our times.
+					Without you, our fearless, independent journalism wouldn't
+					have reached millions around the world. We're so grateful.
 				</p>
 			</Stack>
 			<div>Image placeholder</div>

--- a/client/components/mma/cancel/cancellationSaves/ValueOfSupport.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ValueOfSupport.tsx
@@ -61,7 +61,7 @@ export const ValueOfSupport = () => {
 				</p>
 			</Stack>
 			<div>Image placeholder</div>
-			<div css={[stackedButtonLayoutCss, { textAlign: 'right' }]}>
+			<div css={stackedButtonLayoutCss}>
 				<Button
 					priority="tertiary"
 					cssOverrides={buttonCentredCss}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?


Update the copy and design of the Value of Support (step 2) page in the Membership Cancellation Save journey.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Go to `cancel/membership/details` (or the second step of the journey).

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://github.com/guardian/manage-frontend/assets/114918544/6b278846-5628-4866-8881-90e789a770dc)
![image](https://github.com/guardian/manage-frontend/assets/114918544/3304eaa9-b4ed-48b4-97d7-64fe34ffa05a)
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
