### PR TITLE
Add eligibility check for post price risen members

### DIFF
--- a/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
@@ -15,6 +15,7 @@ import {
 	LoadingState,
 	useAsyncLoader,
 } from '../../../../utilities/hooks/useAsyncLoader';
+import { getNewMembershipPrice } from '../../../../utilities/membershipPriceRise';
 import { allRecurringProductsDetailFetcher } from '../../../../utilities/productUtils';
 import type { PhoneRegionKey } from '../../../shared/CallCenterEmailAndNumbers';
 import { CallCentreEmailAndNumbers } from '../../../shared/CallCenterEmailAndNumbers';
@@ -42,15 +43,21 @@ function ineligibleForSave(
 	const membershipTierIsNotSupporter =
 		membershipToCancel.tier !== 'Supporter';
 
-	const membershipIsAnnual =
-		(getMainPlan(membershipToCancel.subscription) as PaidSubscriptionPlan)
-			.billingPeriod === 'year';
+	const mainPlan = getMainPlan(
+		membershipToCancel.subscription,
+	) as PaidSubscriptionPlan;
+
+	const membershipIsAnnual = mainPlan.billingPeriod === 'year';
+
+	const hasBeenPriceRisen =
+		getNewMembershipPrice(mainPlan) === mainPlan.price / 100;
 
 	return (
 		inPaymentFailure ||
 		hasOtherProduct ||
 		membershipTierIsNotSupporter ||
-		membershipIsAnnual
+		membershipIsAnnual ||
+		hasBeenPriceRisen
 	);
 }
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

the server side is NOT using the price passed through from the client

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

add new 2023 price membership in zuora -> cancel membership and see OLD journey

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
