### PR TITLE
Temporarily disabling Google Analytics

### DIFF
--- a/client/utilities/hooks/useAnalytics.ts
+++ b/client/utilities/hooks/useAnalytics.ts
@@ -17,6 +17,7 @@ declare global {
 	}
 }
 
+const GA_AVAILABLE = false;
 const GA_UA = 'UA-51507017-5';
 
 export const useAnalytics = () => {
@@ -111,7 +112,7 @@ export const useAnalytics = () => {
 					// @ts-expect-error: Suppressing "element implicitly has an 'any' type because index expression is not of type 'number'."
 					window[`ga-disable-${GA_UA}`] = !gaConsentState;
 
-					if (gaConsentState && !gaIsInitialised) {
+					if (GA_AVAILABLE && gaConsentState && !gaIsInitialised) {
 						initialiseGa();
 					}
 
@@ -150,7 +151,6 @@ export const useAnalytics = () => {
 				dimension12: window.guardian.INTCMP,
 				dimension29: MMA_AB_TEST_DIMENSION_VALUE,
 			});
-			// TODO add ophan pageViewId as a GA dimension
 			applyAnyOptimiseExperiments();
 		}
 	}, [location, cmpIsInitialised, gaIsInitialised]);


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Temporarily disabling Google Analytics to see who shouts when no more data appears. This is to help validate our desire not to upgrade the account to GA4.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Visit manage.theguardian.com with full consent and confirm that no GA tag is loaded.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
