### PR TITLE
Replace GetHolidayStopsAsyncLoader with hooks pattern

### DIFF
--- a/client/components/mma/holiday/ExistingHolidayStopActions.tsx
+++ b/client/components/mma/holiday/ExistingHolidayStopActions.tsx
@@ -9,7 +9,6 @@ import {
 } from '../../../utilities/hooks/useAsyncLoader';
 import { JsonResponseHandler } from '../shared/asyncComponents/DefaultApiResponseHandler';
 import { DefaultLoadingView } from '../shared/asyncComponents/DefaultLoadingView';
-import type { ReFetch } from '../shared/AsyncLoader';
 import type {
 	HolidayStopRequest,
 	MinimalHolidayStopRequest,
@@ -21,7 +20,6 @@ import { formatDateRangeAsFriendly } from './SummaryTable';
 
 interface ExistingHolidayStopActionsProps extends MinimalHolidayStopRequest {
 	isTestUser: boolean;
-	reloadParent?: ReFetch;
 	setExistingHolidayStopToAmend?: (
 		newValue: HolidayStopRequest | null,
 	) => void;

--- a/client/components/mma/holiday/ExistingHolidayStopActions.tsx
+++ b/client/components/mma/holiday/ExistingHolidayStopActions.tsx
@@ -27,6 +27,12 @@ interface ExistingHolidayStopActionsProps extends MinimalHolidayStopRequest {
 	) => void;
 }
 
+const Refresh = () => {
+	const navigate = useNavigate();
+	useEffect(() => navigate(0), []);
+	return null;
+};
+
 const DeleteHolidayStop = (props: {
 	friendlyDateRange: string;
 	subscriptionName: string | undefined;
@@ -79,8 +85,7 @@ const DeleteHolidayStop = (props: {
 		);
 	}
 
-	useEffect(() => navigate(0), []);
-	return <></>;
+	return <Refresh />;
 };
 
 export const ExistingHolidayStopActions = (

--- a/client/components/mma/holiday/ExistingHolidayStopActions.tsx
+++ b/client/components/mma/holiday/ExistingHolidayStopActions.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@guardian/source-react-components';
 import { useEffect, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { Navigate, useLocation, useNavigate } from 'react-router-dom';
 import { DATE_FNS_LONG_OUTPUT_FORMAT } from '../../../../shared/dates';
 import { MDA_TEST_USER_HEADER } from '../../../../shared/productResponse';
 import {
@@ -35,8 +35,8 @@ const Refresh = () => {
 
 const DeleteHolidayStop = (props: {
 	friendlyDateRange: string;
-	subscriptionName: string | undefined;
-	id: string | undefined;
+	subscriptionName: string;
+	id: string;
 	isTestUser: boolean;
 }) => {
 	const navigate = useNavigate();
@@ -57,7 +57,6 @@ const DeleteHolidayStop = (props: {
 				title="Sorry"
 				instigator={null}
 				extraOnHideFunctionality={() => {
-					console.log('extra hide');
 					navigate(0);
 				}}
 			>
@@ -75,7 +74,6 @@ const DeleteHolidayStop = (props: {
 				title="Sorry"
 				instigator={null}
 				extraOnHideFunctionality={() => {
-					console.log('extra hide');
 					navigate(0);
 				}}
 			>
@@ -157,6 +155,10 @@ export const ExistingHolidayStopActions = (
 		);
 
 		const friendlyDateRange = formatDateRangeAsFriendly(props.dateRange);
+
+		if (props.subscriptionName === undefined || props.id === undefined) {
+			return <Navigate to="/" />;
+		}
 
 		return isDeleting ? (
 			<DeleteHolidayStop

--- a/client/components/mma/holiday/ExistingHolidayStopActions.tsx
+++ b/client/components/mma/holiday/ExistingHolidayStopActions.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@guardian/source-react-components';
-import { useEffect, useState } from 'react';
-import { Navigate, useLocation, useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { DATE_FNS_LONG_OUTPUT_FORMAT } from '../../../../shared/dates';
 import { MDA_TEST_USER_HEADER } from '../../../../shared/productResponse';
 import {
@@ -24,12 +24,6 @@ interface ExistingHolidayStopActionsProps extends MinimalHolidayStopRequest {
 		newValue: HolidayStopRequest | null,
 	) => void;
 }
-
-const Refresh = () => {
-	const navigate = useNavigate();
-	useEffect(() => navigate(0), []);
-	return null;
-};
 
 const DeleteHolidayStop = (props: {
 	friendlyDateRange: string;
@@ -81,7 +75,8 @@ const DeleteHolidayStop = (props: {
 		);
 	}
 
-	return <Refresh />;
+	navigate(0);
+	return null;
 };
 
 export const ExistingHolidayStopActions = (
@@ -155,7 +150,8 @@ export const ExistingHolidayStopActions = (
 		const friendlyDateRange = formatDateRangeAsFriendly(props.dateRange);
 
 		if (props.subscriptionName === undefined || props.id === undefined) {
-			return <Navigate to="/" />;
+			navigate('/');
+			return null;
 		}
 
 		return isDeleting ? (

--- a/client/components/mma/holiday/HolidayConfirmed.tsx
+++ b/client/components/mma/holiday/HolidayConfirmed.tsx
@@ -25,7 +25,7 @@ export const HolidayConfirmed = () => {
 		holidayStopResponse,
 		setSelectedRange,
 		setPublicationsImpacted,
-		reload,
+		setShouldReload,
 	} = useContext(HolidayStopsContext) as HolidayStopsContextInterface;
 
 	const navigate = useNavigate();
@@ -67,7 +67,7 @@ export const HolidayConfirmed = () => {
 						<Button
 							priority="secondary"
 							onClick={() => {
-								reload();
+								setShouldReload(true);
 								setSelectedRange(undefined);
 								setPublicationsImpacted([]);
 								navigate('../create', { state: routerState });

--- a/client/components/mma/holiday/HolidayStopApi.ts
+++ b/client/components/mma/holiday/HolidayStopApi.ts
@@ -105,8 +105,6 @@ export const convertRawPotentialHolidayStopDetail = (
 	publicationDate: parseDate(raw.publicationDate),
 });
 
-export class GetHolidayStopsAsyncLoader extends AsyncLoader<GetHolidayStopsResponse> {}
-
 // tslint:disable-next-line:max-classes-per-file
 export class PotentialHolidayStopsAsyncLoader extends AsyncLoader<PotentialHolidayStopsResponse> {}
 

--- a/client/components/mma/holiday/HolidayStopApi.ts
+++ b/client/components/mma/holiday/HolidayStopApi.ts
@@ -8,7 +8,6 @@ import {
 	parseDate,
 } from '../../../../shared/dates';
 import { MDA_TEST_USER_HEADER } from '../../../../shared/productResponse';
-import type { ReFetch } from '../shared/AsyncLoader';
 import { AsyncLoader } from '../shared/AsyncLoader';
 
 interface CommonCreditProperties {
@@ -84,7 +83,6 @@ export interface GetHolidayStopsResponse {
 
 export interface ReloadableGetHolidayStopsResponse
 	extends GetHolidayStopsResponse {
-	reload: ReFetch;
 	existingHolidayStopToAmend?: HolidayStopRequest;
 }
 

--- a/client/components/mma/holiday/HolidayStopsContainer.tsx
+++ b/client/components/mma/holiday/HolidayStopsContainer.tsx
@@ -1,5 +1,5 @@
 import type { Context, Dispatch, SetStateAction } from 'react';
-import { createContext, useEffect, useState } from 'react';
+import { createContext, useState } from 'react';
 import { Navigate, useLocation, useNavigate } from 'react-router-dom';
 import type { DateRange } from '../../../../shared/dates';
 import type {
@@ -106,11 +106,9 @@ export const HolidayStopsContainer = (
 
 	const [shouldReload, setShouldReload] = useState<boolean>(false);
 
-	useEffect(() => {
-		if (shouldReload) {
-			navigate(0);
-		}
-	}, [shouldReload]);
+	if (shouldReload) {
+		navigate(0);
+	}
 
 	return (
 		<PageContainer

--- a/client/components/mma/holiday/HolidayStopsContainer.tsx
+++ b/client/components/mma/holiday/HolidayStopsContainer.tsx
@@ -1,6 +1,6 @@
 import type { Context, Dispatch, SetStateAction } from 'react';
 import { createContext, useState } from 'react';
-import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 import type { DateRange } from '../../../../shared/dates';
 import type {
 	MembersDataApiResponse,
@@ -24,11 +24,7 @@ import type {
 	HolidayStopDetail,
 	HolidayStopRequest,
 } from './HolidayStopApi';
-import {
-	createGetHolidayStopsFetcher,
-	embellishExistingHolidayStops,
-	GetHolidayStopsAsyncLoader,
-} from './HolidayStopApi';
+import { HolidayStopsPage } from './HolidayStopsPage';
 
 export interface HolidayStopsRouterState {
 	productDetail: ProductDetail;
@@ -51,40 +47,6 @@ export interface HolidayStopsContextInterface {
 export const HolidayStopsContext: Context<HolidayStopsContextInterface | {}> =
 	createContext({});
 
-const renderHolidayStopsContextAndOutlet =
-	(
-		productType: ProductTypeWithHolidayStopsFlow,
-		productDetail: ProductDetail,
-		existingHolidayStopToAmend: HolidayStopRequest | null,
-		setExistingHolidayStopToAmend: Dispatch<
-			SetStateAction<HolidayStopRequest | null>
-		>,
-		selectedRange: DateRange | undefined,
-		setSelectedRange: Dispatch<SetStateAction<DateRange | undefined>>,
-		publicationsImpacted: HolidayStopDetail[],
-		setPublicationsImpacted: Dispatch<SetStateAction<HolidayStopDetail[]>>,
-	) =>
-	(holidayStopResponse: GetHolidayStopsResponse, reload: ReFetch) => {
-		return (
-			<HolidayStopsContext.Provider
-				value={{
-					productType,
-					productDetail,
-					existingHolidayStopToAmend,
-					setExistingHolidayStopToAmend,
-					selectedRange,
-					setSelectedRange,
-					publicationsImpacted,
-					setPublicationsImpacted,
-					holidayStopResponse,
-					reload,
-				}}
-			>
-				<Outlet />
-			</HolidayStopsContext.Provider>
-		);
-	};
-
 const handleMembersDataResponse =
 	(
 		productType: ProductTypeWithHolidayStopsFlow,
@@ -103,23 +65,17 @@ const handleMembersDataResponse =
 		if (filteredProductDetails.length === 1) {
 			const productDetail = filteredProductDetails[0];
 			return productDetail.subscription.start ? (
-				<GetHolidayStopsAsyncLoader
-					fetch={createGetHolidayStopsFetcher(
-						productDetail.subscription.subscriptionId,
-						productDetail.isTestUser,
-					)}
-					render={renderHolidayStopsContextAndOutlet(
-						productType,
-						productDetail,
-						existingHolidayStopToAmend,
-						setExistingHolidayStopToAmend,
-						selectedRange,
-						setSelectedRange,
-						publicationsImpacted,
-						setPublicationsImpacted,
-					)}
-					loadingMessage="Loading existing suspensions..."
-					readerOnOK={embellishExistingHolidayStops}
+				<HolidayStopsPage
+					productDetail={productDetail}
+					productType={productType}
+					existingHolidayStopToAmend={existingHolidayStopToAmend}
+					setExistingHolidayStopToAmend={
+						setExistingHolidayStopToAmend
+					}
+					selectedRange={selectedRange}
+					setSelectedRange={setSelectedRange}
+					publicationsImpacted={publicationsImpacted}
+					setPublicationsImpacted={setPublicationsImpacted}
 				/>
 			) : (
 				<GenericErrorScreen loggingMessage="Subscription had no start date" />
@@ -152,23 +108,17 @@ export const HolidayStopsContainer = (
 		>
 			{productDetail ? (
 				productDetail.subscription.start ? (
-					<GetHolidayStopsAsyncLoader
-						fetch={createGetHolidayStopsFetcher(
-							productDetail.subscription.subscriptionId,
-							productDetail.isTestUser,
-						)}
-						render={renderHolidayStopsContextAndOutlet(
-							props.productType,
-							productDetail,
-							existingHolidayStopToAmend,
-							setExistingHolidayStopToAmend,
-							selectedRange,
-							setSelectedRange,
-							publicationsImpacted,
-							setPublicationsImpacted,
-						)}
-						loadingMessage="Loading existing suspensions..."
-						readerOnOK={embellishExistingHolidayStops}
+					<HolidayStopsPage
+						productDetail={productDetail}
+						productType={props.productType}
+						existingHolidayStopToAmend={existingHolidayStopToAmend}
+						setExistingHolidayStopToAmend={
+							setExistingHolidayStopToAmend
+						}
+						selectedRange={selectedRange}
+						setSelectedRange={setSelectedRange}
+						publicationsImpacted={publicationsImpacted}
+						setPublicationsImpacted={setPublicationsImpacted}
 					/>
 				) : (
 					<GenericErrorScreen loggingMessage="Subscription had no start date" />

--- a/client/components/mma/holiday/HolidayStopsPage.tsx
+++ b/client/components/mma/holiday/HolidayStopsPage.tsx
@@ -35,6 +35,7 @@ export const HolidayStopsPage = ({
 	setSelectedRange,
 	publicationsImpacted,
 	setPublicationsImpacted,
+	setShouldReload,
 }: {
 	productDetail: ProductDetail;
 	productType: ProductTypeWithHolidayStopsFlow;
@@ -46,6 +47,7 @@ export const HolidayStopsPage = ({
 	setSelectedRange: Dispatch<SetStateAction<DateRange | undefined>>;
 	publicationsImpacted: HolidayStopDetail[];
 	setPublicationsImpacted: Dispatch<SetStateAction<HolidayStopDetail[]>>;
+	setShouldReload: Dispatch<SetStateAction<boolean>>;
 }) => {
 	const { data: holidayStopResponse, loadingState } =
 		useAsyncLoader<GetHolidayStopsResponse>(
@@ -84,6 +86,7 @@ export const HolidayStopsPage = ({
 				publicationsImpacted,
 				setPublicationsImpacted,
 				holidayStopResponse,
+				setShouldReload,
 			}}
 		>
 			<Outlet />

--- a/client/components/mma/holiday/HolidayStopsPage.tsx
+++ b/client/components/mma/holiday/HolidayStopsPage.tsx
@@ -1,0 +1,92 @@
+import type { Dispatch, SetStateAction } from 'react';
+import { Outlet } from 'react-router';
+import type { DateRange } from '../../../../shared/dates';
+import { MDA_TEST_USER_HEADER } from '../../../../shared/productResponse';
+import type { ProductDetail } from '../../../../shared/productResponse';
+import type { ProductTypeWithHolidayStopsFlow } from '../../../../shared/productTypes';
+import {
+	LoadingState,
+	useAsyncLoader,
+} from '../../../utilities/hooks/useAsyncLoader';
+import { GenericErrorScreen } from '../../shared/GenericErrorScreen';
+import { handleResponses } from '../shared/asyncComponents/DefaultApiResponseHandler';
+import { DefaultLoadingView } from '../shared/asyncComponents/DefaultLoadingView';
+import type { ResponseProcessor } from '../shared/asyncComponents/ResponseProcessor';
+import { embellishExistingHolidayStops } from './HolidayStopApi';
+import type {
+	GetHolidayStopsResponse,
+	HolidayStopDetail,
+	HolidayStopRequest,
+} from './HolidayStopApi';
+import { HolidayStopsContext } from './HolidayStopsContainer';
+
+const HolidayStopsResponseHandler: ResponseProcessor = (
+	response: Response | Response[],
+) => {
+	return handleResponses(response, embellishExistingHolidayStops);
+};
+
+export const HolidayStopsPage = ({
+	productType,
+	productDetail,
+	existingHolidayStopToAmend,
+	setExistingHolidayStopToAmend,
+	selectedRange,
+	setSelectedRange,
+	publicationsImpacted,
+	setPublicationsImpacted,
+}: {
+	productDetail: ProductDetail;
+	productType: ProductTypeWithHolidayStopsFlow;
+	existingHolidayStopToAmend: HolidayStopRequest | null;
+	setExistingHolidayStopToAmend: Dispatch<
+		SetStateAction<HolidayStopRequest | null>
+	>;
+	selectedRange: DateRange | undefined;
+	setSelectedRange: Dispatch<SetStateAction<DateRange | undefined>>;
+	publicationsImpacted: HolidayStopDetail[];
+	setPublicationsImpacted: Dispatch<SetStateAction<HolidayStopDetail[]>>;
+}) => {
+	const { data: holidayStopResponse, loadingState } =
+		useAsyncLoader<GetHolidayStopsResponse>(
+			() =>
+				fetch(
+					`/api/holidays/${productDetail.subscription.subscriptionId}`,
+					{
+						headers: {
+							[MDA_TEST_USER_HEADER]: `${productDetail.isTestUser}`,
+						},
+					},
+				),
+			HolidayStopsResponseHandler,
+		);
+
+	if (loadingState == LoadingState.HasError) {
+		return <GenericErrorScreen />;
+	}
+	if (loadingState == LoadingState.IsLoading) {
+		return <DefaultLoadingView />;
+	}
+
+	if (holidayStopResponse === null) {
+		return <GenericErrorScreen />;
+	}
+
+	return (
+		<HolidayStopsContext.Provider
+			value={{
+				productType,
+				productDetail,
+				existingHolidayStopToAmend,
+				setExistingHolidayStopToAmend,
+				selectedRange,
+				setSelectedRange,
+				publicationsImpacted,
+				setPublicationsImpacted,
+				holidayStopResponse,
+			}}
+		>
+			<Outlet />
+		</HolidayStopsContext.Provider>
+	);
+};

--- a/client/components/mma/holiday/HolidaysOverview.tsx
+++ b/client/components/mma/holiday/HolidaysOverview.tsx
@@ -68,7 +68,6 @@ export const HolidaysOverview = () => {
 		productDetail,
 		setExistingHolidayStopToAmend,
 		holidayStopResponse,
-		reload,
 		setSelectedRange,
 	} = holidayStopsContext;
 
@@ -278,7 +277,6 @@ export const HolidaysOverview = () => {
 								issueKeyword={
 									productType.holidayStops.issueKeyword
 								}
-								reloadParent={reload}
 								setExistingHolidayStopToAmend={
 									setExistingHolidayStopToAmend
 								}

--- a/client/components/mma/holiday/Modal.tsx
+++ b/client/components/mma/holiday/Modal.tsx
@@ -18,9 +18,7 @@ export const Modal = (props: ModalProps) => {
 
 	const hide = () => {
 		setIsDisplayed(false);
-		console.log('hide');
 		if (props.extraOnHideFunctionality) {
-			console.log('here we go');
 			props.extraOnHideFunctionality();
 		}
 	};

--- a/client/components/mma/holiday/Modal.tsx
+++ b/client/components/mma/holiday/Modal.tsx
@@ -1,6 +1,6 @@
 import { palette } from '@guardian/source-foundations';
-import * as React from 'react';
-import { Button } from '../shared/Buttons';
+import { Button } from '@guardian/source-react-components';
+import { useState } from 'react';
 
 export type HideFunction = () => void;
 
@@ -13,30 +13,27 @@ interface ModalProps {
 	extraOnHideFunctionality?: () => void;
 }
 
-interface ModalState {
-	isDisplayed: boolean;
-}
+export const Modal = (props: ModalProps) => {
+	const [isDisplayed, setIsDisplayed] = useState(props.instigator == null);
 
-export class Modal extends React.Component<ModalProps, ModalState> {
-	public state = {
-		isDisplayed: false,
+	const hide = () => {
+		setIsDisplayed(false);
+		console.log('hide');
+		if (props.extraOnHideFunctionality) {
+			console.log('here we go');
+			props.extraOnHideFunctionality();
+		}
 	};
 
-	public componentDidMount(): void {
-		if (this.props.instigator == null) {
-			this.setState({ isDisplayed: true });
-		}
-	}
-
-	public render = () => (
+	return (
 		<>
 			<div
 				css={{ display: 'inline-block' }}
-				onClick={() => this.setState({ isDisplayed: true })}
+				onClick={() => setIsDisplayed(true)}
 			>
-				{this.props.instigator}
+				{props.instigator}
 			</div>
-			{this.state.isDisplayed && (
+			{isDisplayed && (
 				<div
 					css={{
 						zIndex: 9999,
@@ -51,7 +48,7 @@ export class Modal extends React.Component<ModalProps, ModalState> {
 						justifyContent: 'space-around',
 						background: 'rgba(192,192,192,0.5)',
 					}}
-					onClick={this.hide}
+					onClick={hide}
 				>
 					<div
 						css={{
@@ -70,7 +67,7 @@ export class Modal extends React.Component<ModalProps, ModalState> {
 						onClick={(e) => e.stopPropagation()}
 					>
 						<span
-							onClick={this.hide}
+							onClick={hide}
 							css={{
 								position: 'absolute',
 								top: '5px',
@@ -83,28 +80,19 @@ export class Modal extends React.Component<ModalProps, ModalState> {
 							</svg>
 						</span>
 						<h2 css={{ fontWeight: 900, marginTop: 0 }}>
-							{this.props.title}
+							{props.title}
 						</h2>
-						{this.props.children}
+						{props.children}
 						<div css={{ textAlign: 'right' }}>
-							{this.props.additionalButton &&
-								this.props.additionalButton(this.hide)}
-							<Button
-								text={this.props.alternateOkText || 'Ok'}
-								onClick={this.hide}
-								fontWeight="bold"
-							/>
+							{props.additionalButton &&
+								props.additionalButton(hide)}
+							<Button onClick={hide}>
+								{props.alternateOkText || 'Ok'}
+							</Button>
 						</div>
 					</div>
 				</div>
 			)}
 		</>
 	);
-
-	private hide: HideFunction = () => {
-		this.setState({ isDisplayed: false });
-		if (this.props.extraOnHideFunctionality) {
-			this.props.extraOnHideFunctionality();
-		}
-	};
-}
+};

--- a/client/components/mma/holiday/SummaryTable.tsx
+++ b/client/components/mma/holiday/SummaryTable.tsx
@@ -12,7 +12,6 @@ import {
 } from '../../../../shared/productResponse';
 import { sans } from '../../../styles/fonts';
 import { ExpanderButton } from '../../shared/ExpanderButton';
-import type { ReFetch } from '../shared/AsyncLoader';
 import { CollatedCredits } from './CollatedCredits';
 import { ExistingHolidayStopActions } from './ExistingHolidayStopActions';
 import type { SharedHolidayDateChooserState } from './HolidayDateChooser';
@@ -34,7 +33,6 @@ interface SummaryTableProps {
 	subscription: Subscription;
 	issueKeyword: string;
 	alternateSuspendedColumnHeading?: string;
-	reloadParent?: ReFetch;
 	setExistingHolidayStopToAmend?: (
 		newValue: HolidayStopRequest | null,
 	) => void;
@@ -52,7 +50,6 @@ interface SummaryTableRowProps extends MinimalHolidayStopRequest {
 	issueKeyword: string;
 	isTestUser: boolean;
 	isOperatingOnNewHolidayStop: boolean;
-	reloadParent?: ReFetch;
 	currency?: string;
 	asTD?: true;
 }

--- a/client/components/mma/shared/asyncComponents/DefaultApiResponseHandler.tsx
+++ b/client/components/mma/shared/asyncComponents/DefaultApiResponseHandler.tsx
@@ -12,7 +12,7 @@ export const TextResponseHandler: ResponseProcessor = (
 	return handleResponses(response, (r: Response) => r.text());
 };
 
-function handleResponses(
+export function handleResponses(
 	response: Response | Response[],
 	transformResponse: (response: Response) => any,
 ): Promise<any> {

--- a/cypress/integration/parallel-3/holidayStops.spec.ts
+++ b/cypress/integration/parallel-3/holidayStops.spec.ts
@@ -43,7 +43,7 @@ describe('Holiday stops', () => {
 		}).as('create_holiday_stop');
 	});
 
-	it('can add a new holiday stop', () => {
+	it('can add a new holiday stop and add another', () => {
 		cy.visit('/suspend/guardianweekly');
 		cy.wait('@fetch_existing_holidays');
 		cy.wait('@product_detail');
@@ -70,6 +70,11 @@ describe('Holiday stops', () => {
 		cy.wait('@create_holiday_stop');
 		cy.findByText('Your schedule has been set').should('exist');
 
+		cy.findByText('Schedule another suspension').click();
+		cy.wait('@fetch_existing_holidays');
+		cy.wait('@product_detail');
+
+		cy.get('@fetch_existing_holidays.all').should('have.length', 2);
 		cy.get('@create_holiday_stop.all').should('have.length', 1);
 	});
 

--- a/cypress/integration/parallel-3/holidayStops.spec.ts
+++ b/cypress/integration/parallel-3/holidayStops.spec.ts
@@ -186,12 +186,13 @@ describe('Holiday stops', () => {
 
 		cy.findByRole('button', { name: 'Yes' }).click();
 		cy.wait('@delete_holiday_stop');
+		cy.wait('@product_detail');
 		cy.wait('@fetch_existing_holidays');
 
 		cy.get('table').contains('Deleted on 7 April 2022');
 
 		cy.get('@fetch_existing_holidays.all').should('have.length', 2);
-		cy.get('@product_detail.all').should('have.length', 1);
+		cy.get('@product_detail.all').should('have.length', 2);
 		cy.get('@delete_holiday_stop.all').should('have.length', 1);
 	});
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Replace the AsyncLoader pattern with a hooks based approach in the HolidayStopsContainer component

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Can still create, amend and delete holiday stops. Take out eg a Guardian Weekly and go to `/suspend/guardianweekly`

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
