### PR TITLE
Supporter Plus Amount Change Copy Updates

### DIFF
--- a/client/__tests__/components/updateAmount/supporterPlusUpdateAmount.test.tsx
+++ b/client/__tests__/components/updateAmount/supporterPlusUpdateAmount.test.tsx
@@ -62,7 +62,11 @@ it.each([
 		fireEvent.click(screen.getByText('Change amount'));
 
 		// assert that the minimum amount validation error message is shown
-		expect(screen.findByText(/is the minimum payment/i)).toBeTruthy();
+		expect(
+			screen.findByText(
+				/minimum payment to receive this subscription. Please call our customer service team/i,
+			),
+		).toBeTruthy();
 	},
 );
 
@@ -99,7 +103,7 @@ it.each([
 		// assert that the maximum amount validation error message is shown
 		expect(
 			screen.queryByText(
-				`There is a maximum ${billingPeriod}ly contribution amount of £${expectedMaxAmount.toFixed(
+				`There is a maximum ${billingPeriod}ly amount of £${expectedMaxAmount.toFixed(
 					2,
 				)} GBP`,
 			),

--- a/client/__tests__/components/updateAmount/supporterPlusUpdateAmount.test.tsx
+++ b/client/__tests__/components/updateAmount/supporterPlusUpdateAmount.test.tsx
@@ -103,9 +103,7 @@ it.each([
 		// assert that the maximum amount validation error message is shown
 		expect(
 			screen.queryByText(
-				`There is a maximum ${billingPeriod}ly amount of £${expectedMaxAmount.toFixed(
-					2,
-				)} GBP`,
+				`There is a maximum ${billingPeriod}ly amount of £${expectedMaxAmount} GBP`,
 			),
 		).toBeTruthy();
 	},

--- a/client/__tests__/supporterPlus.test.tsx
+++ b/client/__tests__/supporterPlus.test.tsx
@@ -31,10 +31,10 @@ describe('suggested support amounts for annual', () => {
 	it.each([
 		[95, 105, 120, 145],
 		[100, 110, 125, 150],
-		[103, 115, 125, 150],
+		[103, 115, 130, 155],
 		[99, 110, 125, 150],
 	])(
-		'returns options 10%, 25%, 50% more than the current amount %s',
+		'returns options 10%, 25%, 50% more (rounded to 5) than the current amount %s',
 		(
 			currentAmount: number,
 			expectedFirstAmount: number,

--- a/client/__tests__/supporterPlus.test.tsx
+++ b/client/__tests__/supporterPlus.test.tsx
@@ -1,6 +1,6 @@
 import { suggestedAmounts } from '../utilities/supporterPlusPricing';
 
-describe('suggested support amounts', () => {
+describe('suggested support amounts for monthly', () => {
 	it.each([
 		[10, 12, 15, 20],
 		[17, 19, 20, 25],
@@ -14,13 +14,40 @@ describe('suggested support amounts', () => {
 			expectedSecondAmount: number,
 			expectedThirdAmount: number,
 		) => {
-			expect(suggestedAmounts(currentAmount)[0]).toEqual(
+			expect(suggestedAmounts(currentAmount, 'Monthly')[0]).toEqual(
 				expectedFirstAmount,
 			);
-			expect(suggestedAmounts(currentAmount)[1]).toEqual(
+			expect(suggestedAmounts(currentAmount, 'Monthly')[1]).toEqual(
 				expectedSecondAmount,
 			);
-			expect(suggestedAmounts(currentAmount)[2]).toEqual(
+			expect(suggestedAmounts(currentAmount, 'Monthly')[2]).toEqual(
+				expectedThirdAmount,
+			);
+		},
+	);
+});
+
+describe('suggested support amounts for annual', () => {
+	it.each([
+		[95, 105, 120, 145],
+		[100, 110, 125, 150],
+		[103, 115, 125, 150],
+		[99, 110, 125, 150],
+	])(
+		'returns options 10%, 25%, 50% more than the current amount %s',
+		(
+			currentAmount: number,
+			expectedFirstAmount: number,
+			expectedSecondAmount: number,
+			expectedThirdAmount: number,
+		) => {
+			expect(suggestedAmounts(currentAmount, 'Annual')[0]).toEqual(
+				expectedFirstAmount,
+			);
+			expect(suggestedAmounts(currentAmount, 'Annual')[1]).toEqual(
+				expectedSecondAmount,
+			);
+			expect(suggestedAmounts(currentAmount, 'Annual')[2]).toEqual(
 				expectedThirdAmount,
 			);
 		},

--- a/client/components/mma/accountoverview/ManageProduct.stories.tsx
+++ b/client/components/mma/accountoverview/ManageProduct.stories.tsx
@@ -1,10 +1,12 @@
 import type { Meta, StoryFn } from '@storybook/react';
 import { ReactRouterDecorator } from '../../../../.storybook/ReactRouterDecorator';
+import { featureSwitches } from '../../../../shared/featureSwitches';
 import { GROUPED_PRODUCT_TYPES } from '../../../../shared/productTypes';
 import {
 	digitalPackPaidByDirectDebit,
 	guardianWeeklyPaidByCard,
 	newspaperVoucherPaidByPaypal,
+	supporterPlus,
 } from '../../../fixtures/productBuilder/testProducts';
 import { ManageProduct } from './ManageProduct';
 
@@ -39,5 +41,18 @@ export const NewspaperSubscriptionCard = Template.bind({});
 NewspaperSubscriptionCard.parameters = {
 	reactRouter: {
 		state: { productDetail: newspaperVoucherPaidByPaypal() },
+	},
+};
+
+featureSwitches.supporterPlusUpdateAmount = true;
+export const SupporterPlus = () => (
+	<ManageProduct
+		groupedProductType={GROUPED_PRODUCT_TYPES.recurringSupport}
+	/>
+);
+
+SupporterPlus.parameters = {
+	reactRouter: {
+		state: { productDetail: supporterPlus() },
 	},
 };

--- a/client/components/mma/accountoverview/ManageProduct.stories.tsx
+++ b/client/components/mma/accountoverview/ManageProduct.stories.tsx
@@ -6,7 +6,7 @@ import {
 	digitalPackPaidByDirectDebit,
 	guardianWeeklyPaidByCard,
 	newspaperVoucherPaidByPaypal,
-	supporterPlus,
+	supporterPlusAnnual,
 } from '../../../fixtures/productBuilder/testProducts';
 import { ManageProduct } from './ManageProduct';
 
@@ -53,6 +53,6 @@ export const SupporterPlus = () => (
 
 SupporterPlus.parameters = {
 	reactRouter: {
-		state: { productDetail: supporterPlus() },
+		state: { productDetail: supporterPlusAnnual() },
 	},
 };

--- a/client/components/mma/accountoverview/updateAmount/SupporterPlusUpdateAmountForm.tsx
+++ b/client/components/mma/accountoverview/updateAmount/SupporterPlusUpdateAmountForm.tsx
@@ -246,6 +246,7 @@ export const SupporterPlusUpdateAmountForm = (
 					</dt>
 					<dd
 						css={css`
+							margin-left: ${space[4]}px;
 							display: inline-block;
 						`}
 					>{`${props.mainPlan.currency}${props.currentAmount.toFixed(
@@ -331,7 +332,7 @@ export const SupporterPlusUpdateAmountForm = (
 						<section
 							css={[
 								css`
-									margin-top: ${space[3]}px;
+									margin-top: ${space[5]}px;
 								`,
 								buttonContainerCss,
 							]}

--- a/client/components/mma/accountoverview/updateAmount/SupporterPlusUpdateAmountForm.tsx
+++ b/client/components/mma/accountoverview/updateAmount/SupporterPlusUpdateAmountForm.tsx
@@ -10,10 +10,8 @@ import {
 	SvgInfoRound,
 	TextInput,
 } from '@guardian/source-react-components';
-import { capitalize } from 'lodash';
 import { useEffect, useState } from 'react';
 import type { PaidSubscriptionPlan } from '../../../../../shared/productResponse';
-import { augmentBillingPeriod } from '../../../../../shared/productResponse';
 import { calculateMonthlyOrAnnualFromBillingPeriod } from '../../../../../shared/productTypes';
 import type { CurrencyIso } from '../../../../utilities/currencyIso';
 import { fetchWithDefaultParameters } from '../../../../utilities/fetch';
@@ -229,10 +227,7 @@ export const SupporterPlusUpdateAmountForm = (
 							display: inline-block;
 						`}
 					>
-						{capitalize(
-							augmentBillingPeriod(props.mainPlan.billingPeriod),
-						)}{' '}
-						amount
+						Current amount
 					</dt>
 					<dd
 						css={css`

--- a/client/components/mma/accountoverview/updateAmount/SupporterPlusUpdateAmountForm.tsx
+++ b/client/components/mma/accountoverview/updateAmount/SupporterPlusUpdateAmountForm.tsx
@@ -368,7 +368,9 @@ export const SupporterPlusUpdateAmountForm = (
 								If you would like to lower your{' '}
 								{monthlyOrAnnual.toLowerCase()} amount below{' '}
 								{minPriceDisplay} please call us via the{' '}
-								<Link href="/help-centre">Help Centre</Link>
+								<Link href="/help-centre#call-us">
+									Help Centre
+								</Link>
 							</p>
 						</div>
 						<p css={smallPrintCss}>

--- a/client/components/mma/accountoverview/updateAmount/SupporterPlusUpdateAmountForm.tsx
+++ b/client/components/mma/accountoverview/updateAmount/SupporterPlusUpdateAmountForm.tsx
@@ -63,15 +63,9 @@ function validateChoice(
 	} else if (!chosenAmount || isNaN(chosenOptionNum)) {
 		return 'There is a problem with the amount you have selected, please make sure it is a valid amount';
 	} else if (!isNaN(chosenOptionNum) && chosenOptionNum < minAmount) {
-		return `${mainPlan.currency}${minAmount.toFixed(2)} per ${
-			mainPlan.billingPeriod
-		} is the minimum payment to receive this subscription. Please call our customer service team to lower your monthly amount below ${
-			mainPlan.currency
-		}${minAmount.toFixed(2)}`;
+		return `${mainPlan.currency}${minAmount} per ${mainPlan.billingPeriod} is the minimum payment to receive this subscription. Please call our customer service team to lower your monthly amount below ${mainPlan.currency}${minAmount}`;
 	} else if (!isNaN(chosenOptionNum) && chosenOptionNum > maxAmount) {
-		return `There is a maximum ${mainPlan.billingPeriod}ly amount of ${
-			mainPlan.currency
-		}${maxAmount.toFixed(2)} ${mainPlan.currencyISO}`;
+		return `There is a maximum ${mainPlan.billingPeriod}ly amount of ${mainPlan.currency}${maxAmount} ${mainPlan.currencyISO}`;
 	}
 	return null;
 }

--- a/client/components/mma/accountoverview/updateAmount/SupporterPlusUpdateAmountForm.tsx
+++ b/client/components/mma/accountoverview/updateAmount/SupporterPlusUpdateAmountForm.tsx
@@ -65,7 +65,7 @@ function validateChoice(
 	} else if (!isNaN(chosenOptionNum) && chosenOptionNum < minAmount) {
 		return `${mainPlan.currency}${minAmount.toFixed(2)} per ${
 			mainPlan.billingPeriod
-		} is the minimum  payment to receive this subscription. Please call our customer service team to lower your monthly amount below ${
+		} is the minimum payment to receive this subscription. Please call our customer service team to lower your monthly amount below ${
 			mainPlan.currency
 		}${minAmount.toFixed(2)}`;
 	} else if (!isNaN(chosenOptionNum) && chosenOptionNum > maxAmount) {
@@ -266,7 +266,7 @@ export const SupporterPlusUpdateAmountForm = (
 						<ChoiceCardGroup
 							name="amounts"
 							data-cy="supporter-plus-amount-choices"
-							label="Choose the amount to pay"
+							label="Choose your new amount"
 							columns={2}
 						>
 							<>

--- a/client/components/mma/accountoverview/updateAmount/SupporterPlusUpdateAmountForm.tsx
+++ b/client/components/mma/accountoverview/updateAmount/SupporterPlusUpdateAmountForm.tsx
@@ -59,21 +59,19 @@ function validateChoice(
 	if (!chosenAmount && !isOtherAmountSelected) {
 		return 'Please make a selection';
 	} else if (chosenOptionNum === currentAmount) {
-		return 'You have selected the same amount as you currently contribute';
+		return 'You have selected the same amount as you currently pay';
 	} else if (!chosenAmount || isNaN(chosenOptionNum)) {
 		return 'There is a problem with the amount you have selected, please make sure it is a valid amount';
 	} else if (!isNaN(chosenOptionNum) && chosenOptionNum < minAmount) {
-		return `There is a minimum ${
+		return `${mainPlan.currency}${minAmount.toFixed(2)} per ${
 			mainPlan.billingPeriod
-		}ly contribution amount of ${mainPlan.currency}${minAmount.toFixed(
-			2,
-		)} ${mainPlan.currencyISO}`;
+		} is the minimum  payment to receive this subscription. Please call our customer service team to lower your monthly amount below ${
+			mainPlan.currency
+		}${minAmount.toFixed(2)}`;
 	} else if (!isNaN(chosenOptionNum) && chosenOptionNum > maxAmount) {
-		return `There is a maximum ${
-			mainPlan.billingPeriod
-		}ly contribution amount of ${mainPlan.currency}${maxAmount.toFixed(
-			2,
-		)} ${mainPlan.currencyISO}`;
+		return `There is a maximum ${mainPlan.billingPeriod}ly amount of ${
+			mainPlan.currency
+		}${maxAmount.toFixed(2)} ${mainPlan.currencyISO}`;
 	}
 	return null;
 }
@@ -267,8 +265,8 @@ export const SupporterPlusUpdateAmountForm = (
 					>
 						<ChoiceCardGroup
 							name="amounts"
-							data-cy="contribution-amount-choices"
-							label="Choose the amount to contribute"
+							data-cy="supporter-plus-amount-choices"
+							label="Choose the amount to pay"
 							columns={2}
 						>
 							<>

--- a/client/components/mma/accountoverview/updateAmount/UpdateAmount.tsx
+++ b/client/components/mma/accountoverview/updateAmount/UpdateAmount.tsx
@@ -61,7 +61,7 @@ export const UpdateAmount = (props: UpdateAmountProps) => {
 		<>
 			{status === Status.CONFIRMED && (
 				<SuccessMessage
-					message={`We have successfully updated the amount of your contribution. ${
+					message={`We have successfully updated the amount of your support. ${
 						props.nextPaymentDate &&
 						`This amount will be taken on ${parseDate(
 							props.nextPaymentDate,

--- a/client/fixtures/productBuilder/testProducts.ts
+++ b/client/fixtures/productBuilder/testProducts.ts
@@ -153,6 +153,14 @@ export function supporterPlus() {
 		.getProductDetailObject();
 }
 
+export function supporterPlusAnnual() {
+	return new ProductBuilder(baseSupporterPlus())
+		.payByCard()
+		.withPrice(9500)
+		.withBillingPeriod('year')
+		.getProductDetailObject();
+}
+
 export function supporterPlusCancelled() {
 	return new ProductBuilder(baseSupporterPlus())
 		.payByCard()

--- a/client/utilities/supporterPlusPricing.ts
+++ b/client/utilities/supporterPlusPricing.ts
@@ -49,7 +49,16 @@ export function getBenefitsThreshold(
 	return region[billingPeriod].minAmount;
 }
 
-export function suggestedAmounts(currentAmount: number) {
+export function suggestedAmounts(
+	currentAmount: number,
+	monthlyOrAnnual: 'Monthly' | 'Annual',
+) {
+	return monthlyOrAnnual === 'Monthly'
+		? suggestedAmountsMonthly(currentAmount)
+		: suggestedAmountsAnnual(currentAmount);
+}
+
+function suggestedAmountsMonthly(currentAmount: number) {
 	const firstValue = currentAmount + 2;
 
 	const secondValue = Math.ceil((firstValue + 1) / 5) * 5;
@@ -57,4 +66,12 @@ export function suggestedAmounts(currentAmount: number) {
 	const thirdValue = secondValue + 5;
 
 	return [firstValue, secondValue, thirdValue];
+}
+
+function suggestedAmountsAnnual(currentAmount: number) {
+	const percentageStepUps = [1.1, 1.25, 1.5];
+
+	return percentageStepUps.map(
+		(p) => Math.round((currentAmount * p) / 5) * 5,
+	);
 }

--- a/cypress/integration/parallel-1/updateContributionAmount.spec.ts
+++ b/cypress/integration/parallel-1/updateContributionAmount.spec.ts
@@ -99,7 +99,7 @@ describe('Update contribution amount', () => {
 		cy.findByText('Change amount').click();
 
 		cy.get(
-			'[data-cy="contribution-amount-choices"] label:first-of-type',
+			'[data-cy="supporter-plus-amount-choices"] label:first-of-type',
 		).click();
 
 		cy.findByText('Change amount').click();

--- a/cypress/integration/parallel-1/updateContributionAmount.spec.ts
+++ b/cypress/integration/parallel-1/updateContributionAmount.spec.ts
@@ -80,7 +80,7 @@ describe('Update contribution amount', () => {
 		cy.wait('@update_amount');
 
 		cy.contains(
-			'We have successfully updated the amount of your contribution.',
+			'We have successfully updated the amount of your support.',
 		).should('exist');
 	});
 
@@ -107,7 +107,7 @@ describe('Update contribution amount', () => {
 		cy.wait('@supporter_plus_update_amount');
 
 		cy.contains(
-			'We have successfully updated the amount of your contribution.',
+			'We have successfully updated the amount of your support.',
 		).should('exist');
 	});
 });


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Updates to copy + design in Supporter Plus Amount Change component. Copy should not reference 'contributions'.

Also updates the suggested amounts for annual subscriptions, the suggested amounts will be 10%, 25% and 50% more than the current amount.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Take out supporter plus -> go to `/recurringsupport` and click "Change amount". 
See new label 'Choose your new amount', lower amount below the threshold and see error message that does not reference 'contribution'

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Before
<img width="896" alt="image" src="https://github.com/guardian/manage-frontend/assets/114918544/06642e74-baf8-4521-a8d4-ec0ac4f34ed2">

After
![image](https://github.com/guardian/manage-frontend/assets/114918544/b8a813d1-de12-4f20-83c9-9248d894e1ac)

Mobile
![image](https://github.com/guardian/manage-frontend/assets/114918544/b009be40-d084-417a-817b-9bdad8f0bb62)
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
