### PR TITLE
Small Cancellation Save Fixes

### DIFF
--- a/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
@@ -30,7 +30,9 @@ function ineligibleForSave(
 	const inPaymentFailure = products.find((product) => product.alertText);
 
 	const hasOtherProduct = products.find(
-		(product) => product.mmaCategory != 'membership',
+		(product) =>
+			product.mmaCategory != 'membership' &&
+			!product.subscription.cancelledAt,
 	);
 
 	const membershipTierIsNotSupporter =

--- a/client/components/mma/cancel/cancellationSaves/SaveOptions.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SaveOptions.tsx
@@ -94,7 +94,7 @@ export const SaveOptions = () => {
 			<ProgressStepper
 				steps={[
 					{ title: 'Details' },
-					{ title: 'Offer', isCurrentStep: true },
+					{ title: 'Options', isCurrentStep: true },
 					{ title: 'Confirmation' },
 				]}
 				additionalCSS={css`

--- a/client/components/mma/cancel/cancellationSaves/ValueOfSupport.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ValueOfSupport.tsx
@@ -67,7 +67,6 @@ export const ValueOfSupport = () => {
 					have reached millions around the world. We're so grateful.
 				</p>
 			</Stack>
-			<div>Image placeholder</div>
 			<div css={reverseStackedButtonLayoutCss}>
 				<Button
 					priority="tertiary"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Rename step 2 on the Options page to be 'Options' in the progress bar
- Remove image placeholder
- Change eligibility check to ignore recently cancelled products

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
Remove this
![image](https://github.com/guardian/manage-frontend/assets/114918544/824d085a-7918-4db6-be1a-ab0d9db67477)
Before: step 2 had wrong label
![image](https://github.com/guardian/manage-frontend/assets/114918544/14b39771-267c-402a-a426-6aa612be7419)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
