### PR TITLE
Membership Cancellation - minor copy changes 

### DIFF
--- a/client/components/mma/cancel/cancellationSaves/ConfirmMembershipCancellation.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ConfirmMembershipCancellation.tsx
@@ -152,7 +152,7 @@ export const ConfirmMembershipCancellation = () => {
 			/>
 			<Stack space={4}>
 				<Heading>
-					Are you sure you want to cancel <br /> your membership?
+					Are you sure you want to cancel your membership?
 				</Heading>
 				<p
 					css={css`
@@ -160,7 +160,7 @@ export const ConfirmMembershipCancellation = () => {
 					`}
 				>
 					Please keep in mind that you will be losing access to your
-					supporter extras.{' '}
+					supporter benefits.{' '}
 				</p>
 				<p
 					css={css`

--- a/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
@@ -107,7 +107,7 @@ export const MembershipCancellationLanding = () => {
 							${textSans.medium()}
 						`}
 					>
-						Phone one of our customer service agents
+						Phone one of our customer service agents.
 					</p>
 					<CallCentreEmailAndNumbers hideEmailAddress={true} />
 				</Stack>

--- a/client/components/mma/cancel/cancellationSaves/SaveOptions.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SaveOptions.tsx
@@ -116,9 +116,9 @@ export const SaveOptions = () => {
 						${textSans.medium()};
 					`}
 				>
-					Enjoy all of your exclusive extras. The new price has
-					increased from {oldPriceDisplay} to {newPriceDisplay}/
-					{billingPeriod}.
+					Enjoy all of your exclusive benefits. The new price has
+					increased from {oldPriceDisplay}/{billingPeriod} to{' '}
+					{newPriceDisplay}/{billingPeriod}.
 				</p>
 				<Card>
 					<Card.Header backgroundColor={palette.sport[300]}>

--- a/client/components/mma/cancel/cancellationSaves/ValueOfSupport.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ValueOfSupport.tsx
@@ -74,7 +74,7 @@ export const ValueOfSupport = () => {
 					cssOverrides={buttonCentredCss}
 					onClick={() => navigate('../landing')}
 				>
-					Go back to my account
+					Back to my account
 				</Button>
 				<Button
 					iconSide="right"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Minor copy changes from Rob and Helene on the Membership Cancellation journey:
- Landing page - full stop at end of sentence
- Value of support - back button reworded 
- Save Options - reworded the sub sub header and added in the billing period for the new price
- Confirm Cancellation - removed line break from the header (screenshot of mobile) and rewording
- Reminder - TBC

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
Landing page
![image](https://github.com/guardian/manage-frontend/assets/115992455/af848621-73e4-4979-b8a2-dcc3a1327b65)

Value of Support
![image](https://github.com/guardian/manage-frontend/assets/115992455/92823c4b-699e-46a3-9ff1-926c747a79f0)

Save Options
![image](https://github.com/guardian/manage-frontend/assets/115992455/c6ac66e2-2113-4b5f-872d-b949be7e0c94)

Confirm Cancellation 
![image](https://github.com/guardian/manage-frontend/assets/115992455/aeb34f22-5a69-4f32-9f3d-0665e5ad04f1)

Reminder
TBC

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
