### PR TITLE
Create a specific URL for Manage product pages

### DIFF
--- a/client/components/mma/MMAPage.tsx
+++ b/client/components/mma/MMAPage.tsx
@@ -9,15 +9,11 @@ import {
 	initFeatureSwitchUrlParamOverride,
 } from '../../../shared/featureSwitches';
 import type {
-	GroupedProductType,
 	ProductType,
 	ProductTypeWithDeliveryRecordsProperties,
 	ProductTypeWithHolidayStopsFlow,
 } from '../../../shared/productTypes';
-import {
-	GROUPED_PRODUCT_TYPES,
-	PRODUCT_TYPES,
-} from '../../../shared/productTypes';
+import { PRODUCT_TYPES } from '../../../shared/productTypes';
 import { abSwitches } from '../../experiments/abSwitches';
 import { tests } from '../../experiments/abTests';
 import { fonts } from '../../styles/fonts';
@@ -431,16 +427,14 @@ const MMARouter = () => {
 								/>
 							</Route>
 						))}
-						{Object.values(GROUPED_PRODUCT_TYPES).map(
-							(groupedProductType: GroupedProductType) => (
+						{Object.values(PRODUCT_TYPES).map(
+							(productType: ProductType) => (
 								<Route
-									key={groupedProductType.urlPart}
-									path={`/${groupedProductType.urlPart}`}
+									key={productType.urlPart}
+									path={`/${productType.urlPart}`}
 									element={
 										<ManageProduct
-											groupedProductType={
-												groupedProductType
-											}
+											productType={productType}
 										/>
 									}
 								/>

--- a/client/components/mma/MMAPageSkeleton.tsx
+++ b/client/components/mma/MMAPageSkeleton.tsx
@@ -17,13 +17,14 @@ interface LocationObject {
 }
 
 const manageProductLocationObjects: LocationObject[] = Object.values(
-	GROUPED_PRODUCT_TYPES,
-).map((groupedProductType) => ({
+	PRODUCT_TYPES,
+).map((productType) => ({
 	title: `Manage ${
-		groupedProductType.shortFriendlyName ||
-		groupedProductType.friendlyName()
+		GROUPED_PRODUCT_TYPES[productType.groupedProductType]
+			.shortFriendlyName ||
+		GROUPED_PRODUCT_TYPES[productType.groupedProductType].friendlyName()
 	}`,
-	path: `/${groupedProductType.urlPart}`,
+	path: `/${productType.urlPart}`,
 	selectedNavItem: NAV_LINKS.accountOverview,
 }));
 

--- a/client/components/mma/accountoverview/ManageProduct.stories.tsx
+++ b/client/components/mma/accountoverview/ManageProduct.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryFn } from '@storybook/react';
 import { ReactRouterDecorator } from '../../../../.storybook/ReactRouterDecorator';
 import { featureSwitches } from '../../../../shared/featureSwitches';
-import { GROUPED_PRODUCT_TYPES } from '../../../../shared/productTypes';
+import { PRODUCT_TYPES } from '../../../../shared/productTypes';
 import {
 	digitalPackPaidByDirectDebit,
 	guardianWeeklyPaidByCard,
@@ -19,25 +19,30 @@ export default {
 	},
 } as Meta<typeof ManageProduct>;
 
-const Template: StoryFn<typeof ManageProduct> = () => (
-	<ManageProduct groupedProductType={GROUPED_PRODUCT_TYPES.subscriptions} />
-);
+export const GuardianWeekly: StoryFn<typeof ManageProduct> = () => {
+	return <ManageProduct productType={PRODUCT_TYPES.guardianweekly} />;
+};
 
-export const GuardianWeekly = Template.bind({});
 GuardianWeekly.parameters = {
 	reactRouter: {
 		state: { productDetail: guardianWeeklyPaidByCard() },
 	},
 };
 
-export const DigitalSubscription = Template.bind({});
+export const DigitalSubscription: StoryFn<typeof ManageProduct> = () => {
+	return <ManageProduct productType={PRODUCT_TYPES.digipack} />;
+};
+
 DigitalSubscription.parameters = {
 	reactRouter: {
 		state: { productDetail: digitalPackPaidByDirectDebit() },
 	},
 };
 
-export const NewspaperSubscriptionCard = Template.bind({});
+export const NewspaperSubscriptionCard: StoryFn<typeof ManageProduct> = () => {
+	return <ManageProduct productType={PRODUCT_TYPES.digitalvoucher} />;
+};
+
 NewspaperSubscriptionCard.parameters = {
 	reactRouter: {
 		state: { productDetail: newspaperVoucherPaidByPaypal() },
@@ -45,11 +50,9 @@ NewspaperSubscriptionCard.parameters = {
 };
 
 featureSwitches.supporterPlusUpdateAmount = true;
-export const SupporterPlus = () => (
-	<ManageProduct
-		groupedProductType={GROUPED_PRODUCT_TYPES.recurringSupport}
-	/>
-);
+export const SupporterPlus: StoryFn<typeof ManageProduct> = () => {
+	return <ManageProduct productType={PRODUCT_TYPES.supporterplus} />;
+};
 
 SupporterPlus.parameters = {
 	reactRouter: {

--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -335,7 +335,7 @@ export const ProductCard = ({
 											eventLabel: `manage_${groupedProductType.urlPart}`,
 										});
 										navigate(
-											`/${groupedProductType.urlPart}`,
+											`/${specificProductType.urlPart}`,
 											{
 												state: {
 													productDetail:

--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -332,7 +332,7 @@ export const ProductCard = ({
 										trackEvent({
 											eventCategory: 'account_overview',
 											eventAction: 'click',
-											eventLabel: `manage_${groupedProductType.urlPart}`,
+											eventLabel: `manage_${specificProductType.urlPart}`,
 										});
 										navigate(
 											`/${specificProductType.urlPart}`,

--- a/client/components/mma/delivery/address/DeliveryAddressConfirmation.tsx
+++ b/client/components/mma/delivery/address/DeliveryAddressConfirmation.tsx
@@ -217,7 +217,7 @@ const AddressConfirmation = (props: ProductType) => {
 						`}
 					>
 						<LinkButton
-							to={'/subscriptions'}
+							to={`/${props.urlPart}`}
 							text={'Return to subscription'}
 							state={{ productDetail }}
 							colour={palette.brand[400]}

--- a/cypress/integration/parallel-5/membership.spec.ts
+++ b/cypress/integration/parallel-5/membership.spec.ts
@@ -43,7 +43,7 @@ describe('membership test', () => {
 	});
 
 	it('membership subscription', () => {
-		cy.visit('/membership');
+		cy.visit('/');
 
 		cy.findByText('Manage Membership').click();
 

--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -651,7 +651,6 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 		groupedProductType: 'subscriptions',
 		allProductsProductTypeFilterString: 'GuardianPatron',
 		urlPart: 'guardianpatron',
-		legacyUrlPart: 'guardianpatron',
 		getOphanProductType: () => 'GUARDIAN_PATRON', //TODO: This value doesn't exist in Ophan yet
 		showTrialRemainingIfApplicable: true,
 		softOptInIDs: [


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR changes the URL that the `Manage product` page exists on - and adds async loading if you go directly to this page through the URL.

The motivation for this change is to have a URL that readers can be linked to which will allow them to change the amount they support. I.e. `/support` in this case. In order to do this the routing for this page has changed from being at the `GROUPED_PRODUCT_TYPE` url to the specific `PRODUCT_TYPE`. For example, previously when managing a supporter plus subscription the URL would be `/recurringSupport`, it will now be `/support`. The same applies to other products, homedelivery, guardianweekly etc. 

Async loading: before, this page only worked when clicked through from another page that passes props. Now, there is logic to try and load the product from MDAPI, filtered by the productType specified in the URL. If there are multiple products returned the page loads the first in the list (unlikely that a user has multiple of the same product)

Using the specific product type also sidesteps the bug found in this PR: #1137 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

With a Supporter Plus subscription 

1) -> on account overview, click `Manage recurring support` and see the URL is `/support`

2) go directly to `/support` and see a "Loading your product..." and then see the page load (see image)

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

Potential risk: breaking existing URLs. This shouldn't make a difference since previously the page could not load via URL directly 
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://github.com/guardian/manage-frontend/assets/114918544/6be74c0f-24ed-4422-a4d5-643b01161f6f)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
