### PR TITLE
Use CODE environment in AWS not DEV

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ NOTE: nginx proxies CODE instances of [`identity-frontend`](https://github.com/g
 
 #### Running locally (each day you need use it)
 
-1.  You will also need to have [members-data-api](https://github.com/guardian/members-data-api) (`./start-api.sh`) running, to get subscription data (from DEV Zuora/Salesforce).
+1.  You will also need to have [members-data-api](https://github.com/guardian/members-data-api) (`./start-api.sh`) running, to get subscription data (from CODE Zuora/Salesforce).
 1.  You will probably also need the tunnel to the `contributions-store`, see point 2 of [members-data-api#running-locally](https://github.com/guardian/members-data-api#running-locally)
 
 ## SSH into running instances in AWS

--- a/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
@@ -1658,39 +1658,7 @@ systemctl start manage-frontend
                       Object {
                         "Ref": "AWS::AccountId",
                       },
-                      ":stack/membership-DEV-*",
-                    ],
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:aws:cloudformation:",
-                      Object {
-                        "Ref": "AWS::Region",
-                      },
-                      ":",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
                       ":stack/membership-CODE-*",
-                    ],
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:aws:cloudformation:",
-                      Object {
-                        "Ref": "AWS::Region",
-                      },
-                      ":",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":stack/support-DEV-*",
                     ],
                   ],
                 },
@@ -1970,22 +1938,6 @@ systemctl start manage-frontend
               "Action": "execute-api:Invoke",
               "Effect": "Allow",
               "Resource": Array [
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:aws:execute-api:",
-                      Object {
-                        "Ref": "AWS::Region",
-                      },
-                      ":",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":*/DEV/*",
-                    ],
-                  ],
-                },
                 Object {
                   "Fn::Join": Array [
                     "",

--- a/cdk/lib/manage-frontend.ts
+++ b/cdk/lib/manage-frontend.ts
@@ -141,16 +141,11 @@ systemctl start manage-frontend
 					new GuAllowPolicy(this, 'DiscoverApiGatewayLambdas', {
 						actions: ['cloudformation:ListStackResources'],
 						resources: [
-							`arn:aws:cloudformation:${this.region}:${this.account}:stack/membership-DEV-*`,
 							`arn:aws:cloudformation:${this.region}:${this.account}:stack/membership-CODE-*`,
-							`arn:aws:cloudformation:${this.region}:${this.account}:stack/support-DEV-*`,
 							`arn:aws:cloudformation:${this.region}:${this.account}:stack/support-CODE-*`,
 							`arn:aws:cloudformation:${this.region}:${this.account}:stack/membership-${this.stage}-*`,
 							`arn:aws:cloudformation:${this.region}:${this.account}:stack/support-${this.stage}-*`,
 						],
-						/*
-						 * TODO: why does CODE depend on DEV here?
-						 */
 						/*
 						 * NOTE: PROD currently requires access to CODE lambdas see here:
 						 * https://github.com/guardian/manage-frontend/wiki/test-users
@@ -169,13 +164,9 @@ systemctl start manage-frontend
 					new GuAllowPolicy(this, 'InvokeApiGateway', {
 						actions: ['execute-api:Invoke'],
 						resources: [
-							`arn:aws:execute-api:${this.region}:${this.account}:*/DEV/*`,
 							`arn:aws:execute-api:${this.region}:${this.account}:*/CODE/*`,
 							`arn:aws:execute-api:${this.region}:${this.account}:*/${this.stage}/*`,
 						],
-						/*
-						 * TODO: why does CODE depend on DEV here?
-						 */
 						/*
 						 * NOTE: PROD currently requires access to CODE lambdas see here:
 						 * https://github.com/guardian/manage-frontend/wiki/test-users
@@ -210,7 +201,7 @@ systemctl start manage-frontend
 		});
 
 		if (this.stage === 'PROD') {
-			// TODO: It might be better to undestand the shorthand properties of the existing
+			// TODO: It might be better to understand the shorthand properties of the existing
 			// dashboard and recreate it using level 2 constructs (cdk/guCDK)
 			try {
 				const jsonFilePath = join(__dirname, 'dashboard.json');

--- a/client/__tests__/components/payment/stripe.test.ts
+++ b/client/__tests__/components/payment/stripe.test.ts
@@ -7,11 +7,11 @@ import { getStripeKey } from '../../../utilities/stripe';
 // @ts-expect-error
 window.guardian = {
 	stripeKeyAustralia: {
-		uat: 'uatKeyAustralia',
+		test: 'testKeyAustralia',
 		default: 'defaultKeyAustralia',
 	},
 	stripeKeyDefaultCurrencies: {
-		uat: 'uatKeyDefaultCurrencies',
+		test: 'testKeyDefaultCurrencies',
 		default: 'defaultKeyDefaultCurrencies',
 	},
 };

--- a/client/utilities/stripe.ts
+++ b/client/utilities/stripe.ts
@@ -10,12 +10,12 @@ export function getStripeKey(
 	switch (country) {
 		case 'Australia':
 			return isTestUser
-				? window.guardian?.stripeKeyAustralia?.uat
+				? window.guardian?.stripeKeyAustralia?.test
 				: window.guardian?.stripeKeyAustralia?.default;
 
 		default:
 			return isTestUser
-				? window.guardian?.stripeKeyDefaultCurrencies?.uat
+				? window.guardian?.stripeKeyDefaultCurrencies?.test
 				: window.guardian?.stripeKeyDefaultCurrencies?.default;
 	}
 }

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -3,6 +3,9 @@ regions:
 stacks:
   - support
 deployments:
+  allowedStages:
+    - CODE
+    - PROD
   assets-static:
     type: aws-s3
     parameters:

--- a/server/apiGatewayDiscovery.ts
+++ b/server/apiGatewayDiscovery.ts
@@ -17,7 +17,7 @@ import { log } from './log';
 
 const isProd = conf.STAGE.toUpperCase() === 'PROD';
 
-const normalUserApiStage = isProd ? 'PROD' : 'DEV'; // i.e. CODE manage-frontend uses DEV when in normal mode
+const normalUserApiStage = isProd ? 'PROD' : 'CODE';
 const testUserApiStage = 'CODE';
 
 const apiNames = [

--- a/server/stripeSetupIntentConfig.ts
+++ b/server/stripeSetupIntentConfig.ts
@@ -1,9 +1,8 @@
 import { s3ConfigPromise } from './awsIntegration';
 
-
 type StripePublicToSecretKeyMapping = Record<string, string>;
 export interface StripePublicKeySet {
-	uat: string;
+	test: string;
 	default: string;
 }
 export interface StripePublicKeys {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

There has been a lot of confusion over the years about what the different stages or environments (DEV/CODE/PROD) mean and which should be used for what. This PR is part of a piece of work intended to clear that up.

Full details are [in this document](https://docs.google.com/document/d/1wg1kMk7U7ht3AmPpsPUimtz1FkVbu5BWjijjme2598s/edit#) but in summary:
- The DEV environment refers only to a developers local machine and config settings here are things like local domain names eg. manage.thegulocal.com
- The CODE and PROD environments are for systems running in AWS or production and test versions of external systems

![Supporter Revenue Environments(4)](https://github.com/guardian/manage-frontend/assets/181371/ca129079-89a9-457a-a53c-6985721165e3)

## Changes
- Point all api gateway endpoints to their CODE versions not DEV (these will be deleted eventually)
- Remove permissions for manage to access DEV api gateway
- Rename uat to test in Stripe config, we are not using the term UAT any more as we don't have a separate environment for test users any more, test users just use the CODE environment

## How to test
In CODE carry out a product switch, if it works then all is good.

## Have we considered potential risks?
These changes only affect the CODE environment so risks are minimal, I have tested:
- changing contribution amount
- product switch
- cancellation
