### PR TITLE
Fix cancel-reminders page routing

### DIFF
--- a/client/components/mma/MMAPage.tsx
+++ b/client/components/mma/MMAPage.tsx
@@ -677,7 +677,7 @@ const MMARouter = () => {
 						<Route path="/help" element={<Help />} />
 						{/*Does not require sign in*/}
 						<Route
-							path="/cancel-reminders/*reminderCode"
+							path="/cancel-reminders/:reminderCode"
 							element={<CancelReminders />}
 						/>
 						<Route path="/maintenance" element={<Maintenance />} />

--- a/client/components/mma/cancelReminders/CancelReminders.stories.tsx
+++ b/client/components/mma/cancelReminders/CancelReminders.stories.tsx
@@ -1,28 +1,41 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
-import fetchMock from 'fetch-mock';
-import type { CancelRemindersProps } from './CancelReminders';
+import { rest } from 'msw';
+import { ReactRouterDecorator } from '../../../../.storybook/ReactRouterDecorator';
 import { CancelReminders } from './CancelReminders';
 
 export default {
 	title: 'Pages/CancelReminders',
 	component: CancelReminders,
+	decorators: [ReactRouterDecorator],
 	parameters: {
 		layout: 'fullscreen',
+		reactRouter: {
+			location: '/cancel-reminders/test',
+			path: 'cancel-reminders/:reminderCode',
+		},
 	},
 } as ComponentMeta<typeof CancelReminders>;
 
-export const Error: ComponentStory<typeof CancelReminders> = (
-	_: CancelRemindersProps,
-) => {
-	fetchMock.restore().post('/api/reminders/cancel', 500);
-
-	return <CancelReminders reminderCode="123" />;
+export const Error: ComponentStory<typeof CancelReminders> = () => {
+	return <CancelReminders />;
 };
 
-export const Success: ComponentStory<typeof CancelReminders> = (
-	_: CancelRemindersProps,
-) => {
-	fetchMock.restore().post('/api/reminders/cancel', 200);
+Error.parameters = {
+	msw: [
+		rest.post('/api/reminders/cancel', (_req, res, ctx) => {
+			return res(ctx.status(500));
+		}),
+	],
+};
 
-	return <CancelReminders reminderCode="123" />;
+export const Success: ComponentStory<typeof CancelReminders> = () => {
+	return <CancelReminders />;
+};
+
+Success.parameters = {
+	msw: [
+		rest.post('/api/reminders/cancel', (_req, res, ctx) => {
+			return res(ctx.status(200));
+		}),
+	],
 };

--- a/client/components/mma/cancelReminders/CancelReminders.tsx
+++ b/client/components/mma/cancelReminders/CancelReminders.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import * as Sentry from '@sentry/browser';
 import { useEffect, useState } from 'react';
+import { useParams } from 'react-router';
 import { sendReminderCancellation } from '../identity/idapi/supportReminders';
 
 const containerStyle = css`
@@ -25,20 +26,17 @@ const linkStyle = css`
 
 type CancelStatus = 'PENDING' | 'SUCCESS' | 'FAILURE';
 
-export interface CancelRemindersProps {
-	reminderCode?: string;
-}
-
-export const CancelReminders = (props: CancelRemindersProps) => {
+export const CancelReminders = () => {
+	const { reminderCode } = useParams();
 	const [cancelStatus, setCancelStatus] = useState<CancelStatus>('PENDING');
 
 	useEffect(() => {
-		if (props.reminderCode) {
-			sendReminderCancellation(props.reminderCode).then((response) => {
+		if (reminderCode) {
+			sendReminderCancellation(reminderCode).then((response) => {
 				if (!response.ok) {
 					setCancelStatus('FAILURE');
 					Sentry.captureMessage(
-						`Failed to cancel reminders for code: ${props.reminderCode}`,
+						`Failed to cancel reminders for code: ${reminderCode}`,
 					);
 				} else {
 					setCancelStatus('SUCCESS');


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR fixes the routing to the cancel-reminders page, and uses the `useParams` hook to get the token passed to the page. The react-router api seems to have changed since this page was built and the route was added - so it's unclear how long this page has been broken. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Go to `/cancel-reminders/*token here*`, you should see the message "Unsubscribing" then a success or failure screen depending on if the token was valid.

The Storybook stories have been updated to use the param instead of component props.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
