### PR TITLE
Open Specific Region in Call Centre Contact Component

### DIFF
--- a/client/__tests__/components/callCenterEmailAndNumbers.test.tsx
+++ b/client/__tests__/components/callCenterEmailAndNumbers.test.tsx
@@ -1,0 +1,65 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { CallCentreEmailAndNumbers } from '../../components/shared/CallCenterEmailAndNumbers';
+
+afterEach(cleanup);
+
+describe('Call Center Email and Numbers', () => {
+	it('displays default options with first option open', () => {
+		render(<CallCentreEmailAndNumbers />);
+		expect(screen.getAllByText('Email:')).toBeDefined();
+		expect(screen.getAllByText('Hide')).toBeDefined();
+		expect(screen.getByText(/United Kingdom/)).toHaveStyle({
+			'font-weight': 'bold',
+		});
+	});
+
+	it('has no details when collapsed', () => {
+		render(<CallCentreEmailAndNumbers collapsed />);
+		expect(
+			screen
+				.getAllByText('Email:')
+				.every((e) => expect(e).not.toBeVisible()),
+		).toBe(true);
+		expect(screen.queryByText('Hide')).not.toBeInTheDocument();
+		expect(screen.getByText(/United Kingdom/)).toHaveStyle({
+			'font-weight': '400',
+		});
+	});
+
+	it('displays compact layout', () => {
+		render(<CallCentreEmailAndNumbers compactLayout />);
+		expect(screen.getByText('Hide')).not.toBeVisible();
+		expect(
+			screen
+				.getAllByText('Show')
+				.every((e) => expect(e).not.toBeVisible()),
+		).toBe(true);
+	});
+
+	it('filters phone regions', () => {
+		render(<CallCentreEmailAndNumbers phoneRegionFilterKeys={['US']} />);
+		expect(screen.queryByText(/United Kingdom/)).not.toBeInTheDocument();
+		expect(screen.queryByText(/Australia/)).not.toBeInTheDocument();
+		expect(screen.getByText(/Canada and USA/)).toHaveStyle({
+			'font-weight': 'bold',
+		});
+	});
+
+	it('opens specific region', () => {
+		render(<CallCentreEmailAndNumbers openPhoneRegion={'US'} />);
+		expect(
+			screen.queryByText(/United Kingdom, Europe and rest of world/),
+		).toHaveStyle({
+			'font-weight': 400,
+		});
+		expect(
+			screen.queryByText(/Australia, New Zealand, and Asia Pacific/),
+		).toHaveStyle({
+			'font-weight': 400,
+		});
+		expect(screen.getByText(/Canada and USA/)).toHaveStyle({
+			'font-weight': 'bold',
+		});
+	});
+});

--- a/client/__tests__/components/callCenterEmailAndNumbers.test.tsx
+++ b/client/__tests__/components/callCenterEmailAndNumbers.test.tsx
@@ -16,11 +16,9 @@ describe('Call Center Email and Numbers', () => {
 
 	it('has no details when collapsed', () => {
 		render(<CallCentreEmailAndNumbers collapsed />);
-		expect(
-			screen
-				.getAllByText('Email:')
-				.every((e) => expect(e).not.toBeVisible()),
-		).toBe(true);
+		screen
+			.getAllByText('Email:')
+			.forEach((e) => expect(e).not.toBeVisible());
 		expect(screen.queryByText('Hide')).not.toBeInTheDocument();
 		expect(screen.getByText(/United Kingdom/)).toHaveStyle({
 			'font-weight': '400',
@@ -30,11 +28,7 @@ describe('Call Center Email and Numbers', () => {
 	it('displays compact layout', () => {
 		render(<CallCentreEmailAndNumbers compactLayout />);
 		expect(screen.getByText('Hide')).not.toBeVisible();
-		expect(
-			screen
-				.getAllByText('Show')
-				.every((e) => expect(e).not.toBeVisible()),
-		).toBe(true);
+		screen.getAllByText('Show').forEach((e) => expect(e).not.toBeVisible());
 	});
 
 	it('filters phone regions', () => {

--- a/client/components/mma/cancel/cancellationSaves/CancellationSaves.stories.tsx
+++ b/client/components/mma/cancel/cancellationSaves/CancellationSaves.stories.tsx
@@ -1,9 +1,9 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { rest } from 'msw';
 import { ReactRouterDecorator } from '../../../../../.storybook/ReactRouterDecorator';
 import { PRODUCT_TYPES } from '../../../../../shared/productTypes';
 import { toMembersDataApiResponse } from '../../../../fixtures/mdapiResponse';
-import { membershipSupporter } from '../../../../fixtures/productBuilder/testProducts';
+import { membershipSupporterCurrencyUSD } from '../../../../fixtures/productBuilder/testProducts';
 import { CancellationContainer } from '../CancellationContainer';
 import { ConfirmMembershipCancellation } from './ConfirmMembershipCancellation';
 import { ContinueMembershipConfirmation } from './ContinueMembershipConfirmation';
@@ -23,7 +23,7 @@ export default {
 		layout: 'fullscreen',
 		reactRouter: {
 			state: {
-				productDetail: membershipSupporter(),
+				productDetail: membershipSupporterCurrencyUSD(),
 				user: { email: 'test@test.com' },
 			},
 			container: (
@@ -31,17 +31,17 @@ export default {
 			),
 		},
 	},
-} as ComponentMeta<typeof CancellationContainer>;
+} as Meta<typeof CancellationContainer>;
 
-export const ValueOfSupportPage: ComponentStory<typeof ValueOfSupport> = () => {
+export const ValueOfSupportPage: StoryFn<typeof ValueOfSupport> = () => {
 	return <ValueOfSupport />;
 };
 
-export const SwitchReview: ComponentStory<typeof MembershipSwitch> = () => {
+export const SwitchReview: StoryFn<typeof MembershipSwitch> = () => {
 	return <MembershipSwitch />;
 };
 
-export const LandingPage: ComponentStory<
+export const LandingPage: StoryFn<
 	typeof MembershipCancellationLanding
 > = () => {
 	return <MembershipCancellationLanding />;
@@ -51,39 +51,39 @@ LandingPage.parameters = {
 	msw: [
 		rest.get('/api/me/mma', (_req, res, ctx) => {
 			return res(
-				ctx.json(toMembersDataApiResponse(membershipSupporter())),
+				ctx.json(
+					toMembersDataApiResponse(membershipSupporterCurrencyUSD()),
+				),
 			);
 		}),
 	],
 };
 
-export const SwitchOptions: ComponentStory<typeof SaveOptions> = () => {
+export const SwitchOptions: StoryFn<typeof SaveOptions> = () => {
 	return <SaveOptions />;
 };
 
-export const Reasons: ComponentStory<typeof SelectReason> = () => {
+export const Reasons: StoryFn<typeof SelectReason> = () => {
 	return <SelectReason />;
 };
 
-export const ContinueMembership: ComponentStory<
+export const ContinueMembership: StoryFn<
 	typeof ContinueMembershipConfirmation
 > = () => {
 	return <ContinueMembershipConfirmation />;
 };
 
-export const ConfirmCancellation: ComponentStory<
+export const ConfirmCancellation: StoryFn<
 	typeof ConfirmMembershipCancellation
 > = () => {
 	return <ConfirmMembershipCancellation />;
 };
 
-export const SwitchCompleteThankYou: ComponentStory<
-	typeof SwitchThankYou
-> = () => {
+export const SwitchCompleteThankYou: StoryFn<typeof SwitchThankYou> = () => {
 	return <SwitchThankYou />;
 };
 
-export const Reminder: ComponentStory<typeof SupportReminder> = () => {
+export const Reminder: StoryFn<typeof SupportReminder> = () => {
 	// @ts-expect-error set identity details email in the window
 	window.guardian = { identityDetails: { email: 'test' } };
 

--- a/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
@@ -6,14 +6,22 @@ import { Navigate, useNavigate } from 'react-router';
 import { featureSwitches } from '../../../../../shared/featureSwitches';
 import type {
 	MembersDataApiResponse,
-	ProductDetail,
+	PaidSubscriptionPlan,
+	ProductDetail} from '../../../../../shared/productResponse';
+import {
+	getMainPlan,
 } from '../../../../../shared/productResponse';
+import type { CurrencyIso } from '../../../../utilities/currencyIso';
 import {
 	LoadingState,
 	useAsyncLoader,
 } from '../../../../utilities/hooks/useAsyncLoader';
 import { allRecurringProductsDetailFetcher } from '../../../../utilities/productUtils';
-import { CallCentreEmailAndNumbers } from '../../../shared/CallCenterEmailAndNumbers';
+import type {
+	PhoneRegionKey} from '../../../shared/CallCenterEmailAndNumbers';
+import {
+	CallCentreEmailAndNumbers
+} from '../../../shared/CallCenterEmailAndNumbers';
 import { GenericErrorScreen } from '../../../shared/GenericErrorScreen';
 import { JsonResponseHandler } from '../../shared/asyncComponents/DefaultApiResponseHandler';
 import { DefaultLoadingView } from '../../shared/asyncComponents/DefaultLoadingView';
@@ -39,6 +47,18 @@ function ineligibleForSave(
 		membershipToCancel.tier !== 'Supporter';
 
 	return inPaymentFailure || hasOtherProduct || membershipTierIsNotSupporter;
+}
+
+function getPhoneRegion(currencyIso: CurrencyIso): PhoneRegionKey {
+	switch (currencyIso) {
+		case 'USD':
+		case 'CAD':
+			return 'US';
+		case 'AUD':
+			return 'AUS';
+		default:
+			return 'UK & ROW';
+	}
 }
 
 export const MembershipCancellationLanding = () => {
@@ -84,6 +104,12 @@ export const MembershipCancellationLanding = () => {
 		);
 	}
 
+	const mainPlan = getMainPlan(
+		membership.subscription,
+	) as PaidSubscriptionPlan;
+
+	const phoneRegion = getPhoneRegion(mainPlan.currencyISO as CurrencyIso);
+
 	return (
 		<>
 			<section css={sectionSpacing}>
@@ -111,7 +137,14 @@ export const MembershipCancellationLanding = () => {
 					>
 						Phone one of our customer service agents.
 					</p>
-					<CallCentreEmailAndNumbers hideEmailAddress={true} />
+					<CallCentreEmailAndNumbers
+						hideEmailAddress={true}
+						phoneRegionFilterKeys={
+							membership.selfServiceCancellation
+								.phoneRegionsToDisplay
+						}
+						openPhoneRegion={phoneRegion}
+					/>
 				</Stack>
 			</section>
 			<section css={sectionSpacing}>

--- a/client/components/shared/CallCenterEmailAndNumbers.tsx
+++ b/client/components/shared/CallCenterEmailAndNumbers.tsx
@@ -80,21 +80,30 @@ export interface CallCentreEmailAndNumbersProps extends CallCentreNumbersProps {
 	phoneRegionFilterKeys?: PhoneRegionKey[];
 	compactLayout?: boolean;
 	collapsed?: boolean;
+	openPhoneRegion?: PhoneRegionKey;
 }
 
 export const CallCentreEmailAndNumbers = (
 	props: CallCentreEmailAndNumbersProps,
 ) => {
-	const initialIndex = props.collapsed ? -1 : 0;
-
-	const [indexOfOpenSection, setIndexOfOpenSection] =
-		useState<number>(initialIndex);
-
 	const filteredPhoneData = PHONE_DATA.filter(
 		(phoneRegion) =>
 			!props.phoneRegionFilterKeys ||
 			props.phoneRegionFilterKeys.includes(phoneRegion.key),
 	);
+
+	const openPhoneRegionIndex = filteredPhoneData.findIndex(
+		(region) => region.key === props.openPhoneRegion,
+	);
+
+	const initialIndex = props.collapsed
+		? -1
+		: props.openPhoneRegion
+		? openPhoneRegionIndex
+		: 0;
+
+	const [indexOfOpenSection, setIndexOfOpenSection] =
+		useState<number>(initialIndex);
 
 	const sectionTitleCss = (isOpen: boolean, isNotFirstOption: boolean) => `
     ${textSans.medium()};

--- a/client/components/shared/CallCentreEmailAndNumbers.stories.tsx
+++ b/client/components/shared/CallCentreEmailAndNumbers.stories.tsx
@@ -1,4 +1,4 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { CallCentreEmailAndNumbersProps } from './CallCenterEmailAndNumbers';
 import { CallCentreEmailAndNumbers } from './CallCenterEmailAndNumbers';
 
@@ -11,9 +11,9 @@ export default {
 		compactLayout: false,
 		phoneRegionFilterKeys: undefined,
 	},
-} as ComponentMeta<typeof CallCentreEmailAndNumbers>;
+} as Meta<typeof CallCentreEmailAndNumbers>;
 
-const Template: ComponentStory<typeof CallCentreEmailAndNumbers> = (
+const Template: StoryFn<typeof CallCentreEmailAndNumbers> = (
 	args: CallCentreEmailAndNumbersProps,
 ) => {
 	return <CallCentreEmailAndNumbers {...args} />;

--- a/client/fixtures/productBuilder/productBuilder.ts
+++ b/client/fixtures/productBuilder/productBuilder.ts
@@ -1,5 +1,15 @@
-import type { Card, ProductDetail } from '../../../shared/productResponse';
+import type {
+	Card,
+	ProductDetail} from '../../../shared/productResponse';
+import {
+	isPaidSubscriptionPlan,
+} from '../../../shared/productResponse';
 import type { GroupedProductTypeKeys } from '../../../shared/productTypes';
+import type {
+	CurrencyIso} from '../../utilities/currencyIso';
+import {
+	convertCurrencyToSymbol,
+} from '../../utilities/currencyIso';
 
 export const cards = {
 	visaActive: () => {
@@ -110,6 +120,31 @@ export class ProductBuilder {
 
 	asPatron() {
 		this.productToBuild.subscription.readerType = 'Patron';
+		return this;
+	}
+
+	withCurrency(currencyIso: CurrencyIso) {
+		const { plan, currentPlans, futurePlans } =
+			this.productToBuild.subscription;
+		const currencySymbol = convertCurrencyToSymbol(currencyIso);
+		if (plan) {
+			plan.currencyISO = currencyIso;
+			plan.currency = currencySymbol;
+		}
+		for (const currentPlan of currentPlans) {
+			if (isPaidSubscriptionPlan(currentPlan)) {
+				currentPlan.currency = currencySymbol;
+				currentPlan.currencyISO = currencyIso;
+			}
+		}
+
+		for (const futurePlan of futurePlans) {
+			if (isPaidSubscriptionPlan(futurePlan)) {
+				futurePlan.currency = currencySymbol;
+				futurePlan.currencyISO = currencyIso;
+			}
+		}
+
 		return this;
 	}
 }

--- a/client/fixtures/productBuilder/productBuilder.ts
+++ b/client/fixtures/productBuilder/productBuilder.ts
@@ -1,15 +1,12 @@
 import type {
 	Card,
-	ProductDetail} from '../../../shared/productResponse';
-import {
-	isPaidSubscriptionPlan,
+	PaidSubscriptionPlan,
+	ProductDetail,
+	SubscriptionPlan,
 } from '../../../shared/productResponse';
 import type { GroupedProductTypeKeys } from '../../../shared/productTypes';
-import type {
-	CurrencyIso} from '../../utilities/currencyIso';
-import {
-	convertCurrencyToSymbol,
-} from '../../utilities/currencyIso';
+import type { CurrencyIso } from '../../utilities/currencyIso';
+import { convertCurrencyToSymbol } from '../../utilities/currencyIso';
 
 export const cards = {
 	visaActive: () => {
@@ -147,4 +144,14 @@ export class ProductBuilder {
 
 		return this;
 	}
+}
+
+function isPaidSubscriptionPlan(
+	subscriptionPlan: SubscriptionPlan,
+): subscriptionPlan is PaidSubscriptionPlan {
+	return (
+		!!subscriptionPlan &&
+		(subscriptionPlan.hasOwnProperty('price') ||
+			subscriptionPlan.hasOwnProperty('amount'))
+	);
 }

--- a/client/fixtures/productBuilder/testProducts.ts
+++ b/client/fixtures/productBuilder/testProducts.ts
@@ -99,6 +99,13 @@ export function membershipSupporter() {
 		.getProductDetailObject();
 }
 
+export function membershipSupporterCurrencyUSD() {
+	return new ProductBuilder(baseMembership())
+		.payByCard()
+		.withCurrency('USD')
+		.getProductDetailObject();
+}
+
 export function membershipStaff() {
 	return new ProductBuilder(baseMembership())
 		.payByCard()


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR adds an option to the `CallCentreEmailAndNumbers` component to have one region open by default. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Navigate to `cancel/membership?withFeature=membershipSave` with USD currency and see the US and Canada section open first.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://github.com/guardian/manage-frontend/assets/114918544/ae225033-6d09-435d-9ad7-523f00acab81)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
