### PR TITLE
Improve CreateReminder component at mobile

### DIFF
--- a/client/components/mma/reminders/CreateReminder.tsx
+++ b/client/components/mma/reminders/CreateReminder.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { from } from '@guardian/source-foundations';
 import * as Sentry from '@sentry/browser';
 import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
@@ -6,8 +7,10 @@ import type { ReminderType } from '../identity/idapi/supportReminders';
 import { sendReminderCreation } from '../identity/idapi/supportReminders';
 
 const containerStyle = css`
-	width: 100%;
-	margin-left: 20%;
+	margin: 0 5px;
+	${from.desktop} {
+		margin-left: 20%;
+	}
 
 	max-width: 400px;
 	display: flex;


### PR DESCRIPTION
Before:
<img width="319" alt="Screenshot 2023-05-11 at 15 35 52" src="https://github.com/guardian/manage-frontend/assets/1513454/a8778439-10b4-4abc-8584-9697722c46be">


After:
<img width="328" alt="Screenshot 2023-05-11 at 15 30 34" src="https://github.com/guardian/manage-frontend/assets/1513454/3bf73a6a-dc6d-43e7-b3e4-42babe467466">
<img width="1001" alt="Screenshot 2023-05-11 at 15 30 46" src="https://github.com/guardian/manage-frontend/assets/1513454/69e84097-a6c2-4c1a-80d9-2aa342f0d677">
