### PR TITLE
test why chromatic Storybook check not happening

### DIFF
--- a/client/components/mma/accountoverview/PersonalisedHeader.tsx
+++ b/client/components/mma/accountoverview/PersonalisedHeader.tsx
@@ -58,7 +58,8 @@ export const PersonalisedHeader = ({
 					margin-bottom: 0;
 				`}
 			>
-				{calculateTimeOfDay()}, {userDetails.firstName ?? 'supporter'}
+				test:{calculateTimeOfDay()},{' '}
+				{userDetails.firstName ?? 'supporter'}
 			</h2>
 			<p
 				css={css`

--- a/client/components/mma/accountoverview/PersonalisedHeader.tsx
+++ b/client/components/mma/accountoverview/PersonalisedHeader.tsx
@@ -58,7 +58,7 @@ export const PersonalisedHeader = ({
 					margin-bottom: 0;
 				`}
 			>
-				test:{calculateTimeOfDay()},{' '}
+				test2:{calculateTimeOfDay()},{' '}
 				{userDetails.firstName ?? 'supporter'}
 			</h2>
 			<p

--- a/client/components/mma/billing/Billing.stories.tsx
+++ b/client/components/mma/billing/Billing.stories.tsx
@@ -1,4 +1,4 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { ComponentMeta, ComponentStory, StoryFn } from '@storybook/react';
 import { rest } from 'msw';
 import { ReactRouterDecorator } from '../../../../.storybook/ReactRouterDecorator';
 import { featureSwitches } from '../../../../shared/featureSwitches';
@@ -27,7 +27,7 @@ export default {
 	},
 } as ComponentMeta<typeof Billing>;
 
-export const NoSubscription: ComponentStory<typeof Billing> = () => {
+export const NoSubscription: StoryFn<typeof Billing> = () => {
 	return <Billing />;
 };
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Testing - why did the Storybook checks not trigger last PR

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

There were 10 checks - 
![image](https://github.com/guardian/manage-frontend/assets/114918544/aefe4918-e2b0-469a-990b-1397b70161da)
Now only 8 checks - 
![image](https://github.com/guardian/manage-frontend/assets/114918544/ef9f1fd7-fa6c-4e6e-b677-37c66db6a4a9)

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
