### PR TITLE
Cc/membership cancellation tidy up v1

### DIFF
--- a/client/components/mma/cancel/cancellationContributionReminder.tsx
+++ b/client/components/mma/cancel/cancellationContributionReminder.tsx
@@ -6,6 +6,10 @@ import type * as React from 'react';
 import { useNavigate } from 'react-router';
 import { trackEventInOphanOnly } from '../../../utilities/analytics';
 import { getGeoLocation } from '../../../utilities/geolocation';
+import {
+	buttonCentredCss,
+	stackedButtonLayoutCss,
+} from './cancellationSaves/SaveStyles';
 
 const containerStyles = css`
 	padding-bottom: ${space[24]}px;
@@ -20,12 +24,6 @@ const setReminderContainerStyles = css`
 const formContainerStyles = css`
 	& > * + * {
 		margin-top: ${space[6]}px;
-	}
-`;
-
-const buttonLayoutCss = css`
-	> * + * {
-		margin-left: ${space[3]}px;
 	}
 `;
 
@@ -167,11 +165,17 @@ export const CancellationContributionReminder: React.FC = () => {
 								/>
 							))}
 						</RadioGroup>
-						<div css={buttonLayoutCss}>
-							<Button onClick={onSubmit}>Set my reminder</Button>
+						<div css={stackedButtonLayoutCss}>
+							<Button
+								onClick={onSubmit}
+								cssOverrides={buttonCentredCss}
+							>
+								Set my reminder
+							</Button>
 							<Button
 								priority="tertiary"
 								onClick={() => navigate('/')}
+								cssOverrides={buttonCentredCss}
 							>
 								Back to your account
 							</Button>

--- a/client/components/mma/cancel/cancellationSaves/ContinueMembershipConfirmation.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ContinueMembershipConfirmation.tsx
@@ -65,7 +65,7 @@ export const ContinueMembershipConfirmation = () => {
 					onClick={() => navigate('/')}
 					cssOverrides={buttonCentredCss}
 				>
-					Back to account overview
+					Back to my account
 				</Button>
 				<Button
 					onClick={() => navigate('https://www.theguardian.com')}

--- a/client/components/mma/cancel/cancellationSaves/ValueOfSupport.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ValueOfSupport.tsx
@@ -1,10 +1,6 @@
 import { css } from '@emotion/react';
 import { space, textSans } from '@guardian/source-foundations';
-import {
-	Button,
-	Stack,
-	SvgArrowRightStraight,
-} from '@guardian/source-react-components';
+import { Button, Stack } from '@guardian/source-react-components';
 import { useContext } from 'react';
 import { Navigate, useLocation, useNavigate } from 'react-router';
 import { dateString } from '../../../../../shared/dates';
@@ -78,10 +74,9 @@ export const ValueOfSupport = () => {
 					cssOverrides={buttonCentredCss}
 					onClick={() => navigate('../landing')}
 				>
-					Back
+					Go back to my account
 				</Button>
 				<Button
-					icon={<SvgArrowRightStraight />}
 					iconSide="right"
 					cssOverrides={buttonCentredCss}
 					onClick={() =>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Just a small tidy up on the new cancellation flow page.

- Reminder buttons reformatted for mobile
- Continue Membership wording change on return to account button
- Value of support arrow removed from continue cancellation button

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
Reminders 
![image](https://github.com/guardian/manage-frontend/assets/115992455/a3fdb4fc-34e1-4669-b409-0f478ee2b9eb)

Continue Membership 
![image](https://github.com/guardian/manage-frontend/assets/115992455/79adae93-6111-47bf-acd7-c40617a8f44d)

Value of support
![image](https://github.com/guardian/manage-frontend/assets/115992455/1a4dfcee-bbc3-48ef-9c4d-75b10011cade)


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
