### PR TITLE
Cancellation saves - preserve state (for email address) between pages

### DIFF
--- a/client/components/mma/cancel/cancellationSaves/ConfirmMembershipCancellation.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ConfirmMembershipCancellation.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { palette, space, textSans } from '@guardian/source-foundations';
 import { Button, Stack } from '@guardian/source-react-components';
 import { useContext, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import { MDA_TEST_USER_HEADER } from '../../../../../shared/productResponse';
 import type {
 	MembersDataApiResponse,
@@ -15,7 +15,10 @@ import { GenericErrorScreen } from '../../../shared/GenericErrorScreen';
 import { JsonResponseHandler } from '../../shared/asyncComponents/DefaultApiResponseHandler';
 import { Heading } from '../../shared/Heading';
 import { ProgressStepper } from '../../shared/ProgressStepper';
-import type { CancellationContextInterface } from '../CancellationContainer';
+import type {
+	CancellationContextInterface,
+	CancellationRouterState,
+} from '../CancellationContainer';
 import { CancellationContext } from '../CancellationContainer';
 import type { OptionalCancellationReasonId } from '../cancellationReason';
 import { stackedButtonLayoutCss } from './SaveStyles';
@@ -29,6 +32,9 @@ export const ConfirmMembershipCancellation = () => {
 
 	const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
 	const [loadingFailed, setLoadingFailed] = useState<boolean>(false);
+
+	const location = useLocation();
+	const routerState = location.state as CancellationRouterState;
 
 	const reason: OptionalCancellationReasonId =
 		'mma_membership_cancellation_default'; //reason needs to be provided as undefined doesn't work. Reason updated if user provides one on next screen.
@@ -115,7 +121,9 @@ export const ConfirmMembershipCancellation = () => {
 				setIsSubmitting(false);
 				setLoadingFailed(true);
 			} else {
-				navigate('../reasons');
+				navigate('../reasons', {
+					state: { ...routerState },
+				});
 			}
 		} catch (e) {
 			setIsSubmitting(false);
@@ -176,7 +184,9 @@ export const ConfirmMembershipCancellation = () => {
 				</Button>
 				<Button
 					priority="tertiary"
-					onClick={() => navigate('../offers')}
+					onClick={() =>
+						navigate('../offers', { state: { ...routerState } })
+					}
 					cssOverrides={css`
 						justify-content: center;
 					`}

--- a/client/components/mma/cancel/cancellationSaves/SelectReason.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SelectReason.tsx
@@ -16,10 +16,12 @@ import {
 } from '../../../../../shared/dates';
 import type {
 	PaidSubscriptionPlan,
-	ProductDetail} from '../../../../../shared/productResponse';
+	ProductDetail,
+} from '../../../../../shared/productResponse';
 import {
 	getMainPlan,
- MDA_TEST_USER_HEADER } from '../../../../../shared/productResponse';
+	MDA_TEST_USER_HEADER,
+} from '../../../../../shared/productResponse';
 import type { ProductTypeWithCancellationFlow } from '../../../../../shared/productTypes';
 import { GenericErrorScreen } from '../../../shared/GenericErrorScreen';
 import { JsonResponseHandler } from '../../shared/asyncComponents/DefaultApiResponseHandler';


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds the routerState to the navigation between `cancel` and `reasons` in order to preserve the email address of the user

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
