### PR TITLE
Uncomment tests that should not be commented out

### DIFF
--- a/cypress/integration/parallel-3/holidayStops.spec.ts
+++ b/cypress/integration/parallel-3/holidayStops.spec.ts
@@ -27,12 +27,12 @@ describe('Holiday stops', () => {
 
 		cy.intercept('GET', '/api/holidays/*/potential?*', {
 			statusCode: 200,
-			body: yearSpanningPotentialDeliveries,
+			body: potentialDeliveries,
 		}).as('fetch_potential_holidays');
 
 		cy.intercept('GET', '/api/holidays/*', {
 			statusCode: 200,
-			body: existingHolidaysFirstIssueDecember,
+			body: existingHolidays,
 		}).as('fetch_existing_holidays');
 
 		cy.intercept('POST', '/api/holidays', {

--- a/cypress/integration/parallel-3/holidayStops.spec.ts
+++ b/cypress/integration/parallel-3/holidayStops.spec.ts
@@ -43,294 +43,294 @@ describe('Holiday stops', () => {
 		}).as('create_holiday_stop');
 	});
 
-	// it('can add a new holiday stop', () => {
-	// 	cy.visit('/suspend/guardianweekly');
-	// 	cy.wait('@fetch_existing_holidays');
-	// 	cy.wait('@product_detail');
-	// 	cy.get('[data-cy="create-suspension-cta"] button').click();
-
-	// 	cy.findByText('Choose the dates you will be away');
-
-	// 	// Selects 09/02/2022 - 11/02/2022
-	// 	cy.get('[data-cy="date-picker"] div').eq(9).click();
-	// 	cy.get('[data-cy="date-picker"] div').eq(11).click();
-	// 	cy.wait('@fetch_potential_holidays');
-
-	// 	// Total issues suspended
-	// 	cy.get('[data-cy="suspension-issue-count"]').eq(0).contains('1 issue');
-
-	// 	cy.findByText('Review details').click();
-
-	// 	cy.get('table').contains('9 February - 11 February 2022');
-	// 	cy.get('table').contains('1 issue');
-	// 	cy.get('table').contains('$2.89 off your 1 February 2023 payment');
-
-	// 	cy.findByText('Confirm').click();
-
-	// 	cy.wait('@create_holiday_stop');
-	// 	cy.findByText('Your schedule has been set').should('exist');
-
-	// 	cy.get('@create_holiday_stop.all').should('have.length', 1);
-	// });
-
-	// it('can amend a non-confirmed holiday stop', () => {
-	// 	cy.visit('/suspend/guardianweekly');
-	// 	cy.wait('@fetch_existing_holidays');
-	// 	cy.wait('@product_detail');
-	// 	cy.get('[data-cy="create-suspension-cta"] button').click();
-
-	// 	// Selects 09/02/2022 - 11/02/2022
-	// 	cy.get('[data-cy="date-picker"] div').eq(9).click();
-	// 	cy.get('[data-cy="date-picker"] div').eq(11).click();
-	// 	cy.wait('@fetch_potential_holidays');
-	// 	cy.findByText('Review details').click();
-
-	// 	cy.findByText('Amend').click();
-
-	// 	cy.findByText('Choose the dates you will be away').should('exist');
-	// 	cy.findByText('Please select your new dates...').should('exist');
-	// 	cy.get('[aria-label="day"]').eq(0).should('have.value', '9');
-	// 	cy.get('[aria-label="month"]').eq(0).should('have.value', '2');
-	// 	cy.get('[aria-label="year"]').eq(0).should('have.value', '2022');
-	// 	cy.get('[aria-label="day"]').eq(1).should('have.value', '11');
-	// 	cy.get('[aria-label="month"]').eq(1).should('have.value', '2');
-	// 	cy.get('[aria-label="year"]').eq(1).should('have.value', '2022');
-
-	// 	cy.get('[data-cy="date-picker"] div').eq(16).click();
-	// 	cy.get('[data-cy="date-picker"] div').eq(18).click();
-	// 	cy.wait('@fetch_potential_holidays');
-
-	// 	// Selects 16/02/2022 - 18/02/2022
-	// 	cy.get('[aria-label="day"]').eq(0).should('have.value', '16');
-	// 	cy.get('[aria-label="day"]').eq(1).should('have.value', '18');
-
-	// 	// Total issues suspended
-	// 	cy.get('[data-cy="suspension-issue-count"]').eq(0).contains('1 issue');
-
-	// 	cy.get('@fetch_existing_holidays.all').should('have.length', 1);
-	// 	cy.get('@product_detail.all').should('have.length', 1);
-	// 	cy.get('@fetch_potential_holidays.all').should('have.length', 2);
-	// });
-
-	// it('can not create a holiday stop for date range when there are no deliveries', () => {
-	// 	cy.intercept('GET', '/api/holidays/*/potential?*', {
-	// 		statusCode: 200,
-	// 		body: noPotentialDeliveries,
-	// 	}).as('fetch_potential_holidays');
-
-	// 	cy.visit('/suspend/guardianweekly');
-	// 	cy.wait('@fetch_existing_holidays');
-	// 	cy.wait('@product_detail');
-	// 	cy.get('[data-cy="create-suspension-cta"] button').click();
-
-	// 	// Selects 08/02/2022 - 10/02/2022
-	// 	cy.get('[data-cy="date-picker"] div').eq(8).click();
-	// 	cy.get('[data-cy="date-picker"] div').eq(10).click();
-	// 	cy.wait('@fetch_potential_holidays');
-
-	// 	cy.findByText('No issues occur during selected period').should('exist');
-
-	// 	cy.get('@product_detail.all').should('have.length', 1);
-	// 	cy.get('@fetch_potential_holidays.all').should('have.length', 1);
-	// });
-
-	// it('shows existing holidays stops on overview page', () => {
-	// 	cy.visit('/suspend/guardianweekly');
-	// 	cy.wait('@fetch_existing_holidays');
-	// 	cy.wait('@product_detail');
-
-	// 	cy.get('table').contains('11 March - 12 March 2022');
-
-	// 	cy.get('@fetch_existing_holidays.all').should('have.length', 1);
-	// 	cy.get('@product_detail.all').should('have.length', 1);
-	// });
-
-	// it('can amend an existing holiday stop from overview page', () => {
-	// 	cy.visit('/suspend/guardianweekly');
-	// 	cy.wait('@fetch_existing_holidays');
-	// 	cy.wait('@product_detail');
-
-	// 	cy.get('table').findByText('Amend').click();
-	// 	cy.findByText('Please select your new dates...').should('exist');
-
-	// 	// Selects 09/02/2022 - 11/02/2022
-	// 	cy.get('[data-cy="date-picker"] div').eq(9).click();
-	// 	cy.get('[data-cy="date-picker"] div').eq(11).click();
-	// 	cy.wait('@fetch_potential_holidays');
-
-	// 	cy.findByText('Review details').click();
-	// 	cy.get('table').contains('9 February - 11 February 2022');
-
-	// 	cy.get('@fetch_existing_holidays.all').should('have.length', 1);
-	// 	cy.get('@product_detail.all').should('have.length', 1);
-	// });
-
-	// it('can delete an existing holiday stop from overview page', () => {
-	// 	cy.intercept('DELETE', '/api/holidays/*/*', {
-	// 		statusCode: 200,
-	// 		body: {
-	// 			message: 'success',
-	// 		},
-	// 	}).as('delete_holiday_stop');
-
-	// 	cy.visit('/suspend/guardianweekly');
-	// 	cy.wait('@fetch_existing_holidays');
-	// 	cy.wait('@product_detail');
-
-	// 	cy.get('table').findByText('Delete').click();
-
-	// 	cy.intercept('GET', '/api/holidays/*', {
-	// 		statusCode: 200,
-	// 		body: existingHolidaysWithDeletion,
-	// 	}).as('fetch_existing_holidays');
-
-	// 	cy.findByRole('button', { name: 'Yes' }).click();
-	// 	cy.wait('@delete_holiday_stop');
-	// 	cy.wait('@fetch_existing_holidays');
-
-	// 	cy.get('table').contains('Deleted on 7 April 2022');
-
-	// 	cy.get('@fetch_existing_holidays.all').should('have.length', 2);
-	// 	cy.get('@product_detail.all').should('have.length', 1);
-	// 	cy.get('@delete_holiday_stop.all').should('have.length', 1);
-	// });
-
-	// it('can create a holiday stop where multiple products of the same type exist by navigating from the Account Overview page', () => {
-	// 	cy.intercept('GET', '/api/me/mma', {
-	// 		statusCode: 200,
-	// 		body: toMembersDataApiResponse(
-	// 			guardianWeeklyPaidByCard(),
-	// 			guardianWeeklyPaidByCard(),
-	// 		),
-	// 	}).as('mma');
-
-	// 	cy.intercept('GET', '/mpapi/user/mobile-subscriptions', {
-	// 		statusCode: 200,
-	// 		body: { subscriptions: [] },
-	// 	}).as('mobile_subscriptions');
-
-	// 	cy.intercept('GET', '/api/me/one-off-contributions', {
-	// 		statusCode: 200,
-	// 		body: [],
-	// 	}).as('single_contributions');
-
-	// 	cy.intercept('GET', '/api/holidays/*', {
-	// 		statusCode: 200,
-	// 		body: existingHolidays,
-	// 	}).as('fetch_existing_holidays');
-
-	// 	cy.intercept('GET', '/api/holidays/*/potential?*', {
-	// 		statusCode: 200,
-	// 		body: potentialDeliveries,
-	// 	}).as('fetch_potential_holidays');
-
-	// 	cy.visit('/');
-	// 	cy.wait('@mma');
-	// 	cy.wait('@cancelled');
-	// 	cy.wait('@mobile_subscriptions');
-	// 	cy.wait('@single_contributions');
-
-	// 	cy.findByRole('heading', { name: 'Account overview' }).should('exist');
-	// 	cy.findAllByText('Manage subscription').eq(0).click();
-
-	// 	cy.findByText(/A-S00/).should('exist');
-
-	// 	cy.visit('/');
-	// 	cy.wait('@mma');
-	// 	cy.wait('@cancelled');
-	// 	cy.wait('@mobile_subscriptions');
-	// 	cy.wait('@single_contributions');
-
-	// 	cy.findAllByText('Manage subscription').eq(1).click();
-
-	// 	cy.findByText(/A-S00/).should('exist');
-	// 	cy.findByRole('link', { name: 'Manage suspensions' }).click();
-
-	// 	cy.wait('@fetch_existing_holidays');
-	// 	cy.get('[data-cy="create-suspension-cta"] button').click();
-
-	// 	cy.findByText('Choose the dates you will be away').should('exist');
-
-	// 	// Selects 09/02/2022 - 11/02/2022
-	// 	cy.get('[data-cy="date-picker"] div').eq(9).click();
-	// 	cy.get('[data-cy="date-picker"] div').eq(11).click();
-	// 	cy.wait('@fetch_potential_holidays');
-
-	// 	// Total issues suspended
-	// 	cy.get('[data-cy="suspension-issue-count"]').eq(0).contains('1 issue');
-
-	// 	cy.findByText('Review details').click();
-
-	// 	cy.get('table').contains('9 February - 11 February 2022');
-	// 	cy.get('table').contains('1 issue');
-	// 	cy.get('table').contains('£2.89 off your 1 February 2023 payment');
-
-	// 	cy.findByText('Confirm').click();
-
-	// 	cy.wait('@create_holiday_stop');
-	// 	cy.findByText('Your schedule has been set').should('exist');
-
-	// 	cy.get('@create_holiday_stop.all').should('have.length', 1);
-	// });
-
-	// it('redirects you to the Account Overview page if the suspend URL is visited directly and there are multiple products of the same type', () => {
-	// 	cy.intercept('GET', '/api/me/mma?productType=Weekly', {
-	// 		statusCode: 200,
-	// 		body: toMembersDataApiResponse(
-	// 			guardianWeeklyPaidByCard(),
-	// 			guardianWeeklyPaidByCard(),
-	// 		),
-	// 	}).as('mma_filtered');
-
-	// 	cy.intercept('GET', '/api/me/mma', {
-	// 		statusCode: 200,
-	// 		body: toMembersDataApiResponse(
-	// 			guardianWeeklyPaidByCard(),
-	// 			guardianWeeklyPaidByCard(),
-	// 		),
-	// 	}).as('mma');
-
-	// 	cy.intercept('GET', '/mpapi/user/mobile-subscriptions', {
-	// 		statusCode: 200,
-	// 		body: { subscriptions: [] },
-	// 	}).as('mobile_subscriptions');
-
-	// 	cy.intercept('GET', '/api/me/one-off-contributions', {
-	// 		statusCode: 200,
-	// 		body: { subscriptions: [] },
-	// 	}).as('single_contributions');
-
-	// 	cy.visit('/suspend/guardianweekly');
-
-	// 	cy.wait('@mma_filtered');
-	// 	cy.wait('@mma');
-	// 	cy.wait('@cancelled');
-
-	// 	cy.findByRole('heading', { name: 'Account overview' }).should('exist');
-	// 	cy.findAllByText(/A-S00/).should('have.length', 2);
-	// });
-
-	// it('does not allow you to create more holiday stops than the subscriptions annual suspension limit', () => {
-	// 	cy.intercept('GET', '/api/holidays/*/potential?*', {
-	// 		statusCode: 200,
-	// 		body: multiplePotentialDeliveries,
-	// 	}).as('fetch_potential_holidays');
-
-	// 	cy.visit('/suspend/guardianweekly');
-	// 	cy.wait('@fetch_existing_holidays');
-	// 	cy.wait('@product_detail');
-	// 	cy.get('[data-cy="create-suspension-cta"] button').click();
-
-	// 	cy.findByRole('button', { name: 'Go forward a month' }).click();
-
-	// 	// Calendar has been advanced to the next month.
-	// 	// Selects 18/03/2022 - 22/04/2022
-	// 	cy.get('[data-cy="date-picker"] div').eq(53).click();
-	// 	cy.get('[data-cy="date-picker"] div').eq(95).click();
-	// 	cy.wait('@fetch_potential_holidays');
-
-	// 	cy.findByText(/Exceeded issue limit of 6/).should('exist');
-	// });
+	it('can add a new holiday stop', () => {
+		cy.visit('/suspend/guardianweekly');
+		cy.wait('@fetch_existing_holidays');
+		cy.wait('@product_detail');
+		cy.get('[data-cy="create-suspension-cta"] button').click();
+
+		cy.findByText('Choose the dates you will be away');
+
+		// Selects 09/02/2022 - 11/02/2022
+		cy.get('[data-cy="date-picker"] div').eq(9).click();
+		cy.get('[data-cy="date-picker"] div').eq(11).click();
+		cy.wait('@fetch_potential_holidays');
+
+		// Total issues suspended
+		cy.get('[data-cy="suspension-issue-count"]').eq(0).contains('1 issue');
+
+		cy.findByText('Review details').click();
+
+		cy.get('table').contains('9 February - 11 February 2022');
+		cy.get('table').contains('1 issue');
+		cy.get('table').contains('$2.89 off your 1 February 2023 payment');
+
+		cy.findByText('Confirm').click();
+
+		cy.wait('@create_holiday_stop');
+		cy.findByText('Your schedule has been set').should('exist');
+
+		cy.get('@create_holiday_stop.all').should('have.length', 1);
+	});
+
+	it('can amend a non-confirmed holiday stop', () => {
+		cy.visit('/suspend/guardianweekly');
+		cy.wait('@fetch_existing_holidays');
+		cy.wait('@product_detail');
+		cy.get('[data-cy="create-suspension-cta"] button').click();
+
+		// Selects 09/02/2022 - 11/02/2022
+		cy.get('[data-cy="date-picker"] div').eq(9).click();
+		cy.get('[data-cy="date-picker"] div').eq(11).click();
+		cy.wait('@fetch_potential_holidays');
+		cy.findByText('Review details').click();
+
+		cy.findByText('Amend').click();
+
+		cy.findByText('Choose the dates you will be away').should('exist');
+		cy.findByText('Please select your new dates...').should('exist');
+		cy.get('[aria-label="day"]').eq(0).should('have.value', '9');
+		cy.get('[aria-label="month"]').eq(0).should('have.value', '2');
+		cy.get('[aria-label="year"]').eq(0).should('have.value', '2022');
+		cy.get('[aria-label="day"]').eq(1).should('have.value', '11');
+		cy.get('[aria-label="month"]').eq(1).should('have.value', '2');
+		cy.get('[aria-label="year"]').eq(1).should('have.value', '2022');
+
+		cy.get('[data-cy="date-picker"] div').eq(16).click();
+		cy.get('[data-cy="date-picker"] div').eq(18).click();
+		cy.wait('@fetch_potential_holidays');
+
+		// Selects 16/02/2022 - 18/02/2022
+		cy.get('[aria-label="day"]').eq(0).should('have.value', '16');
+		cy.get('[aria-label="day"]').eq(1).should('have.value', '18');
+
+		// Total issues suspended
+		cy.get('[data-cy="suspension-issue-count"]').eq(0).contains('1 issue');
+
+		cy.get('@fetch_existing_holidays.all').should('have.length', 1);
+		cy.get('@product_detail.all').should('have.length', 1);
+		cy.get('@fetch_potential_holidays.all').should('have.length', 2);
+	});
+
+	it('can not create a holiday stop for date range when there are no deliveries', () => {
+		cy.intercept('GET', '/api/holidays/*/potential?*', {
+			statusCode: 200,
+			body: noPotentialDeliveries,
+		}).as('fetch_potential_holidays');
+
+		cy.visit('/suspend/guardianweekly');
+		cy.wait('@fetch_existing_holidays');
+		cy.wait('@product_detail');
+		cy.get('[data-cy="create-suspension-cta"] button').click();
+
+		// Selects 08/02/2022 - 10/02/2022
+		cy.get('[data-cy="date-picker"] div').eq(8).click();
+		cy.get('[data-cy="date-picker"] div').eq(10).click();
+		cy.wait('@fetch_potential_holidays');
+
+		cy.findByText('No issues occur during selected period').should('exist');
+
+		cy.get('@product_detail.all').should('have.length', 1);
+		cy.get('@fetch_potential_holidays.all').should('have.length', 1);
+	});
+
+	it('shows existing holidays stops on overview page', () => {
+		cy.visit('/suspend/guardianweekly');
+		cy.wait('@fetch_existing_holidays');
+		cy.wait('@product_detail');
+
+		cy.get('table').contains('11 March - 12 March 2022');
+
+		cy.get('@fetch_existing_holidays.all').should('have.length', 1);
+		cy.get('@product_detail.all').should('have.length', 1);
+	});
+
+	it('can amend an existing holiday stop from overview page', () => {
+		cy.visit('/suspend/guardianweekly');
+		cy.wait('@fetch_existing_holidays');
+		cy.wait('@product_detail');
+
+		cy.get('table').findByText('Amend').click();
+		cy.findByText('Please select your new dates...').should('exist');
+
+		// Selects 09/02/2022 - 11/02/2022
+		cy.get('[data-cy="date-picker"] div').eq(9).click();
+		cy.get('[data-cy="date-picker"] div').eq(11).click();
+		cy.wait('@fetch_potential_holidays');
+
+		cy.findByText('Review details').click();
+		cy.get('table').contains('9 February - 11 February 2022');
+
+		cy.get('@fetch_existing_holidays.all').should('have.length', 1);
+		cy.get('@product_detail.all').should('have.length', 1);
+	});
+
+	it('can delete an existing holiday stop from overview page', () => {
+		cy.intercept('DELETE', '/api/holidays/*/*', {
+			statusCode: 200,
+			body: {
+				message: 'success',
+			},
+		}).as('delete_holiday_stop');
+
+		cy.visit('/suspend/guardianweekly');
+		cy.wait('@fetch_existing_holidays');
+		cy.wait('@product_detail');
+
+		cy.get('table').findByText('Delete').click();
+
+		cy.intercept('GET', '/api/holidays/*', {
+			statusCode: 200,
+			body: existingHolidaysWithDeletion,
+		}).as('fetch_existing_holidays');
+
+		cy.findByRole('button', { name: 'Yes' }).click();
+		cy.wait('@delete_holiday_stop');
+		cy.wait('@fetch_existing_holidays');
+
+		cy.get('table').contains('Deleted on 7 April 2022');
+
+		cy.get('@fetch_existing_holidays.all').should('have.length', 2);
+		cy.get('@product_detail.all').should('have.length', 1);
+		cy.get('@delete_holiday_stop.all').should('have.length', 1);
+	});
+
+	it('can create a holiday stop where multiple products of the same type exist by navigating from the Account Overview page', () => {
+		cy.intercept('GET', '/api/me/mma', {
+			statusCode: 200,
+			body: toMembersDataApiResponse(
+				guardianWeeklyPaidByCard(),
+				guardianWeeklyPaidByCard(),
+			),
+		}).as('mma');
+
+		cy.intercept('GET', '/mpapi/user/mobile-subscriptions', {
+			statusCode: 200,
+			body: { subscriptions: [] },
+		}).as('mobile_subscriptions');
+
+		cy.intercept('GET', '/api/me/one-off-contributions', {
+			statusCode: 200,
+			body: [],
+		}).as('single_contributions');
+
+		cy.intercept('GET', '/api/holidays/*', {
+			statusCode: 200,
+			body: existingHolidays,
+		}).as('fetch_existing_holidays');
+
+		cy.intercept('GET', '/api/holidays/*/potential?*', {
+			statusCode: 200,
+			body: potentialDeliveries,
+		}).as('fetch_potential_holidays');
+
+		cy.visit('/');
+		cy.wait('@mma');
+		cy.wait('@cancelled');
+		cy.wait('@mobile_subscriptions');
+		cy.wait('@single_contributions');
+
+		cy.findByRole('heading', { name: 'Account overview' }).should('exist');
+		cy.findAllByText('Manage subscription').eq(0).click();
+
+		cy.findByText(/A-S00/).should('exist');
+
+		cy.visit('/');
+		cy.wait('@mma');
+		cy.wait('@cancelled');
+		cy.wait('@mobile_subscriptions');
+		cy.wait('@single_contributions');
+
+		cy.findAllByText('Manage subscription').eq(1).click();
+
+		cy.findByText(/A-S00/).should('exist');
+		cy.findByRole('link', { name: 'Manage suspensions' }).click();
+
+		cy.wait('@fetch_existing_holidays');
+		cy.get('[data-cy="create-suspension-cta"] button').click();
+
+		cy.findByText('Choose the dates you will be away').should('exist');
+
+		// Selects 09/02/2022 - 11/02/2022
+		cy.get('[data-cy="date-picker"] div').eq(9).click();
+		cy.get('[data-cy="date-picker"] div').eq(11).click();
+		cy.wait('@fetch_potential_holidays');
+
+		// Total issues suspended
+		cy.get('[data-cy="suspension-issue-count"]').eq(0).contains('1 issue');
+
+		cy.findByText('Review details').click();
+
+		cy.get('table').contains('9 February - 11 February 2022');
+		cy.get('table').contains('1 issue');
+		cy.get('table').contains('£2.89 off your 1 February 2023 payment');
+
+		cy.findByText('Confirm').click();
+
+		cy.wait('@create_holiday_stop');
+		cy.findByText('Your schedule has been set').should('exist');
+
+		cy.get('@create_holiday_stop.all').should('have.length', 1);
+	});
+
+	it('redirects you to the Account Overview page if the suspend URL is visited directly and there are multiple products of the same type', () => {
+		cy.intercept('GET', '/api/me/mma?productType=Weekly', {
+			statusCode: 200,
+			body: toMembersDataApiResponse(
+				guardianWeeklyPaidByCard(),
+				guardianWeeklyPaidByCard(),
+			),
+		}).as('mma_filtered');
+
+		cy.intercept('GET', '/api/me/mma', {
+			statusCode: 200,
+			body: toMembersDataApiResponse(
+				guardianWeeklyPaidByCard(),
+				guardianWeeklyPaidByCard(),
+			),
+		}).as('mma');
+
+		cy.intercept('GET', '/mpapi/user/mobile-subscriptions', {
+			statusCode: 200,
+			body: { subscriptions: [] },
+		}).as('mobile_subscriptions');
+
+		cy.intercept('GET', '/api/me/one-off-contributions', {
+			statusCode: 200,
+			body: { subscriptions: [] },
+		}).as('single_contributions');
+
+		cy.visit('/suspend/guardianweekly');
+
+		cy.wait('@mma_filtered');
+		cy.wait('@mma');
+		cy.wait('@cancelled');
+
+		cy.findByRole('heading', { name: 'Account overview' }).should('exist');
+		cy.findAllByText(/A-S00/).should('have.length', 2);
+	});
+
+	it('does not allow you to create more holiday stops than the subscriptions annual suspension limit', () => {
+		cy.intercept('GET', '/api/holidays/*/potential?*', {
+			statusCode: 200,
+			body: multiplePotentialDeliveries,
+		}).as('fetch_potential_holidays');
+
+		cy.visit('/suspend/guardianweekly');
+		cy.wait('@fetch_existing_holidays');
+		cy.wait('@product_detail');
+		cy.get('[data-cy="create-suspension-cta"] button').click();
+
+		cy.findByRole('button', { name: 'Go forward a month' }).click();
+
+		// Calendar has been advanced to the next month.
+		// Selects 18/03/2022 - 22/04/2022
+		cy.get('[data-cy="date-picker"] div').eq(53).click();
+		cy.get('[data-cy="date-picker"] div').eq(95).click();
+		cy.wait('@fetch_potential_holidays');
+
+		cy.findByText(/Exceeded issue limit of 6/).should('exist');
+	});
 
 	it('allows you to create a holiday stop that begins and ends in different years and correctly calculates remaining issues', () => {
 		cy.intercept('GET', '/api/holidays/*', {

--- a/cypress/integration/parallel-3/holidayStops.spec.ts
+++ b/cypress/integration/parallel-3/holidayStops.spec.ts
@@ -63,7 +63,7 @@ describe('Holiday stops', () => {
 
 		cy.get('table').contains('9 February - 11 February 2022');
 		cy.get('table').contains('1 issue');
-		cy.get('table').contains('$2.89 off your 1 February 2023 payment');
+		cy.get('table').contains('£2.89 off your 1 February 2023 payment');
 
 		cy.findByText('Confirm').click();
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

When updating the test product #1100 - accidentally commented out most of the cypress test for holiday stops. This wasn't caught in the diff since it wasn't rendered because the diff was too large (`Large diffs are not rendered by default.`) 🤦 


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
