### PR TITLE
Removal of newsletter and uninterrupted reading from Support+ benefits

### DIFF
--- a/client/components/mma/shared/benefits/BenefitsConfiguration.ts
+++ b/client/components/mma/shared/benefits/BenefitsConfiguration.ts
@@ -37,7 +37,7 @@ export const benefitsConfiguration: {
 			isUnavailable: true,
 		},
 	],
-	supporterplus: [newsApp, supporterNewsletter, uninterruptedReading, adFree],
+	supporterplus: [newsApp, adFree],
 	membership: [newsApp, uninterruptedReading, supporterNewsletter],
 	digipack: [],
 	digitalvoucher: [],

--- a/client/components/mma/shared/benefits/BenefitsConfiguration.ts
+++ b/client/components/mma/shared/benefits/BenefitsConfiguration.ts
@@ -26,6 +26,8 @@ export interface ProductBenefit {
 	isUnavailable?: boolean;
 }
 
+export const supporterPlusSwitch = [newsApp, adFree];
+
 export const benefitsConfiguration: {
 	[productType in ProductTypeKeys]: ProductBenefit[];
 } = {
@@ -37,7 +39,7 @@ export const benefitsConfiguration: {
 			isUnavailable: true,
 		},
 	],
-	supporterplus: [newsApp, adFree],
+	supporterplus: [newsApp, supporterNewsletter, uninterruptedReading, adFree],
 	membership: [newsApp, uninterruptedReading, supporterNewsletter],
 	digipack: [],
 	digitalvoucher: [],

--- a/client/components/mma/shared/benefits/BenefitsConfiguration.ts
+++ b/client/components/mma/shared/benefits/BenefitsConfiguration.ts
@@ -26,7 +26,7 @@ export interface ProductBenefit {
 	isUnavailable?: boolean;
 }
 
-export const supporterPlusSwitch = [newsApp, adFree];
+export const supporterPlusSwitchBenefits = [newsApp, adFree];
 
 export const benefitsConfiguration: {
 	[productType in ProductTypeKeys]: ProductBenefit[];

--- a/client/components/mma/switch/options/SwitchOptions.tsx
+++ b/client/components/mma/switch/options/SwitchOptions.tsx
@@ -10,7 +10,7 @@ import { useContext, useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { Link } from 'react-router-dom';
 import { formatAmount } from '../../../../utilities/utils';
-import { supporterPlusSwitch } from '../../shared/benefits/BenefitsConfiguration';
+import { supporterPlusSwitchBenefits } from '../../shared/benefits/BenefitsConfiguration';
 import { BenefitsSection } from '../../shared/benefits/BenefitsSection';
 import { Card } from '../../shared/Card';
 import { Heading } from '../../shared/Heading';
@@ -245,7 +245,9 @@ export const SwitchOptions = () => {
 							</div>
 						</Card.Header>
 						<Card.Section>
-							<BenefitsSection benefits={supporterPlusSwitch} />
+							<BenefitsSection
+								benefits={supporterPlusSwitchBenefits}
+							/>
 						</Card.Section>
 					</Card>
 				</Stack>

--- a/client/components/mma/switch/options/SwitchOptions.tsx
+++ b/client/components/mma/switch/options/SwitchOptions.tsx
@@ -10,15 +10,15 @@ import { useContext, useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { Link } from 'react-router-dom';
 import { formatAmount } from '../../../../utilities/utils';
-import { benefitsConfiguration } from '../../shared/benefits/BenefitsConfiguration';
+import { supporterPlusSwitch } from '../../shared/benefits/BenefitsConfiguration';
 import { BenefitsSection } from '../../shared/benefits/BenefitsSection';
 import { Card } from '../../shared/Card';
 import { Heading } from '../../shared/Heading';
 import type {
 	SwitchContextInterface,
 	SwitchRouterState,
-} from '.././SwitchContainer';
-import { SwitchContext } from '.././SwitchContainer';
+} from '../SwitchContainer';
+import { SwitchContext } from '../SwitchContainer';
 import {
 	buttonCentredCss,
 	errorSummaryBlockLinkCss,
@@ -27,7 +27,7 @@ import {
 	productTitleCss,
 	sectionSpacing,
 	smallPrintCss,
-} from '.././SwitchStyles';
+} from '../SwitchStyles';
 
 const cardHeaderDivCss = css`
 	display: flex;
@@ -245,11 +245,7 @@ export const SwitchOptions = () => {
 							</div>
 						</Card.Header>
 						<Card.Section>
-							<BenefitsSection
-								benefits={
-									benefitsConfiguration['supporterplus']
-								}
-							/>
+							<BenefitsSection benefits={supporterPlusSwitch} />
 						</Card.Section>
 					</Card>
 				</Stack>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
DRR have requested that we don't displayed the supporter newsletter and uninterrupted reading from the Supporter+ benefits. This is because they are already included benefits for RC. This change doesn't impact the benefits being listed on the Account Overview.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Either on Storybook or product switch journey, check that only two benefits are displayed and they are not about the newsletter or uninterrupted ready.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
![image](https://github.com/guardian/manage-frontend/assets/115992455/21682b9b-2f16-4198-8342-a63e7d688a8a)

Account Overview is not impacted by this change
<img width="972" alt="image" src="https://github.com/guardian/manage-frontend/assets/115992455/5cb5c048-3f43-493c-b835-c1fec3315f4e">

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
