### PR TITLE
add new endpoint for updating subscription cancellation reason in Zuora

### DIFF
--- a/client/components/mma/cancel/cancellationSaves/SelectReason.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SelectReason.tsx
@@ -151,6 +151,24 @@ function cancellationCaseFetch(
 	});
 }
 
+function updateZuoraCancellationReason(
+	selectedReasonId: string,
+	productDetail: ProductDetail,
+) {
+	return fetch(
+		'/api/update-cancellation-reason/' +
+			productDetail.subscription.subscriptionId,
+		{
+			method: 'POST',
+			body: JSON.stringify({ reason: selectedReasonId }),
+			headers: {
+				'Content-Type': 'application/json',
+				[MDA_TEST_USER_HEADER]: `${productDetail.isTestUser}`,
+			},
+		},
+	);
+}
+
 export const SelectReason = () => {
 	const navigate = useNavigate();
 	const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
@@ -196,11 +214,15 @@ export const SelectReason = () => {
 
 		try {
 			setIsSubmitting(true);
-			const response = await cancellationCaseFetch(
-				selectedReasonId,
-				productType,
-				productDetail,
-			);
+			const response = await Promise.all([
+				cancellationCaseFetch(
+					selectedReasonId,
+					productType,
+					productDetail,
+				),
+				updateZuoraCancellationReason(selectedReasonId, productDetail),
+			]);
+
 			const data = await JsonResponseHandler(response);
 
 			if (data === null) {

--- a/cypress/integration/parallel-2/membershipSave.spec.ts
+++ b/cypress/integration/parallel-2/membershipSave.spec.ts
@@ -56,6 +56,13 @@ if (featureSwitches.membershipSave) {
 				},
 			}).as('get_case');
 
+			cy.intercept('POST', '/api/update-cancellation-reason/**', {
+				statusCode: 204,
+				body: {
+					reason: 'reason',
+				},
+			}).as('update_zuora_cancellation_reason');
+
 			cy.intercept('POST', '/api/cancel/**', {
 				statusCode: 200,
 			}).as('cancel_membership');

--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -110,6 +110,15 @@ router.post(
 );
 
 router.post(
+	'/update-cancellation-reason/:subscriptionName?',
+	membersDataApiHandler(
+		'/user-attributes/me/update-cancellation-reason/:subscriptionName',
+		'MDA_UPDATE_CANCELLATION_REASON',
+		['subscriptionName'],
+	),
+);
+
+router.post(
 	'/supporter-plus-cancel/:subscriptionName',
 	productMoveAPI(
 		'supporter-plus-cancel/:subscriptionName',


### PR DESCRIPTION
This is part of the new cancellation saves work, which allows customers to optionally select the reason for cancelling at the end of the journey, after the cancellation is complete.

Previously, customers had to select the cancellation reason before cancelling. When confirming the cancellation, the reason would be sent to the API, which would perform both the reason update and cancellation. Now, these two actions must be done separately.

[see the PR in members-data-api](https://github.com/guardian/members-data-api/pull/1024)

- [x] Tested in CODE
- [x] merge server-side PR first