### PR TITLE
Membership saves -  continue membership v2 

### DIFF
--- a/client/components/mma/cancel/cancellationSaves/ContinueMembershipConfirmation.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ContinueMembershipConfirmation.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { space, textSans } from '@guardian/source-foundations';
+import { from, space, textSans } from '@guardian/source-foundations';
 import { Button, Stack } from '@guardian/source-react-components';
 import { useContext } from 'react';
 import { useNavigate } from 'react-router';
@@ -42,12 +42,22 @@ export const ContinueMembershipConfirmation = () => {
 				<h2 css={headingCss}>Thank you for keeping your Membership</h2>
 				<p
 					css={css`
-						${textSans.medium()}
+						${textSans.medium()};
+						${from.tablet} {
+							span {
+								display: block;
+							}
+						}
 					`}
 				>
-					The new price of your Membership is £7/month. <br />
-					Your first billing date will be{' '}
-					{cancellationFormatDate(`${mainPlan.chargedThrough}`)}.
+					The new price of your Membership is £7/month.{' '}
+					<span>
+						Your first billing date will be{' '}
+						{cancellationFormatDate(
+							mainPlan.chargedThrough ?? undefined,
+						)}
+						.
+					</span>
 				</p>
 			</Stack>
 			<div css={stackedButtonLeftLayoutCss}>

--- a/client/components/mma/cancel/cancellationSaves/ContinueMembershipConfirmation.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ContinueMembershipConfirmation.tsx
@@ -1,28 +1,12 @@
 import { css } from '@emotion/react';
 import { space } from '@guardian/source-foundations';
-import {
-	Button,
-	Stack,
-	SvgArrowRightStraight,
-} from '@guardian/source-react-components';
-import { useContext } from 'react';
+import { Button, Stack } from '@guardian/source-react-components';
 import { useNavigate } from 'react-router';
-import { Heading } from '../../shared/Heading';
 import { ProgressIndicator } from '../../shared/ProgressIndicator';
-import type {
-	CancellationPageTitleInterface} from '../CancellationContainer';
-import {
-	CancellationPageTitleContext
-} from '../CancellationContainer';
-import { buttonLayoutCss } from './SaveStyles';
+import { headingCss, stackedButtonLeftLayoutCss } from './SaveStyles';
 
 export const ContinueMembershipConfirmation = () => {
 	const navigate = useNavigate();
-
-	const pageTitleContext = useContext(
-		CancellationPageTitleContext,
-	) as CancellationPageTitleInterface;
-	pageTitleContext.setPageTitle('Membership confirmation');
 
 	return (
 		<>
@@ -37,19 +21,18 @@ export const ContinueMembershipConfirmation = () => {
 				`}
 			/>
 			<Stack space={4}>
-				<Heading>Thank you for continuing your membership</Heading>
+				<h2 css={headingCss}>Thank you for keeping your Membership</h2>
 				<p>
-					No action is needed from your side. Your membership will
-					continue as normal.
+					The new price of your Membership is £7/month. <br />
+					Your first billing date will be XX Month.
 				</p>
 			</Stack>
-			<div css={[buttonLayoutCss, { textAlign: 'left' }]}>
-				<Button
-					icon={<SvgArrowRightStraight />}
-					iconSide="right"
-					onClick={() => navigate('https://www.theguardian.com')}
-				>
-					Continue reading the Guardian
+			<div css={stackedButtonLeftLayoutCss}>
+				<Button priority="tertiary" onClick={() => navigate('/')}>
+					Back to account overview
+				</Button>
+				<Button onClick={() => navigate('https://www.theguardian.com')}>
+					Continue to the Guardian
 				</Button>
 			</div>
 		</>

--- a/client/components/mma/cancel/cancellationSaves/ContinueMembershipConfirmation.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ContinueMembershipConfirmation.tsx
@@ -1,12 +1,34 @@
 import { css } from '@emotion/react';
 import { space } from '@guardian/source-foundations';
 import { Button, Stack } from '@guardian/source-react-components';
+import { useContext } from 'react';
 import { useNavigate } from 'react-router';
+import { cancellationFormatDate } from '../../../../../shared/dates';
+import type {
+	PaidSubscriptionPlan} from '../../../../../shared/productResponse';
+import {
+	getMainPlan
+} from '../../../../../shared/productResponse';
 import { ProgressIndicator } from '../../shared/ProgressIndicator';
+import type {
+	CancellationContextInterface} from '../CancellationContainer';
+import {
+	CancellationContext
+} from '../CancellationContainer';
 import { headingCss, stackedButtonLeftLayoutCss } from './SaveStyles';
 
 export const ContinueMembershipConfirmation = () => {
 	const navigate = useNavigate();
+	const cancellationContext = useContext(
+		CancellationContext,
+	) as CancellationContextInterface;
+	const membership = cancellationContext.productDetail;
+
+	const mainPlan = getMainPlan(
+		membership.subscription,
+	) as PaidSubscriptionPlan;
+
+	const chargeThroughDate = `${mainPlan.chargedThrough}`;
 
 	return (
 		<>
@@ -24,7 +46,8 @@ export const ContinueMembershipConfirmation = () => {
 				<h2 css={headingCss}>Thank you for keeping your Membership</h2>
 				<p>
 					The new price of your Membership is £7/month. <br />
-					Your first billing date will be XX Month.
+					Your first billing date will be{' '}
+					{cancellationFormatDate(chargeThroughDate)}.
 				</p>
 			</Stack>
 			<div css={stackedButtonLeftLayoutCss}>

--- a/client/components/mma/cancel/cancellationSaves/ContinueMembershipConfirmation.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ContinueMembershipConfirmation.tsx
@@ -1,21 +1,19 @@
 import { css } from '@emotion/react';
-import { space } from '@guardian/source-foundations';
+import { space, textSans } from '@guardian/source-foundations';
 import { Button, Stack } from '@guardian/source-react-components';
 import { useContext } from 'react';
 import { useNavigate } from 'react-router';
 import { cancellationFormatDate } from '../../../../../shared/dates';
-import type {
-	PaidSubscriptionPlan} from '../../../../../shared/productResponse';
-import {
-	getMainPlan
-} from '../../../../../shared/productResponse';
+import type { PaidSubscriptionPlan } from '../../../../../shared/productResponse';
+import { getMainPlan } from '../../../../../shared/productResponse';
 import { ProgressIndicator } from '../../shared/ProgressIndicator';
-import type {
-	CancellationContextInterface} from '../CancellationContainer';
+import type { CancellationContextInterface } from '../CancellationContainer';
+import { CancellationContext } from '../CancellationContainer';
 import {
-	CancellationContext
-} from '../CancellationContainer';
-import { headingCss, stackedButtonLeftLayoutCss } from './SaveStyles';
+	buttonCentredCss,
+	headingCss,
+	stackedButtonLeftLayoutCss,
+} from './SaveStyles';
 
 export const ContinueMembershipConfirmation = () => {
 	const navigate = useNavigate();
@@ -27,8 +25,6 @@ export const ContinueMembershipConfirmation = () => {
 	const mainPlan = getMainPlan(
 		membership.subscription,
 	) as PaidSubscriptionPlan;
-
-	const chargeThroughDate = `${mainPlan.chargedThrough}`;
 
 	return (
 		<>
@@ -44,17 +40,28 @@ export const ContinueMembershipConfirmation = () => {
 			/>
 			<Stack space={4}>
 				<h2 css={headingCss}>Thank you for keeping your Membership</h2>
-				<p>
+				<p
+					css={css`
+						${textSans.medium()}
+					`}
+				>
 					The new price of your Membership is £7/month. <br />
 					Your first billing date will be{' '}
-					{cancellationFormatDate(chargeThroughDate)}.
+					{cancellationFormatDate(`${mainPlan.chargedThrough}`)}.
 				</p>
 			</Stack>
 			<div css={stackedButtonLeftLayoutCss}>
-				<Button priority="tertiary" onClick={() => navigate('/')}>
+				<Button
+					priority="tertiary"
+					onClick={() => navigate('/')}
+					cssOverrides={buttonCentredCss}
+				>
 					Back to account overview
 				</Button>
-				<Button onClick={() => navigate('https://www.theguardian.com')}>
+				<Button
+					onClick={() => navigate('https://www.theguardian.com')}
+					cssOverrides={buttonCentredCss}
+				>
 					Continue to the Guardian
 				</Button>
 			</div>

--- a/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
+++ b/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
@@ -106,6 +106,23 @@ export const stackedButtonLayoutCss = css`
 	}
 `;
 
+export const stackedButtonLeftLayoutCss = css`
+	display: flex;
+	flex-direction: column-reverse;
+	margin-top: ${space[5]}px;
+	padding-top: 32px;
+	> * + * {
+		margin-bottom: ${space[3]}px;
+	}
+	${from.tablet} {
+		flex-direction: row;
+		> * + * {
+			margin-top: 0;
+			margin-left: ${space[3]}px;
+		}
+	}
+`;
+
 export const smallPrintCss = css`
 	${textSans.xxsmall()};
 	margin-top: 0;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Making changes as per the design copy:

Updated wording
Added in the next billing date 
New button style added to align with the design (buttons on the left and stackable on mobile)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Turn on feature switch and navigate to cancel/membership/thank-you with an eligible membership
Storybook
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
![image](https://github.com/guardian/manage-frontend/assets/115992455/f8b45c3b-b0f0-4f09-a300-504b245ccfef)

![image](https://github.com/guardian/manage-frontend/assets/115992455/7ddf9ccf-92e1-46b7-b5fb-254cf85afc61)


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
