### PR TITLE
Create new progress bar component

### DIFF
--- a/client/components/mma/cancel/cancellationSaves/ConfirmMembershipCancellation.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ConfirmMembershipCancellation.tsx
@@ -18,7 +18,7 @@ import { ProgressStepper } from '../../shared/ProgressStepper';
 import type { CancellationContextInterface } from '../CancellationContainer';
 import { CancellationContext } from '../CancellationContainer';
 import type { OptionalCancellationReasonId } from '../cancellationReason';
-import { buttonLayoutCss, stackedButtonLayoutCss } from './SaveStyles';
+import { stackedButtonLayoutCss } from './SaveStyles';
 
 export const ConfirmMembershipCancellation = () => {
 	const navigate = useNavigate();

--- a/client/components/mma/cancel/cancellationSaves/ConfirmMembershipCancellation.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ConfirmMembershipCancellation.tsx
@@ -23,6 +23,7 @@ export const ConfirmMembershipCancellation = () => {
 				]}
 				additionalCSS={css`
 					margin: ${space[5]}px 0 ${space[12]}px;
+					max-width: 350px;
 				`}
 			/>
 			<Stack space={4}>

--- a/client/components/mma/cancel/cancellationSaves/ConfirmMembershipCancellation.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ConfirmMembershipCancellation.tsx
@@ -7,7 +7,7 @@ import {
 } from '@guardian/source-react-components';
 import { useNavigate } from 'react-router';
 import { Heading } from '../../shared/Heading';
-import { ProgressIndicator } from '../../shared/ProgressIndicator';
+import { ProgressStepper } from '../../shared/ProgressStepper';
 import { buttonLayoutCss } from './SaveStyles';
 
 export const ConfirmMembershipCancellation = () => {
@@ -15,10 +15,10 @@ export const ConfirmMembershipCancellation = () => {
 
 	return (
 		<>
-			<ProgressIndicator
+			<ProgressStepper
 				steps={[
-					{ title: '' },
-					{ title: '' },
+					{ title: 'Details' },
+					{ title: 'Options' },
 					{ title: 'Confirmation', isCurrentStep: true },
 				]}
 				additionalCSS={css`

--- a/client/components/mma/cancel/cancellationSaves/ContinueMembershipConfirmation.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ContinueMembershipConfirmation.tsx
@@ -7,7 +7,7 @@ import { cancellationFormatDate } from '../../../../../shared/dates';
 import type { PaidSubscriptionPlan } from '../../../../../shared/productResponse';
 import { getMainPlan } from '../../../../../shared/productResponse';
 import { getNewMembershipPrice } from '../../../../utilities/membershipPriceRise';
-import { ProgressIndicator } from '../../shared/ProgressIndicator';
+import { ProgressStepper } from '../../shared/ProgressStepper';
 import type { CancellationContextInterface } from '../CancellationContainer';
 import { CancellationContext } from '../CancellationContainer';
 import {
@@ -34,10 +34,10 @@ export const ContinueMembershipConfirmation = () => {
 
 	return (
 		<>
-			<ProgressIndicator
+			<ProgressStepper
 				steps={[
-					{ title: '' },
-					{ title: '' },
+					{ title: 'Details' },
+					{ title: 'Options' },
 					{ title: 'Confirmation', isCurrentStep: true },
 				]}
 				additionalCSS={css`

--- a/client/components/mma/cancel/cancellationSaves/ContinueMembershipConfirmation.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ContinueMembershipConfirmation.tsx
@@ -42,6 +42,7 @@ export const ContinueMembershipConfirmation = () => {
 				]}
 				additionalCSS={css`
 					margin: ${space[5]}px 0 ${space[12]}px;
+					max-width: 350px;
 				`}
 			/>
 			<Stack space={4}>

--- a/client/components/mma/cancel/cancellationSaves/SaveOptions.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SaveOptions.tsx
@@ -99,6 +99,7 @@ export const SaveOptions = () => {
 				]}
 				additionalCSS={css`
 					margin: ${space[5]}px 0 ${space[12]}px;
+					max-width: 350px;
 				`}
 			/>
 			<Stack space={4}>

--- a/client/components/mma/cancel/cancellationSaves/SaveOptions.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SaveOptions.tsx
@@ -22,7 +22,7 @@ import {
 import { Card } from '../../shared/Card';
 import { Heading } from '../../shared/Heading';
 import { MembershipBenefitsSection } from '../../shared/MembershipBenefits';
-import { ProgressIndicator } from '../../shared/ProgressIndicator';
+import { ProgressIndicatorV2 } from '../../shared/ProgressIndicatorV2';
 import { RecurringSupporterBenefitsSection } from '../../shared/RecurringSupporterBenefits';
 import type {
 	CancellationContextInterface,
@@ -91,11 +91,11 @@ export const SaveOptions = () => {
 
 	return (
 		<>
-			<ProgressIndicator
+			<ProgressIndicatorV2
 				steps={[
-					{ title: '' },
+					{ title: 'Details' },
 					{ title: 'Offer', isCurrentStep: true },
-					{ title: '' },
+					{ title: 'Confirmation' },
 				]}
 				additionalCSS={css`
 					margin: ${space[5]}px 0 ${space[12]}px;

--- a/client/components/mma/cancel/cancellationSaves/SaveOptions.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SaveOptions.tsx
@@ -22,7 +22,7 @@ import {
 import { Card } from '../../shared/Card';
 import { Heading } from '../../shared/Heading';
 import { MembershipBenefitsSection } from '../../shared/MembershipBenefits';
-import { ProgressIndicatorV2 } from '../../shared/ProgressIndicatorV2';
+import { ProgressStepper } from '../../shared/ProgressStepper';
 import { RecurringSupporterBenefitsSection } from '../../shared/RecurringSupporterBenefits';
 import type {
 	CancellationContextInterface,
@@ -91,7 +91,7 @@ export const SaveOptions = () => {
 
 	return (
 		<>
-			<ProgressIndicatorV2
+			<ProgressStepper
 				steps={[
 					{ title: 'Details' },
 					{ title: 'Offer', isCurrentStep: true },

--- a/client/components/mma/cancel/cancellationSaves/ValueOfSupport.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ValueOfSupport.tsx
@@ -8,7 +8,7 @@ import {
 import { useContext } from 'react';
 import { Navigate, useLocation, useNavigate } from 'react-router';
 import { dateString } from '../../../../../shared/dates';
-import { ProgressIndicator } from '../../shared/ProgressIndicator';
+import { ProgressStepper } from '../../shared/ProgressStepper';
 import type {
 	CancellationContextInterface,
 	CancellationRouterState,
@@ -41,11 +41,11 @@ export const ValueOfSupport = () => {
 
 	return (
 		<>
-			<ProgressIndicator
+			<ProgressStepper
 				steps={[
 					{ title: 'Details', isCurrentStep: true },
-					{ title: '' },
-					{ title: '' },
+					{ title: 'Options' },
+					{ title: 'Confirmation' },
 				]}
 				additionalCSS={css`
 					margin: ${space[5]}px 0 ${space[12]}px;

--- a/client/components/mma/cancel/cancellationSaves/ValueOfSupport.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ValueOfSupport.tsx
@@ -49,6 +49,7 @@ export const ValueOfSupport = () => {
 				]}
 				additionalCSS={css`
 					margin: ${space[5]}px 0 ${space[12]}px;
+					max-width: 350px;
 				`}
 			/>
 			<Stack space={4}>

--- a/client/components/mma/shared/ProgressIndicator.stories.tsx
+++ b/client/components/mma/shared/ProgressIndicator.stories.tsx
@@ -1,36 +1,36 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 import { ProgressIndicator } from './ProgressIndicator';
-import { ProgressIndicatorV2 } from './ProgressIndicatorV2';
+import { ProgressStepper } from './ProgressStepper';
 
 export default {
 	title: 'Components/ProgressIndicator',
-	component: ProgressIndicatorV2,
+	component: ProgressStepper,
 	parameters: {
 		layout: 'fullscreen',
 	},
-} as ComponentMeta<typeof ProgressIndicatorV2>;
+} as ComponentMeta<typeof ProgressStepper>;
 
-export const Default: ComponentStory<typeof ProgressIndicatorV2> = () => {
+export const Default: ComponentStory<typeof ProgressStepper> = () => {
 	return (
 		<>
-			<ProgressIndicatorV2
+			<ProgressStepper
 				steps={[{ title: 'Reason' }, { title: 'Review' }]}
 			/>
-			<ProgressIndicatorV2
+			<ProgressStepper
 				steps={[
 					{ title: 'Reason' },
 					{ title: 'Review', isCurrentStep: true },
 					{ title: 'Confirmation' },
 				]}
 			/>
-			<ProgressIndicatorV2
+			<ProgressStepper
 				steps={[
 					{ title: 'Reason', isCurrentStep: true },
 					{ title: 'Review' },
 					{ title: 'Confirmation' },
 				]}
 			/>
-			<ProgressIndicatorV2
+			<ProgressStepper
 				steps={[
 					{ title: 'Reason' },
 					{ title: 'Review' },

--- a/client/components/mma/shared/ProgressIndicator.stories.tsx
+++ b/client/components/mma/shared/ProgressIndicator.stories.tsx
@@ -1,0 +1,54 @@
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import { ProgressIndicator } from './ProgressIndicator';
+import { ProgressIndicatorV2 } from './ProgressIndicatorV2';
+
+export default {
+	title: 'Components/ProgressIndicator',
+	component: ProgressIndicatorV2,
+	parameters: {
+		layout: 'fullscreen',
+	},
+} as ComponentMeta<typeof ProgressIndicatorV2>;
+
+export const Default: ComponentStory<typeof ProgressIndicatorV2> = () => {
+	return (
+		<>
+			<ProgressIndicatorV2
+				steps={[{ title: 'Reason' }, { title: 'Review' }]}
+			/>
+			<ProgressIndicatorV2
+				steps={[
+					{ title: 'Reason' },
+					{ title: 'Review', isCurrentStep: true },
+					{ title: 'Confirmation' },
+				]}
+			/>
+			<ProgressIndicatorV2
+				steps={[
+					{ title: 'Reason', isCurrentStep: true },
+					{ title: 'Review' },
+					{ title: 'Confirmation' },
+				]}
+			/>
+			<ProgressIndicatorV2
+				steps={[
+					{ title: 'Reason' },
+					{ title: 'Review' },
+					{ title: 'Confirmation', isCurrentStep: true },
+				]}
+			/>
+		</>
+	);
+};
+
+export const OldVersion: ComponentStory<typeof ProgressIndicator> = () => {
+	return (
+		<ProgressIndicator
+			steps={[
+				{ title: 'Reason' },
+				{ title: 'Review', isCurrentStep: true },
+				{ title: 'Confirmation' },
+			]}
+		/>
+	);
+};

--- a/client/components/mma/shared/ProgressIndicatorV2.tsx
+++ b/client/components/mma/shared/ProgressIndicatorV2.tsx
@@ -55,14 +55,14 @@ const Step = ({
 				color: ${index > currentStep
 					? palette.neutral[46]
 					: palette.brand[400]};
-				flex: 1;
+				flex: ${index > 0 ? '1' : '0.5'};
 			`}
 		>
 			<div
 				css={css`
-					display: flex;
-					flex-direction: column;
-					align-items: center;
+					${index > 0
+						? 'display: flex; flex-direction: column; align-items: center;'
+						: ''}
 				`}
 			>
 				<span>{step.title}</span>
@@ -107,7 +107,11 @@ export const ProgressIndicatorV2 = ({
 					background-color: ${palette.neutral[60]};
 					order: -1;
 				}
-				> :nth-child(-n + ${currentStep}):after {
+				> :first-of-type:after {
+					left: calc(22px + ${space[2]}px);
+					width: calc(200% - 33px - 2 * ${space[2]}px);
+				}
+				> :nth-of-type(-n + ${currentStep}):after {
 					background-color: ${palette.brand[400]};
 				}
 			`}

--- a/client/components/mma/shared/ProgressIndicatorV2.tsx
+++ b/client/components/mma/shared/ProgressIndicatorV2.tsx
@@ -1,0 +1,125 @@
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
+import { palette, space, textSans } from '@guardian/source-foundations';
+import { TickInCircle } from './assets/TickInCircle';
+
+interface Step {
+	title: string;
+	isCurrentStep?: true;
+}
+
+export interface ProgressIndicatorProps {
+	steps: Step[];
+	additionalCSS?: SerializedStyles;
+}
+
+const NumberedBullet = ({
+	stepNumber,
+	backgroundColor,
+}: {
+	stepNumber: number;
+	backgroundColor: string;
+}) => {
+	return (
+		<div
+			css={css`
+				${textSans.xsmall({ fontWeight: 'bold' })};
+				color: ${palette.neutral[100]};
+				width: 22px;
+				height: 22px;
+				background-color: ${backgroundColor};
+				border-radius: 50%;
+				display: flex;
+				justify-content: center;
+				align-items: center;
+			`}
+		>
+			{stepNumber}
+		</div>
+	);
+};
+
+const Step = ({
+	step,
+	currentStep,
+	index,
+}: {
+	step: Step;
+	currentStep: number;
+	index: number;
+}) => {
+	return (
+		<div
+			css={css`
+				${textSans.xsmall({ fontWeight: 'bold' })};
+				color: ${index > currentStep
+					? palette.neutral[46]
+					: palette.brand[400]};
+				flex: 1;
+			`}
+		>
+			<div
+				css={css`
+					display: flex;
+					flex-direction: column;
+					align-items: center;
+				`}
+			>
+				<span>{step.title}</span>
+				{index < currentStep ? (
+					<div>
+						<TickInCircle fill={palette.brand[400]} />
+					</div>
+				) : (
+					<NumberedBullet
+						stepNumber={index + 1}
+						backgroundColor={
+							index > currentStep
+								? palette.neutral[60]
+								: palette.brand[400]
+						}
+					/>
+				)}
+			</div>
+		</div>
+	);
+};
+
+export const ProgressIndicatorV2 = ({
+	steps,
+	additionalCSS,
+}: ProgressIndicatorProps) => {
+	const currentStep = steps.findIndex((step) => step.isCurrentStep) || 0;
+	return (
+		<div
+			css={css`
+				margin-top: 10px;
+				display: flex;
+				${additionalCSS};
+				> :not(:last-child):after {
+					content: '';
+					position: relative;
+					display: block;
+					top: -0.75rem;
+					left: calc(50% + 11px + ${space[2]}px);
+					width: calc(100% - 22px - 2 * ${space[2]}px);
+					height: 2px;
+					background-color: ${palette.neutral[60]};
+					order: -1;
+				}
+				> :nth-child(-n + ${currentStep}):after {
+					background-color: ${palette.brand[400]};
+				}
+			`}
+		>
+			{steps.map((step, index) => (
+				<Step
+					key={step.title}
+					step={step}
+					currentStep={currentStep}
+					index={index}
+				/>
+			))}
+		</div>
+	);
+};

--- a/client/components/mma/shared/ProgressStepper.tsx
+++ b/client/components/mma/shared/ProgressStepper.tsx
@@ -8,7 +8,7 @@ interface Step {
 	isCurrentStep?: true;
 }
 
-export interface ProgressIndicatorProps {
+export interface ProgressStepperProps {
 	steps: Step[];
 	additionalCSS?: SerializedStyles;
 }
@@ -85,10 +85,10 @@ const Step = ({
 	);
 };
 
-export const ProgressIndicatorV2 = ({
+export const ProgressStepper = ({
 	steps,
 	additionalCSS,
-}: ProgressIndicatorProps) => {
+}: ProgressStepperProps) => {
 	const currentStep = steps.findIndex((step) => step.isCurrentStep) || 0;
 	return (
 		<div


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR adds a new progress bar component - as seen in new cancellation journey designs - and uses them in the new journey.

Figma:
![image](https://github.com/guardian/manage-frontend/assets/114918544/cabf4576-e5e8-4725-b06c-3419f027bb45)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

The component:
![image](https://github.com/guardian/manage-frontend/assets/114918544/157d7d41-8b59-44de-af78-253b187d6529)

On a page:
![image](https://github.com/guardian/manage-frontend/assets/114918544/0fb4db11-1a9a-4fae-a37a-e8a210fd498c)


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
