### PR TITLE
Update Supporter Plus V2 Ts and Cs in Product Switching

### DIFF
--- a/client/components/mma/switch/review/SwitchReview.stories.tsx
+++ b/client/components/mma/switch/review/SwitchReview.stories.tsx
@@ -1,7 +1,8 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { rest } from 'msw';
 import { ReactRouterDecorator } from '../../../../../.storybook/ReactRouterDecorator';
 import {
+	annualContributionPaidByCardWithCurrency,
 	contributionPaidByCard,
 	contributionPaidByDirectDebit,
 	contributionPaidByPayPal,
@@ -26,11 +27,9 @@ export default {
 			}),
 		],
 	},
-} as ComponentMeta<typeof SwitchContainer>;
+} as Meta<typeof SwitchContainer>;
 
-export const Default: ComponentStory<typeof SwitchReview> = () => (
-	<SwitchReview />
-);
+export const Default: StoryFn<typeof SwitchReview> = () => <SwitchReview />;
 // We're not setting `state` in the component-level parameters above due to how
 // parameters on individual stories are merged with these. This doesn't
 // necessarily cause an issue, but in the case of payments different properties
@@ -45,7 +44,7 @@ Default.parameters = {
 	},
 };
 
-export const WithPayPalPayment: ComponentStory<typeof SwitchReview> = () => (
+export const WithPayPalPayment: StoryFn<typeof SwitchReview> = () => (
 	<SwitchReview />
 );
 WithPayPalPayment.parameters = {
@@ -54,46 +53,38 @@ WithPayPalPayment.parameters = {
 	},
 };
 
-export const WithDirectDebitPayment: ComponentStory<
-	typeof SwitchReview
-> = () => <SwitchReview />;
+export const WithDirectDebitPayment: StoryFn<typeof SwitchReview> = () => (
+	<SwitchReview />
+);
 WithDirectDebitPayment.parameters = {
 	reactRouter: {
 		state: { productDetail: contributionPaidByDirectDebit() },
 	},
 };
 
-export const WithSEPAPayment: ComponentStory<typeof SwitchReview> = () => (
+export const WithSEPAPayment: StoryFn<typeof SwitchReview> = () => (
 	<SwitchReview />
 );
+
 WithSEPAPayment.parameters = {
 	reactRouter: {
 		state: { productDetail: contributionPaidBySepa() },
 	},
 };
 
-export const YearlyOtherCurrency: ComponentStory<typeof SwitchReview> = () => (
+export const YearlyOtherCurrency: StoryFn<typeof SwitchReview> = () => (
 	<SwitchReview />
 );
-
-const contributionBelowThreshold = JSON.parse(
-	JSON.stringify(contributionPaidByCard()),
-);
-const plan = contributionBelowThreshold.subscription.currentPlans[0];
-plan.price = 300;
-plan.currency = '$';
-plan.billingPeriod = 'year';
-plan.currencyISO = 'NZD';
 
 YearlyOtherCurrency.parameters = {
 	reactRouter: {
-		state: { productDetail: contributionBelowThreshold },
+		state: {
+			productDetail: annualContributionPaidByCardWithCurrency('NZD'),
+		},
 	},
 };
 
-export const FromApp: ComponentStory<typeof SwitchReview> = () => (
-	<SwitchReview />
-);
+export const FromApp: StoryFn<typeof SwitchReview> = () => <SwitchReview />;
 
 FromApp.parameters = {
 	reactRouter: {

--- a/client/components/mma/switch/review/SwitchReview.tsx
+++ b/client/components/mma/switch/review/SwitchReview.tsx
@@ -392,7 +392,7 @@ export const SwitchReview = () => {
 					per {mainPlan.billingPeriod}, these additional amounts will
 					be separate {monthlyOrAnnual.toLowerCase()} voluntary
 					financial contributions to the Guardian. The Supporter Plus
-					subscription and any contributions will auto-renew each
+					subscription and any contributions will auto-renew each{' '}
 					{mainPlan.billingPeriod}. You will be charged the
 					subscription and contribution amounts using your chosen
 					payment method at each renewal unless you cancel. You can

--- a/client/components/mma/switch/review/SwitchReview.tsx
+++ b/client/components/mma/switch/review/SwitchReview.tsx
@@ -378,22 +378,34 @@ export const SwitchReview = () => {
 			)}
 			<section css={sectionSpacing}>
 				<p css={smallPrintCss}>
-					This subscription auto-renews each {mainPlan.billingPeriod}.
-					You will be charged the applicable{' '}
-					{monthlyOrAnnual.toLowerCase()} amount at each renewal
-					unless you cancel. Payment can only be made using your
-					existing payment method. You can cancel or change how much
-					you pay for these benefits at any time before your next
-					renewal date, but {mainPlan.currency}
+					If you pay at least {mainPlan.currency}
 					{formatAmount(monthlyThreshold)} per month or{' '}
 					{mainPlan.currency}
-					{formatAmount(annualThreshold)} per year is the minimum
-					payment. If you cancel within 14 days of taking out this
-					subscription, you’ll receive a full refund and your benefits
-					will stop immediately. Changes to your payment amount or
-					cancellation made after 14 days will take effect at the end
-					of your current subscription {mainPlan.billingPeriod}. To
-					cancel,{' '}
+					{formatAmount(annualThreshold)} per year, you will receive
+					the Supporter Plus benefits on a subscription basis. If you
+					pay more than {mainPlan.currency}
+					{formatAmount(
+						monthlyOrAnnual === 'Annual'
+							? annualThreshold
+							: monthlyThreshold,
+					)}{' '}
+					per {mainPlan.billingPeriod}, these additional amounts will
+					be separate {monthlyOrAnnual.toLowerCase()} voluntary
+					financial contributions to the Guardian. The Supporter Plus
+					subscription and any contributions will auto-renew each
+					{mainPlan.billingPeriod}. You will be charged the
+					subscription and contribution amounts using your chosen
+					payment method at each renewal unless you cancel. You can
+					cancel your subscription or change your contributions at any
+					time before your next renewal date. If you cancel within 14
+					days of taking out a Supporter Plus subscription, you’ll
+					receive a full refund (including of any contributions) and
+					your subscription and any contribution will stop
+					immediately. Cancellation of your subscription (which will
+					also cancel any contribution) or cancellation of your
+					contribution made after 14 days will take effect at the end
+					of your current {monthlyOrAnnual.toLowerCase()} payment
+					period. To cancel,{' '}
 					<Link to="/recurringsupport">go to Manage My Account</Link>{' '}
 					or{' '}
 					<a href="https://www.theguardian.com/info/2022/oct/28/the-guardian-supporter-plus-terms-and-conditions">

--- a/client/fixtures/productBuilder/testProducts.ts
+++ b/client/fixtures/productBuilder/testProducts.ts
@@ -1,3 +1,4 @@
+import type { CurrencyIso } from '../../utilities/currencyIso';
 import {
 	baseContribution,
 	baseDigitalPack,
@@ -47,6 +48,17 @@ export function guardianWeeklyCancelled() {
 export function digitalPackPaidByDirectDebit() {
 	return new ProductBuilder(baseDigitalPack())
 		.payByDirectDebit()
+		.getProductDetailObject();
+}
+
+export function annualContributionPaidByCardWithCurrency(
+	currency: CurrencyIso,
+) {
+	return new ProductBuilder(baseContribution())
+		.payByCard()
+		.withBillingPeriod('year')
+		.withCurrency(currency)
+		.withPrice(300)
 		.getProductDetailObject();
 }
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Updates the disclaimer Ts and Cs in Product Switching (as we have also done on Support frontend). This copy is dynamic for annual vs monthly.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Take out a Recurring Contribution. Go to `/switch`, click 'Upgrade' CTA. See new Ts and Cs at bottom of `/switch/review`

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Monthly, £
<img width="746" alt="image" src="https://github.com/guardian/manage-frontend/assets/114918544/e90baffa-6377-4397-8ed7-d2c3ebeab3e6">

Yearly, NZD
<img width="721" alt="image" src="https://github.com/guardian/manage-frontend/assets/114918544/467d7720-628c-4bf2-83c6-483937f98549">


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
