### PR TITLE
Membership cancellation landing v2 cc

### DIFF
--- a/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
@@ -92,7 +92,7 @@ export const MembershipCancellationLanding = () => {
 						We're sorry to hear you're thinking of leaving
 					</Heading>
 					<p>
-						To cancel today, please chose from the following
+						To cancel today, please choose from the following
 						options.
 					</p>
 				</Stack>

--- a/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
@@ -100,7 +100,7 @@ export const MembershipCancellationLanding = () => {
 			<section css={sectionSpacing}>
 				<Stack space={3}>
 					<Heading sansSerif>Call us</Heading>
-					You can call one of our customer service agents.
+					Phone one of our customer service agents.
 					<CallCentreEmailAndNumbers hideEmailAddress={true} />
 				</Stack>
 			</section>

--- a/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
@@ -23,7 +23,7 @@ import { Heading } from '../../shared/Heading';
 import { sectionSpacing } from '../../switch/SwitchStyles';
 import type { CancellationContextInterface } from '../CancellationContainer';
 import { CancellationContext } from '../CancellationContainer';
-import { buttonLayoutCss, headingCss } from './SaveStyles';
+import { buttonLayoutCss } from './SaveStyles';
 
 function ineligibleForSave(
 	products: ProductDetail[],
@@ -89,42 +89,25 @@ export const MembershipCancellationLanding = () => {
 			<section css={sectionSpacing}>
 				<Stack space={3}>
 					<Heading>
-						We're sorry to hear you're thinking of cancelling.
+						We're sorry to hear you're thinking of leaving
 					</Heading>
-					<p>Lorem Lipsum Loremm Lipsum</p>
-					<h2 css={headingCss}>
-						We offer different ways for cancelling your membership
-					</h2>
+					<p>
+						To cancel today, please chose from the following
+						options.
+					</p>
 				</Stack>
 			</section>
 			<section css={sectionSpacing}>
 				<Stack space={3}>
 					<Heading sansSerif>Call us</Heading>
-					You can call one of our customer service...
-					<CallCentreEmailAndNumbers
-						hideEmailAddress={true}
-						collapsed
-					/>
-				</Stack>
-			</section>
-			<section css={sectionSpacing}>
-				<Stack space={3}>
-					<Heading sansSerif>Chat to us</Heading>
-					You can chat with our customer service..
-					<div css={buttonLayoutCss}>
-						<Button
-							icon={<SvgArrowRightStraight />}
-							iconSide="right"
-						>
-							Contact Us
-						</Button>
-					</div>
+					You can call one of our customer service agents.
+					<CallCentreEmailAndNumbers hideEmailAddress={true} />
 				</Stack>
 			</section>
 			<section css={sectionSpacing}>
 				<Stack space={3}>
 					<Heading sansSerif>Cancel online</Heading>
-					You can cancel online Lorem Lipsum.
+					Continue without speaking to our customer service team.
 					<div css={buttonLayoutCss}>
 						<Button
 							icon={<SvgArrowRightStraight />}

--- a/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
@@ -1,8 +1,4 @@
-import {
-	Button,
-	Stack,
-	SvgArrowRightStraight,
-} from '@guardian/source-react-components';
+import { Button, Stack } from '@guardian/source-react-components';
 import { useContext } from 'react';
 import { Navigate, useNavigate } from 'react-router';
 import { featureSwitches } from '../../../../../shared/featureSwitches';
@@ -23,7 +19,7 @@ import { Heading } from '../../shared/Heading';
 import { sectionSpacing } from '../../switch/SwitchStyles';
 import type { CancellationContextInterface } from '../CancellationContainer';
 import { CancellationContext } from '../CancellationContainer';
-import { buttonLayoutCss } from './SaveStyles';
+import { buttonLayoutCss, headingCss } from './SaveStyles';
 
 function ineligibleForSave(
 	products: ProductDetail[],
@@ -88,9 +84,9 @@ export const MembershipCancellationLanding = () => {
 		<>
 			<section css={sectionSpacing}>
 				<Stack space={3}>
-					<Heading>
+					<h2 css={headingCss}>
 						We're sorry to hear you're thinking of leaving
-					</Heading>
+					</h2>
 					<p>
 						To cancel today, please choose from the following
 						options.
@@ -99,8 +95,8 @@ export const MembershipCancellationLanding = () => {
 			</section>
 			<section css={sectionSpacing}>
 				<Stack space={3}>
-					<Heading sansSerif>Call us</Heading>
-					Phone one of our customer service agents.
+					<Heading sansSerif>Call us to cancel</Heading>
+					Phone one of our customer service agents
 					<CallCentreEmailAndNumbers hideEmailAddress={true} />
 				</Stack>
 			</section>
@@ -109,11 +105,7 @@ export const MembershipCancellationLanding = () => {
 					<Heading sansSerif>Cancel online</Heading>
 					Continue without speaking to our customer service team.
 					<div css={buttonLayoutCss}>
-						<Button
-							icon={<SvgArrowRightStraight />}
-							iconSide="right"
-							onClick={() => navigate('../details')}
-						>
+						<Button onClick={() => navigate('../details')}>
 							Cancel online
 						</Button>
 					</div>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Making changes as per the design copy:
- Removed chat to us button
- Updated wording 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
![image](https://github.com/guardian/manage-frontend/assets/115992455/91b086d6-b6f1-4754-9728-d9c42c2c9203)

![image](https://github.com/guardian/manage-frontend/assets/115992455/e402836e-6f10-43b1-b385-c95d67e29a3c)


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
