### PR TITLE
Remove feature switch on routing membership cancellation journey 

### DIFF
--- a/client/components/mma/MMAPage.tsx
+++ b/client/components/mma/MMAPage.tsx
@@ -4,10 +4,7 @@ import { breakpoints, from, space } from '@guardian/source-foundations';
 import type { ReactNode } from 'react';
 import { lazy, Suspense, useEffect, useState } from 'react';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
-import {
-	featureSwitches,
-	initFeatureSwitchUrlParamOverride,
-} from '../../../shared/featureSwitches';
+import { initFeatureSwitchUrlParamOverride } from '../../../shared/featureSwitches';
 import type {
 	GroupedProductType,
 	ProductType,
@@ -587,52 +584,48 @@ const MMARouter = () => {
 										path="confirmed"
 										element={<ExecuteCancellation />}
 									/>
-									{featureSwitches.membershipSave && (
-										<>
-											<Route
-												path="landing"
-												element={
-													<MembershipCancellationLanding />
-												}
-											/>
-											<Route
-												path="details"
-												element={<ValueOfSupport />}
-											/>
-											<Route
-												path="offers"
-												element={<SaveOptions />}
-											/>
-											<Route
-												path="reasons"
-												element={<SelectReason />}
-											/>
-											<Route
-												path="switch-offer"
-												element={<MembershipSwitch />}
-											/>
-											<Route
-												path="thank-you"
-												element={
-													<ContinueMembershipConfirmation />
-												}
-											/>
-											<Route
-												path="confirm"
-												element={
-													<ConfirmMembershipCancellation />
-												}
-											/>
-											<Route
-												path="reminder"
-												element={<SupportReminder />}
-											/>
-											<Route
-												path="switch-thank-you"
-												element={<SwitchThankYou />}
-											/>
-										</>
-									)}
+									<Route
+										path="landing"
+										element={
+											<MembershipCancellationLanding />
+										}
+									/>
+									<Route
+										path="details"
+										element={<ValueOfSupport />}
+									/>
+									<Route
+										path="offers"
+										element={<SaveOptions />}
+									/>
+									<Route
+										path="reasons"
+										element={<SelectReason />}
+									/>
+									<Route
+										path="switch-offer"
+										element={<MembershipSwitch />}
+									/>
+									<Route
+										path="thank-you"
+										element={
+											<ContinueMembershipConfirmation />
+										}
+									/>
+									<Route
+										path="confirm"
+										element={
+											<ConfirmMembershipCancellation />
+										}
+									/>
+									<Route
+										path="reminder"
+										element={<SupportReminder />}
+									/>
+									<Route
+										path="switch-thank-you"
+										element={<SwitchThankYou />}
+									/>
 								</Route>
 							),
 						)}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Removes the feature switch which conditionally added membership cancellation saves pages to the router. These pages will now be accessible with the `withFeature` url param

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
