### PR TITLE
Membership saves testing changes

### DIFF
--- a/client/components/mma/cancel/cancellationSaves/ConfirmMembershipCancellation.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ConfirmMembershipCancellation.tsx
@@ -178,6 +178,9 @@ export const ConfirmMembershipCancellation = () => {
 					cssOverrides={css`
 						background-color: ${palette.news['400']};
 						justify-content: center;
+						:hover {
+							background-color: ${palette.news['200']};
+						}
 					`}
 				>
 					Confirm Cancellation

--- a/client/components/mma/cancel/cancellationSaves/ContinueMembershipConfirmation.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ContinueMembershipConfirmation.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { space } from '@guardian/source-foundations';
-import { Button, Stack } from '@guardian/source-react-components';
+import { Button, LinkButton, Stack } from '@guardian/source-react-components';
 import { useContext } from 'react';
 import { useNavigate } from 'react-router';
 import { cancellationFormatDate } from '../../../../../shared/dates';
@@ -67,12 +67,12 @@ export const ContinueMembershipConfirmation = () => {
 				>
 					Back to my account
 				</Button>
-				<Button
-					onClick={() => navigate('https://www.theguardian.com')}
+				<LinkButton
+					href="https://theguardian.com"
 					cssOverrides={buttonCentredCss}
 				>
 					Continue to the Guardian
-				</Button>
+				</LinkButton>
 			</div>
 		</>
 	);

--- a/client/components/mma/cancel/cancellationSaves/ContinueMembershipConfirmation.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ContinueMembershipConfirmation.tsx
@@ -48,8 +48,8 @@ export const ContinueMembershipConfirmation = () => {
 			<Stack space={4}>
 				<h2 css={headingCss}>Thank you for keeping your Membership</h2>
 				<p css={paragraphListCss}>
-					The new price of your Membership is{' '}
-					{newMembershipPriceDisplay}/{mainPlan.billingPeriod}.{' '}
+					The price of your Membership is {newMembershipPriceDisplay}/
+					{mainPlan.billingPeriod}.{' '}
 					<span>
 						Your first billing date will be{' '}
 						{cancellationFormatDate(

--- a/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
@@ -144,7 +144,7 @@ const TsAndCs = (props: {
 		</p>
 		<p css={smallPrintCss}>
 			By proceeding, you are agreeing to our{' '}
-			<a href="https://www.theguardian.com/info/2022/oct/28/the-guardian-supporter-plus-terms-and-conditions">
+			<a href="https://www.theguardian.com/info/2016/apr/04/contribution-terms-and-conditions">
 				Terms and Conditions
 			</a>
 			.

--- a/client/components/mma/cancel/cancellationSaves/ValueOfSupport.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ValueOfSupport.tsx
@@ -71,7 +71,7 @@ export const ValueOfSupport = () => {
 				<Button
 					priority="tertiary"
 					cssOverrides={buttonCentredCss}
-					onClick={() => navigate('../landing')}
+					onClick={() => navigate('/')}
 				>
 					Back to my account
 				</Button>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Minor changes after feedback from the E2E testing on the Membership cancellation journey.
**Continue Membership Confirmation** 
- Updated wording to remove _new_ from the price of the Membership. This should cover the scenario where a customer is already paying £7.
- Updated Continue to the Guardian button to be a LinkButton so it actually redirects to the Guardian homepage

**Membership Switch** 
- Updated T &Cs link to direct users to the contributor policy

**Value of Support**
- 'Back to my account' button returns to the Account Overview page

**Confirm Membership Cancellation**
- Cancellation button on hover has an update background as per the figma

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Check links,  buttons and wording on CODE or locally when going through the journey 
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
Confirm cancellation button background on hover 

![image](https://github.com/guardian/manage-frontend/assets/115992455/68ea65c6-7b72-42bd-ae74-cc65d07d44b7)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
