### PR TITLE
Fix deliveryAddress change bug when user has supporterPlus

### DIFF
--- a/client/utilities/deliveryAddress.ts
+++ b/client/utilities/deliveryAddress.ts
@@ -36,9 +36,9 @@ export const getValidDeliveryAddressChangeEffectiveDates = (
 		.map((productDetail) => ({
 			productDetail,
 			productType:
-				GROUPED_PRODUCT_TYPES.subscriptions.mapGroupedToSpecific(
-					productDetail,
-				),
+				GROUPED_PRODUCT_TYPES[
+					productDetail.mmaCategory
+				].mapGroupedToSpecific(productDetail),
 		}))
 		.filter((_) => _.productType.delivery?.showAddress)
 		.reduce(

--- a/cypress/integration/parallel-4/deliveryAddress.spec.ts
+++ b/cypress/integration/parallel-4/deliveryAddress.spec.ts
@@ -1,4 +1,7 @@
-import { guardianWeeklyPaidByCard } from '../../../client/fixtures/productBuilder/testProducts';
+import {
+	guardianWeeklyPaidByCard,
+	supporterPlus,
+} from '../../../client/fixtures/productBuilder/testProducts';
 import { toMembersDataApiResponse } from '../../../client/fixtures/mdapiResponse';
 import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
 
@@ -8,7 +11,10 @@ describe('Delivery address', () => {
 
 		cy.intercept('GET', '/api/me/mma?productType=ContentSubscription', {
 			statusCode: 200,
-			body: toMembersDataApiResponse(guardianWeeklyPaidByCard()),
+			body: toMembersDataApiResponse(
+				guardianWeeklyPaidByCard(),
+				supporterPlus(),
+			),
 		}).as('product_detail');
 
 		cy.intercept('GET', '/api/cancelled/', {
@@ -20,7 +26,10 @@ describe('Delivery address', () => {
 	it('Can update delivery address. Navigating from account overview', () => {
 		cy.intercept('GET', '/api/me/mma', {
 			statusCode: 200,
-			body: toMembersDataApiResponse(guardianWeeklyPaidByCard()),
+			body: toMembersDataApiResponse(
+				guardianWeeklyPaidByCard(),
+				supporterPlus(),
+			),
 		}).as('mma');
 
 		cy.intercept('GET', '/mpapi/user/mobile-subscriptions', {
@@ -70,7 +79,10 @@ describe('Delivery address', () => {
 	it('Shows updated address when returning to manage subscription page', () => {
 		cy.intercept('GET', '/api/me/mma', {
 			statusCode: 200,
-			body: toMembersDataApiResponse(guardianWeeklyPaidByCard()),
+			body: toMembersDataApiResponse(
+				guardianWeeklyPaidByCard(),
+				supporterPlus(),
+			),
 		}).as('mma');
 
 		cy.intercept('GET', '/mpapi/user/mobile-subscriptions', {

--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -608,7 +608,7 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 			return calculateSupporterPlusTitle(billingPeriod);
 		},
 		productType: 'supporterplus',
-		groupedProductType: 'subscriptions',
+		groupedProductType: 'recurringSupport',
 		allProductsProductTypeFilterString: 'SupporterPlus',
 		urlPart: 'support',
 		getOphanProductType: () => 'SUPPORTER_PLUS',
@@ -688,6 +688,8 @@ export const GROUPED_PRODUCT_TYPES: {
 		) => {
 			if (productDetail.tier === 'Contributor') {
 				return PRODUCT_TYPES.contributions;
+			} else if (productDetail.tier === 'Supporter Plus') {
+				return PRODUCT_TYPES.supporterplus;
 			}
 			throw `recurringSupport: Specific product type for tier '${productDetail.tier}' not found.`;
 		},
@@ -716,8 +718,6 @@ export const GROUPED_PRODUCT_TYPES: {
 				return PRODUCT_TYPES.guardianweekly;
 			} else if (productDetail.tier.startsWith('guardianpatron')) {
 				return PRODUCT_TYPES.guardianpatron;
-			} else if (productDetail.tier === 'Supporter Plus') {
-				return PRODUCT_TYPES.supporterplus;
 			}
 			throw `subscriptions: Specific product type for tier '${productDetail.tier}' not found.`;
 		},

--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -681,17 +681,17 @@ export const GROUPED_PRODUCT_TYPES: {
 		productTitle: () => 'Recurring support',
 		friendlyName: () => 'recurring support',
 		groupFriendlyName: 'recurring support',
-		allProductsProductTypeFilterString: 'Contribution',
+		allProductsProductTypeFilterString: 'SupporterPlus', // this will only return SupporterPlus, and not Contributions
 		urlPart: 'recurringsupport',
 		mapGroupedToSpecific: (
 			productDetail: ProductDetail | CancelledProductDetail,
 		) => {
-			if (productDetail.tier === 'Contributor') {
-				return PRODUCT_TYPES.contributions;
-			} else if (productDetail.tier === 'Supporter Plus') {
+			if (productDetail.tier === 'Supporter Plus') {
 				return PRODUCT_TYPES.supporterplus;
+			} else if (productDetail.tier === 'Contributor') {
+				return PRODUCT_TYPES.contributions;
 			}
-			throw `recurringSupport: Specific product type for tier '${productDetail.tier}' not found.`;
+			throw `Specific product type for tier '${productDetail.tier}' not found.`;
 		},
 		showSupporterId: true,
 	},
@@ -719,7 +719,7 @@ export const GROUPED_PRODUCT_TYPES: {
 			} else if (productDetail.tier.startsWith('guardianpatron')) {
 				return PRODUCT_TYPES.guardianpatron;
 			}
-			throw `subscriptions: Specific product type for tier '${productDetail.tier}' not found.`;
+			throw `Specific product type for tier '${productDetail.tier}' not found.`;
 		},
 		cancelledCopy:
 			'Your subscription has been cancelled. You are able to access your subscription until',

--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -608,7 +608,7 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 			return calculateSupporterPlusTitle(billingPeriod);
 		},
 		productType: 'supporterplus',
-		groupedProductType: 'recurringSupport',
+		groupedProductType: 'subscriptions',
 		allProductsProductTypeFilterString: 'SupporterPlus',
 		urlPart: 'support',
 		getOphanProductType: () => 'SUPPORTER_PLUS',

--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -681,17 +681,15 @@ export const GROUPED_PRODUCT_TYPES: {
 		productTitle: () => 'Recurring support',
 		friendlyName: () => 'recurring support',
 		groupFriendlyName: 'recurring support',
-		allProductsProductTypeFilterString: 'SupporterPlus', // this will only return SupporterPlus, and not Contributions
+		allProductsProductTypeFilterString: 'Contribution',
 		urlPart: 'recurringsupport',
 		mapGroupedToSpecific: (
 			productDetail: ProductDetail | CancelledProductDetail,
 		) => {
-			if (productDetail.tier === 'Supporter Plus') {
-				return PRODUCT_TYPES.supporterplus;
-			} else if (productDetail.tier === 'Contributor') {
+			if (productDetail.tier === 'Contributor') {
 				return PRODUCT_TYPES.contributions;
 			}
-			throw `Specific product type for tier '${productDetail.tier}' not found.`;
+			throw `recurringSupport: Specific product type for tier '${productDetail.tier}' not found.`;
 		},
 		showSupporterId: true,
 	},
@@ -718,8 +716,10 @@ export const GROUPED_PRODUCT_TYPES: {
 				return PRODUCT_TYPES.guardianweekly;
 			} else if (productDetail.tier.startsWith('guardianpatron')) {
 				return PRODUCT_TYPES.guardianpatron;
+			} else if (productDetail.tier === 'Supporter Plus') {
+				return PRODUCT_TYPES.supporterplus;
 			}
-			throw `Specific product type for tier '${productDetail.tier}' not found.`;
+			throw `subscriptions: Specific product type for tier '${productDetail.tier}' not found.`;
 		},
 		cancelledCopy:
 			'Your subscription has been cancelled. You are able to access your subscription until',


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Attempting to fix a bug: 
Supporter Plus products are returned when using the filter string `ContentSubscription` ([mdapi reference](https://github.com/guardian/members-data-api/blob/65a424f35ee484f2e30a3e9bbfed4062e1e8c6e8/membership-attribute-service/app/services/AccountDetailsFromZuora.scala#L207)). MMA expects everything returned when using that filter string to belong to the `GROUPED_PRODUCT_TYPE` of `subscriptions`. In the delivery address components there is a lookup to get the specific product type which threw an error since `supporterPlus` is not in `subscriptions`. 

This PR fixes the error by using the `mmaCategory` from `MDAPI` to get the `GROUPED_PRODUCT_TYPE` instead of assuming it is `subscriptions` (the supporterPlus is then filtered out anyway)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Take out a supporter plus - then a newspaper home delivery. Go to manage subscription of the delivery product and update the address, do not see error screen.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
