### PR TITLE
Update delivery records storybook

### DIFF
--- a/client/components/mma/delivery/records/DeliveryRecords.stories.tsx
+++ b/client/components/mma/delivery/records/DeliveryRecords.stories.tsx
@@ -1,4 +1,4 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { rest } from 'msw';
 import { ReactRouterDecorator } from '../../../../../.storybook/ReactRouterDecorator';
 import type { ProductTypeWithDeliveryRecordsProperties } from '../../../../../shared/productTypes';
@@ -10,20 +10,6 @@ import { DeliveryRecordsContainer } from './DeliveryRecordsContainer';
 import { DeliveryRecordsProblemConfirmation } from './DeliveryRecordsProblemConfirmation';
 import { DeliveryRecordsProblemReview } from './DeliveryRecordsProblemReview';
 
-const productTypeWithDeliveryRecords = {
-	...PRODUCT_TYPES.guardianweekly,
-	delivery: {
-		records: {
-			productNameForProblemReport: '',
-			showDeliveryInstructions: true,
-			numberOfProblemRecordsToShow: 0,
-			contactUserOnExistingProblemReport: true,
-			availableProblemTypes: [],
-		},
-		enableDeliveryInstructionsUpdate: true,
-	},
-} as ProductTypeWithDeliveryRecordsProperties;
-
 export default {
 	component: DeliveryRecordsContainer,
 	title: 'Pages/DeliveryHistory',
@@ -33,14 +19,16 @@ export default {
 			state: { productDetail: guardianWeeklyPaidByCard() },
 			container: (
 				<DeliveryRecordsContainer
-					productType={productTypeWithDeliveryRecords}
+					productType={
+						PRODUCT_TYPES.guardianweekly as ProductTypeWithDeliveryRecordsProperties
+					}
 				/>
 			),
 		},
 	},
-} as ComponentMeta<typeof DeliveryRecordsContainer>;
+} as Meta<typeof DeliveryRecordsContainer>;
 
-export const DeliveryHistory: ComponentStory<typeof DeliveryRecords> = () => {
+export const DeliveryHistory: StoryFn<typeof DeliveryRecords> = () => {
 	return <DeliveryRecords />;
 };
 
@@ -52,9 +40,7 @@ DeliveryHistory.parameters = {
 	],
 };
 
-export const Review: ComponentStory<
-	typeof DeliveryRecordsProblemReview
-> = () => {
+export const Review: StoryFn<typeof DeliveryRecordsProblemReview> = () => {
 	return <DeliveryRecordsProblemReview />;
 };
 
@@ -69,7 +55,7 @@ Review.parameters = {
 	},
 };
 
-export const Confirmation: ComponentStory<
+export const Confirmation: StoryFn<
 	typeof DeliveryRecordsProblemConfirmation
 > = () => {
 	return <DeliveryRecordsProblemConfirmation />;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Update the delivery records storybook - use the normal GuardianWeekly productType. The extra const seems unnecessary and made taking screenshots from the storybook confusing. If you click the `Report a problem` button in the story now you see:
![image](https://github.com/guardian/manage-frontend/assets/114918544/e678966a-c71b-49c3-b9c0-63c23d5742b1)


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
