### PR TITLE
Membership Saves - Copy changes V2 - Save options

### DIFF
--- a/client/components/mma/cancel/cancellationSaves/SaveOptions.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SaveOptions.tsx
@@ -4,7 +4,6 @@ import {
 	Button,
 	buttonThemeReaderRevenueBrand,
 	Stack,
-	SvgArrowRightStraight,
 } from '@guardian/source-react-components';
 import { useNavigate } from 'react-router';
 import { Card } from '../../shared/Card';
@@ -12,11 +11,15 @@ import { Heading } from '../../shared/Heading';
 import { MembershipBenefitsSection } from '../../shared/MembershipBenefits';
 import { ProgressIndicator } from '../../shared/ProgressIndicator';
 import { RecurringSupporterBenefitsSection } from '../../shared/RecurringSupporterBenefits';
-import { productTitleCss, sectionSpacing } from '../../switch/SwitchStyles';
 import {
-	buttonLayoutCss,
+	buttonCentredCss,
+	buttonContainerCss,
 	cardHeaderDivCss,
+	cardSectionCss,
+	headingCss,
 	productSubtitleCss,
+	productTitleCss,
+	sectionSpacing,
 } from './SaveStyles';
 
 export const SaveOptions = () => {
@@ -36,9 +39,9 @@ export const SaveOptions = () => {
 			/>
 			<Stack space={4}>
 				<section css={sectionSpacing}>
-					<Heading>
+					<h2 css={headingCss}>
 						Are you sure you want to lose your exclusive benefits?
-					</Heading>
+					</h2>
 				</section>
 				<section css={sectionSpacing}>
 					<Heading sansSerif>Keep your Membership</Heading>
@@ -54,66 +57,70 @@ export const SaveOptions = () => {
 					</Card.Header>
 					<Card.Section>
 						<MembershipBenefitsSection />
-						{/*todo: add  border border-top: 1px solid ${palette.neutral[86]}; */}
-						<section css={sectionSpacing}>
-							<div css={buttonLayoutCss}>
-								<ThemeProvider
-									theme={buttonThemeReaderRevenueBrand}
+						<section css={[cardSectionCss, buttonContainerCss]}>
+							<ThemeProvider
+								theme={buttonThemeReaderRevenueBrand}
+							>
+								<Button
+									cssOverrides={buttonCentredCss}
+									size="small"
 								>
-									<Button>
-										Keep my Membership for xx/yy
-									</Button>
-								</ThemeProvider>
-							</div>
+									Keep my Membership for xx/yy
+								</Button>
+							</ThemeProvider>
 						</section>
 					</Card.Section>
 				</Card>
 				<section css={sectionSpacing}>
 					<Heading sansSerif>
-						Continue your membership at X per month
+						Stay a supporter at no extra cost
 					</Heading>
 				</section>
-				You will still be able to enjoy uninterrupted reading and
-				receive the supporter newsletter.
+				You will lose access to some of your benefits, but will keep
+				funding Guardian journalism.
 				<Card>
 					<Card.Header backgroundColor={palette.brand[600]}>
 						<div css={cardHeaderDivCss}>
-							<h3 css={productTitleCss}>Recurring supporter</h3>
+							<h3 css={productTitleCss}>Monthly contribution</h3>
 							<p css={productSubtitleCss}>XY/Z</p>
 						</div>
 					</Card.Header>
 					<Card.Section>
 						<RecurringSupporterBenefitsSection />
-						<section css={sectionSpacing}>
-							<div css={buttonLayoutCss}>
+						<section css={[cardSectionCss, buttonContainerCss]}>
+							<ThemeProvider
+								theme={buttonThemeReaderRevenueBrand}
+							>
 								<Button
-									icon={<SvgArrowRightStraight />}
-									iconSide="right"
+									cssOverrides={buttonCentredCss}
+									size="small"
 									onClick={() => navigate('../switch-offer')}
 								>
-									Become a recurring supporter
+									Become a recurring contributor
 								</Button>
-							</div>
+							</ThemeProvider>
 						</section>
 					</Card.Section>
 				</Card>
 				<section css={sectionSpacing}>
 					<Heading sansSerif>Cancel your membership</Heading>
-					Copy to say that you cannot become a member again once you
-					have cancelled.
+					<p>
+						Please note if you cancel you will not be able to rejoin
+						the Guardian Members scheme, as it’s now closed to new
+						members
+					</p>
+					<div css={buttonContainerCss}>
+						<Button
+							cssOverrides={buttonCentredCss}
+							priority="tertiary"
+							size="small"
+							onClick={() => navigate('../confirm')}
+						>
+							Cancel Membership
+						</Button>
+					</div>
 				</section>
 			</Stack>
-			<section css={sectionSpacing}>
-				<div css={buttonLayoutCss}>
-					<Button
-						icon={<SvgArrowRightStraight />}
-						iconSide="right"
-						onClick={() => navigate('../confirm')}
-					>
-						Cancel membership
-					</Button>
-				</div>
-			</section>
 		</>
 	);
 };

--- a/client/components/mma/cancel/cancellationSaves/SaveOptions.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SaveOptions.tsx
@@ -1,16 +1,28 @@
 import { css, ThemeProvider } from '@emotion/react';
-import { palette, space } from '@guardian/source-foundations';
+import { palette, space, textSans } from '@guardian/source-foundations';
 import {
 	Button,
 	buttonThemeReaderRevenueBrand,
 	Stack,
 } from '@guardian/source-react-components';
-import { useNavigate } from 'react-router';
+import { useContext } from 'react';
+import { Navigate, useNavigate } from 'react-router';
+import type { PaidSubscriptionPlan } from '../../../../../shared/productResponse';
+import { getMainPlan  } from '../../../../../shared/productResponse';
+import {
+	getNewMembershipPrice,
+	getOldMembershipPrice,
+} from '../../../../utilities/membershipPriceRise';
 import { Card } from '../../shared/Card';
 import { Heading } from '../../shared/Heading';
 import { MembershipBenefitsSection } from '../../shared/MembershipBenefits';
 import { ProgressIndicator } from '../../shared/ProgressIndicator';
 import { RecurringSupporterBenefitsSection } from '../../shared/RecurringSupporterBenefits';
+import type {
+	CancellationContextInterface} from '../CancellationContainer';
+import {
+	CancellationContext
+} from '../CancellationContainer';
 import {
 	buttonCentredCss,
 	buttonContainerCss,
@@ -24,6 +36,26 @@ import {
 
 export const SaveOptions = () => {
 	const navigate = useNavigate();
+	const cancellationContext = useContext(
+		CancellationContext,
+	) as CancellationContextInterface;
+	const membership = cancellationContext.productDetail;
+
+	if (!membership) {
+		return <Navigate to="/" />;
+	}
+
+	const mainPlan = getMainPlan(
+		membership.subscription,
+	) as PaidSubscriptionPlan;
+
+	const oldPriceDisplay = `${mainPlan.currency}${getOldMembershipPrice(
+		mainPlan,
+	)}`;
+	const newPriceDisplay = `${mainPlan.currency}${getNewMembershipPrice(
+		mainPlan,
+	)}`;
+	const billingPeriod = mainPlan.billingPeriod;
 
 	return (
 		<>
@@ -46,13 +78,22 @@ export const SaveOptions = () => {
 				<section css={sectionSpacing}>
 					<Heading sansSerif>Keep your Membership</Heading>
 				</section>
-				Enjoy all of your exclusive extras. The new price has increased
-				from XX to YY/ZZ.
+				<p
+					css={css`
+						${textSans.medium()};
+					`}
+				>
+					Enjoy all of your exclusive extras. The new price has
+					increased from {oldPriceDisplay} to {newPriceDisplay}/
+					{billingPeriod}.
+				</p>
 				<Card>
 					<Card.Header backgroundColor={palette.brand[600]}>
 						<div css={cardHeaderDivCss}>
 							<h3 css={productTitleCss}>Membership</h3>
-							<p css={productSubtitleCss}>XY/Z</p>
+							<p css={productSubtitleCss}>
+								{newPriceDisplay}/{billingPeriod}
+							</p>
 						</div>
 					</Card.Header>
 					<Card.Section>
@@ -65,7 +106,8 @@ export const SaveOptions = () => {
 									cssOverrides={buttonCentredCss}
 									size="small"
 								>
-									Keep my Membership for xx/yy
+									Keep my Membership for {newPriceDisplay}/
+									{billingPeriod}
 								</Button>
 							</ThemeProvider>
 						</section>
@@ -76,13 +118,21 @@ export const SaveOptions = () => {
 						Stay a supporter at no extra cost
 					</Heading>
 				</section>
-				You will lose access to some of your benefits, but will keep
-				funding Guardian journalism.
+				<p
+					css={css`
+						${textSans.medium()};
+					`}
+				>
+					You will lose access to some of your benefits, but will keep
+					funding Guardian journalism.
+				</p>
 				<Card>
 					<Card.Header backgroundColor={palette.brand[600]}>
 						<div css={cardHeaderDivCss}>
 							<h3 css={productTitleCss}>Monthly contribution</h3>
-							<p css={productSubtitleCss}>XY/Z</p>
+							<p css={productSubtitleCss}>
+								{oldPriceDisplay}/{billingPeriod}
+							</p>
 						</div>
 					</Card.Header>
 					<Card.Section>
@@ -104,7 +154,11 @@ export const SaveOptions = () => {
 				</Card>
 				<section css={sectionSpacing}>
 					<Heading sansSerif>Cancel your membership</Heading>
-					<p>
+					<p
+						css={css`
+							${textSans.medium()};
+						`}
+					>
 						Please note if you cancel you will not be able to rejoin
 						the Guardian Members scheme, as it’s now closed to new
 						members

--- a/client/components/mma/cancel/cancellationSaves/SaveOptions.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SaveOptions.tsx
@@ -1,7 +1,8 @@
-import { css } from '@emotion/react';
+import { css, ThemeProvider } from '@emotion/react';
 import { palette, space } from '@guardian/source-foundations';
 import {
 	Button,
+	buttonThemeReaderRevenueBrand,
 	Stack,
 	SvgArrowRightStraight,
 } from '@guardian/source-react-components';
@@ -36,16 +37,14 @@ export const SaveOptions = () => {
 			<Stack space={4}>
 				<section css={sectionSpacing}>
 					<Heading>
-						Before you go, would you consider different support
-						options
+						Are you sure you want to lose your exclusive benefits?
 					</Heading>
 				</section>
 				<section css={sectionSpacing}>
-					<Heading sansSerif>
-						Continue your membership at X per month
-					</Heading>
+					<Heading sansSerif>Keep your Membership</Heading>
 				</section>
-				You will keep your current set of benefits
+				Enjoy all of your exclusive extras. The new price has increased
+				from XX to YY/ZZ.
 				<Card>
 					<Card.Header backgroundColor={palette.brand[600]}>
 						<div css={cardHeaderDivCss}>
@@ -55,14 +54,16 @@ export const SaveOptions = () => {
 					</Card.Header>
 					<Card.Section>
 						<MembershipBenefitsSection />
+						{/*todo: add  border border-top: 1px solid ${palette.neutral[86]}; */}
 						<section css={sectionSpacing}>
 							<div css={buttonLayoutCss}>
-								<Button
-									icon={<SvgArrowRightStraight />}
-									iconSide="right"
+								<ThemeProvider
+									theme={buttonThemeReaderRevenueBrand}
 								>
-									Continue your membership
-								</Button>
+									<Button>
+										Keep my Membership for xx/yy
+									</Button>
+								</ThemeProvider>
 							</div>
 						</section>
 					</Card.Section>

--- a/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
+++ b/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
@@ -5,12 +5,21 @@ import {
 	palette,
 	space,
 	textSans,
+	until,
 } from '@guardian/source-foundations';
 
 export const sectionSpacing = css`
 	margin-top: ${space[6]}px;
 	${from.tablet} {
 		margin-top: ${space[9]}px;
+	}
+`;
+
+export const cardSectionCss = css`
+	margin-top: ${space[5]}px;
+	${from.tablet} {
+		padding-top: ${space[5]}px;
+		border-top: 1px solid ${palette.neutral[86]};
 	}
 `;
 
@@ -125,5 +134,12 @@ export const headingCss = css`
 		span {
 			display: block;
 		}
+	}
+`;
+
+export const buttonContainerCss = css`
+	${until.tablet} {
+		display: flex;
+		flex-direction: column;
 	}
 `;

--- a/client/components/mma/shared/MembershipBenefits.tsx
+++ b/client/components/mma/shared/MembershipBenefits.tsx
@@ -7,29 +7,22 @@ export const MembershipBenefitsSection = () => {
 			<li>
 				<SvgTickRound size="small" />
 				<span>
-					<strong>Unlimited app access.</strong>
-					<br css={lineBreakCss} /> For the best mobile experience
-				</span>
-			</li>
-			<li>
-				<SvgTickRound size="small" />
-				<span>
-					<strong>Ad-free reading.</strong>
-					<br css={lineBreakCss} /> On any device when signed in
+					<strong>Full access to our news app.</strong>
+					<br css={lineBreakCss} /> Read our reporting on the go
 				</span>
 			</li>
 			<li>
 				<SvgTickRound size="small" />
 				<span>
 					<strong>Uninterrupted reading.</strong>
-					<br css={lineBreakCss} /> No more yellow banners
+					<br css={lineBreakCss} /> See far fewer asks for support
 				</span>
 			</li>
 			<li>
 				<SvgTickRound size="small" />
 				<span>
-					<strong>Supporter newsletter.</strong> Giving you editorial
-					insight on the week's top stories
+					<strong>A regular supporter newsletter.</strong> Get
+					exclusive insight from our newsroom
 				</span>
 			</li>
 		</ul>

--- a/client/components/mma/shared/RecurringSupporterBenefits.tsx
+++ b/client/components/mma/shared/RecurringSupporterBenefits.tsx
@@ -16,29 +16,22 @@ export const RecurringSupporterBenefitsSection = () => {
 			<li>
 				<SvgTickRound size="small" />
 				<span>
-					<strong>Uninterrupted reading.</strong>
-					<br css={lineBreakCss} /> No more yellow banners
+					<strong>A regular supporter newsletter.</strong> Get
+					exclusive insight from our newsroom
 				</span>
 			</li>
 			<li>
 				<SvgTickRound size="small" />
 				<span>
-					<strong>Supporter newsletter.</strong> Giving you editorial
-					insight on the week's top stories
+					<strong>Uninterrupted reading.</strong>
+					<br css={lineBreakCss} /> See far fewer asks for support
 				</span>
 			</li>
 			<li css={unavailableBenefits}>
 				<SvgCrossRound size="small" />
 				<span>
-					<strong>Unlimited app access.</strong>
-					<br css={lineBreakCss} /> For the best mobile experience
-				</span>
-			</li>
-			<li css={unavailableBenefits}>
-				<SvgCrossRound size="small" />
-				<span>
-					<strong>Ad-free reading.</strong>
-					<br css={lineBreakCss} /> On any device when signed in
+					<strong>Full access to our news app.</strong>
+					<br css={lineBreakCss} /> Read our reporting on the go
 				</span>
 			</li>
 		</ul>

--- a/client/utilities/currencyIso.ts
+++ b/client/utilities/currencyIso.ts
@@ -1,1 +1,3 @@
 export type CurrencyIso = 'GBP' | 'USD' | 'AUD' | 'EUR' | 'NZD' | 'CAD';
+
+export type MembershipCurrencyIso = 'GBP' | 'USD' | 'AUD' | 'EUR' | 'CAD';

--- a/client/utilities/membershipPriceRise.ts
+++ b/client/utilities/membershipPriceRise.ts
@@ -1,0 +1,83 @@
+import type { PaidSubscriptionPlan } from '../../shared/productResponse';
+import type { MembershipCurrencyIso } from './currencyIso';
+
+//ToDo: TBC annual prices
+export const newSupporterMembershipByCountryGroup: Record<
+	MembershipCurrencyIso,
+	Record<'Monthly' | 'Annual', number>
+> = {
+	GBP: {
+		Monthly: 7,
+		Annual: 0,
+	},
+	USD: {
+		Monthly: 9.99,
+		Annual: 0,
+	},
+	EUR: {
+		Monthly: 9.99,
+		Annual: 0,
+	},
+	AUD: {
+		Monthly: 14.99,
+		Annual: 0,
+	},
+	CAD: {
+		Monthly: 12.99,
+		Annual: 0,
+	},
+};
+
+export const oldSupporterMembershipByCountryGroup: Record<
+	MembershipCurrencyIso,
+	Record<'Monthly' | 'Annual', number>
+> = {
+	GBP: {
+		Monthly: 5,
+		Annual: 49,
+	},
+	USD: {
+		Monthly: 6.99,
+		Annual: 69,
+	},
+	EUR: {
+		Monthly: 4.99,
+		Annual: 49,
+	},
+	AUD: {
+		Monthly: 10,
+		Annual: 100,
+	},
+	CAD: {
+		Monthly: 6.99,
+		Annual: 69,
+	},
+};
+
+function getMembershipPrice(
+	plan: PaidSubscriptionPlan,
+	priceConfig: Record<
+		MembershipCurrencyIso,
+		Record<'Monthly' | 'Annual', number>
+	>,
+) {
+	const currency = plan.currencyISO as MembershipCurrencyIso;
+	const monthlyOrAnnual =
+		plan.billingPeriod === 'month' ? 'Monthly' : 'Annual';
+
+	const region = priceConfig[currency];
+
+	if (region === undefined) {
+		throw new Error('Unsupported membership currency');
+	}
+
+	return region[monthlyOrAnnual];
+}
+
+export function getNewMembershipPrice(plan: PaidSubscriptionPlan): number {
+	return getMembershipPrice(plan, newSupporterMembershipByCountryGroup);
+}
+
+export function getOldMembershipPrice(plan: PaidSubscriptionPlan): number {
+	return getMembershipPrice(plan, oldSupporterMembershipByCountryGroup);
+}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Updates the copy and design on the Save options page of the membership save journey. Also adds in config to display the old and new prices for each country that supports memberships.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- Turn on feature switch and navigate to `cancel/membership/offers` with an eligible membership
- Storybook 

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://github.com/guardian/manage-frontend/assets/114918544/d7364e29-3f6c-40b2-94d6-d2c67453cd1d)
![image](https://github.com/guardian/manage-frontend/assets/114918544/3fffd75a-591a-4b04-bb82-6413203658c9)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
