### PR TITLE
Membership Save - Switch Confirmation - Update copy and keep user details through journey

### DIFF
--- a/client/components/mma/cancel/CancellationContainer.tsx
+++ b/client/components/mma/cancel/CancellationContainer.tsx
@@ -3,6 +3,7 @@ import { createContext, useState } from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
 import type {
 	MembersDataApiResponse,
+	MembersDataApiUser,
 	ProductDetail,
 } from '../../../../shared/productResponse';
 import { isProduct } from '../../../../shared/productResponse';
@@ -98,6 +99,7 @@ const contextAndOutletContainer = (
 export interface CancellationRouterState {
 	productDetail: ProductDetail;
 	productType?: ProductTypeWithCancellationFlow;
+	user?: MembersDataApiUser;
 	selectedReasonId?: OptionalCancellationReasonId;
 	cancellationPolicy?: string;
 	caseId?: string;

--- a/client/components/mma/cancel/cancellationSaves/CancellationSaves.stories.tsx
+++ b/client/components/mma/cancel/cancellationSaves/CancellationSaves.stories.tsx
@@ -24,7 +24,10 @@ export default {
 	parameters: {
 		layout: 'fullscreen',
 		reactRouter: {
-			state: { productDetail: membershipSupporter },
+			state: {
+				productDetail: membershipSupporter,
+				user: { email: 'test@test.com' },
+			},
 			container: (
 				<CancellationContainer productType={PRODUCT_TYPES.membership} />
 			),

--- a/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
@@ -123,7 +123,13 @@ export const MembershipCancellationLanding = () => {
 						Continue without speaking to our customer service team.
 					</p>
 					<div css={buttonLayoutCss}>
-						<Button onClick={() => navigate('../details')}>
+						<Button
+							onClick={() =>
+								navigate('../details', {
+									state: { user: data.user },
+								})
+							}
+						>
 							Cancel online
 						</Button>
 					</div>

--- a/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
@@ -9,7 +9,7 @@ import {
 } from '@guardian/source-react-components';
 import { ErrorSummary } from '@guardian/source-react-components-development-kitchen';
 import { useContext, useEffect, useState } from 'react';
-import { Navigate, useNavigate } from 'react-router';
+import { Navigate, useLocation, useNavigate } from 'react-router';
 import { dateString, parseDate } from '../../../../../shared/dates';
 import type {
 	PaidSubscriptionPlan,
@@ -25,6 +25,7 @@ import { PaymentDetails } from '../../shared/PaymentDetails';
 import type {
 	CancellationContextInterface,
 	CancellationPageTitleInterface,
+	CancellationRouterState,
 } from '../CancellationContainer';
 import {
 	CancellationContext,
@@ -161,6 +162,9 @@ const TsAndCs = (props: {
 
 export const MembershipSwitch = () => {
 	const navigate = useNavigate();
+	const location = useLocation();
+	const routerState = location.state as CancellationRouterState;
+
 	const cancellationContext = useContext(
 		CancellationContext,
 	) as CancellationContextInterface;
@@ -224,7 +228,7 @@ export const MembershipSwitch = () => {
 				setIsSwitching(false);
 				setSwitchingError(true);
 			} else {
-				navigate('../switch-thank-you');
+				navigate('../switch-thank-you', { state: { ...routerState } });
 			}
 		} catch (e) {
 			setIsSwitching(false);
@@ -289,7 +293,9 @@ export const MembershipSwitch = () => {
 				<Button
 					priority="tertiary"
 					cssOverrides={[buttonCentredCss, buttonMutedCss]}
-					onClick={() => navigate('../offers')}
+					onClick={() =>
+						navigate('../offers', { state: { ...routerState } })
+					}
 				>
 					Back
 				</Button>

--- a/client/components/mma/cancel/cancellationSaves/SaveOptions.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SaveOptions.tsx
@@ -6,9 +6,9 @@ import {
 	Stack,
 } from '@guardian/source-react-components';
 import { useContext } from 'react';
-import { Navigate, useNavigate } from 'react-router';
+import { Navigate, useLocation, useNavigate } from 'react-router';
 import type { PaidSubscriptionPlan } from '../../../../../shared/productResponse';
-import { getMainPlan  } from '../../../../../shared/productResponse';
+import { getMainPlan } from '../../../../../shared/productResponse';
 import {
 	getNewMembershipPrice,
 	getOldMembershipPrice,
@@ -19,10 +19,10 @@ import { MembershipBenefitsSection } from '../../shared/MembershipBenefits';
 import { ProgressIndicator } from '../../shared/ProgressIndicator';
 import { RecurringSupporterBenefitsSection } from '../../shared/RecurringSupporterBenefits';
 import type {
-	CancellationContextInterface} from '../CancellationContainer';
-import {
-	CancellationContext
+	CancellationContextInterface,
+	CancellationRouterState,
 } from '../CancellationContainer';
+import { CancellationContext } from '../CancellationContainer';
 import {
 	buttonCentredCss,
 	buttonContainerCss,
@@ -36,6 +36,9 @@ import {
 
 export const SaveOptions = () => {
 	const navigate = useNavigate();
+	const location = useLocation();
+	const routerState = location.state as CancellationRouterState;
+
 	const cancellationContext = useContext(
 		CancellationContext,
 	) as CancellationContextInterface;
@@ -144,7 +147,11 @@ export const SaveOptions = () => {
 								<Button
 									cssOverrides={buttonCentredCss}
 									size="small"
-									onClick={() => navigate('../switch-offer')}
+									onClick={() =>
+										navigate('../switch-offer', {
+											state: { ...routerState },
+										})
+									}
 								>
 									Become a recurring contributor
 								</Button>
@@ -168,7 +175,11 @@ export const SaveOptions = () => {
 							cssOverrides={buttonCentredCss}
 							priority="tertiary"
 							size="small"
-							onClick={() => navigate('../confirm')}
+							onClick={() =>
+								navigate('../confirm', {
+									state: { ...routerState },
+								})
+							}
 						>
 							Cancel Membership
 						</Button>

--- a/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
+++ b/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
@@ -101,8 +101,6 @@ export const stackedButtonLayoutCss = css`
 	display: flex;
 	flex-direction: column;
 	margin-top: ${space[5]}px;
-	padding-top: 32px;
-	border-top: 1px solid ${palette.neutral[86]};
 	> * + * {
 		margin-top: ${space[3]}px;
 	}
@@ -221,4 +219,10 @@ export const errorSummaryOverrideCss = css`
 export const errorSummaryLinkCss = css`
 	color: currentColor;
 	text-decoration: underline;
+`;
+
+export const whatHappensNextCss = css`
+	li > svg {
+		fill: ${palette.brand[500]};
+	}
 `;

--- a/client/components/mma/cancel/cancellationSaves/SwitchThankYou.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SwitchThankYou.tsx
@@ -1,69 +1,118 @@
 import {
 	Button,
+	LinkButton,
 	Stack,
-	SvgArrowRightStraight,
 	SvgCalendar,
 	SvgEnvelope,
 } from '@guardian/source-react-components';
 import { useContext, useEffect } from 'react';
-import { useNavigate } from 'react-router';
+import { Navigate, useLocation, useNavigate } from 'react-router';
+import {
+	DATE_FNS_LONG_OUTPUT_FORMAT,
+	parseDate,
+} from '../../../../../shared/dates';
+import type { PaidSubscriptionPlan } from '../../../../../shared/productResponse';
+import { getMainPlan } from '../../../../../shared/productResponse';
+import { getOldMembershipPrice } from '../../../../utilities/membershipPriceRise';
 import { Heading } from '../../shared/Heading';
 import { iconListCss, sectionSpacing } from '../../switch/SwitchStyles';
-import type { CancellationPageTitleInterface } from '../CancellationContainer';
-import { CancellationPageTitleContext } from '../CancellationContainer';
-import { buttonLayoutCss } from './SaveStyles';
+import type {
+	CancellationContextInterface,
+	CancellationPageTitleInterface,
+	CancellationRouterState,
+} from '../CancellationContainer';
+import {
+	CancellationContext,
+	CancellationPageTitleContext,
+} from '../CancellationContainer';
+import {
+	buttonCentredCss,
+	headingCss,
+	stackedButtonLayoutCss,
+	whatHappensNextCss,
+} from './SaveStyles';
 
 export const SwitchThankYou = () => {
 	const navigate = useNavigate();
+	const location = useLocation();
+	const routerState = location.state as CancellationRouterState;
 
 	const pageTitleContext = useContext(
 		CancellationPageTitleContext,
 	) as CancellationPageTitleInterface;
 
+	const cancellationContext = useContext(
+		CancellationContext,
+	) as CancellationContextInterface;
+	const membership = cancellationContext.productDetail;
+	const userEmailAddress = routerState?.user?.email;
+
 	useEffect(() => {
 		pageTitleContext.setPageTitle('Change your support');
 	}, []);
+
+	if (!membership) {
+		return <Navigate to="/" />;
+	}
+
+	const mainPlan = getMainPlan(
+		membership.subscription,
+	) as PaidSubscriptionPlan;
+
+	const contributionPriceDisplay = `${
+		mainPlan.currency
+	}${getOldMembershipPrice(mainPlan)}`;
+
+	const billingPeriod = mainPlan.billingPeriod;
+	const nextBillingDate = parseDate(
+		mainPlan.chargedThrough ?? undefined,
+	).dateStr(DATE_FNS_LONG_OUTPUT_FORMAT);
 
 	return (
 		<>
 			<section css={sectionSpacing}>
 				<Stack space={4}>
-					<Heading>
-						Thank you for continuing to support Guardian journalism
-						every month
-					</Heading>
+					<h2 css={headingCss}>
+						Thank you for supporting us with{' '}
+						{contributionPriceDisplay}/{billingPeriod}
+					</h2>
 				</Stack>
 			</section>
 			<section css={sectionSpacing}>
 				<Stack space={4}>
 					<Heading sansSerif>What happens next?</Heading>
-					<ul css={[iconListCss]}>
+					<ul css={[iconListCss, whatHappensNextCss]}>
 						<li>
 							<SvgEnvelope size="medium" />
 							<span data-qm-masking="blocklist">
-								We will send you a confirmation email to
-								email@email.com
+								We will send a confirmation email to you at{' '}
+								{userEmailAddress}
 							</span>
 						</li>
 						<li>
 							<SvgCalendar size="medium" />
 							<span>
 								This change will happen on your next billing
-								date of XYZ. Until then, you have access to all
-								of your current supporter extras
+								date of {nextBillingDate}.
 							</span>
 						</li>
 					</ul>
 				</Stack>
 			</section>
 			<section css={sectionSpacing}>
-				<div css={[buttonLayoutCss, { textAlign: 'left' }]}>
+				<div css={stackedButtonLayoutCss}>
+					<LinkButton
+						href="https://theguardian.com"
+						cssOverrides={buttonCentredCss}
+					>
+						Continue to the Guardian
+					</LinkButton>
 					<Button
-						icon={<SvgArrowRightStraight />}
-						iconSide="right"
+						priority="tertiary"
+						cssOverrides={buttonCentredCss}
 						onClick={() => navigate('/')}
 					>
-						Back to your account
+						Back to my account
 					</Button>
 				</div>
 			</section>

--- a/client/components/mma/cancel/cancellationSaves/ValueOfSupport.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ValueOfSupport.tsx
@@ -6,10 +6,13 @@ import {
 	SvgArrowRightStraight,
 } from '@guardian/source-react-components';
 import { useContext } from 'react';
-import { Navigate, useNavigate } from 'react-router';
+import { Navigate, useLocation, useNavigate } from 'react-router';
 import { dateString } from '../../../../../shared/dates';
 import { ProgressIndicator } from '../../shared/ProgressIndicator';
-import type { CancellationContextInterface } from '../CancellationContainer';
+import type {
+	CancellationContextInterface,
+	CancellationRouterState,
+} from '../CancellationContainer';
 import { CancellationContext } from '../CancellationContainer';
 import {
 	buttonCentredCss,
@@ -23,6 +26,9 @@ export const ValueOfSupport = () => {
 		CancellationContext,
 	) as CancellationContextInterface;
 	const productDetail = cancellationContext.productDetail;
+
+	const location = useLocation();
+	const routerState = location.state as CancellationRouterState;
 
 	if (!productDetail) {
 		return <Navigate to="/" />;
@@ -77,7 +83,9 @@ export const ValueOfSupport = () => {
 					icon={<SvgArrowRightStraight />}
 					iconSide="right"
 					cssOverrides={buttonCentredCss}
-					onClick={() => navigate('../offers')}
+					onClick={() =>
+						navigate('../offers', { state: { ...routerState } })
+					}
 				>
 					Continue to cancellation
 				</Button>

--- a/cypress/integration/parallel-2/membershipSave.spec.ts
+++ b/cypress/integration/parallel-2/membershipSave.spec.ts
@@ -23,7 +23,6 @@ if (featureSwitches.membershipSave) {
 
 		beforeEach(() => {
 			signInAndAcceptCookies();
-			console.log('beforeEach');
 			cy.intercept('GET', '/api/me/mma?productType=Membership', {
 				statusCode: 200,
 				body: toMembersDataApiResponse(membershipSupporter),
@@ -92,6 +91,7 @@ if (featureSwitches.membershipSave) {
 
 			cy.wait('@product_move');
 			cy.findByText(/Thank you/).should('exist');
+			cy.findByText(/test@test.com/).should('exist');
 		});
 
 		it('cancels membership', () => {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Update the copy and design of the Confirmation (Flow 2) aka Switch Thank you page.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Complete a product switch from `cancel/membership/landing` - you should see the contribution amount, user email address and billing date on screen.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://github.com/guardian/manage-frontend/assets/114918544/75ea2258-0cb0-4878-b8c0-98b8c2578277)
![image](https://github.com/guardian/manage-frontend/assets/114918544/bfd7c876-1396-4285-bdd2-4088b63bf0ab)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
