### PR TITLE
Replace fetch-mock with msw in stories

### DIFF
--- a/client/components/helpCentre/HelpCentre.stories.tsx
+++ b/client/components/helpCentre/HelpCentre.stories.tsx
@@ -1,5 +1,5 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
-import fetchMock from 'fetch-mock';
+import { rest } from 'msw';
 import { ReactRouterDecorator } from '../../../.storybook/ReactRouterDecorator';
 import { HelpCenterContentWrapper } from './HelpCenterContentWrapper';
 import { HelpCentre } from './HelpCentre';
@@ -14,13 +14,19 @@ export default {
 } as ComponentMeta<typeof HelpCentre>;
 
 export const Default: ComponentStory<typeof HelpCentre> = () => {
-	fetchMock.restore().get('/api/known-issues/', { body: [] });
-
 	return (
 		<HelpCenterContentWrapper knownIssues={[]}>
 			<HelpCentre />
 		</HelpCenterContentWrapper>
 	);
+};
+
+Default.parameters = {
+	msw: [
+		rest.get('/api/known-issues/', (_req, res, ctx) => {
+			return res(ctx.json([]));
+		}),
+	],
 };
 
 export const WithKnownIssue: ComponentStory<typeof HelpCentre> = () => {

--- a/client/components/helpCentre/HelpCentreArticle.stories.tsx
+++ b/client/components/helpCentre/HelpCentreArticle.stories.tsx
@@ -1,5 +1,5 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
-import fetchMock from 'fetch-mock';
+import { rest } from 'msw';
 import { ReactRouterDecorator } from '../../../.storybook/ReactRouterDecorator';
 import { SectionContent } from '../shared/SectionContent';
 import { SectionHeader } from '../shared/SectionHeader';
@@ -41,13 +41,6 @@ const articleContent = {
 };
 
 export const Default: ComponentStory<typeof HelpCentreArticle> = () => {
-	fetchMock
-		.restore()
-		.get('/api/known-issues/', { body: [] })
-		.get('/api/help-centre/article/i-need-to-pause-my-delivery', {
-			body: articleContent,
-		});
-
 	return (
 		<>
 			<SectionHeader title="How can we help you?" pageHasNav={true} />
@@ -57,7 +50,19 @@ export const Default: ComponentStory<typeof HelpCentreArticle> = () => {
 		</>
 	);
 };
+
 Default.parameters = {
+	msw: [
+		rest.get('/api/known-issues/', (_req, res, ctx) => {
+			return res(ctx.json([]));
+		}),
+		rest.get(
+			'/api/help-centre/article/i-need-to-pause-my-delivery',
+			(_req, res, ctx) => {
+				return res(ctx.json(articleContent));
+			},
+		),
+	],
 	reactRouter: {
 		location: '/article/i-need-to-pause-my-delivery',
 		path: '/article/:articleCode',

--- a/client/components/helpCentre/HelpCentreTopic.stories.tsx
+++ b/client/components/helpCentre/HelpCentreTopic.stories.tsx
@@ -1,5 +1,5 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
-import fetchMock from 'fetch-mock';
+import { rest } from 'msw';
 import { ReactRouterDecorator } from '../../../.storybook/ReactRouterDecorator';
 import { SectionContent } from '../shared/SectionContent';
 import { SectionHeader } from '../shared/SectionHeader';
@@ -34,10 +34,6 @@ const topicContent = {
 };
 
 export const Default: ComponentStory<typeof HelpCentreTopic> = () => {
-	fetchMock
-		.restore()
-		.get('/api/help-centre/topic/delivery', { body: topicContent });
-
 	return (
 		<>
 			<SectionHeader title="How can we help you?" pageHasNav={true} />
@@ -47,7 +43,13 @@ export const Default: ComponentStory<typeof HelpCentreTopic> = () => {
 		</>
 	);
 };
+
 Default.parameters = {
+	msw: [
+		rest.get('/api/help-centre/topic/delivery', (_req, res, ctx) => {
+			return res(ctx.json(topicContent));
+		}),
+	],
 	reactRouter: {
 		location: '/topic/delivery',
 		path: '/topic/:topicCode',

--- a/client/components/helpCentre/contactUs/ContactUs.stories.tsx
+++ b/client/components/helpCentre/contactUs/ContactUs.stories.tsx
@@ -1,5 +1,5 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
-import fetchMock from 'fetch-mock';
+import { rest } from 'msw';
 import { ReactRouterDecorator } from '../../../../.storybook/ReactRouterDecorator';
 import { SectionContent } from '../../shared/SectionContent';
 import { SectionHeader } from '../../shared/SectionHeader';
@@ -16,8 +16,6 @@ export default {
 } as ComponentMeta<typeof ContactUs>;
 
 export const Default: ComponentStory<typeof ContactUs> = () => {
-	fetchMock.restore().get('/api/known-issues/', { body: [] });
-
 	return (
 		<>
 			<SectionHeader title="Need to contact us?" />
@@ -29,16 +27,22 @@ export const Default: ComponentStory<typeof ContactUs> = () => {
 	);
 };
 
+Default.parameters = {
+	msw: [
+		rest.get('/api/known-issues/', (_req, res, ctx) => {
+			return res(ctx.json([]));
+		}),
+	],
+};
+
+const knownIssue = [
+	{
+		date: '20 Jan 2022 12:00',
+		message: 'Live Chat is currently unavailable.',
+	},
+];
+
 export const WithKnownIssue: ComponentStory<typeof ContactUs> = () => {
-	const knownIssue = [
-		{
-			date: '20 Jan 2022 12:00',
-			message: 'Live Chat is currently unavailable.',
-		},
-	];
-
-	fetchMock.restore().get('/api/known-issues/', { body: knownIssue });
-
 	return (
 		<>
 			<SectionHeader title="Need to contact us?" />
@@ -48,6 +52,14 @@ export const WithKnownIssue: ComponentStory<typeof ContactUs> = () => {
 			</SectionContent>
 		</>
 	);
+};
+
+WithKnownIssue.parameters = {
+	msw: [
+		rest.get('/api/known-issues/', (_req, res, ctx) => {
+			return res(ctx.json(knownIssue));
+		}),
+	],
 };
 
 export const TopicSelected: ComponentStory<typeof ContactUs> = () => (

--- a/client/components/mma/accountoverview/AccountOverview.stories.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.stories.tsx
@@ -30,6 +30,7 @@ import { user } from '../../../fixtures/user';
 import { AccountOverview } from './AccountOverview';
 
 featureSwitches['appSubscriptions'] = true;
+featureSwitches['singleContributions'] = true;
 
 export default {
 	title: 'Pages/AccountOverview',
@@ -41,10 +42,6 @@ export default {
 } as ComponentMeta<typeof AccountOverview>;
 
 export const NoSubscription: ComponentStory<typeof AccountOverview> = () => {
-	return <AccountOverview />;
-};
-
-export const WithSubscriptions: ComponentStory<typeof AccountOverview> = () => {
 	return <AccountOverview />;
 };
 
@@ -61,6 +58,9 @@ NoSubscription.parameters = {
 		}),
 		rest.get('/idapi/user', (_req, res, ctx) => {
 			return res(ctx.json(user));
+		}),
+		rest.get('/api/me/one-off-contributions', (_req, res, ctx) => {
+			return res(ctx.json([]));
 		}),
 	],
 };
@@ -88,6 +88,9 @@ WithSubscriptions.parameters = {
 				),
 			);
 		}),
+		rest.get('/api/me/one-off-contributions', (_req, res, ctx) => {
+			return res(ctx.json([]));
+		}),
 	],
 };
 
@@ -107,6 +110,9 @@ WithContributionAndSwitchPossible.parameters = {
 		}),
 		rest.get('/api/me/mma', (_req, res, ctx) => {
 			return res(ctx.json(toMembersDataApiResponse(contributionPayPal)));
+		}),
+		rest.get('/api/me/one-off-contributions', (_req, res, ctx) => {
+			return res(ctx.json([]));
 		}),
 	],
 };
@@ -140,6 +146,9 @@ WithContributionInPaymentFailure.parameters = {
 				),
 			);
 		}),
+		rest.get('/api/me/one-off-contributions', (_req, res, ctx) => {
+			return res(ctx.json([]));
+		}),
 	],
 };
 
@@ -163,6 +172,9 @@ WithContributionAndSwitchNotPossible.parameters = {
 					toMembersDataApiResponse(contributionPayPal, digitalDD),
 				),
 			);
+		}),
+		rest.get('/api/me/one-off-contributions', (_req, res, ctx) => {
+			return res(ctx.json([]));
 		}),
 	],
 };
@@ -194,6 +206,9 @@ WithCancelledSubscriptions.parameters = {
 				),
 			);
 		}),
+		rest.get('/api/me/one-off-contributions', (_req, res, ctx) => {
+			return res(ctx.json([]));
+		}),
 	],
 };
 
@@ -221,16 +236,13 @@ WithGiftSubscriptions.parameters = {
 				),
 			);
 		}),
+		rest.get('/api/me/one-off-contributions', (_req, res, ctx) => {
+			return res(ctx.json([]));
+		}),
 	],
 };
 
 export const WithAppSubscriptions: ComponentStory<
-	typeof AccountOverview
-> = () => {
-	return <AccountOverview />;
-};
-
-export const WithSingleContribution: ComponentStory<
 	typeof AccountOverview
 > = () => {
 	return <AccountOverview />;
@@ -255,6 +267,36 @@ WithAppSubscriptions.parameters = {
 		}),
 		rest.get('/api/me/mma', (_req, res, ctx) => {
 			return res(ctx.json(toMembersDataApiResponse()));
+		}),
+		rest.get('/api/me/one-off-contributions', (_req, res, ctx) => {
+			return res(ctx.json([]));
+		}),
+	],
+};
+
+export const WithSingleContribution: ComponentStory<
+	typeof AccountOverview
+> = () => {
+	return <AccountOverview />;
+};
+
+WithSingleContribution.parameters = {
+	msw: [
+		rest.get('/api/cancelled/', (_req, res, ctx) => {
+			return res(ctx.json([]));
+		}),
+		rest.get('/mpapi/user/mobile-subscriptions', (_req, res, ctx) => {
+			return res(
+				ctx.json({
+					subscriptions: [],
+				}),
+			);
+		}),
+		rest.get('/api/me/mma', (_req, res, ctx) => {
+			return res(ctx.json(toMembersDataApiResponse()));
+		}),
+		rest.get('/api/me/one-off-contributions', (_req, res, ctx) => {
+			return res(ctx.json(singleContributionsAPIResponse));
 		}),
 	],
 };

--- a/client/components/mma/accountoverview/AccountOverview.stories.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.stories.tsx
@@ -1,5 +1,5 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
-import fetchMock from 'fetch-mock';
+import { rest } from 'msw';
 import { ReactRouterDecorator } from '../../../../.storybook/ReactRouterDecorator';
 import { featureSwitches } from '../../../../shared/featureSwitches';
 import {
@@ -41,195 +41,220 @@ export default {
 } as ComponentMeta<typeof AccountOverview>;
 
 export const NoSubscription: ComponentStory<typeof AccountOverview> = () => {
-	fetchMock
-		.restore()
-		.get('/api/cancelled/', { body: [] })
-		.get('/mpapi/user/mobile-subscriptions', {
-			body: { subscriptions: [] },
-		})
-		.get('/api/me/one-off-contributions', {
-			body: [],
-		})
-		.get('/api/me/mma', { body: toMembersDataApiResponse() })
-		.get('/idapi/user', { body: user });
-
 	return <AccountOverview />;
 };
 
 export const WithSubscriptions: ComponentStory<typeof AccountOverview> = () => {
-	fetchMock
-		.restore()
-		.get('/api/cancelled/', { body: [] })
-		.get('/mpapi/user/mobile-subscriptions', {
-			body: { subscriptions: [] },
-		})
-		.get('/api/me/one-off-contributions', {
-			body: [],
-		})
-		.get('/api/me/mma', {
-			body: toMembersDataApiResponse(
-				guardianWeeklyCard,
-				digitalDD,
-				newspaperVoucherPaypal,
-			),
-		});
-
 	return <AccountOverview />;
+};
+
+NoSubscription.parameters = {
+	msw: [
+		rest.get('/api/cancelled/', (_req, res, ctx) => {
+			return res(ctx.json([]));
+		}),
+		rest.get('/mpapi/user/mobile-subscriptions', (_req, res, ctx) => {
+			return res(ctx.json({ subscriptions: [] }));
+		}),
+		rest.get('/api/me/mma', (_req, res, ctx) => {
+			return res(ctx.json(toMembersDataApiResponse()));
+		}),
+		rest.get('/idapi/user', (_req, res, ctx) => {
+			return res(ctx.json(user));
+		}),
+	],
+};
+
+export const WithSubscriptions: ComponentStory<typeof AccountOverview> = () => {
+	return <AccountOverview />;
+};
+
+WithSubscriptions.parameters = {
+	msw: [
+		rest.get('/api/cancelled/', (_req, res, ctx) => {
+			return res(ctx.json([]));
+		}),
+		rest.get('/mpapi/user/mobile-subscriptions', (_req, res, ctx) => {
+			return res(ctx.json({ subscriptions: [] }));
+		}),
+		rest.get('/api/me/mma', (_req, res, ctx) => {
+			return res(
+				ctx.json(
+					toMembersDataApiResponse(
+						guardianWeeklyCard,
+						digitalDD,
+						newspaperVoucherPaypal,
+					),
+				),
+			);
+		}),
+	],
 };
 
 export const WithContributionAndSwitchPossible: ComponentStory<
 	typeof AccountOverview
 > = () => {
-	fetchMock
-		.restore()
-		.get('/api/cancelled/', { body: [] })
-		.get('/mpapi/user/mobile-subscriptions', {
-			body: { subscriptions: [] },
-		})
-		.get('/api/me/one-off-contributions', {
-			body: [],
-		})
-		.get('/api/me/mma', {
-			body: toMembersDataApiResponse(contributionPayPal),
-		});
-
 	return <AccountOverview />;
+};
+
+WithContributionAndSwitchPossible.parameters = {
+	msw: [
+		rest.get('/api/cancelled/', (_req, res, ctx) => {
+			return res(ctx.json([]));
+		}),
+		rest.get('/mpapi/user/mobile-subscriptions', (_req, res, ctx) => {
+			return res(ctx.json({ subscriptions: [] }));
+		}),
+		rest.get('/api/me/mma', (_req, res, ctx) => {
+			return res(ctx.json(toMembersDataApiResponse(contributionPayPal)));
+		}),
+	],
 };
 
 export const WithContributionInPaymentFailure: ComponentStory<
 	typeof AccountOverview
 > = () => {
-	const contributionPaymentFailure = {
-		...contributionPayPal,
-		alertText: 'Your payment has failed.',
-	};
-
-	fetchMock
-		.restore()
-		.get('/api/cancelled/', { body: [] })
-		.get('/mpapi/user/mobile-subscriptions', {
-			body: { subscriptions: [] },
-		})
-		.get('/api/me/one-off-contributions', {
-			body: [],
-		})
-		.get('/api/me/mma', {
-			body: toMembersDataApiResponse(
-				contributionPaymentFailure,
-				supporterPlus,
-			),
-		});
-
 	return <AccountOverview />;
+};
+
+const contributionPaymentFailure = {
+	...contributionPayPal,
+	alertText: 'Your payment has failed.',
+};
+
+WithContributionInPaymentFailure.parameters = {
+	msw: [
+		rest.get('/api/cancelled/', (_req, res, ctx) => {
+			return res(ctx.json([]));
+		}),
+		rest.get('/mpapi/user/mobile-subscriptions', (_req, res, ctx) => {
+			return res(ctx.json({ subscriptions: [] }));
+		}),
+		rest.get('/api/me/mma', (_req, res, ctx) => {
+			return res(
+				ctx.json(
+					toMembersDataApiResponse(
+						contributionPaymentFailure,
+						supporterPlus,
+					),
+				),
+			);
+		}),
+	],
 };
 
 export const WithContributionAndSwitchNotPossible: ComponentStory<
 	typeof AccountOverview
 > = () => {
-	fetchMock
-		.restore()
-		.get('/api/cancelled/', { body: [] })
-		.get('/mpapi/user/mobile-subscriptions', {
-			body: { subscriptions: [] },
-		})
-		.get('/api/me/one-off-contributions', {
-			body: [],
-		})
-		.get('/api/me/mma', {
-			body: toMembersDataApiResponse(contributionPayPal, digitalDD),
-		});
-
 	return <AccountOverview />;
+};
+
+WithContributionAndSwitchNotPossible.parameters = {
+	msw: [
+		rest.get('/api/cancelled/', (_req, res, ctx) => {
+			return res(ctx.json([]));
+		}),
+		rest.get('/mpapi/user/mobile-subscriptions', (_req, res, ctx) => {
+			return res(ctx.json({ subscriptions: [] }));
+		}),
+		rest.get('/api/me/mma', (_req, res, ctx) => {
+			return res(
+				ctx.json(
+					toMembersDataApiResponse(contributionPayPal, digitalDD),
+				),
+			);
+		}),
+	],
 };
 
 export const WithCancelledSubscriptions: ComponentStory<
 	typeof AccountOverview
 > = () => {
-	fetchMock
-		.restore()
-		.get('/api/me/mma', {
-			body: toMembersDataApiResponse(
-				contributionCancelled,
-				guardianWeeklyCancelled,
-				supporterPlusCancelled,
-			),
-		})
-		.get('/api/cancelled/', {
-			body: [cancelledContribution, cancelledGuardianWeekly],
-		})
-		.get('/mpapi/user/mobile-subscriptions', {
-			body: { subscriptions: [] },
-		})
-		.get('/api/me/one-off-contributions', {
-			body: [],
-		});
-
 	return <AccountOverview />;
+};
+
+WithCancelledSubscriptions.parameters = {
+	msw: [
+		rest.get('/api/cancelled/', (_req, res, ctx) => {
+			return res(
+				ctx.json([cancelledContribution, cancelledGuardianWeekly]),
+			);
+		}),
+		rest.get('/mpapi/user/mobile-subscriptions', (_req, res, ctx) => {
+			return res(ctx.json({ subscriptions: [] }));
+		}),
+		rest.get('/api/me/mma', (_req, res, ctx) => {
+			return res(
+				ctx.json(
+					toMembersDataApiResponse(
+						contributionCancelled,
+						guardianWeeklyCancelled,
+						supporterPlusCancelled,
+					),
+				),
+			);
+		}),
+	],
 };
 
 export const WithGiftSubscriptions: ComponentStory<
 	typeof AccountOverview
 > = () => {
-	fetchMock
-		.restore()
-		.get('/api/me/mma', {
-			body: toMembersDataApiResponse(
-				guardianWeeklyGiftRecipient,
-				guardianWeeklyGiftPurchase,
-			),
-		})
-		.get('/api/cancelled/', { body: [] })
-		.get('/mpapi/user/mobile-subscriptions', {
-			body: { subscriptions: [] },
-		})
-		.get('/api/me/one-off-contributions', {
-			body: [],
-		});
-
 	return <AccountOverview />;
+};
+
+WithGiftSubscriptions.parameters = {
+	msw: [
+		rest.get('/api/cancelled/', (_req, res, ctx) => {
+			return res(ctx.json([]));
+		}),
+		rest.get('/mpapi/user/mobile-subscriptions', (_req, res, ctx) => {
+			return res(ctx.json({ subscriptions: [] }));
+		}),
+		rest.get('/api/me/mma', (_req, res, ctx) => {
+			return res(
+				ctx.json(
+					toMembersDataApiResponse(
+						guardianWeeklyGiftRecipient,
+						guardianWeeklyGiftPurchase,
+					),
+				),
+			);
+		}),
+	],
 };
 
 export const WithAppSubscriptions: ComponentStory<
 	typeof AccountOverview
 > = () => {
-	fetchMock
-		.restore()
-		.get('/api/cancelled/', { body: [] })
-		.get('/mpapi/user/mobile-subscriptions', {
-			body: {
-				subscriptions: [
-					CancelledInAppPurchase,
-					InAppPurchaseIos,
-					PuzzleAppPurchaseAndroid,
-					PuzzleAppPurchaseIos,
-				],
-			},
-		})
-		.get('/api/me/one-off-contributions', {
-			body: [],
-		})
-		.get('/api/me/mma', { body: toMembersDataApiResponse() })
-		.get('/idapi/user', { body: user });
-
 	return <AccountOverview />;
 };
 
 export const WithSingleContribution: ComponentStory<
 	typeof AccountOverview
 > = () => {
-	fetchMock
-		.restore()
-		.get('/api/cancelled/', { body: [] })
-		.get('/mpapi/user/mobile-subscriptions', {
-			body: {
-				subscriptions: [],
-			},
-		})
-		.get('/api/me/one-off-contributions', {
-			body: singleContributionsAPIResponse,
-		})
-		.get('/api/me/mma', { body: toMembersDataApiResponse() })
-		.get('/idapi/user', { body: user });
-
 	return <AccountOverview />;
+};
+
+WithAppSubscriptions.parameters = {
+	msw: [
+		rest.get('/api/cancelled/', (_req, res, ctx) => {
+			return res(ctx.json([]));
+		}),
+		rest.get('/mpapi/user/mobile-subscriptions', (_req, res, ctx) => {
+			return res(
+				ctx.json({
+					subscriptions: [
+						CancelledInAppPurchase,
+						InAppPurchaseIos,
+						PuzzleAppPurchaseAndroid,
+						PuzzleAppPurchaseIos,
+					],
+				}),
+			);
+		}),
+		rest.get('/api/me/mma', (_req, res, ctx) => {
+			return res(ctx.json(toMembersDataApiResponse()));
+		}),
+	],
 };

--- a/client/components/mma/cancel/Cancellation.stories.tsx
+++ b/client/components/mma/cancel/Cancellation.stories.tsx
@@ -1,5 +1,5 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
-import fetchMock from 'fetch-mock';
+import { rest } from 'msw';
 import { ReactRouterDecorator } from '../../../../.storybook/ReactRouterDecorator';
 import { PRODUCT_TYPES } from '../../../../shared/productTypes';
 import {
@@ -35,11 +35,15 @@ export default {
 export const SelectReason: ComponentStory<
 	typeof CancellationReasonSelection
 > = () => {
-	fetchMock.restore().get('glob:/api/cancellation-date/*', {
-		body: { cancellationEffectiveDate: '2022-09-01' },
-	});
-
 	return <CancellationReasonSelection />;
+};
+
+SelectReason.parameters = {
+	msw: [
+		rest.get('glob:/api/cancellation-date/*', (_req, res, ctx) => {
+			return res(ctx.json({ cancellationEffectiveDate: '2022-09-01' }));
+		}),
+	],
 };
 
 export const ContactCustomerService: ComponentStory<
@@ -56,12 +60,15 @@ ContactCustomerService.parameters = {
 };
 
 export const Review: ComponentStory<typeof CancellationContainer> = () => {
-	fetchMock.restore().post('/api/case', { body: { id: 'caseId' } });
-
 	return <CancellationReasonReview />;
 };
 
 Review.parameters = {
+	msw: [
+		rest.post('/api/case', (_req, res, ctx) => {
+			return res(ctx.json({ id: 'caseId' }));
+		}),
+	],
 	reactRouter: {
 		state: {
 			productDetail: contributionPayPal,

--- a/client/components/mma/cancel/Cancellation.stories.tsx
+++ b/client/components/mma/cancel/Cancellation.stories.tsx
@@ -38,14 +38,6 @@ export const SelectReason: ComponentStory<
 	return <CancellationReasonSelection />;
 };
 
-SelectReason.parameters = {
-	msw: [
-		rest.get('glob:/api/cancellation-date/*', (_req, res, ctx) => {
-			return res(ctx.json({ cancellationEffectiveDate: '2022-09-01' }));
-		}),
-	],
-};
-
 export const ContactCustomerService: ComponentStory<
 	typeof CancellationReasonSelection
 > = () => <CancellationReasonSelection />;

--- a/client/components/mma/dataPrivacy/DataPrivacy.stories.tsx
+++ b/client/components/mma/dataPrivacy/DataPrivacy.stories.tsx
@@ -1,16 +1,30 @@
-import type { ComponentStory } from '@storybook/react';
-import fetchMock from 'fetch-mock';
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import { rest } from 'msw';
+import { ReactRouterDecorator } from '../../../../.storybook/ReactRouterDecorator';
 import { consents } from '../../../fixtures/consents';
 import { user } from '../../../fixtures/user';
 import { DataPrivacy } from './DataPrivacy';
 
-export const NoSubscription: ComponentStory<typeof DataPrivacy> = () => {
-	fetchMock
-		.restore()
-		.get('/consents?filter=all', {
-			body: consents,
-		})
-		.get('/idapi/user', { body: user });
+export default {
+	title: 'Pages/DataPrivacy',
+	component: DataPrivacy,
+	decorators: [ReactRouterDecorator],
+	parameters: {
+		layout: 'fullscreen',
+	},
+} as ComponentMeta<typeof DataPrivacy>;
 
+export const Default: ComponentStory<typeof DataPrivacy> = () => {
 	return <DataPrivacy />;
+};
+
+Default.parameters = {
+	msw: [
+		rest.get('idapicodeproxy/consents', (_req, res, ctx) => {
+			return res(ctx.json(consents));
+		}),
+		rest.get('/idapi/user', (_req, res, ctx) => {
+			return res(ctx.json(user));
+		}),
+	],
 };

--- a/client/components/mma/identity/emailAndMarketing/EmailAndMarketing.stories.tsx
+++ b/client/components/mma/identity/emailAndMarketing/EmailAndMarketing.stories.tsx
@@ -1,5 +1,5 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
-import fetchMock from 'fetch-mock';
+import { rest } from 'msw';
 import { ReactRouterDecorator } from '../../../../../.storybook/ReactRouterDecorator';
 import { featureSwitches } from '../../../../../shared/featureSwitches';
 import { consents } from '../../../../fixtures/consents';
@@ -26,78 +26,112 @@ export default {
 } as ComponentMeta<typeof EmailAndMarketing>;
 
 export const Default: ComponentStory<typeof EmailAndMarketing> = () => {
-	fetchMock
-		.restore()
-		.get('/api/me/mma', {
-			body: toMembersDataApiResponse(
-				guardianWeeklyCard,
-				digitalDD,
-				newspaperVoucherPaypal,
-			),
-		})
-		.get('/idapi/user', { body: user })
-		.get('/idapicodeproxy/newsletters', { body: newsletters })
-		.get('/idapicodeproxy/users/me/newsletters', {
-			body: newsletterSubscriptions,
-		})
-		.get('/mpapi/user/mobile-subscriptions', {
-			body: { subscriptions: [] },
-		})
-		.get('/api/me/one-off-contributions', {
-			body: [],
-		})
-		.get('/idapicodeproxy/consents?filter=all', { body: consents })
-		.get('/api/reminders/status', { body: { recurringStatus: 'NotSet' } });
-
 	return <EmailAndMarketing />;
 };
 
-export const WithNoProducts: ComponentStory<typeof EmailAndMarketing> = () => {
-	fetchMock
-		.restore()
-		.get('/api/me/mma', {
-			body: toMembersDataApiResponse(),
-		})
-		.get('/idapi/user', { body: user })
-		.get('/idapicodeproxy/newsletters', { body: newsletters })
-		.get('/idapicodeproxy/users/me/newsletters', {
-			body: newsletterSubscriptions,
-		})
-		.get('/mpapi/user/mobile-subscriptions', {
-			body: { subscriptions: [] },
-		})
-		.get('/api/me/one-off-contributions', {
-			body: [],
-		})
-		.get('/idapicodeproxy/consents?filter=all', { body: consents })
-		.get('/api/reminders/status', { body: { recurringStatus: 'NotSet' } });
+Default.parameters = {
+	msw: [
+		rest.get('/api/me/mma', (_req, res, ctx) => {
+			return res(
+				ctx.json(
+					toMembersDataApiResponse(
+						guardianWeeklyCard,
+						digitalDD,
+						newspaperVoucherPaypal,
+					),
+				),
+			);
+		}),
+		rest.get('/idapi/user', (_req, res, ctx) => {
+			return res(ctx.json(user));
+		}),
+		rest.get('/idapicodeproxy/newsletters', (_req, res, ctx) => {
+			return res(ctx.json(newsletters));
+		}),
+		rest.get('/idapicodeproxy/users/me/newsletters', (_req, res, ctx) => {
+			return res(ctx.json(newsletterSubscriptions));
+		}),
+		rest.get('/mpapi/user/mobile-subscriptions', (_req, res, ctx) => {
+			return res(ctx.json({ subscriptions: [] }));
+		}),
+		rest.get('/api/me/one-off-contributions', (_req, res, ctx) => {
+			return res(ctx.json([]));
+		}),
+		rest.get('/idapicodeproxy/consents', (_req, res, ctx) => {
+			return res(ctx.json(consents));
+		}),
+		rest.get('/api/reminders/status', (_req, res, ctx) => {
+			return res(ctx.json({ recurringStatus: 'NotSet' }));
+		}),
+	],
+};
 
+export const WithNoProducts: ComponentStory<typeof EmailAndMarketing> = () => {
 	return <EmailAndMarketing />;
+};
+
+WithNoProducts.parameters = {
+	msw: [
+		rest.get('/api/me/mma', (_req, res, ctx) => {
+			return res(ctx.json(toMembersDataApiResponse()));
+		}),
+		rest.get('/idapi/user', (_req, res, ctx) => {
+			return res(ctx.json(user));
+		}),
+		rest.get('/idapicodeproxy/newsletters', (_req, res, ctx) => {
+			return res(ctx.json(newsletters));
+		}),
+		rest.get('/idapicodeproxy/users/me/newsletters', (_req, res, ctx) => {
+			return res(ctx.json(newsletterSubscriptions));
+		}),
+		rest.get('/mpapi/user/mobile-subscriptions', (_req, res, ctx) => {
+			return res(ctx.json({ subscriptions: [] }));
+		}),
+		rest.get('/api/me/one-off-contributions', (_req, res, ctx) => {
+			return res(ctx.json([]));
+		}),
+		rest.get('/idapicodeproxy/consents', (_req, res, ctx) => {
+			return res(ctx.json(consents));
+		}),
+		rest.get('/api/reminders/status', (_req, res, ctx) => {
+			return res(ctx.json({ recurringStatus: 'NotSet' }));
+		}),
+	],
 };
 
 export const WithIAP: ComponentStory<typeof EmailAndMarketing> = () => {
 	featureSwitches['appSubscriptions'] = true;
 
-	fetchMock
-		.restore()
-		.get('/api/me/mma', {
-			body: toMembersDataApiResponse(),
-		})
-		.get('/idapi/user', { body: user })
-		.get('/idapicodeproxy/newsletters', { body: newsletters })
-		.get('/idapicodeproxy/users/me/newsletters', {
-			body: newsletterSubscriptions,
-		})
-		.get('/mpapi/user/mobile-subscriptions', {
-			body: { subscriptions: [InAppPurchase] },
-		})
-		.get('/api/me/one-off-contributions', {
-			body: [],
-		})
-		.get('/idapicodeproxy/consents?filter=all', { body: consents })
-		.get('/api/reminders/status', { body: { recurringStatus: 'NotSet' } });
-
 	return <EmailAndMarketing />;
+};
+
+WithIAP.parameters = {
+	msw: [
+		rest.get('/api/me/mma', (_req, res, ctx) => {
+			return res(ctx.json(toMembersDataApiResponse()));
+		}),
+		rest.get('/idapi/user', (_req, res, ctx) => {
+			return res(ctx.json(user));
+		}),
+		rest.get('/idapicodeproxy/newsletters', (_req, res, ctx) => {
+			return res(ctx.json(newsletters));
+		}),
+		rest.get('/idapicodeproxy/users/me/newsletters', (_req, res, ctx) => {
+			return res(ctx.json(newsletterSubscriptions));
+		}),
+		rest.get('/mpapi/user/mobile-subscriptions', (_req, res, ctx) => {
+			return res(ctx.json({ subscriptions: [InAppPurchase] }));
+		}),
+		rest.get('/api/me/one-off-contributions', (_req, res, ctx) => {
+			return res(ctx.json([]));
+		}),
+		rest.get('/idapicodeproxy/consents', (_req, res, ctx) => {
+			return res(ctx.json(consents));
+		}),
+		rest.get('/api/reminders/status', (_req, res, ctx) => {
+			return res(ctx.json({ recurringStatus: 'NotSet' }));
+		}),
+	],
 };
 
 export const WithSingleContribution: ComponentStory<
@@ -105,24 +139,34 @@ export const WithSingleContribution: ComponentStory<
 > = () => {
 	featureSwitches['singleContributions'] = true;
 
-	fetchMock
-		.restore()
-		.get('/api/me/mma', {
-			body: toMembersDataApiResponse(),
-		})
-		.get('/idapi/user', { body: user })
-		.get('/idapicodeproxy/newsletters', { body: newsletters })
-		.get('/idapicodeproxy/users/me/newsletters', {
-			body: newsletterSubscriptions,
-		})
-		.get('/mpapi/user/mobile-subscriptions', {
-			body: { subscriptions: [InAppPurchase] },
-		})
-		.get('/api/me/one-off-contributions', {
-			body: singleContributionsAPIResponse,
-		})
-		.get('/idapicodeproxy/consents?filter=all', { body: consents })
-		.get('/api/reminders/status', { body: { recurringStatus: 'NotSet' } });
-
 	return <EmailAndMarketing />;
+};
+
+WithSingleContribution.parameters = {
+	msw: [
+		rest.get('/api/me/mma', (_req, res, ctx) => {
+			return res(ctx.json(toMembersDataApiResponse()));
+		}),
+		rest.get('/idapi/user', (_req, res, ctx) => {
+			return res(ctx.json(user));
+		}),
+		rest.get('/idapicodeproxy/newsletters', (_req, res, ctx) => {
+			return res(ctx.json(newsletters));
+		}),
+		rest.get('/idapicodeproxy/users/me/newsletters', (_req, res, ctx) => {
+			return res(ctx.json(newsletterSubscriptions));
+		}),
+		rest.get('/mpapi/user/mobile-subscriptions', (_req, res, ctx) => {
+			return res(ctx.json({ subscriptions: [] }));
+		}),
+		rest.get('/api/me/one-off-contributions', (_req, res, ctx) => {
+			return res(ctx.json(singleContributionsAPIResponse));
+		}),
+		rest.get('/idapicodeproxy/consents', (_req, res, ctx) => {
+			return res(ctx.json(consents));
+		}),
+		rest.get('/api/reminders/status', (_req, res, ctx) => {
+			return res(ctx.json({ recurringStatus: 'NotSet' }));
+		}),
+	],
 };

--- a/client/components/mma/identity/publicProfile/PublicProfile.stories.tsx
+++ b/client/components/mma/identity/publicProfile/PublicProfile.stories.tsx
@@ -1,5 +1,5 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
-import fetchMock from 'fetch-mock';
+import { rest } from 'msw';
 import { ReactRouterDecorator } from '../../../../../.storybook/ReactRouterDecorator';
 import { user } from '../../../../fixtures/user';
 import { PublicProfile } from './PublicProfile';
@@ -14,7 +14,13 @@ export default {
 } as ComponentMeta<typeof PublicProfile>;
 
 export const Default: ComponentStory<typeof PublicProfile> = () => {
-	fetchMock.restore().get('/idapi/user', { body: user });
-
 	return <PublicProfile />;
+};
+
+Default.parameters = {
+	msw: [
+		rest.get('/idapi/user', (_req, res, ctx) => {
+			return res(ctx.json(user));
+		}),
+	],
 };

--- a/client/components/mma/identity/settings/Settings.stories.tsx
+++ b/client/components/mma/identity/settings/Settings.stories.tsx
@@ -20,7 +20,7 @@ export const Default: ComponentStory<typeof Settings> = () => {
 Default.parameters = {
 	msw: [
 		rest.get('/idapi/user', (_req, res, ctx) => {
-			return res(ctx.json({ body: user }));
+			return res(ctx.json(user));
 		}),
 	],
 };

--- a/client/components/mma/identity/settings/Settings.stories.tsx
+++ b/client/components/mma/identity/settings/Settings.stories.tsx
@@ -1,5 +1,5 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
-import fetchMock from 'fetch-mock';
+import { rest } from 'msw';
 import { ReactRouterDecorator } from '../../../../../.storybook/ReactRouterDecorator';
 import { user } from '../../../../fixtures/user';
 import { Settings } from './Settings';
@@ -14,7 +14,13 @@ export default {
 } as ComponentMeta<typeof Settings>;
 
 export const Default: ComponentStory<typeof Settings> = () => {
-	fetchMock.restore().get('/idapi/user', { body: user });
-
 	return <Settings />;
+};
+
+Default.parameters = {
+	msw: [
+		rest.get('/idapi/user', (_req, res, ctx) => {
+			return res(ctx.json({ body: user }));
+		}),
+	],
 };

--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
     "eslint": "8.16.0",
     "eslint-plugin-jest": "27.0.4",
     "eslint-plugin-react": "7.30.0",
-    "fetch-mock": "9.11.0",
     "git-revision-webpack-plugin": "3.0.6",
     "husky": "1.3.1",
     "jest": "27.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -104,27 +104,6 @@
     json5 "^2.1.2"
     semver "^6.3.0"
 
-"@babel/core@^7.0.0", "@babel/core@^7.12.10":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.16.7.tgz#db990f931f6d40cb9b87a0dc7d2adc749f1dcbcf"
-  integrity sha512-aeLaqcqThRNZYmbMqtulsetOQZ/5gbR/dWruUCJcpas4Qoyy+QeagfDsPdMrqwsPRDNxJvBlRiZxxX7THO7qtA==
-  dependencies:
-    "@babel/code-frame" "^7.16.7"
-    "@babel/generator" "^7.16.7"
-    "@babel/helper-compilation-targets" "^7.16.7"
-    "@babel/helper-module-transforms" "^7.16.7"
-    "@babel/helpers" "^7.16.7"
-    "@babel/parser" "^7.16.7"
-    "@babel/template" "^7.16.7"
-    "@babel/traverse" "^7.16.7"
-    "@babel/types" "^7.16.7"
-    convert-source-map "^1.7.0"
-    debug "^4.1.0"
-    gensync "^1.0.0-beta.2"
-    json5 "^2.1.2"
-    semver "^6.3.0"
-    source-map "^0.5.0"
-
 "@babel/core@^7.1.0", "@babel/core@^7.12.3", "@babel/core@^7.7.2", "@babel/core@^7.7.5":
   version "7.16.5"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.16.5.tgz#924aa9e1ae56e1e55f7184c8bf073a50d8677f5c"
@@ -139,6 +118,27 @@
     "@babel/template" "^7.16.0"
     "@babel/traverse" "^7.16.5"
     "@babel/types" "^7.16.0"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.1.2"
+    semver "^6.3.0"
+    source-map "^0.5.0"
+
+"@babel/core@^7.12.10":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.16.7.tgz#db990f931f6d40cb9b87a0dc7d2adc749f1dcbcf"
+  integrity sha512-aeLaqcqThRNZYmbMqtulsetOQZ/5gbR/dWruUCJcpas4Qoyy+QeagfDsPdMrqwsPRDNxJvBlRiZxxX7THO7qtA==
+  dependencies:
+    "@babel/code-frame" "^7.16.7"
+    "@babel/generator" "^7.16.7"
+    "@babel/helper-compilation-targets" "^7.16.7"
+    "@babel/helper-module-transforms" "^7.16.7"
+    "@babel/helpers" "^7.16.7"
+    "@babel/parser" "^7.16.7"
+    "@babel/template" "^7.16.7"
+    "@babel/traverse" "^7.16.7"
+    "@babel/types" "^7.16.7"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
@@ -7290,11 +7290,6 @@ core-js@3.19.1:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.19.1.tgz#f6f173cae23e73a7d88fa23b6e9da329276c6641"
   integrity sha512-Tnc7E9iKd/b/ff7GFbhwPVzJzPztGrChB8X8GLqoYGdEOG8IpLnK1xPyo3ZoO3HsK6TodJS58VGPOxA+hLHQMg==
 
-core-js@^3.0.0:
-  version "3.20.3"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.20.3.tgz#c710d0a676e684522f3db4ee84e5e18a9d11d69a"
-  integrity sha512-vVl8j8ph6tRS3B8qir40H7yw7voy17xL0piAjlbBUsH7WIfzoedL/ZOr1OV9FyZQLWXsayOJyV4tnRyXR85/ag==
-
 core-js@^3.0.4, core-js@^3.6.5, core-js@^3.8.2:
   version "3.20.2"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.20.2.tgz#46468d8601eafc8b266bd2dd6bf9dee622779581"
@@ -9009,22 +9004,6 @@ fecha@^2.3.3:
   resolved "https://registry.yarnpkg.com/fecha/-/fecha-2.3.3.tgz#948e74157df1a32fd1b12c3a3c3cdcb6ec9d96cd"
   integrity sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg==
 
-fetch-mock@9.11.0:
-  version "9.11.0"
-  resolved "https://registry.yarnpkg.com/fetch-mock/-/fetch-mock-9.11.0.tgz#371c6fb7d45584d2ae4a18ee6824e7ad4b637a3f"
-  integrity sha512-PG1XUv+x7iag5p/iNHD4/jdpxL9FtVSqRMUQhPab4hVDt80T1MH5ehzVrL2IdXO9Q2iBggArFvPqjUbHFuI58Q==
-  dependencies:
-    "@babel/core" "^7.0.0"
-    "@babel/runtime" "^7.0.0"
-    core-js "^3.0.0"
-    debug "^4.1.1"
-    glob-to-regexp "^0.4.0"
-    is-subset "^0.1.1"
-    lodash.isequal "^4.5.0"
-    path-to-regexp "^2.2.1"
-    querystring "^0.2.0"
-    whatwg-url "^6.5.0"
-
 fetch-retry@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/fetch-retry/-/fetch-retry-5.0.2.tgz#4c55663a7c056cb45f182394e479464f0ff8f3e3"
@@ -9564,7 +9543,7 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
-glob-to-regexp@^0.4.0, glob-to-regexp@^0.4.1:
+glob-to-regexp@^0.4.1:
   version "0.4.1"
   resolved "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
@@ -10899,11 +10878,6 @@ is-string@^1.0.5, is-string@^1.0.6, is-string@^1.0.7:
   dependencies:
     has-tostringtag "^1.0.0"
 
-is-subset@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/is-subset/-/is-subset-0.1.1.tgz#8a59117d932de1de00f245fcdd39ce43f1e939a6"
-  integrity sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=
-
 is-symbol@^1.0.2, is-symbol@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.4.tgz#a6dac93b635b063ca6872236de88910a57af139c"
@@ -12077,11 +12051,6 @@ lodash.once@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
-
-lodash.sortby@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
-  integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
 lodash.union@^4.6.0:
   version "4.6.0"
@@ -13582,11 +13551,6 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
-
-path-to-regexp@^2.2.1:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.4.0.tgz#35ce7f333d5616f1c1e1bfe266c3aba2e5b2e704"
-  integrity sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==
 
 path-to-regexp@^6.2.0:
   version "6.2.1"
@@ -16278,13 +16242,6 @@ tough-cookie@~2.5.0:
     psl "^1.1.28"
     punycode "^2.1.1"
 
-tr46@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
-  integrity sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=
-  dependencies:
-    punycode "^2.1.0"
-
 tr46@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-2.1.0.tgz#fa87aa81ca5d5941da8cbf1f9b749dc969a4e240"
@@ -17008,11 +16965,6 @@ webidl-conversions@^3.0.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
   integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
 
-webidl-conversions@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
-  integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
-
 webidl-conversions@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
@@ -17287,15 +17239,6 @@ whatwg-url@^5.0.0:
   dependencies:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
-
-whatwg-url@^6.5.0:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
-  integrity sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==
-  dependencies:
-    lodash.sortby "^4.7.0"
-    tr46 "^1.0.1"
-    webidl-conversions "^4.0.2"
 
 whatwg-url@^8.0.0, whatwg-url@^8.5.0:
   version "8.7.0"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Replaces all uses of `fetch-mock` in storybook stories with `msw` - introduced by me in #923 because MSW was seemingly more easier to use. In the intervening time there has been a mix of `fetch-mock` and `msw` - which causes stories to break when clicking between the two.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

If all Chromatic tests are unaffected it should be all good.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
