### PR TITLE
Group newsletters based on Group property

### DIFF
--- a/client/components/mma/identity/emailAndMarketing/NewsletterSection.tsx
+++ b/client/components/mma/identity/emailAndMarketing/NewsletterSection.tsx
@@ -3,7 +3,7 @@ import uniq from 'lodash/uniq';
 import type { FC } from 'react';
 import { DropMenu } from '../DropMenu';
 import type { ConsentOption } from '../models';
-import { Theme } from '../models';
+import { NewsletterGroup } from '../models';
 import { NewsletterPreference } from '../NewsletterPreference';
 import { PageSection } from '../PageSection';
 
@@ -41,21 +41,21 @@ function notEmpty<T>(value: T | undefined): value is T {
 	return value !== undefined;
 }
 
-function getColor(theme: string): string {
-	const colors: { [T in Theme]: string } = {
-		[Theme.news]: palette.news[400],
-		[Theme.opinion]: palette.opinion[500],
-		[Theme.features]: palette.neutral[7],
-		[Theme.sport]: palette.sport[400],
-		[Theme.culture]: '#a1845c',
-		[Theme.lifestyle]: palette.lifestyle[400],
-		[Theme.comment]: '#e05e00',
-		[Theme.work]: palette.neutral[7],
-		[Theme.fromThePapers]: palette.neutral[7],
+function getGroupColor(group: string): string {
+	const colors: { [T in NewsletterGroup]: string } = {
+		[NewsletterGroup.newsInBrief]: palette.news[400],
+		[NewsletterGroup.newsInDepth]: palette.news[400],
+		[NewsletterGroup.opinion]: palette.opinion[500],
+		[NewsletterGroup.features]: palette.neutral[7],
+		[NewsletterGroup.sport]: palette.sport[400],
+		[NewsletterGroup.culture]: '#a1845c',
+		[NewsletterGroup.lifestyle]: palette.lifestyle[400],
+		[NewsletterGroup.work]: palette.neutral[7],
+		[NewsletterGroup.fromThePapers]: palette.neutral[7],
 	};
 
-	if (theme in Theme) {
-		return colors[theme as Theme];
+	if (Object.values(NewsletterGroup).includes(group as NewsletterGroup)) {
+		return colors[group as NewsletterGroup];
 	}
 	return palette.neutral[7];
 }
@@ -64,12 +64,15 @@ const newsletterPreferenceGroups = (
 	newsletters: ConsentOption[],
 	clickHandler: ClickHandler,
 ) => {
-	const themes = uniq(newsletters.map((_) => _.theme)).filter(notEmpty);
-
-	return themes.map((theme) => (
-		<DropMenu key={theme} color={getColor(theme)} title={theme}>
+	const groups = uniq(newsletters.map((_) => _.group)).filter(notEmpty);
+	return groups.map((group) => (
+		<DropMenu
+			key={group}
+			color={getGroupColor(group.toLowerCase())}
+			title={group}
+		>
 			{newsletters
-				.filter((n) => n.theme === theme)
+				.filter((n) => n.group === group)
 				.map((n) => newsletterPreference(n, clickHandler))}
 		</DropMenu>
 	));

--- a/client/components/mma/identity/idapi/newsletters.ts
+++ b/client/components/mma/identity/idapi/newsletters.ts
@@ -5,6 +5,7 @@ import { APIPatchOptions, APIUseCredentials, identityFetch } from './fetch';
 interface NewsletterAPIResponse {
 	id: string;
 	theme: string;
+	group: string;
 	name: string;
 	description: string;
 	frequency: string;
@@ -19,6 +20,7 @@ const newsletterToConsentOption = (
 		id: identityName,
 		theme,
 		name,
+		group,
 		description,
 		frequency,
 		exactTargetListId,
@@ -28,6 +30,7 @@ const newsletterToConsentOption = (
 		description,
 		theme,
 		type: ConsentOptionType.NEWSLETTER,
+		group,
 		name,
 		frequency,
 		subscribed: false,
@@ -37,9 +40,11 @@ const newsletterToConsentOption = (
 
 export const read = async (): Promise<ConsentOption[]> => {
 	const url = '/newsletters';
-	return (await identityFetch<NewsletterAPIResponse[]>(url)).map(
-		newsletterToConsentOption,
+	const newslettersResponse = await identityFetch<NewsletterAPIResponse[]>(
+		url,
 	);
+	console.log({ idapiNewslettersResponse: newslettersResponse });
+	return newslettersResponse.map(newsletterToConsentOption);
 };
 
 export const readRestricted = async (): Promise<ConsentOption[]> => {

--- a/client/components/mma/identity/idapi/newsletters.ts
+++ b/client/components/mma/identity/idapi/newsletters.ts
@@ -43,7 +43,6 @@ export const read = async (): Promise<ConsentOption[]> => {
 	const newslettersResponse = await identityFetch<NewsletterAPIResponse[]>(
 		url,
 	);
-	console.log({ idapiNewslettersResponse: newslettersResponse });
 	return newslettersResponse.map(newsletterToConsentOption);
 };
 

--- a/client/components/mma/identity/models.ts
+++ b/client/components/mma/identity/models.ts
@@ -1,14 +1,15 @@
 /* eslint-disable @typescript-eslint/naming-convention -- disabling this rule due to uncertainty around coupling between enum values and API responses in Identity code */
-export enum Theme {
-	news = 'news',
+
+export enum NewsletterGroup {
+	newsInDepth = 'news in depth',
+	newsInBrief = 'news in brief',
 	opinion = 'opinion',
 	features = 'features',
-	sport = 'sport',
 	culture = 'culture',
 	lifestyle = 'lifestyle',
-	comment = 'comment',
+	sport = 'sport',
 	work = 'work',
-	fromThePapers = 'From the papers',
+	fromThePapers = 'from the papers',
 }
 
 export enum ErrorTypes {
@@ -64,6 +65,7 @@ export interface ConsentOption {
 	frequency?: string;
 	name: string;
 	theme?: string;
+	group?: string;
 	type: ConsentOptionType;
 	subscribed: boolean;
 	identityName?: string;

--- a/client/fixtures/newsletters.ts
+++ b/client/fixtures/newsletters.ts
@@ -11,6 +11,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'TodayUk_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'today_uk',
 		theme: 'news',
+		group: 'news in brief',
 		description:
 			"A digest of the morning's main headlines emailed direct to you every week day",
 		frequency: 'Every day',
@@ -37,6 +38,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'TodayUs_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'today_us',
 		theme: 'news',
+		group: 'news in brief',
 		description:
 			'For US readers, we offer a regional edition of our daily email, delivering the most important headlines every morning',
 		frequency: 'Every day',
@@ -94,6 +96,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'MorningBriefingUk_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'morning_briefing_uk',
 		theme: 'news',
+		group: 'news in brief',
 		description:
 			'Start the day one step ahead. Our email breaks down the key stories of the day and why they matter',
 		frequency: 'Every weekday',
@@ -122,6 +125,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'MorningBriefingUs_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'morning_briefing_us',
 		theme: 'news',
+		group: 'news in brief',
 		description:
 			'Start the day with the top stories from the US, plus the day’s must-reads from across the Guardian',
 		frequency: 'Every weekday',
@@ -155,6 +159,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'MorningMailAus_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'morning_mail_aus',
 		theme: 'news',
+		group: 'news in brief',
 		description:
 			'Our Australian morning briefing email breaks down the key national and international stories of the day and why they matter',
 		frequency: 'Every weekday',
@@ -184,6 +189,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'TechScape_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'tech_scape',
 		theme: 'news',
+		group: 'news in depth',
 		description:
 			"Alex Hern's weekly dive in to how technology is shaping our lives",
 		frequency: 'Weekly',
@@ -209,6 +215,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'GlobalDispatch_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'global_dispatch',
 		theme: 'news',
+		group: 'news in brief',
 		description:
 			'Get a different world view with a roundup of the best news, features and pictures, curated by our global development team',
 		frequency: 'Every fortnight',
@@ -236,6 +243,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'BusinessToday_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'business_today',
 		theme: 'news',
+		group: 'news in brief',
 		description:
 			"Get set for the working day – we'll point you to the all the business news and analysis you need every morning",
 		frequency: 'Every weekday',
@@ -268,6 +276,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'GreenLight_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'green_light',
 		theme: 'news',
+		group: 'news in depth',
 		description:
 			"The planet's most important stories. Get all the week's environment news - the good, the bad and the essential",
 		frequency: 'Weekly',
@@ -299,6 +308,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'TheUsPoliticsMinute_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'the_us_politics_minute',
 		theme: 'news',
+		group: 'news in brief',
 		description:
 			'Keeping you up to date on the systemic ways voting rights are denied to so many Americans',
 		frequency: 'Weekly during election season',
@@ -332,6 +342,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'AustralianPolitics_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'australian_politics',
 		theme: 'news',
+		group: 'news in brief',
 		description:
 			'From the big, breaking news to quiet, thoughtful analysis, all you need to keep up with Australian political manoeuvres',
 		frequency: 'Every weekday',
@@ -359,6 +370,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'TheRuralNetwork_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'the_rural_network',
 		theme: 'news',
+		group: 'news in depth',
 		description:
 			'Subscribe to Gabrielle Chan’s fortnightly update on Australian rural and regional affairs',
 		frequency: 'Every fortnight',
@@ -384,6 +396,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'GuardianDocumentaries_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'guardian_documentaries',
 		theme: 'features',
+		group: 'features',
 		description:
 			'Be the first to see our latest thought-provoking films, bringing you bold and original storytelling from around the world',
 		frequency: 'Whenever a new film is available',
@@ -412,6 +425,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'TheLongRead_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'the_long_read',
 		theme: 'features',
+		group: 'features',
 		description:
 			'Lose yourself in a great story: from politics to psychology, food to technology, culture to crime',
 		frequency: 'Weekly',
@@ -438,6 +452,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'AnimalsFarmed_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'animals_farmed',
 		theme: 'features',
+		group: 'features',
 		description:
 			'Get a round-up of the best farming and food stories across the world and keep up with our investigation as we track the impact intensive practices and meet those offering sustainable solutions to feed us all.',
 		frequency: 'Monthly',
@@ -466,6 +481,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'HerStage_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'her_stage',
 		theme: 'features',
+		group: 'features',
 		description:
 			' Hear directly from incredible women from around the world on the issues that matter most to them – from the climate crisis to the arts to sport',
 		frequency: 'Monthly',
@@ -490,6 +506,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'Tokyo2020DailyBriefing_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'tokyo_2020_daily_briefing',
 		theme: 'sport',
+		group: 'sport',
 		description:
 			'Our daily email briefing will help you keep up with all the goings on at the Olympics',
 		frequency: 'Daily',
@@ -515,6 +532,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'TheRecap_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'the_recap',
 		theme: 'sport',
+		group: 'sport',
 		description:
 			'The best of our sports journalism from the past seven days and a heads-up on the weekend’s action',
 		frequency: 'Weekly',
@@ -547,6 +565,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'TheFiver_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'the_fiver',
 		theme: 'sport',
+		group: 'sport',
 		description:
 			"Kick off your evenings with the Guardian's take on the world of football",
 		frequency: 'Every weekday',
@@ -579,6 +598,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'TheBreakdown_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'the_breakdown',
 		theme: 'sport',
+		group: 'sport',
 		description:
 			"The latest rugby union news and analysis, plus all the week's action reviewed",
 		frequency: 'Weekly',
@@ -611,6 +631,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'TheSpin_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'the_spin',
 		theme: 'sport',
+		group: 'sport',
 		description:
 			"Subscribe to our cricket newsletter for our writers' thoughts on the biggest stories and a review of the week’s action",
 		frequency: 'Weekly',
@@ -643,6 +664,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'GuardianAustraliaSports_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'guardian_australia_sports',
 		theme: 'sport',
+		group: 'sport',
 		description:
 			'Get a daily roundup of the latest sports news, features and comment from our Australian sports desk',
 		frequency: 'Every day',
@@ -675,6 +697,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'SleeveNotes_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'sleeve_notes',
 		theme: 'culture',
+		group: 'culture',
 		description:
 			'Get music news, bold reviews and unexpected extras. Every genre, every era, every week',
 		frequency: 'Weekly',
@@ -702,6 +725,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'FilmToday_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'film_today',
 		theme: 'culture',
+		group: 'culture',
 		description:
 			'Take a front seat at the cinema with our weekly email filled with all the latest news and all the movie action that matters',
 		frequency: 'Every week',
@@ -728,6 +752,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'Bookmarks_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'bookmarks',
 		theme: 'culture',
+		group: 'culture',
 		description:
 			'Discover new books with our expert reviews, author interviews and top 10s. Literary delights delivered direct you',
 		frequency: 'Weekly',
@@ -754,6 +779,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'ArtWeekly_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'art_weekly',
 		theme: 'culture',
+		group: 'culture',
 		description:
 			'Your weekly art world round-up, sketching out all the biggest stories, scandals and exhibitions',
 		frequency: 'Weekly',
@@ -781,6 +807,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'HearHere_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'hear_here',
 		theme: 'culture',
+		group: 'culture',
 		description:
 			"Podcast recommendations for unexpected audio pleasures. Our reviewers and audio producers pick the week's top shows",
 		frequency: 'Weekly',
@@ -809,6 +836,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'PushingButtons_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'pushing_buttons',
 		theme: 'culture',
+		group: 'culture',
 		description: "Keza MacDonald's weekly look at the world of gaming",
 		frequency: 'Weekly',
 		exactTargetListId: 6017,
@@ -831,6 +859,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'DesignReview_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'design_review',
 		theme: 'lifestyle',
+		group: 'lifestyle',
 		description:
 			'Get a dose of creative inspiration. Expect original, sustainable ideas and reflection from designers and crafters, along with clever, beautiful products for smarter living',
 		frequency: 'Monthly',
@@ -858,6 +887,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'FashionStatement_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'fashion_statement',
 		theme: 'lifestyle',
+		group: 'lifestyle',
 		description:
 			'Style with substance: smart fashion writing and inspiring shopping galleries - expect both expertise and irreverence',
 		frequency: 'Weekly',
@@ -885,6 +915,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'TheGuideStayingIn_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'the_guide_staying_in',
 		theme: 'lifestyle',
+		group: 'lifestyle',
 		description:
 			'Home entertainment tips delivered straight to your sofa. The best TV and box sets, games, podcasts, books and more',
 		frequency: 'Weekly',
@@ -912,6 +943,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'SavedForLater_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'saved_for_later',
 		theme: 'lifestyle',
+		group: 'lifestyle',
 		description:
 			"Catch up on the fun stuff with Guardian Australia's culture and lifestyle rundown of pop culture, trends and tips",
 		frequency: 'Weekly',
@@ -939,6 +971,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'FiveGreatReads_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'five_great_reads',
 		theme: 'lifestyle',
+		group: 'lifestyle',
 		description:
 			'During the holiday season Lifestyle editor Alyx Gorman will do the heavy lifting for you and list five of the most interesting, entertaining, and thoughtful reads. Sign up and receive it in your inbox from Monday to Friday.',
 		frequency: 'Monday to Friday',
@@ -963,6 +996,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'WordOfMouth_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'word_of_mouth',
 		theme: 'lifestyle',
+		group: 'lifestyle',
 		description:
 			'Recipes from all our star cooks, seasonal eating ideas and restaurant reviews. Get our best food writing every week',
 		frequency: 'Weekly',
@@ -990,6 +1024,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'BestOfGuardianOpinionUK_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'best_of_guardian_opinion_uk',
 		theme: 'comment',
+		group: 'opinion',
 		description:
 			'Get out of your bubble. Sign up for our daily selection of opinion pieces and and see things from another point of view',
 		frequency: 'Every weekday',
@@ -1016,6 +1051,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'ThisIsEurope_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'this_is_europe',
 		theme: 'comment',
+		group: 'opinion',
 		description:
 			'The most pivotal stories and debates for Europeans – from identity to economics to the environment',
 		frequency: 'Weekly',
@@ -1043,6 +1079,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'BestOfGuardianOpinionUS_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'best_of_guardian_opinion_us',
 		theme: 'comment',
+		group: 'opinion',
 		description:
 			"Join the debate on America's most pressing issues with the US edition of our daily op-ed selection",
 		frequency: 'Every weekday',
@@ -1070,6 +1107,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'TheWeekInPatriarchy_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'the_week_in_patriarchy',
 		theme: 'comment',
+		group: 'opinion',
 		description:
 			'Reviewing the most important stories on feminism and sexism and those fighting for equality',
 		frequency: 'Weekly',
@@ -1098,6 +1136,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'BestOfGuardianOpinionAus_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'best_of_guardian_opinion_aus',
 		theme: 'comment',
+		group: 'opinion',
 		description:
 			'Challenge your own perceptions with a daily selection of the opinion pieces from Australia',
 		frequency: 'Every weekday',
@@ -1125,6 +1164,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'FirstDogOnTheMoon_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'first_dog_on_the_moon',
 		theme: 'comment',
+		group: 'opinion',
 		description:
 			'Get an email alert whenever a new First Dog on the Moon cartoon is published by Guardian Australia',
 		frequency: 'About three times a week',
@@ -1152,6 +1192,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'InsideSaturday_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'inside_saturday',
 		theme: 'From the papers',
+		group: 'From the papers',
 		description:
 			'The only way to get a look behind the scenes of our brand new magazine, Saturday. Sign up to get the inside story from our top writers as well as all the must-read articles and columns, delivered to your inbox every weekend.',
 		frequency: 'Weekly',
@@ -1178,6 +1219,7 @@ export const newsletters = [
 		brazeSubscribeAttributeName: 'TheObserverFoodMonthly_Subscribe_Email',
 		brazeSubscribeEventNamePrefix: 'the_observer_food_monthly',
 		theme: 'From the papers',
+		group: 'From the papers',
 		description:
 			'Find out what’s coming up in the latest edition of the magazine plus our favourite food and drink tips',
 		frequency: 'Monthly',


### PR DESCRIPTION
Newsletters in the MMA page are currently grouped using the theme property. This is different to the grouping logic in the [all Newsletters Page](https://www.theguardian.com/email-newsletters). 

## What does this change?

Updates the Newsletters type to include the group property which is [now returned from the identity API](https://github.com/guardian/identity/pull/2420) & uses this to group Newsletters instead of theme. The Colour mapping has been updated too. With the `News in Brief` & `News in Depth` sections using the News colour. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Verify changes as expected and Subscribe / unsubscribe behaviour as before

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?


## Have we considered potential risks?

Behaviour very similar to previous state. Not expecting any issues. 
Needs a test in code but should be ok

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

**Before**

![Screenshot 2023-07-04 at 08 37 50](https://github.com/guardian/manage-frontend/assets/3277259/b90d5fe0-30f3-4c80-af61-91a6c8701a41)

**After**

![Screenshot 2023-07-04 at 08 37 44](https://github.com/guardian/manage-frontend/assets/3277259/401014fe-da73-4713-a78a-d6b1e4fd1d62)


![Screenshot 2023-07-04 at 08 38 41](https://github.com/guardian/manage-frontend/assets/3277259/045e00cc-7209-4da2-aaac-7600fcfdcbfc)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
