### PR TITLE
Remove 'Phonelines down' message from contact numbers

### DIFF
--- a/client/__tests__/components/helpCentre/__snapshots__/helpCentreContactOptions.test.tsx.snap
+++ b/client/__tests__/components/helpCentre/__snapshots__/helpCentreContactOptions.test.tsx.snap
@@ -206,19 +206,6 @@ Array [
   font-weight: normal;
 }
 
-.emotion-36 {
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 1.0625rem;
-  line-height: 1.35;
-  font-weight: 400;
-  --source-text-decoration-thickness: 2px;
-  margin-bottom: 0;
-}
-
-.emotion-36+p {
-  margin-top: 16px;
-}
-
 <div
     className="emotion-0"
   >
@@ -402,11 +389,6 @@ Array [
             >
               9am - 5pm on weekdays (EST/EDT)
             </span>
-          </p>
-          <p
-            className="emotion-36"
-          >
-            Phonelines for this region are temporarily down
           </p>
         </div>
       </div>
@@ -621,19 +603,6 @@ Array [
   font-weight: normal;
 }
 
-.emotion-36 {
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 1.0625rem;
-  line-height: 1.35;
-  font-weight: 400;
-  --source-text-decoration-thickness: 2px;
-  margin-bottom: 0;
-}
-
-.emotion-36+p {
-  margin-top: 16px;
-}
-
 <div
     className="emotion-0"
   >
@@ -817,11 +786,6 @@ Array [
             >
               9am - 5pm on weekdays (EST/EDT)
             </span>
-          </p>
-          <p
-            className="emotion-36"
-          >
-            Phonelines for this region are temporarily down
           </p>
         </div>
       </div>
@@ -1314,31 +1278,18 @@ html:not(.src-focus-disabled) .emotion-7:focus {
 }
 
 .emotion-45 {
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 1.0625rem;
-  line-height: 1.35;
-  font-weight: 400;
-  --source-text-decoration-thickness: 2px;
-  margin-bottom: 0;
-}
-
-.emotion-45+p {
-  margin-top: 16px;
-}
-
-.emotion-46 {
   margin-top: 36px;
   padding: 12px;
   background-color: #ecf3fe;
 }
 
 @media (min-width: 980px) {
-  .emotion-46 {
+  .emotion-45 {
     padding: 24px;
   }
 }
 
-.emotion-47 {
+.emotion-46 {
   margin: 0;
   font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
   font-size: 0.9375rem;
@@ -1347,7 +1298,7 @@ html:not(.src-focus-disabled) .emotion-7:focus {
   --source-text-decoration-thickness: 2px;
 }
 
-.emotion-48 {
+.emotion-47 {
   font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
   font-size: 0.9375rem;
   line-height: 1.35;
@@ -1357,7 +1308,7 @@ html:not(.src-focus-disabled) .emotion-7:focus {
   margin: 0;
 }
 
-.emotion-48 a {
+.emotion-47 a {
   color: #0077B6;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -1703,26 +1654,21 @@ html:not(.src-focus-disabled) .emotion-7:focus {
                 9am - 5pm on weekdays (EST/EDT)
               </span>
             </p>
-            <p
-              className="emotion-45"
-            >
-              Phonelines for this region are temporarily down
-            </p>
           </div>
         </div>
       </div>
     </div>
     <div
-      className="emotion-46"
+      className="emotion-45"
       id="livechatPrivacyNotice"
     >
       <h2
-        className="emotion-47"
+        className="emotion-46"
       >
         Data privacy notice
       </h2>
       <p
-        className="emotion-48"
+        className="emotion-47"
       >
         We use a type of cookie technology called an SDK (Software Development Kit) to ensure that our live chat services work correctly and meet your expectations. It cannot be switched off but it is removed at the end of the chat. If you do not wish for this cookie to be dropped on your device, please email or phone us instead. Live chats and phone calls will be recorded for monitoring and training purposes. Please do not disclose personal data of a sensitive nature in the live chat, such as health or financial information. A copy of the chat transcript will be emailed to you unless the chat contains payment card information, in which case no transcript will be sent. Click to find out more in our
          

--- a/client/components/shared/CallCenterEmailAndNumbers.tsx
+++ b/client/components/shared/CallCenterEmailAndNumbers.tsx
@@ -60,8 +60,6 @@ const PHONE_DATA: PhoneRegion[] = [
 		key: 'US',
 		title: 'Canada and USA',
 		openingHours: ['9am - 5pm on weekdays (EST/EDT)'],
-		additionalOpeningHoursInfo:
-			'Phonelines for this region are temporarily down',
 		phoneNumbers: [
 			{
 				phoneNumber: '1-844-632-2010',


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Remove the message about US phonelines being down under contact options.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://github.com/guardian/manage-frontend/assets/114918544/b94203c0-af77-47e5-bed3-4f731cc39b33)
![image](https://github.com/guardian/manage-frontend/assets/114918544/b3b80d5f-884a-49f3-85c5-6e5b55fee512)


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
