### PR TITLE
Add new property to product-move-api calls

### DIFF
--- a/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
@@ -207,6 +207,7 @@ export const MembershipSwitch = () => {
 				body: JSON.stringify({
 					price: getOldMembershipPrice(mainPlan),
 					preview: false,
+					checkChargeAmountBeforeUpdate: false,
 				}),
 				headers: {
 					'Content-Type': 'application/json',

--- a/client/components/mma/switch/review/SwitchReview.tsx
+++ b/client/components/mma/switch/review/SwitchReview.tsx
@@ -102,6 +102,7 @@ interface PreviewResponse {
 	amountPayableToday: number;
 	supporterPlusPurchaseAmount: number;
 	nextPaymentDate: string;
+	checkChargeAmountBeforeUpdate: boolean;
 }
 
 export const SwitchReview = () => {
@@ -132,7 +133,10 @@ export const SwitchReview = () => {
 
 	const newAmount = Math.max(threshold, mainPlan.price / 100);
 
-	const productMoveFetch = (preview: boolean) =>
+	const productMoveFetch = (
+		preview: boolean,
+		checkChargeAmountBeforeUpdate: boolean,
+	) =>
 		fetch(
 			`/api/product-move/${productSwitchType}/${contributionToSwitch.subscription.subscriptionId}`,
 			{
@@ -140,6 +144,7 @@ export const SwitchReview = () => {
 				body: JSON.stringify({
 					price: newAmount,
 					preview,
+					checkChargeAmountBeforeUpdate,
 				}),
 				headers: {
 					'Content-Type': 'application/json',
@@ -147,7 +152,10 @@ export const SwitchReview = () => {
 			},
 		);
 
-	const confirmSwitch = async (amount: number) => {
+	const confirmSwitch = async (
+		amount: number,
+		checkChargeAmountBeforeUpdate: boolean,
+	) => {
 		if (isSwitching) {
 			return;
 		}
@@ -159,7 +167,10 @@ export const SwitchReview = () => {
 
 		try {
 			setIsSwitching(true);
-			const response = await productMoveFetch(false);
+			const response = await productMoveFetch(
+				false,
+				checkChargeAmountBeforeUpdate,
+			);
 			const data = await JsonResponseHandler(response);
 
 			if (data === null) {
@@ -187,7 +198,10 @@ export const SwitchReview = () => {
 	}: {
 		data: PreviewResponse | null;
 		loadingState: LoadingState;
-	} = useAsyncLoader(() => productMoveFetch(true), JsonResponseHandler);
+	} = useAsyncLoader(
+		() => productMoveFetch(true, false),
+		JsonResponseHandler,
+	);
 
 	if (loadingState == LoadingState.HasError) {
 		return <GenericErrorScreen />;
@@ -318,7 +332,10 @@ export const SwitchReview = () => {
 						isLoading={isSwitching}
 						cssOverrides={buttonCentredCss}
 						onClick={() =>
-							confirmSwitch(previewResponse.amountPayableToday)
+							confirmSwitch(
+								previewResponse.amountPayableToday,
+								previewResponse.checkChargeAmountBeforeUpdate,
+							)
 						}
 					>
 						Confirm {isAboveThreshold ? 'change' : 'upgrade'}

--- a/client/fixtures/productMove.ts
+++ b/client/fixtures/productMove.ts
@@ -2,6 +2,7 @@ export const productMovePreviewResponse = {
 	amountPayableToday: 5.0,
 	supporterPlusPurchaseAmount: 10.0,
 	nextPaymentDate: '2023-03-20',
+	checkChargeAmountBeforeUpdate: false,
 };
 
 export const productMoveSuccessfulResponse = {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

To support a [change](https://github.com/guardian/support-service-lambdas/pull/2003) on the server side we need to pass a new property in product switching - `checkChargeAmountBeforeUpdate`. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Take out a Recurring Contribution worth less than 10 GBP and navigate to `/switch` and complete the journey.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

This PR needs to be merged before the server side PR.

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
