### PR TITLE
Fix braze reminder query string

### DIFF
--- a/client/__tests__/components/mma/reminders/reminders.test.ts
+++ b/client/__tests__/components/mma/reminders/reminders.test.ts
@@ -1,0 +1,14 @@
+import { getReminderParams } from '../../../../components/mma/reminders/reminders';
+
+describe('getReminderParams', () => {
+	it('handles a query string with extra "?"', () => {
+		const qs =
+			'?reminderData={"email"%3A"test@test.com"%2C"reminderPlatform"%3A"EMAIL"%2C"reminderComponent"%3A"EMAIL"%2C"reminderStage"%3A"PRE"}&token=c6a58d0281736d2a4a18095b6c74b54a9893595e?cid=1684487428181008414&utm_source=eml&utm_medium=emaq&utm_campaign=MK_CN_PreReminderSingleRESENDMay23&utm_term=Email2_MKSupporterPreReminder_Test&utm_content=variantA';
+		const result = getReminderParams(qs);
+		expect(result).toEqual({
+			reminderData:
+				'{"email":"test@test.com","reminderPlatform":"EMAIL","reminderComponent":"EMAIL","reminderStage":"PRE"}',
+			token: 'c6a58d0281736d2a4a18095b6c74b54a9893595e',
+		});
+	});
+});

--- a/client/components/mma/reminders/reminders.ts
+++ b/client/components/mma/reminders/reminders.ts
@@ -1,0 +1,30 @@
+interface ReminderParams {
+	reminderData: string;
+	token: string;
+}
+
+export const getReminderParams = (
+	querystring: string,
+): ReminderParams | undefined => {
+	const pairs = querystring
+		.slice(1) // drop initial '?'
+		.replace('?', '&') // braze can append a new query string at the end of an existing one
+		.split('&');
+
+	const params = pairs.reduce<Partial<ReminderParams>>((acc, pair) => {
+		const [key, value] = pair.split('=');
+		if (key && value && (key === 'reminderData' || key === 'token')) {
+			return {
+				...acc,
+				[key]: decodeURIComponent(value),
+			};
+		} else {
+			return acc;
+		}
+	}, {});
+
+	if (params.reminderData && params.token) {
+		return params as ReminderParams;
+	}
+	return undefined;
+};

--- a/client/components/mma/reminders/reminders.ts
+++ b/client/components/mma/reminders/reminders.ts
@@ -8,7 +8,7 @@ export const getReminderParams = (
 ): ReminderParams | undefined => {
 	const pairs = querystring
 		.slice(1) // drop initial '?'
-		.replace('?', '&') // braze can append a new query string at the end of an existing one
+		.replaceAll('?', '&') // braze can append a new query string at the end of an existing one
 		.split('&');
 
 	const params = pairs.reduce<Partial<ReminderParams>>((acc, pair) => {


### PR DESCRIPTION
Braze can incorrectly append a new query string to a url that already has a query string, meaning we end up with a second `?` where there should be a `&`.
Braze do not seem likely to fix this any time soon, so we can defend against it here in MMA.