### PR TITLE
Member Save - Switch Review Page

### DIFF
--- a/client/components/mma/cancel/cancellationSaves/CancellationSaves.stories.tsx
+++ b/client/components/mma/cancel/cancellationSaves/CancellationSaves.stories.tsx
@@ -36,7 +36,7 @@ export const ValueOfSupportPage: ComponentStory<typeof ValueOfSupport> = () => {
 	return <ValueOfSupport />;
 };
 
-export const Switch: ComponentStory<typeof MembershipSwitch> = () => {
+export const SwitchReview: ComponentStory<typeof MembershipSwitch> = () => {
 	return <MembershipSwitch />;
 };
 

--- a/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
@@ -1,3 +1,5 @@
+import { css } from '@emotion/react';
+import { textSans } from '@guardian/source-foundations';
 import { Button, Stack } from '@guardian/source-react-components';
 import { useContext } from 'react';
 import { Navigate, useNavigate } from 'react-router';
@@ -87,7 +89,11 @@ export const MembershipCancellationLanding = () => {
 					<h2 css={headingCss}>
 						We're sorry to hear you're thinking of leaving
 					</h2>
-					<p>
+					<p
+						css={css`
+							${textSans.medium()}
+						`}
+					>
 						To cancel today, please choose from the following
 						options.
 					</p>
@@ -96,14 +102,26 @@ export const MembershipCancellationLanding = () => {
 			<section css={sectionSpacing}>
 				<Stack space={3}>
 					<Heading sansSerif>Call us to cancel</Heading>
-					Phone one of our customer service agents
+					<p
+						css={css`
+							${textSans.medium()}
+						`}
+					>
+						Phone one of our customer service agents
+					</p>
 					<CallCentreEmailAndNumbers hideEmailAddress={true} />
 				</Stack>
 			</section>
 			<section css={sectionSpacing}>
 				<Stack space={3}>
 					<Heading sansSerif>Cancel online</Heading>
-					Continue without speaking to our customer service team.
+					<p
+						css={css`
+							${textSans.medium()}
+						`}
+					>
+						Continue without speaking to our customer service team.
+					</p>
 					<div css={buttonLayoutCss}>
 						<Button onClick={() => navigate('../details')}>
 							Cancel online

--- a/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
@@ -17,12 +17,7 @@ import type {
 } from '../../../../../shared/productResponse';
 import { getMainPlan } from '../../../../../shared/productResponse';
 import type { ProductSwitchType } from '../../../../../shared/productSwitchTypes';
-import { getBenefitsThreshold } from '../../../../utilities/benefitsThreshold';
-import type { CurrencyIso } from '../../../../utilities/currencyIso';
-import {
-	getNewMembershipPrice,
-	getOldMembershipPrice,
-} from '../../../../utilities/membershipPriceRise';
+import { getOldMembershipPrice } from '../../../../utilities/membershipPriceRise';
 import { JsonResponseHandler } from '../../shared/asyncComponents/DefaultApiResponseHandler';
 import { Card } from '../../shared/Card';
 import { Heading } from '../../shared/Heading';
@@ -134,12 +129,17 @@ const WhatHappensNext = (props: {
 	);
 };
 
-const TsAndCs = () => (
+const TsAndCs = (props: {
+	contributionPriceDisplay: string;
+	paymentDay: string;
+}) => (
 	<section css={sectionSpacing}>
 		<p css={smallPrintCss}>
-			This subscription auto-renews and you will be charged the applicable
-			monthly amount each time it renews unless you cancel. You can change
-			how much you pay at any time but
+			We will attempt to take payment of {props.contributionPriceDisplay},
+			on the {props.paymentDay} day of every month, from now until you
+			cancel your payment. Payments may take up to 6 days to be recorded
+			in your bank account. You can change how much you give or cancel
+			your payment at any time.
 		</p>
 		<p css={smallPrintCss}>
 			By proceeding, you are agreeing to our{' '}
@@ -189,20 +189,10 @@ export const MembershipSwitch = () => {
 		mainPlan.currency
 	}${getOldMembershipPrice(mainPlan)}`;
 
-	const newPriceDisplay = `${mainPlan.currency}${getNewMembershipPrice(
-		mainPlan,
-	)}`;
-
 	const billingPeriod = mainPlan.billingPeriod;
-	const monthlyOrAnnual = getMonthlyOrAnnual(billingPeriod);
-
-	const supporterPlusPriceDisplay = `${
-		mainPlan.currency
-	}${getBenefitsThreshold(
-		mainPlan.currencyISO as CurrencyIso,
-		monthlyOrAnnual,
-	)}`;
-
+	const paymentDay = parseDate(mainPlan.chargedThrough ?? undefined).dateStr(
+		'do',
+	);
 	const productSwitchType: ProductSwitchType = 'to-recurring-contribution';
 
 	const productMoveFetch = () =>
@@ -244,15 +234,15 @@ export const MembershipSwitch = () => {
 	return (
 		<>
 			<section css={sectionSpacing}>
-				<Heading sansSerif>Review change</Heading>
+				<Heading sansSerif>Review and confirm change</Heading>
 				<p
 					css={css`
 						${textSans.medium()}
 						margin: 0;
 					`}
 				>
-					You are changing your current membership for a{' '}
-					{contributionPriceDisplay} {monthlyOrAnnual}.
+					Please confirm that you’re changing support type from a
+					Membership to a Monthly contribution.
 				</p>
 			</section>
 			<YourNewSupport
@@ -271,9 +261,9 @@ export const MembershipSwitch = () => {
 						padding-top: ${space[5]}px;
 					`}
 				>
-					Please note that, once the change is done, you will not be
-					able to have the full set of benefits for {newPriceDisplay}{' '}
-					again (full price is now {supporterPlusPriceDisplay}).
+					Please note if you confirm the change you will not be able
+					to rejoin the Guardian Members scheme, as it’s now closed to
+					new members.
 				</p>
 			</section>
 			{switchingError && (
@@ -304,7 +294,10 @@ export const MembershipSwitch = () => {
 					Back
 				</Button>
 			</section>
-			<TsAndCs />
+			<TsAndCs
+				contributionPriceDisplay={contributionPriceDisplay}
+				paymentDay={paymentDay}
+			/>
 		</>
 	);
 };

--- a/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
+++ b/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
@@ -99,6 +99,24 @@ export const buttonLayoutCss = css`
 
 export const stackedButtonLayoutCss = css`
 	display: flex;
+	flex-direction: column;
+	margin-top: ${space[5]}px;
+	padding-top: 32px;
+	border-top: 1px solid ${palette.neutral[86]};
+	> * + * {
+		margin-top: ${space[3]}px;
+	}
+	${from.tablet} {
+		flex-direction: row;
+		> * + * {
+			margin-top: 0;
+			margin-left: ${space[3]}px;
+		}
+	}
+`;
+
+export const reverseStackedButtonLayoutCss = css`
+	display: flex;
 	flex-direction: column-reverse;
 	margin-top: ${space[5]}px;
 	padding-top: 32px;
@@ -179,4 +197,28 @@ export const buttonContainerCss = css`
 		display: flex;
 		flex-direction: column;
 	}
+`;
+
+export const buttonMutedCss = css`
+	${until.tablet} {
+		border: none;
+	}
+`;
+
+export const wideButtonCss = css`
+	${from.tablet} {
+		flex-grow: 1;
+		max-width: 300px;
+	}
+`;
+
+export const errorSummaryOverrideCss = css`
+	${until.tablet} {
+		border-radius: 6px;
+	}
+`;
+
+export const errorSummaryLinkCss = css`
+	color: currentColor;
+	text-decoration: underline;
 `;

--- a/client/components/mma/cancel/cancellationSaves/SelectReason.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SelectReason.tsx
@@ -9,23 +9,17 @@ import {
 	SvgCalendar,
 	SvgEnvelope,
 } from '@guardian/source-react-components';
-import type { FormEvent} from 'react';
+import type { FormEvent } from 'react';
 import { useContext, useState } from 'react';
 import { useNavigate } from 'react-router';
-import type {
-	ProductDetail} from '../../../../../shared/productResponse';
-import {
-	MDA_TEST_USER_HEADER
-} from '../../../../../shared/productResponse';
+import type { ProductDetail } from '../../../../../shared/productResponse';
+import { MDA_TEST_USER_HEADER } from '../../../../../shared/productResponse';
 import type { ProductTypeWithCancellationFlow } from '../../../../../shared/productTypes';
 import { GenericErrorScreen } from '../../../shared/GenericErrorScreen';
 import { JsonResponseHandler } from '../../shared/asyncComponents/DefaultApiResponseHandler';
 import { ProgressIndicator } from '../../shared/ProgressIndicator';
-import type {
-	CancellationContextInterface} from '../CancellationContainer';
-import {
-	CancellationContext
-} from '../CancellationContainer';
+import type { CancellationContextInterface } from '../CancellationContainer';
+import { CancellationContext } from '../CancellationContainer';
 import type { CancellationReason } from '../cancellationReason';
 import { membershipCancellationReasons } from '../membership/MembershipCancellationReasons';
 import {

--- a/client/components/mma/cancel/cancellationSaves/SwitchThankYou.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SwitchThankYou.tsx
@@ -5,7 +5,7 @@ import {
 	SvgCalendar,
 	SvgEnvelope,
 } from '@guardian/source-react-components';
-import { useContext } from 'react';
+import { useContext, useEffect } from 'react';
 import { useNavigate } from 'react-router';
 import { Heading } from '../../shared/Heading';
 import { iconListCss, sectionSpacing } from '../../switch/SwitchStyles';
@@ -19,7 +19,10 @@ export const SwitchThankYou = () => {
 	const pageTitleContext = useContext(
 		CancellationPageTitleContext,
 	) as CancellationPageTitleInterface;
-	pageTitleContext.setPageTitle('Change your membership');
+
+	useEffect(() => {
+		pageTitleContext.setPageTitle('Change your support');
+	}, []);
 
 	return (
 		<>

--- a/client/components/mma/cancel/cancellationSaves/ValueOfSupport.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ValueOfSupport.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { space } from '@guardian/source-foundations';
+import { space, textSans } from '@guardian/source-foundations';
 import {
 	Button,
 	Stack,
@@ -14,7 +14,7 @@ import { CancellationContext } from '../CancellationContainer';
 import {
 	buttonCentredCss,
 	headingCss,
-	stackedButtonLayoutCss,
+	reverseStackedButtonLayoutCss,
 } from './SaveStyles';
 
 export const ValueOfSupport = () => {
@@ -53,7 +53,11 @@ export const ValueOfSupport = () => {
 						Your funding has played a vital role in our progress
 					</span>
 				</h2>
-				<p>
+				<p
+					css={css`
+						${textSans.medium()}
+					`}
+				>
 					Since you first joined as a Guardian Member, we've lived
 					through some of the most important news events of our times.
 					Without you, our fearless, independent journalism wouldn't
@@ -61,7 +65,7 @@ export const ValueOfSupport = () => {
 				</p>
 			</Stack>
 			<div>Image placeholder</div>
-			<div css={stackedButtonLayoutCss}>
+			<div css={reverseStackedButtonLayoutCss}>
 				<Button
 					priority="tertiary"
 					cssOverrides={buttonCentredCss}

--- a/cypress.json
+++ b/cypress.json
@@ -20,5 +20,8 @@
     "*openx.net"
   ],
   "fixturesFolder": false,
-  "retries": 2
+  "retries": {
+    "runMode": 2,
+    "openMode": 0
+  }
 }

--- a/cypress/integration/parallel-2/membershipSave.spec.ts
+++ b/cypress/integration/parallel-2/membershipSave.spec.ts
@@ -85,7 +85,7 @@ if (featureSwitches.membershipSave) {
 				name: 'Become a recurring contributor',
 			}).click();
 
-			cy.findByText(/Review change/).should('exist');
+			cy.findByText(/Review and confirm change/).should('exist');
 			cy.findByRole('button', {
 				name: 'Confirm change',
 			}).click();

--- a/cypress/integration/parallel-2/membershipSave.spec.ts
+++ b/cypress/integration/parallel-2/membershipSave.spec.ts
@@ -51,7 +51,7 @@ if (featureSwitches.membershipSave) {
 				},
 			}).as('get_case');
 
-			cy.intercept('POST', '/api/reminders', {
+			cy.intercept('POST', '/api/reminders/create', {
 				statusCode: 200,
 			}).as('set_reminder');
 

--- a/cypress/integration/parallel-2/membershipSave.spec.ts
+++ b/cypress/integration/parallel-2/membershipSave.spec.ts
@@ -4,6 +4,7 @@ import {
 	membershipSupporter,
 	toMembersDataApiResponse,
 } from '../../../client/fixtures/productDetail';
+import { productMovePreviewResponse } from '../../../client/fixtures/productMove';
 import { featureSwitches } from '../../../shared/featureSwitches';
 import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
 
@@ -53,13 +54,18 @@ if (featureSwitches.membershipSave) {
 			cy.intercept('POST', '/api/reminders', {
 				statusCode: 200,
 			}).as('set_reminder');
+
+			cy.intercept('POST', '/api/product-move/**', {
+				statusCode: 200,
+				body: productMovePreviewResponse,
+			}).as('product_move');
 		});
 
 		it('switches to recurring contribution', () => {
 			cy.visit('/cancel/membership');
 
 			cy.findByText(
-				/We're sorry to hear you're thinking of cancelling/,
+				/We're sorry to hear you're thinking of leaving/,
 			).should('exist');
 			cy.findByRole('button', {
 				name: 'Cancel online',
@@ -72,15 +78,20 @@ if (featureSwitches.membershipSave) {
 				name: 'Continue to cancellation',
 			}).click();
 
-			cy.findByText(/consider different support options/).should('exist');
+			cy.findByText(
+				/Are you sure you want to lose your exclusive benefits/,
+			).should('exist');
 			cy.findByRole('button', {
-				name: 'Become a recurring supporter',
+				name: 'Become a recurring contributor',
 			}).click();
 
 			cy.findByText(/Review change/).should('exist');
 			cy.findByRole('button', {
 				name: 'Confirm change',
 			}).click();
+
+			cy.wait('@product_move');
+			cy.findByText(/Thank you/).should('exist');
 		});
 
 		it('cancels membership', () => {
@@ -92,7 +103,7 @@ if (featureSwitches.membershipSave) {
 			cy.findByText(/Cancel/).click();
 
 			cy.findByText(
-				/We're sorry to hear you're thinking of cancelling/,
+				/We're sorry to hear you're thinking of leaving/,
 			).should('exist');
 			cy.findByRole('button', {
 				name: 'Cancel online',
@@ -105,9 +116,11 @@ if (featureSwitches.membershipSave) {
 				name: 'Continue to cancellation',
 			}).click();
 
-			cy.findByText(/consider different support options/).should('exist');
+			cy.findByText(
+				/Are you sure you want to lose your exclusive benefits/,
+			).should('exist');
 			cy.findByRole('button', {
-				name: 'Cancel membership',
+				name: 'Cancel Membership',
 			}).click();
 
 			cy.findByText(/Are you sure/).should('exist');
@@ -146,7 +159,7 @@ if (featureSwitches.membershipSave) {
 			cy.visit('/cancel/membership');
 
 			cy.findByText(
-				/We're sorry to hear you're thinking of cancelling/,
+				/We're sorry to hear you're thinking of leaving/,
 			).should('exist');
 			cy.findByRole('button', {
 				name: 'Cancel online',
@@ -159,9 +172,11 @@ if (featureSwitches.membershipSave) {
 				name: 'Continue to cancellation',
 			}).click();
 
-			cy.findByText(/consider different support options/).should('exist');
+			cy.findByText(
+				/Are you sure you want to lose your exclusive benefits/,
+			).should('exist');
 			cy.findByRole('button', {
-				name: 'Continue your membership',
+				name: /Keep my Membership/,
 			}).click();
 		});
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Updates the copy on the Switch Review page of membership cancellation switch journey. Implements the product move api call on `Confirm` button click

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Go to `cancel/membership/switch-offer` and click "Confirm change"

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://github.com/guardian/manage-frontend/assets/114918544/25e5cc70-a41e-4429-8546-58bb304cc7e7)
![image](https://github.com/guardian/manage-frontend/assets/114918544/c9e4837b-a4c8-4bbf-a957-a48f0a3c7348)


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
