### PR TITLE
Bring back useScrollToTop

### DIFF
--- a/client/components/helpCentre/HelpCentrePage.tsx
+++ b/client/components/helpCentre/HelpCentrePage.tsx
@@ -7,6 +7,7 @@ import { global } from '../../styles/global';
 import { useAnalytics } from '../../utilities/hooks/useAnalytics';
 import { useConsent } from '../../utilities/hooks/useConsent';
 import { useScrollToHashElement } from '../../utilities/hooks/useScrollToHashElement';
+import { useScrollToTop } from '../../utilities/hooks/useScrollToTop';
 import { setPageTitle } from '../../utilities/pageTitle';
 import type { SignInStatus } from '../../utilities/signInStatus';
 import { isSignedIn } from '../../utilities/signInStatus';
@@ -62,6 +63,7 @@ const HelpCentreRouter = () => {
 	useAnalytics();
 	setPageTitle();
 	useConsent();
+	useScrollToTop();
 	useScrollToHashElement();
 
 	/*

--- a/client/components/mma/MMAPage.tsx
+++ b/client/components/mma/MMAPage.tsx
@@ -25,6 +25,7 @@ import { global } from '../../styles/global';
 import { getCookie } from '../../utilities/cookies';
 import { useAnalytics } from '../../utilities/hooks/useAnalytics';
 import { useConsent } from '../../utilities/hooks/useConsent';
+import { useScrollToTop } from '../../utilities/hooks/useScrollToTop';
 import {
 	hasDeliveryFlow,
 	hasDeliveryRecordsFlow,
@@ -378,6 +379,7 @@ const MMARouter = () => {
 
 	useAnalytics();
 	useConsent();
+	useScrollToTop();
 
 	return (
 		<Main signInStatus={signInStatus}>

--- a/client/utilities/hooks/useScrollToTop.ts
+++ b/client/utilities/hooks/useScrollToTop.ts
@@ -1,0 +1,17 @@
+import { useLocation } from 'react-router-dom';
+
+const exceptions: string[] = ['/help-centre/contact-us/'];
+
+const shouldScrollToTop = (path: string) =>
+	!exceptions.some((exception) => path.startsWith(exception));
+
+export const useScrollToTop = () => {
+	const location = useLocation();
+
+	if (shouldScrollToTop(location.pathname)) {
+		// tslint:disable-next-line:no-object-mutation
+		document.body.scrollTop = 0; // For Safari
+		// tslint:disable-next-line:no-object-mutation
+		document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
+	}
+};


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Removed in #1128 - brings back the `useScrollToTop` hook on mma pages

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Scroll down a page - then click a reactRouter link (eg in sidenav) and the page should go back to the top (logo at the top visible)

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
