### PR TITLE
Anchor to error message during Product Switching

### DIFF
--- a/client/components/mma/switch/review/SwitchReview.tsx
+++ b/client/components/mma/switch/review/SwitchReview.tsx
@@ -95,6 +95,13 @@ const buttonLayoutCss = css`
 	}
 `;
 
+const scrollToErrorMessage = () => {
+	const errorMessageElement = document.getElementById(
+		'productSwitchErrorMessage',
+	);
+	errorMessageElement && errorMessageElement.scrollIntoView();
+};
+
 const productSwitchType: ProductSwitchType =
 	'recurring-contribution-to-supporter-plus';
 
@@ -162,6 +169,7 @@ export const SwitchReview = () => {
 
 		if (inPaymentFailure) {
 			setSwitchingError(true);
+			scrollToErrorMessage();
 			return;
 		}
 
@@ -176,6 +184,7 @@ export const SwitchReview = () => {
 			if (data === null) {
 				setIsSwitching(false);
 				setSwitchingError(true);
+				scrollToErrorMessage();
 			} else {
 				navigate('../complete', {
 					state: {
@@ -189,6 +198,7 @@ export const SwitchReview = () => {
 		} catch (e) {
 			setIsSwitching(false);
 			setSwitchingError(true);
+			scrollToErrorMessage();
 		}
 	};
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

When an error happens during product switching scroll to the error message.

Acceptance Criteria:
When a switch fails, user is anchored down to see error message
User can scroll up and continue as usual once the error has been viewed (not forced back to anchor point).

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

https://github.com/guardian/manage-frontend/assets/114918544/06235a8d-bb67-494b-9d6a-bdc2391ca1e3

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
