### PR TITLE
Create eligibility check for annual members

### DIFF
--- a/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
@@ -7,21 +7,17 @@ import { featureSwitches } from '../../../../../shared/featureSwitches';
 import type {
 	MembersDataApiResponse,
 	PaidSubscriptionPlan,
-	ProductDetail} from '../../../../../shared/productResponse';
-import {
-	getMainPlan,
+	ProductDetail,
 } from '../../../../../shared/productResponse';
+import { getMainPlan } from '../../../../../shared/productResponse';
 import type { CurrencyIso } from '../../../../utilities/currencyIso';
 import {
 	LoadingState,
 	useAsyncLoader,
 } from '../../../../utilities/hooks/useAsyncLoader';
 import { allRecurringProductsDetailFetcher } from '../../../../utilities/productUtils';
-import type {
-	PhoneRegionKey} from '../../../shared/CallCenterEmailAndNumbers';
-import {
-	CallCentreEmailAndNumbers
-} from '../../../shared/CallCenterEmailAndNumbers';
+import type { PhoneRegionKey } from '../../../shared/CallCenterEmailAndNumbers';
+import { CallCentreEmailAndNumbers } from '../../../shared/CallCenterEmailAndNumbers';
 import { GenericErrorScreen } from '../../../shared/GenericErrorScreen';
 import { JsonResponseHandler } from '../../shared/asyncComponents/DefaultApiResponseHandler';
 import { DefaultLoadingView } from '../../shared/asyncComponents/DefaultLoadingView';
@@ -46,7 +42,16 @@ function ineligibleForSave(
 	const membershipTierIsNotSupporter =
 		membershipToCancel.tier !== 'Supporter';
 
-	return inPaymentFailure || hasOtherProduct || membershipTierIsNotSupporter;
+	const membershipIsAnnual =
+		(getMainPlan(membershipToCancel.subscription) as PaidSubscriptionPlan)
+			.billingPeriod === 'year';
+
+	return (
+		inPaymentFailure ||
+		hasOtherProduct ||
+		membershipTierIsNotSupporter ||
+		membershipIsAnnual
+	);
 }
 
 function getPhoneRegion(currencyIso: CurrencyIso): PhoneRegionKey {

--- a/client/fixtures/productBuilder/productBuilder.ts
+++ b/client/fixtures/productBuilder/productBuilder.ts
@@ -144,6 +144,27 @@ export class ProductBuilder {
 
 		return this;
 	}
+
+	withBillingPeriod(billingPeriod: 'month' | 'year') {
+		const { plan, currentPlans, futurePlans } =
+			this.productToBuild.subscription;
+		if (plan) {
+			plan.billingPeriod = billingPeriod;
+		}
+		for (const currentPlan of currentPlans) {
+			if (isPaidSubscriptionPlan(currentPlan)) {
+				currentPlan.billingPeriod = billingPeriod;
+			}
+		}
+
+		for (const futurePlan of futurePlans) {
+			if (isPaidSubscriptionPlan(futurePlan)) {
+				futurePlan.billingPeriod = billingPeriod;
+			}
+		}
+
+		return this;
+	}
 }
 
 function isPaidSubscriptionPlan(

--- a/client/fixtures/productBuilder/testProducts.ts
+++ b/client/fixtures/productBuilder/testProducts.ts
@@ -99,6 +99,13 @@ export function membershipSupporter() {
 		.getProductDetailObject();
 }
 
+export function membershipSupporterAnnual() {
+	return new ProductBuilder(baseMembership())
+		.payByDirectDebit()
+		.withBillingPeriod('year')
+		.getProductDetailObject();
+}
+
 export function membershipSupporterCurrencyUSD() {
 	return new ProductBuilder(baseMembership())
 		.payByCard()

--- a/cypress/integration/parallel-2/membershipSave.spec.ts
+++ b/cypress/integration/parallel-2/membershipSave.spec.ts
@@ -2,6 +2,7 @@ import {
 	contributionPaidByCard,
 	guardianWeeklyExpiredCard,
 	membershipSupporter,
+	membershipSupporterAnnual,
 } from '../../../client/fixtures/productBuilder/testProducts';
 import { toMembersDataApiResponse } from '../../../client/fixtures/mdapiResponse';
 import { productMovePreviewResponse } from '../../../client/fixtures/productMove';
@@ -112,7 +113,7 @@ if (featureSwitches.membershipSave) {
 			cy.visit('/');
 			setSignInStatus();
 
-			cy.get(`[data-cy="Manage membership"]`).click();
+			cy.get(`[data-cy="Manage Membership"]`).click();
 
 			cy.findByText(/Cancel/).click();
 
@@ -145,28 +146,7 @@ if (featureSwitches.membershipSave) {
 			cy.wait('@get_case');
 			cy.wait('@cancel_membership');
 
-			cy.findByText(/Your membership has been cancelled/).should('exist');
-
-			cy.findAllByRole('radio', {
-				name: 'Other',
-			}).click();
-
-			cy.findByRole('button', {
-				name: 'Submit',
-			}).click();
-
-			cy.wait('@get_case');
-
-			cy.findByText(/You can support us again any time/).should('exist');
-			cy.findByRole('button', {
-				name: 'Set my reminder',
-			}).click();
-
-			cy.wait('@set_reminder');
-
-			cy.findByText(/Thank you for setting up support reminder/).should(
-				'exist',
-			);
+			cy.findByText(/Your Membership has been cancelled/).should('exist');
 
 			cy.go('back');
 
@@ -214,13 +194,29 @@ if (featureSwitches.membershipSave) {
 			cy.findByText(/Please select a reason/).should('exist');
 		});
 
-		it('redirects user in payment failiure to normal journey', () => {
+		it('redirects user in payment failure to normal journey', () => {
 			cy.intercept('GET', '/api/me/mma', {
 				statusCode: 200,
 				body: toMembersDataApiResponse(
 					membershipSupporter(),
 					guardianWeeklyExpiredCard(),
 				),
+			});
+
+			cy.visit('/cancel/membership');
+
+			cy.findByText(/Please select a reason/).should('exist');
+		});
+
+		it('redirects user with annual membership to normal journey', () => {
+			cy.intercept('GET', '/api/me/mma?productType=Membership', {
+				statusCode: 200,
+				body: toMembersDataApiResponse(membershipSupporterAnnual()),
+			});
+
+			cy.intercept('GET', '/api/me/mma', {
+				statusCode: 200,
+				body: toMembersDataApiResponse(membershipSupporterAnnual()),
 			});
 
 			cy.visit('/cancel/membership');


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The annual membership price rise pricelist has not been confirmed - memberships with a yearly plan should be excluded from the membership saves journey.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Take out a membership with annual rate plan - go to `cancel/membership?withFeature=membershipSave` and see the default journey (choose reason).

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
