### PR TITLE
Create `New Price` Icon on membership switch page

### DIFF
--- a/client/components/mma/cancel/cancellationSaves/SaveOptions.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SaveOptions.tsx
@@ -34,6 +34,26 @@ import {
 	sectionSpacing,
 } from './SaveStyles';
 
+const NewPriceIcon = () => {
+	return (
+		<div
+			css={css`
+				${textSans.xsmall({ fontWeight: 'bold' })};
+				color: ${palette.sport[300]};
+				background-color: ${palette.neutral[100]};
+				border: 1px solid ${palette.sport[300]};
+				border-radius: 19px;
+				padding: 0 ${space[2]}px;
+				margin-left: ${space[3]}px;
+				position: absolute;
+				top: -10px;
+			`}
+		>
+			New price
+		</div>
+	);
+};
+
 export const SaveOptions = () => {
 	const navigate = useNavigate();
 	const location = useLocation();
@@ -91,12 +111,15 @@ export const SaveOptions = () => {
 					{billingPeriod}.
 				</p>
 				<Card>
-					<Card.Header backgroundColor={palette.brand[600]}>
+					<Card.Header backgroundColor={palette.sport[300]}>
 						<div css={cardHeaderDivCss}>
 							<h3 css={productTitleCss}>Membership</h3>
-							<p css={productSubtitleCss}>
-								{newPriceDisplay}/{billingPeriod}
-							</p>
+							<div>
+								<NewPriceIcon />
+								<p css={productSubtitleCss}>
+									{newPriceDisplay}/{billingPeriod}
+								</p>
+							</div>
 						</div>
 					</Card.Header>
 					<Card.Section>
@@ -130,7 +153,7 @@ export const SaveOptions = () => {
 					funding Guardian journalism.
 				</p>
 				<Card>
-					<Card.Header backgroundColor={palette.brand[600]}>
+					<Card.Header backgroundColor={palette.brand[400]}>
 						<div css={cardHeaderDivCss}>
 							<h3 css={productTitleCss}>Monthly contribution</h3>
 							<p css={productSubtitleCss}>

--- a/client/components/mma/cancel/cancellationSaves/SaveOptions.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SaveOptions.tsx
@@ -1,5 +1,11 @@
 import { css, ThemeProvider } from '@emotion/react';
-import { palette, space, textSans } from '@guardian/source-foundations';
+import {
+	from,
+	palette,
+	space,
+	textSans,
+	until,
+} from '@guardian/source-foundations';
 import {
 	Button,
 	buttonThemeReaderRevenueBrand,
@@ -45,8 +51,11 @@ const NewPriceIcon = () => {
 				border-radius: 19px;
 				padding: 0 ${space[2]}px;
 				margin-left: ${space[3]}px;
-				position: absolute;
-				top: -10px;
+
+				${from.tablet} {
+					position: absolute;
+					top: -10px;
+				}
 			`}
 		>
 			New price
@@ -114,7 +123,14 @@ export const SaveOptions = () => {
 					<Card.Header backgroundColor={palette.sport[300]}>
 						<div css={cardHeaderDivCss}>
 							<h3 css={productTitleCss}>Membership</h3>
-							<div>
+							<div
+								css={css`
+									${until.tablet} {
+										display: flex;
+										flex-direction: column-reverse;
+									}
+								`}
+							>
 								<NewPriceIcon />
 								<p css={productSubtitleCss}>
 									{newPriceDisplay}/{billingPeriod}

--- a/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
+++ b/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
@@ -163,7 +163,7 @@ export const smallPrintCss = css`
 `;
 
 export const productSubtitleCss = css`
-	${textSans.medium({ fontWeight: 'bold' })};
+	${textSans.large({ fontWeight: 'bold' })};
 	color: ${palette.neutral[100]};
 	margin: 0;
 	max-width: 20ch;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds an icon that flags the new membership price during the switch journey

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://github.com/guardian/manage-frontend/assets/114918544/70689b0c-4be3-48b6-8c73-5a742791230f)
![image](https://github.com/guardian/manage-frontend/assets/114918544/9d63a590-24e4-44b0-a78a-3325a54569d6)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
