### PR TITLE
QM masking tags added to PII in cancellation journey

### DIFF
--- a/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
@@ -117,7 +117,7 @@ const WhatHappensNext = (props: {
 					</li>
 					<li>
 						<SvgCreditCard size="medium" />
-						<span>
+						<span data-qm-masking="blocklist">
 							<strong>Your payment method</strong>
 							<br />
 							The payment will be taken from{' '}

--- a/client/components/mma/cancel/cancellationSaves/SelectReason.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SelectReason.tsx
@@ -16,10 +16,12 @@ import {
 } from '../../../../../shared/dates';
 import type {
 	PaidSubscriptionPlan,
-	ProductDetail} from '../../../../../shared/productResponse';
+	ProductDetail,
+} from '../../../../../shared/productResponse';
 import {
 	getMainPlan,
- MDA_TEST_USER_HEADER } from '../../../../../shared/productResponse';
+	MDA_TEST_USER_HEADER,
+} from '../../../../../shared/productResponse';
 import type { ProductTypeWithCancellationFlow } from '../../../../../shared/productTypes';
 import { GenericErrorScreen } from '../../../shared/GenericErrorScreen';
 import { JsonResponseHandler } from '../../shared/asyncComponents/DefaultApiResponseHandler';
@@ -60,7 +62,7 @@ const CancellationInfo = ({
 		`}
 	>
 		<Stack space={1}>
-			<p css={paragraphListCss}>
+			<p css={paragraphListCss} data-qm-masking="blocklist">
 				We will send a confirmation email to you at {userEmailAddress}.{' '}
 				<span>
 					You will have access to all of your benefits until{' '}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Adds masking to PII fields which prevents QM from capturing it.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Deploy onto CODE and ask QM to check that all fields on the journey are captured and PII is blocked.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
