### PR TITLE
Minimal recreation of cypress error

### DIFF
--- a/client/fixtures/productBuilder/productBuilder.ts
+++ b/client/fixtures/productBuilder/productBuilder.ts
@@ -1,5 +1,15 @@
-import type { Card, ProductDetail } from '../../../shared/productResponse';
+import type {
+	Card,
+	ProductDetail} from '../../../shared/productResponse';
+import {
+	isPaidSubscriptionPlan,
+} from '../../../shared/productResponse';
 import type { GroupedProductTypeKeys } from '../../../shared/productTypes';
+import type {
+	CurrencyIso} from '../../utilities/currencyIso';
+import {
+	convertCurrencyToSymbol,
+} from '../../utilities/currencyIso';
 
 export const cards = {
 	visaActive: () => {
@@ -110,6 +120,31 @@ export class ProductBuilder {
 
 	asPatron() {
 		this.productToBuild.subscription.readerType = 'Patron';
+		return this;
+	}
+
+	withCurrency(currencyIso: CurrencyIso) {
+		const { plan, currentPlans, futurePlans } =
+			this.productToBuild.subscription;
+		const currencySymbol = convertCurrencyToSymbol(currencyIso);
+		if (plan) {
+			plan.currencyISO = currencyIso;
+			plan.currency = currencySymbol;
+		}
+		for (const currentPlan of currentPlans) {
+			if (isPaidSubscriptionPlan(currentPlan)) {
+				currentPlan.currency = currencySymbol;
+				currentPlan.currencyISO = currencyIso;
+			}
+		}
+
+		for (const futurePlan of futurePlans) {
+			if (isPaidSubscriptionPlan(futurePlan)) {
+				futurePlan.currency = currencySymbol;
+				futurePlan.currencyISO = currencyIso;
+			}
+		}
+
 		return this;
 	}
 }

--- a/client/fixtures/productBuilder/productBuilder.ts
+++ b/client/fixtures/productBuilder/productBuilder.ts
@@ -1,15 +1,6 @@
-import type {
-	Card,
-	ProductDetail} from '../../../shared/productResponse';
-import {
-	isPaidSubscriptionPlan,
-} from '../../../shared/productResponse';
+import type { Card, ProductDetail } from '../../../shared/productResponse';
+import { isPaidSubscriptionPlan } from '../../../shared/productResponse';
 import type { GroupedProductTypeKeys } from '../../../shared/productTypes';
-import type {
-	CurrencyIso} from '../../utilities/currencyIso';
-import {
-	convertCurrencyToSymbol,
-} from '../../utilities/currencyIso';
 
 export const cards = {
 	visaActive: () => {
@@ -123,28 +114,32 @@ export class ProductBuilder {
 		return this;
 	}
 
-	withCurrency(currencyIso: CurrencyIso) {
-		const { plan, currentPlans, futurePlans } =
-			this.productToBuild.subscription;
-		const currencySymbol = convertCurrencyToSymbol(currencyIso);
-		if (plan) {
-			plan.currencyISO = currencyIso;
-			plan.currency = currencySymbol;
-		}
-		for (const currentPlan of currentPlans) {
-			if (isPaidSubscriptionPlan(currentPlan)) {
-				currentPlan.currency = currencySymbol;
-				currentPlan.currencyISO = currencyIso;
-			}
-		}
+	withCurrency() {
+		// const { plan, currentPlans, futurePlans } =
+		// 	this.productToBuild.subscription;
+		// const currencySymbol = convertCurrencyToSymbol(currencyIso);
+		// if (plan) {
+		// 	plan.currencyISO = currencyIso;
+		// 	plan.currency = currencySymbol;
+		// }
+		// for (const currentPlan of currentPlans) {
+		// 	if (isPaidSubscriptionPlan(currentPlan)) {
+		// 		currentPlan.currency = currencySymbol;
+		// 		currentPlan.currencyISO = currencyIso;
+		// 	}
+		// }
 
-		for (const futurePlan of futurePlans) {
-			if (isPaidSubscriptionPlan(futurePlan)) {
-				futurePlan.currency = currencySymbol;
-				futurePlan.currencyISO = currencyIso;
-			}
-		}
-
+		// for (const futurePlan of futurePlans) {
+		// 	if (isPaidSubscriptionPlan(futurePlan)) {
+		// 		futurePlan.currency = currencySymbol;
+		// 		futurePlan.currencyISO = currencyIso;
+		// 	}
+		// }
+		console.log(
+			isPaidSubscriptionPlan(
+				this.productToBuild.subscription.currentPlans[0],
+			),
+		);
 		return this;
 	}
 }

--- a/client/fixtures/productBuilder/productBuilder.ts
+++ b/client/fixtures/productBuilder/productBuilder.ts
@@ -1,5 +1,9 @@
-import type { Card, ProductDetail } from '../../../shared/productResponse';
-import { isPaidSubscriptionPlan } from '../../../shared/productResponse';
+import type {
+	Card,
+	ProductDetail} from '../../../shared/productResponse';
+import {
+	MDA_TEST_USER_HEADER
+} from '../../../shared/productResponse';
 import type { GroupedProductTypeKeys } from '../../../shared/productTypes';
 
 export const cards = {
@@ -114,32 +118,8 @@ export class ProductBuilder {
 		return this;
 	}
 
-	withCurrency() {
-		// const { plan, currentPlans, futurePlans } =
-		// 	this.productToBuild.subscription;
-		// const currencySymbol = convertCurrencyToSymbol(currencyIso);
-		// if (plan) {
-		// 	plan.currencyISO = currencyIso;
-		// 	plan.currency = currencySymbol;
-		// }
-		// for (const currentPlan of currentPlans) {
-		// 	if (isPaidSubscriptionPlan(currentPlan)) {
-		// 		currentPlan.currency = currencySymbol;
-		// 		currentPlan.currencyISO = currencyIso;
-		// 	}
-		// }
-
-		// for (const futurePlan of futurePlans) {
-		// 	if (isPaidSubscriptionPlan(futurePlan)) {
-		// 		futurePlan.currency = currencySymbol;
-		// 		futurePlan.currencyISO = currencyIso;
-		// 	}
-		// }
-		console.log(
-			isPaidSubscriptionPlan(
-				this.productToBuild.subscription.currentPlans[0],
-			),
-		);
+	createBug() {
+		console.log(MDA_TEST_USER_HEADER);
 		return this;
 	}
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## This PR is for illustrative purposes only

This PR recreates an issue (found in #1109 ) with Cypress tests that fail because of an import from another file. Cursory googling suggests something to do with Webpack and or dynamic imports... ([see this issue](https://github.com/cypress-io/cypress/issues/18435))

### Error: 
`  > Automatic publicPath is not supported in this browser`

<img width="466" alt="image" src="https://github.com/guardian/manage-frontend/assets/114918544/74faaf26-835c-467e-850f-bf1f90e1b417">

### Finding the problem

Neither the file changed nor the file referenced have any dynamic imports, but navigating through the imports of each file we eventually find the dynamic import in `Footer.tsx`. 

`
useEffect(() => {
		import('@guardian/consent-management-platform').then(({ cmp }) => {
			setImportedCmp(cmp);
		});
	}, []);
`

Through the very convoluted route - Cypress test -> `productBuilder.ts` -> `productResponse.ts` -> `import { GROUPED_PRODUCT_TYPES } from './productTypes';` -> `productTypes.ts` -> `PRODUCT_TYPES` -> `shuffledContributionsCancellationReasons` -> `contributionsCancellationReasons` -> `ContributionsCancellationFlowFinancialSaveAttempt` -> `CancellationContext` -> `PageContainer` -> `HasMinimalFooterContext` -> `Main.tsx` -> `Footer.tsx` -> dynamic import

If we comment these lines out the Cypress tests start running again.

### What does it mean?

We cannot reference anything that imports something from the chain above in a Cypress test (or we can [upgrade Cypress](https://github.com/cypress-io/cypress/issues/18435#issuecomment-1259788368)). Or else the files should be split up to have fewer responsibilities, maybe the functions/consts in that chain could live in separate files.