### PR TITLE
Add fallback for no billingPeriod in currentPlan

### DIFF
--- a/shared/productResponse.ts
+++ b/shared/productResponse.ts
@@ -116,7 +116,7 @@ interface SepaDetails {
 	iban: string;
 }
 
-interface CurrenyAndBillingPeriodDetail {
+interface CurrencyAndBillingPeriodDetail {
 	currency: string;
 	currencyISO: string;
 	billingPeriod: string;
@@ -131,7 +131,7 @@ export const isSixForSix = (planName: string | null) =>
 
 export interface PaidSubscriptionPlan
 	extends SubscriptionPlan,
-		CurrenyAndBillingPeriodDetail {
+		CurrencyAndBillingPeriodDetail {
 	start: string;
 	end: string;
 	chargedThrough?: string | null;
@@ -237,6 +237,7 @@ export const getMainPlan: (subscription: Subscription) => SubscriptionPlan = (
 		shouldBeVisible: true,
 		currency: subscription.plan?.currency,
 		currencyISO: subscription.plan?.currencyISO,
+		billingPeriod: subscription.plan?.billingPeriod,
 	};
 };
 

--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -232,12 +232,29 @@ const calculateProductTitle =
 	(baseProductTitle: string) => (mainPlan?: SubscriptionPlan) =>
 		baseProductTitle + (mainPlan?.name ? ` - ${mainPlan.name}` : '');
 
-export const calculateSupporterPlusTitle = (billingPeriod: string) =>
-	billingPeriod === 'month' ? 'monthly + extras' : 'annual + extras';
+export function calculateSupporterPlusTitle(billingPeriod: string) {
+	if (billingPeriod === 'month') {
+		return 'monthly + extras';
+	}
+	if (billingPeriod === 'year') {
+		return 'annual + extras';
+	}
 
-export const calculateMonthlyOrAnnualFromBillingPeriod = (
+	return 'recurring support';
+}
+
+export function calculateMonthlyOrAnnualFromBillingPeriod(
 	billingPeriod: string,
-) => (billingPeriod === 'month' ? 'Monthly' : 'Annual');
+) {
+	if (billingPeriod === 'month') {
+		return 'Monthly';
+	}
+	if (billingPeriod === 'year') {
+		return 'Annual';
+	}
+
+	throw new Error('No billing period for subscription');
+}
 
 const FRONT_PAGE_NEWSLETTER_ID = '6009';
 


### PR DESCRIPTION

## What does this change?

Add a fallback for a situation seen on prod - "Annual" being displayed on a cancelled Monthly sub.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

What I saw: 
![image](https://github.com/guardian/manage-frontend/assets/114918544/d2679427-e698-41d9-afbb-9832d9a86c6a)

what the API response had: 

```
"plan": {
        "name": "Supporter Plus",
        "price": 1200,
        "currency": "£",
        "currencyISO": "GBP",
        "billingPeriod": "month"
  },
  "currentPlans": [],
  "futurePlans": [],

````

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
