### PR TITLE
Call new update supporter plus amount endpoint

### DIFF
--- a/client/__tests__/components/updateAmount/supporterPlusUpdateAmount.test.tsx
+++ b/client/__tests__/components/updateAmount/supporterPlusUpdateAmount.test.tsx
@@ -24,8 +24,8 @@ beforeEach(() => {
 				headers: {
 					get: () => 'pass',
 				},
-				text: () => {
-					'hurrah';
+				json: () => {
+					'success';
 				},
 			});
 		});

--- a/cypress/integration/parallel-1/updateContributionAmount.spec.ts
+++ b/cypress/integration/parallel-1/updateContributionAmount.spec.ts
@@ -50,6 +50,11 @@ describe('Update contribution amount', () => {
 		cy.intercept('POST', '/api/update/amount/**', {
 			statusCode: 200,
 		}).as('update_amount');
+
+		cy.intercept('POST', '/api/update-supporter-plus-amount/**', {
+			statusCode: 200,
+			body: { message: 'success' },
+		}).as('supporter_plus_update_amount');
 	});
 
 	it('Updates recurring contribution amount', () => {
@@ -99,7 +104,7 @@ describe('Update contribution amount', () => {
 
 		cy.findByText('Change amount').click();
 
-		cy.wait('@update_amount');
+		cy.wait('@supporter_plus_update_amount');
 
 		cy.contains(
 			'We have successfully updated the amount of your contribution.',

--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -180,6 +180,15 @@ router.post(
 	),
 );
 
+router.post(
+	'/update-supporter-plus-amount/:subscriptionName',
+	productMoveAPI(
+		'update-supporter-plus-amount/:subscriptionName',
+		'MOVE_PRODUCT_UPDATE_AMOUNT',
+		['subscriptionName'],
+	),
+);
+
 router.get(
 	'/holidays/:subscriptionName/potential',
 	holidayStopAPI('potential/:subscriptionName', 'HOLIDAY_STOP_POTENTIALS', [

--- a/shared/featureSwitches.ts
+++ b/shared/featureSwitches.ts
@@ -27,5 +27,5 @@ export const featureSwitches: Record<string, boolean> = {
 	appSubscriptions: true,
 	singleContributions: true,
 	membershipSave: true,
-	supporterPlusUpdateAmount: false,
+	supporterPlusUpdateAmount: true,
 };

--- a/shared/featureSwitches.ts
+++ b/shared/featureSwitches.ts
@@ -27,5 +27,5 @@ export const featureSwitches: Record<string, boolean> = {
 	appSubscriptions: true,
 	singleContributions: true,
 	membershipSave: true,
-	supporterPlusUpdateAmount: true,
+	supporterPlusUpdateAmount: false,
 };


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Call the new endpoint in to update the amount of a supporter plus subscription. This is still behind a feature flag.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

With a supporter plus sub, go to `/?withFeature=supporterPlusUpdateAmount` and click `Manage Recurring Support'. Change the amount, click confirm. 

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
