### PR TITLE
Update designs of Reasons page

### DIFF
--- a/client/components/mma/cancel/cancellationSaves/ContinueMembershipConfirmation.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ContinueMembershipConfirmation.tsx
@@ -1,17 +1,19 @@
 import { css } from '@emotion/react';
-import { from, space, textSans } from '@guardian/source-foundations';
+import { space } from '@guardian/source-foundations';
 import { Button, Stack } from '@guardian/source-react-components';
 import { useContext } from 'react';
 import { useNavigate } from 'react-router';
 import { cancellationFormatDate } from '../../../../../shared/dates';
 import type { PaidSubscriptionPlan } from '../../../../../shared/productResponse';
 import { getMainPlan } from '../../../../../shared/productResponse';
+import { getNewMembershipPrice } from '../../../../utilities/membershipPriceRise';
 import { ProgressIndicator } from '../../shared/ProgressIndicator';
 import type { CancellationContextInterface } from '../CancellationContainer';
 import { CancellationContext } from '../CancellationContainer';
 import {
 	buttonCentredCss,
 	headingCss,
+	paragraphListCss,
 	stackedButtonLeftLayoutCss,
 } from './SaveStyles';
 
@@ -25,6 +27,10 @@ export const ContinueMembershipConfirmation = () => {
 	const mainPlan = getMainPlan(
 		membership.subscription,
 	) as PaidSubscriptionPlan;
+
+	const newMembershipPriceDisplay = `${
+		mainPlan.currency
+	}${getNewMembershipPrice(mainPlan)}`;
 
 	return (
 		<>
@@ -40,17 +46,9 @@ export const ContinueMembershipConfirmation = () => {
 			/>
 			<Stack space={4}>
 				<h2 css={headingCss}>Thank you for keeping your Membership</h2>
-				<p
-					css={css`
-						${textSans.medium()};
-						${from.tablet} {
-							span {
-								display: block;
-							}
-						}
-					`}
-				>
-					The new price of your Membership is £7/month.{' '}
+				<p css={paragraphListCss}>
+					The new price of your Membership is{' '}
+					{newMembershipPriceDisplay}/{mainPlan.billingPeriod}.{' '}
 					<span>
 						Your first billing date will be{' '}
 						{cancellationFormatDate(

--- a/client/components/mma/cancel/cancellationSaves/SaveOptions.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SaveOptions.tsx
@@ -108,6 +108,7 @@ export const SaveOptions = () => {
 								<Button
 									cssOverrides={buttonCentredCss}
 									size="small"
+									onClick={() => navigate('../thank-you')}
 								>
 									Keep my Membership for {newPriceDisplay}/
 									{billingPeriod}

--- a/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
+++ b/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
@@ -226,3 +226,12 @@ export const whatHappensNextCss = css`
 		fill: ${palette.brand[500]};
 	}
 `;
+
+export const paragraphListCss = css`
+	${textSans.medium()};
+	${from.tablet} {
+		span {
+			display: block;
+		}
+	}
+`;

--- a/client/components/mma/cancel/cancellationSaves/SelectReason.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SelectReason.tsx
@@ -1,79 +1,72 @@
 import { css } from '@emotion/react';
-import { from, palette, space, textSans } from '@guardian/source-foundations';
+import { palette, space, textSans } from '@guardian/source-foundations';
 import {
 	Button,
 	InlineError,
 	Radio,
 	RadioGroup,
 	Stack,
-	SvgCalendar,
-	SvgEnvelope,
 } from '@guardian/source-react-components';
 import type { FormEvent } from 'react';
 import { useContext, useState } from 'react';
-import { useNavigate } from 'react-router';
-import type { ProductDetail } from '../../../../../shared/productResponse';
-import { MDA_TEST_USER_HEADER } from '../../../../../shared/productResponse';
+import { useLocation, useNavigate } from 'react-router';
+import {
+	DATE_FNS_LONG_OUTPUT_FORMAT,
+	parseDate,
+} from '../../../../../shared/dates';
+import type {
+	PaidSubscriptionPlan,
+	ProductDetail} from '../../../../../shared/productResponse';
+import {
+	getMainPlan,
+ MDA_TEST_USER_HEADER } from '../../../../../shared/productResponse';
 import type { ProductTypeWithCancellationFlow } from '../../../../../shared/productTypes';
 import { GenericErrorScreen } from '../../../shared/GenericErrorScreen';
 import { JsonResponseHandler } from '../../shared/asyncComponents/DefaultApiResponseHandler';
-import { ProgressIndicator } from '../../shared/ProgressIndicator';
-import type { CancellationContextInterface } from '../CancellationContainer';
+import type {
+	CancellationContextInterface,
+	CancellationRouterState,
+} from '../CancellationContainer';
 import { CancellationContext } from '../CancellationContainer';
 import type { CancellationReason } from '../cancellationReason';
 import { membershipCancellationReasons } from '../membership/MembershipCancellationReasons';
 import {
 	buttonCentredCss,
-	buttonLayoutCss,
 	headingCss,
+	paragraphListCss,
 	sectionSpacing,
+	stackedButtonLayoutCss,
+	wideButtonCss,
 } from './SaveStyles';
-
-const infoCss = css`
-	${textSans.medium()}
-	display: flex;
-	> svg {
-		flex-shrink: 0;
-		margin-right: 8px;
-		fill: currentColor;
-	}
-	> span {
-		padding-top: ${space[1]}px;
-	}
-`;
 
 const reasonLegendCss = css`
 	display: block;
 	width: 100%;
-	margin: 0;
-	padding: ${space[3]}px;
 	float: left;
-	background-color: ${palette.neutral[97]};
-	border-bottom: 1px solid ${palette.neutral[86]};
+	margin-top: ${space[2]}px;
 	${textSans.medium({ fontWeight: 'bold' })};
-	${from.tablet} {
-		padding: ${space[3]}px ${space[5]}px;
-	}
 `;
 
-const CancellationInfo = () => (
+const CancellationInfo = ({
+	userEmailAddress,
+	benefitsEndDate,
+}: {
+	userEmailAddress: string;
+	benefitsEndDate: string;
+}) => (
 	<ul
 		css={css`
 			padding-inline-start: 0;
 		`}
 	>
 		<Stack space={1}>
-			<li css={infoCss}>
-				<SvgCalendar size="medium" />
+			<p css={paragraphListCss}>
+				We will send a confirmation email to you at {userEmailAddress}.{' '}
 				<span>
-					You'll continue to have access to your Membership benefits
-					until xx
+					You will have access to all of your benefits until{' '}
+					{benefitsEndDate}
 				</span>
-			</li>
-			<li css={infoCss}>
-				<SvgEnvelope size="medium" />
-				<span>We will send you a confirmation email at xx.com</span>
-			</li>
+			</p>
 		</Stack>
 	</ul>
 );
@@ -89,37 +82,46 @@ const ReasonSelection = (props: {
 				props.setSelectedReasonId(target.value);
 			}}
 			css={css`
-				border: 1px solid ${palette.neutral[86]};
 				margin: 0 0 ${space[5]}px;
 				padding: 0;
+				border: 0;
 			`}
 		>
 			<legend css={reasonLegendCss}>
-				Why did you cancel your Membership with us today?
+				Why did you cancel your membership today?
 			</legend>
 			<RadioGroup
 				name="issue_type"
 				orientation="vertical"
 				css={css`
 					display: block;
-					padding: ${space[5]}px;
+					padding-top: ${space[4]}px;
 				`}
 			>
 				{membershipCancellationReasons.map(
 					(reason: CancellationReason) => (
-						<Radio
+						<div
 							key={reason.reasonId}
-							name="cancellation-reason"
-							value={reason.reasonId}
-							label={reason.linkLabel}
 							css={css`
-								vertical-align: top;
-								text-transform: lowercase;
-								:checked + div label:first-of-type {
-									font-weight: bold;
-								}
+								border: 1px solid ${palette.neutral[86]};
+								border-radius: 4px;
+								padding: ${space[1]}px ${space[3]}px;
+								margin-bottom: ${space[3]}px;
 							`}
-						/>
+						>
+							<Radio
+								name="cancellation-reason"
+								value={reason.reasonId}
+								label={reason.linkLabel}
+								css={css`
+									vertical-align: top;
+									text-transform: lowercase;
+									:checked + div label:first-of-type {
+										font-weight: bold;
+									}
+								`}
+							/>
+						</div>
 					),
 				)}
 			</RadioGroup>
@@ -158,6 +160,17 @@ export const SelectReason = () => {
 	const { productDetail, productType } = useContext(
 		CancellationContext,
 	) as CancellationContextInterface;
+
+	const mainPlan = getMainPlan(
+		productDetail.subscription,
+	) as PaidSubscriptionPlan;
+
+	const location = useLocation();
+	const routerState = location.state as CancellationRouterState;
+	const userEmailAddress = routerState?.user?.email ?? '';
+	const benefitsEndDate = parseDate(
+		mainPlan.chargedThrough ?? undefined,
+	).dateStr(DATE_FNS_LONG_OUTPUT_FORMAT);
 
 	const submitReason = async () => {
 		{
@@ -205,29 +218,23 @@ export const SelectReason = () => {
 	}
 
 	return (
-		<>
-			<ProgressIndicator
-				steps={[
-					{ title: '' },
-					{ title: '' },
-					{ title: 'Confirmation', isCurrentStep: true },
-				]}
-				additionalCSS={css`
-					margin: ${space[5]}px 0 ${space[12]}px;
-				`}
+		<section css={sectionSpacing}>
+			<h2 css={headingCss}>Your membership has been cancelled</h2>
+			<CancellationInfo
+				userEmailAddress={userEmailAddress}
+				benefitsEndDate={benefitsEndDate}
 			/>
-			<h2 css={headingCss}>Your Membership is cancelled</h2>
-			<CancellationInfo />
 			<p
 				css={css`
-					${textSans.medium()}
+					${paragraphListCss}
 					border-top: 1px solid ${palette.neutral[86]};
 					padding-top: ${space[5]}px;
 				`}
 			>
-				We're always trying to improve our offering and welcome any
-				feedback. If you can, please take a moment to tell us why you've
-				cancelled your Membership.
+				We're always keen to improve, and welcome your feedback.{' '}
+				<span>
+					Please take a moment to tell us more about your decision.
+				</span>
 			</p>
 			<ReasonSelection setSelectedReasonId={setSelectedReasonId} />
 			{inValidationErrorState && !selectedReasonId.length && (
@@ -242,24 +249,22 @@ export const SelectReason = () => {
 					Please select a reason
 				</InlineError>
 			)}
-			<section
-				css={[sectionSpacing, buttonLayoutCss, { textAlign: 'right' }]}
-			>
-				<Button
-					priority="tertiary"
-					cssOverrides={[buttonCentredCss]}
-					onClick={() => navigate('..')}
-				>
-					Skip
-				</Button>
+			<section css={stackedButtonLayoutCss}>
 				<Button
 					isLoading={isSubmitting}
 					onClick={() => submitReason()}
-					cssOverrides={buttonCentredCss}
+					cssOverrides={[buttonCentredCss, wideButtonCss]}
 				>
 					Submit
 				</Button>
+				<Button
+					priority="tertiary"
+					cssOverrides={buttonCentredCss}
+					onClick={() => navigate('../reminder')}
+				>
+					Skip
+				</Button>
 			</section>
-		</>
+		</section>
 	);
 };


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Updates the designs of the reason selection page of the membership save journey. Also fixes two small issues on previous pages, the price on membership confirmation, `keep my membership` button link

## How to test

Navigate through the journey to `cancel/membership/reasons`

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://github.com/guardian/manage-frontend/assets/114918544/3a99ac2f-8723-4397-a461-066d3125debc)
![image](https://github.com/guardian/manage-frontend/assets/114918544/b75a6ca1-adf0-4857-b42d-0ad5304f68dd)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
