### PR TITLE
update deprecated storybook type

### DIFF
--- a/client/components/mma/accountoverview/AccountOverview.stories.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.stories.tsx
@@ -1,4 +1,4 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { rest } from 'msw';
 import { ReactRouterDecorator } from '../../../../.storybook/ReactRouterDecorator';
 import { featureSwitches } from '../../../../shared/featureSwitches';
@@ -40,9 +40,9 @@ export default {
 	parameters: {
 		layout: 'fullscreen',
 	},
-} as ComponentMeta<typeof AccountOverview>;
+} as Meta<typeof AccountOverview>;
 
-export const NoSubscription: ComponentStory<typeof AccountOverview> = () => {
+export const NoSubscription: StoryFn<typeof AccountOverview> = () => {
 	return <AccountOverview />;
 };
 
@@ -66,7 +66,7 @@ NoSubscription.parameters = {
 	],
 };
 
-export const WithSubscriptions: ComponentStory<typeof AccountOverview> = () => {
+export const WithSubscriptions: StoryFn<typeof AccountOverview> = () => {
 	return <AccountOverview />;
 };
 
@@ -97,7 +97,7 @@ WithSubscriptions.parameters = {
 	],
 };
 
-export const WithContributionAndSwitchPossible: ComponentStory<
+export const WithContributionAndSwitchPossible: StoryFn<
 	typeof AccountOverview
 > = () => {
 	return <AccountOverview />;
@@ -122,7 +122,7 @@ WithContributionAndSwitchPossible.parameters = {
 	],
 };
 
-export const WithContributionInPaymentFailure: ComponentStory<
+export const WithContributionInPaymentFailure: StoryFn<
 	typeof AccountOverview
 > = () => {
 	return <AccountOverview />;
@@ -157,7 +157,7 @@ WithContributionInPaymentFailure.parameters = {
 	],
 };
 
-export const WithContributionAndSwitchNotPossible: ComponentStory<
+export const WithContributionAndSwitchNotPossible: StoryFn<
 	typeof AccountOverview
 > = () => {
 	return <AccountOverview />;
@@ -187,7 +187,7 @@ WithContributionAndSwitchNotPossible.parameters = {
 	],
 };
 
-export const WithCancelledSubscriptions: ComponentStory<
+export const WithCancelledSubscriptions: StoryFn<
 	typeof AccountOverview
 > = () => {
 	return <AccountOverview />;
@@ -220,9 +220,7 @@ WithCancelledSubscriptions.parameters = {
 	],
 };
 
-export const WithGiftSubscriptions: ComponentStory<
-	typeof AccountOverview
-> = () => {
+export const WithGiftSubscriptions: StoryFn<typeof AccountOverview> = () => {
 	return <AccountOverview />;
 };
 
@@ -250,9 +248,7 @@ WithGiftSubscriptions.parameters = {
 	],
 };
 
-export const WithAppSubscriptions: ComponentStory<
-	typeof AccountOverview
-> = () => {
+export const WithAppSubscriptions: StoryFn<typeof AccountOverview> = () => {
 	return <AccountOverview />;
 };
 
@@ -282,9 +278,7 @@ WithAppSubscriptions.parameters = {
 	],
 };
 
-export const WithSingleContribution: ComponentStory<
-	typeof AccountOverview
-> = () => {
+export const WithSingleContribution: StoryFn<typeof AccountOverview> = () => {
 	return <AccountOverview />;
 };
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Small harmless change to try kick off a CD deployment - replace deprecated type

<img width="495" alt="image" src="https://github.com/guardian/manage-frontend/assets/114918544/a3917815-6597-46e4-85c0-3595287f6f05">

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
