### PR TITLE
Use Enhanced Domains version of Live Chat URL in Production

### DIFF
--- a/client/components/helpCentre/liveChat/LiveChat.tsx
+++ b/client/components/helpCentre/liveChat/LiveChat.tsx
@@ -163,7 +163,7 @@ const initESW = (
 		if (window.guardian.domain === 'theguardian.com') {
 			liveChatAPI.init(
 				'https://gnmtouchpoint.my.salesforce.com',
-				'https://guardiansurveys.secure.force.com/liveagent',
+				'https://gnmtouchpoint.my.salesforce-sites.com/liveagent',
 				gslbBaseUrl,
 				'00D20000000nq5g',
 				'Chat_Team',


### PR DESCRIPTION
## What does this change?
### Background
Salesforce is releasing a new feature, "Enhanced Domains", in June 2023. This changes a number URL formats across the Salesforce application.

A full outline of impacts to our systems can be viewed [here](https://docs.google.com/document/d/1C_SCvSrwvNLRXRsmrkKnVdf-NLBYVe4afkSHewcnCGA/edit#).

### Changes
One of the changing URL formats is for Salesforce Sites, which we use to serve the Live Chat widget. According to the [Salesforce documentation](https://help.salesforce.com/s/articleView?id=sf.domain_name_url_format_changes_enable_enhanced.htm&type=5) the link we need to use will change from `SitesSubdomainName.secure.force.com` to `MyDomainName.my.salesforce-sites.com`.

### ⚠️  Important
This should ONLY be merged after the Enhanced Domains feature has been enabled in Salesforce. Both tasks should be completed at the same time, to minimise Live Chat down time. Deployment date and time is TBC.

## How to test
Unfortunately, I think this can ONLY be tested in production, and only once we have our Enhanced Domains feature deployed.

But a similar change was made when Enhanced Domains was deployed to our main sandbox environment: #861 

## How can we measure success?
Customers will be able to use Live Chat successfully after the Enhanced Domains feature is enabled in our Salesforce org.

## Have we considered potential risks?
**Live Chat still doesn't work after this change is made and Enhanced Domains are enabled, due to an incorrect URL or some other unforseen problem**
We will be briefing DRR colleagues and contact centre in advance of this change, notifying them of the expected deployment time and that there will be a window when users might encounter errors when using Live Chat. Therefore stakeholders will be aware that we are making changes. If we have any issues, we can revert changes both here and in Salesforce.