### PR TITLE
Upgrade Support - new screen (V1)

### DIFF
--- a/client/components/mma/MMAPage.tsx
+++ b/client/components/mma/MMAPage.tsx
@@ -304,6 +304,14 @@ const SwitchReview = lazy(() =>
 	})),
 );
 
+const UpgradeSupport = lazy(() =>
+	import(
+		/* webpackChunkName: "UpgradeSupport" */ './upgrade/UpgradeSupport'
+	).then(({ UpgradeSupport }) => ({
+		default: UpgradeSupport,
+	})),
+);
+
 const SwitchComplete = lazy(() =>
 	import(
 		/* webpackChunkName: "Switch" */ './switch/complete/SwitchComplete'
@@ -408,6 +416,10 @@ const MMARouter = () => {
 						<Route
 							path="/account-settings"
 							element={<Settings />}
+						/>
+						<Route
+							path="upgrade-support"
+							element={<UpgradeSupport />}
 						/>
 						{[
 							{ path: '/switch', fromApp: false },

--- a/client/components/mma/MMAPage.tsx
+++ b/client/components/mma/MMAPage.tsx
@@ -39,6 +39,7 @@ import { Main } from '../shared/Main';
 import { DeliveryAddressUpdate } from './delivery/address/DeliveryAddressForm';
 import { Maintenance } from './maintenance/Maintenance';
 import { MMAPageSkeleton } from './MMAPageSkeleton';
+import { UpgradeSupportContainer } from './upgrade/UpgradeSupportContainer';
 
 const record = (event: any) => {
 	if (window.guardian?.ophan?.record) {
@@ -419,8 +420,14 @@ const MMARouter = () => {
 						/>
 						<Route
 							path="upgrade-support"
-							element={<UpgradeSupport />}
-						/>
+							element={<UpgradeSupportContainer />}
+						>
+							<Route index element={<UpgradeSupport />} />
+							<Route
+								path={'thank-you'}
+								element={<div>thanks</div>}
+							/>
+						</Route>
 						{[
 							{ path: '/switch', fromApp: false },
 							{ path: '/app/switch', fromApp: true },

--- a/client/components/mma/shared/benefits/BenefitsConfiguration.ts
+++ b/client/components/mma/shared/benefits/BenefitsConfiguration.ts
@@ -38,10 +38,6 @@ export const benefitsConfiguration: {
 			...newsApp,
 			isUnavailable: true,
 		},
-		{
-			...adFree,
-			isUnavailable: true,
-		},
 	],
 	supporterplus: [supporterNewsletter, uninterruptedReading, newsApp, adFree],
 	membership: [newsApp, uninterruptedReading, supporterNewsletter],

--- a/client/components/mma/shared/benefits/BenefitsConfiguration.ts
+++ b/client/components/mma/shared/benefits/BenefitsConfiguration.ts
@@ -38,6 +38,10 @@ export const benefitsConfiguration: {
 			...newsApp,
 			isUnavailable: true,
 		},
+		{
+			...adFree,
+			isUnavailable: true,
+		},
 	],
 	supporterplus: [newsApp, supporterNewsletter, uninterruptedReading, adFree],
 	membership: [newsApp, uninterruptedReading, supporterNewsletter],

--- a/client/components/mma/shared/benefits/BenefitsConfiguration.ts
+++ b/client/components/mma/shared/benefits/BenefitsConfiguration.ts
@@ -43,7 +43,7 @@ export const benefitsConfiguration: {
 			isUnavailable: true,
 		},
 	],
-	supporterplus: [newsApp, supporterNewsletter, uninterruptedReading, adFree],
+	supporterplus: [supporterNewsletter, uninterruptedReading, newsApp, adFree],
 	membership: [newsApp, uninterruptedReading, supporterNewsletter],
 	digipack: [],
 	digitalvoucher: [],

--- a/client/components/mma/upgrade/UpgradeSupport.stories.tsx
+++ b/client/components/mma/upgrade/UpgradeSupport.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryFn } from '@storybook/react';
+import { rest } from 'msw';
 import { ReactRouterDecorator } from '../../../../.storybook/ReactRouterDecorator';
+import { toMembersDataApiResponse } from '../../../fixtures/mdapiResponse';
 import { contributionPaidByCard } from '../../../fixtures/productBuilder/testProducts';
 import { UpgradeSupport } from './UpgradeSupport';
 import { UpgradeSupportContainer } from './UpgradeSupportContainer';
@@ -11,12 +13,17 @@ export default {
 	parameters: {
 		layout: 'fullscreen',
 		reactRouter: {
-			state: {
-				productDetail: contributionPaidByCard,
-				user: { email: 'test@test.com' },
-				container: <UpgradeSupportContainer />,
-			},
+			container: <UpgradeSupportContainer />,
 		},
+		msw: [
+			rest.get('/api/me/mma', (_req, res, ctx) => {
+				return res(
+					ctx.json(
+						toMembersDataApiResponse(contributionPaidByCard()),
+					),
+				);
+			}),
+		],
 	},
 } as Meta<typeof UpgradeSupportContainer>;
 

--- a/client/components/mma/upgrade/UpgradeSupport.stories.tsx
+++ b/client/components/mma/upgrade/UpgradeSupport.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import { ReactRouterDecorator } from '../../../../.storybook/ReactRouterDecorator';
+import { contributionPaidByCard } from '../../../fixtures/productBuilder/testProducts';
+import { UpgradeSupport } from './UpgradeSupport';
+
+export default {
+	title: 'Pages/UpgradeSupport',
+	component: UpgradeSupport,
+	decorators: [ReactRouterDecorator],
+	parameters: {
+		layout: 'fullscreen',
+		reactRouter: {
+			state: {
+				productDetail: contributionPaidByCard,
+				user: { email: 'test@test.com' },
+			},
+		},
+	},
+} as Meta<typeof UpgradeSupport>;
+
+export const UpgradeSupportValue: StoryFn<typeof UpgradeSupport> = () => {
+	return <UpgradeSupport />;
+};

--- a/client/components/mma/upgrade/UpgradeSupport.stories.tsx
+++ b/client/components/mma/upgrade/UpgradeSupport.stories.tsx
@@ -2,10 +2,11 @@ import type { Meta, StoryFn } from '@storybook/react';
 import { ReactRouterDecorator } from '../../../../.storybook/ReactRouterDecorator';
 import { contributionPaidByCard } from '../../../fixtures/productBuilder/testProducts';
 import { UpgradeSupport } from './UpgradeSupport';
+import { UpgradeSupportContainer } from './UpgradeSupportContainer';
 
 export default {
 	title: 'Pages/UpgradeSupport',
-	component: UpgradeSupport,
+	component: UpgradeSupportContainer,
 	decorators: [ReactRouterDecorator],
 	parameters: {
 		layout: 'fullscreen',
@@ -13,10 +14,11 @@ export default {
 			state: {
 				productDetail: contributionPaidByCard,
 				user: { email: 'test@test.com' },
+				container: <UpgradeSupportContainer />,
 			},
 		},
 	},
-} as Meta<typeof UpgradeSupport>;
+} as Meta<typeof UpgradeSupportContainer>;
 
 export const UpgradeSupportValue: StoryFn<typeof UpgradeSupport> = () => {
 	return <UpgradeSupport />;

--- a/client/components/mma/upgrade/UpgradeSupport.tsx
+++ b/client/components/mma/upgrade/UpgradeSupport.tsx
@@ -1,0 +1,34 @@
+import { css } from '@emotion/react';
+import { headline } from '@guardian/source-foundations';
+import { Stack } from '@guardian/source-react-components';
+import { NAV_LINKS } from '../../shared/nav/NavConfig';
+import { PageContainer } from '../Page';
+import { sectionSpacing } from '../switch/SwitchStyles';
+import { UpgradeSupportAmountForm } from './UpgradeSupportAmountForm';
+
+export const UpgradeSupport = () => {
+	return (
+		<>
+			<PageContainer
+				selectedNavItem={NAV_LINKS.accountOverview}
+				pageTitle={'Select your new support'}
+				compactTitle
+				minimalFooter
+			>
+				<section css={sectionSpacing}>
+					<Stack space={3}>
+						<h2
+							css={css`
+								${headline.xsmall({ fontWeight: 'bold' })};
+								margin-bottom: 0;
+							`}
+						>
+							1. Increase your support
+						</h2>
+						<UpgradeSupportAmountForm />
+					</Stack>
+				</section>
+			</PageContainer>
+		</>
+	);
+};

--- a/client/components/mma/upgrade/UpgradeSupport.tsx
+++ b/client/components/mma/upgrade/UpgradeSupport.tsx
@@ -1,34 +1,25 @@
 import { css } from '@emotion/react';
 import { headline } from '@guardian/source-foundations';
 import { Stack } from '@guardian/source-react-components';
-import { NAV_LINKS } from '../../shared/nav/NavConfig';
-import { PageContainer } from '../Page';
 import { sectionSpacing } from '../switch/SwitchStyles';
 import { UpgradeSupportAmountForm } from './UpgradeSupportAmountForm';
 
 export const UpgradeSupport = () => {
 	return (
 		<>
-			<PageContainer
-				selectedNavItem={NAV_LINKS.accountOverview}
-				pageTitle={'Select your new support'}
-				compactTitle
-				minimalFooter
-			>
-				<section css={sectionSpacing}>
-					<Stack space={3}>
-						<h2
-							css={css`
-								${headline.xsmall({ fontWeight: 'bold' })};
-								margin-bottom: 0;
-							`}
-						>
-							1. Increase your support
-						</h2>
-						<UpgradeSupportAmountForm />
-					</Stack>
-				</section>
-			</PageContainer>
+			<section css={sectionSpacing}>
+				<Stack space={3}>
+					<h2
+						css={css`
+							${headline.xsmall({ fontWeight: 'bold' })};
+							margin-bottom: 0;
+						`}
+					>
+						1. Increase your support
+					</h2>
+					<UpgradeSupportAmountForm />
+				</Stack>
+			</section>
 		</>
 	);
 };

--- a/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
@@ -5,9 +5,18 @@ import {
 	ChoiceCard,
 	ChoiceCardGroup,
 } from '@guardian/source-react-components';
+import { useContext } from 'react';
 import { InfoIconDark } from '../shared/assets/InfoIconDark';
+import type { UpgradeSupportInterface } from './UpgradeSupportContainer';
+import { UpgradeSupportContext } from './UpgradeSupportContainer';
 
 export const UpgradeSupportAmountForm = () => {
+	const upgradeSupportContext = useContext(
+		UpgradeSupportContext,
+	) as UpgradeSupportInterface;
+
+	const currentAmount = upgradeSupportContext.mainPlan.price / 100;
+
 	return (
 		<>
 			<div
@@ -19,7 +28,9 @@ export const UpgradeSupportAmountForm = () => {
 				`}
 			>
 				<InfoIconDark />
-				You're currently supporting XYZ.
+				You're currently supporting{' '}
+				{upgradeSupportContext.mainPlan.currency} {currentAmount}
+				{upgradeSupportContext.mainPlan.billingPeriod}.
 				<dl />
 				<ChoiceCardGroup
 					name="amounts"

--- a/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
 import { palette, space, textSans } from '@guardian/source-foundations';
 import {
 	Button,
@@ -51,6 +52,22 @@ function validateChoice(
 	return null;
 }
 
+function isAboveThreshold(chosenAmount: number | null): EmotionJSX.Element {
+	const chosenOptionNum = Number(chosenAmount);
+	if (!isNaN(chosenOptionNum) && chosenOptionNum < 10) {
+		return (
+			<BenefitsSection
+				benefits={benefitsConfiguration['contributions']}
+			/>
+		);
+	} else
+		{return (
+			<BenefitsSection
+				benefits={benefitsConfiguration['supporterplus']}
+			/>
+		);}
+}
+
 export const UpgradeSupportAmountForm = () => {
 	const upgradeSupportContext = useContext(
 		UpgradeSupportContext,
@@ -68,6 +85,7 @@ export const UpgradeSupportAmountForm = () => {
 		return `${upgradeSupportContext.mainPlan.currency}${amount} per ${upgradeSupportContext.mainPlan.billingPeriod}`;
 	};
 	const currentAmount = upgradeSupportContext.mainPlan.price / 100;
+
 	const mainPlan = upgradeSupportContext.mainPlan;
 
 	const otherAmountLabel = `Choose an amount (${upgradeSupportContext.mainPlan.currency} per ${upgradeSupportContext.mainPlan.billingPeriod})`;
@@ -192,11 +210,12 @@ export const UpgradeSupportAmountForm = () => {
 						${textSans.medium()};
 					`}
 				>
-					<BenefitsSection
-						benefits={benefitsConfiguration['contributions']}
-					/>
+					{isAboveThreshold(chosenAmount)}
 				</div>
-				<Button>Continue XYZ</Button>
+				<Button>
+					Continue with {mainPlan.currency}
+					{chosenAmount}/{mainPlan.billingPeriod}
+				</Button>
 			</div>
 		</>
 	);

--- a/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
@@ -52,7 +52,9 @@ function validateChoice(
 	return null;
 }
 
-function isAboveThreshold(chosenAmount: number | null): EmotionJSX.Element {
+function displayRelevantBenefits(
+	chosenAmount: number | null,
+): EmotionJSX.Element {
 	const chosenOptionNum = Number(chosenAmount);
 	if (!isNaN(chosenOptionNum) && chosenOptionNum < 10) {
 		return (
@@ -214,7 +216,7 @@ export const UpgradeSupportAmountForm = () => {
 						${textSans.medium()};
 					`}
 				>
-					{isAboveThreshold(chosenAmount)}
+					{displayRelevantBenefits(chosenAmount)}
 				</div>
 				<Button>
 					Continue with {mainPlan.currency}

--- a/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
@@ -1,0 +1,62 @@
+import { css } from '@emotion/react';
+import { palette, space, textSans } from '@guardian/source-foundations';
+import {
+	Button,
+	ChoiceCard,
+	ChoiceCardGroup,
+} from '@guardian/source-react-components';
+import { InfoIconDark } from '../shared/assets/InfoIconDark';
+
+export const UpgradeSupportAmountForm = () => {
+	return (
+		<>
+			<div
+				css={css`
+					border: 1px solid ${palette.neutral[20]};
+					margin-bottom: ${space[5]}px;
+					padding: ${space[3]}px ${space[5]}px;
+					${textSans.medium()};
+				`}
+			>
+				<InfoIconDark />
+				You're currently supporting XYZ.
+				<dl />
+				<ChoiceCardGroup
+					name="amounts"
+					data-cy="contribution-amount-choices"
+					label="Choose your new amount"
+					columns={2}
+				>
+					<>
+						<ChoiceCard
+							id={`amount-other`}
+							value="£15"
+							label="£15"
+						/>
+						<ChoiceCard
+							id={`amount-other`}
+							value="£12"
+							label="£12"
+						/>
+						<ChoiceCard
+							id={`amount-other`}
+							value="£10"
+							label="£10"
+						/>
+						<ChoiceCard
+							id={`amount-other`}
+							value="Choose your amount"
+							label="Choose your amount"
+						/>
+					</>
+				</ChoiceCardGroup>
+				<div
+					css={css`
+						max-width: 500px;
+					`}
+				></div>
+				<Button>Continue with XYZ</Button>
+			</div>
+		</>
+	);
+};

--- a/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
@@ -65,7 +65,7 @@ export const UpgradeSupportAmountForm = () => {
 	];
 
 	const amountLabel = (amount: number) => {
-		return `${upgradeSupportContext.mainPlan.currency}${amount} a ${upgradeSupportContext.mainPlan.billingPeriod}`;
+		return `${upgradeSupportContext.mainPlan.currency}${amount} per ${upgradeSupportContext.mainPlan.billingPeriod}`;
 	};
 	const currentAmount = upgradeSupportContext.mainPlan.price / 100;
 	const mainPlan = upgradeSupportContext.mainPlan;

--- a/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
@@ -60,12 +60,13 @@ function isAboveThreshold(chosenAmount: number | null): EmotionJSX.Element {
 				benefits={benefitsConfiguration['contributions']}
 			/>
 		);
-	} else
-		{return (
+	} else {
+		return (
 			<BenefitsSection
 				benefits={benefitsConfiguration['supporterplus']}
 			/>
-		);}
+		);
+	}
 }
 
 export const UpgradeSupportAmountForm = () => {
@@ -186,6 +187,9 @@ export const UpgradeSupportAmountForm = () => {
 					>
 						<TextInput
 							label={otherAmountLabel}
+							supporting={
+								'Support £10/month or more to unlock all extras'
+							}
 							error={
 								(shouldShowOtherAmountErrorMessage &&
 									errorMessage) ||

--- a/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
@@ -4,18 +4,113 @@ import {
 	Button,
 	ChoiceCard,
 	ChoiceCardGroup,
+	TextInput,
 } from '@guardian/source-react-components';
-import { useContext } from 'react';
+import { useContext, useEffect, useState } from 'react';
+import type { PaidSubscriptionPlan } from '../../../../shared/productResponse';
+import { calculateMonthlyOrAnnualFromBillingPeriod } from '../../../../shared/productTypes';
+import type { CurrencyIso } from '../../../utilities/currencyIso';
+import {
+	suggestedAmounts,
+	supporterPlusPriceConfigByCountryGroup,
+} from '../../../utilities/supporterPlusPricing';
 import { InfoIconDark } from '../shared/assets/InfoIconDark';
+import { benefitsConfiguration } from '../shared/benefits/BenefitsConfiguration';
+import { BenefitsSection } from '../shared/benefits/BenefitsSection';
 import type { UpgradeSupportInterface } from './UpgradeSupportContainer';
 import { UpgradeSupportContext } from './UpgradeSupportContainer';
+
+function validateChoice(
+	currentAmount: number,
+	chosenAmount: number | null,
+	minAmount: number,
+	maxAmount: number,
+	isOtherAmountSelected: boolean,
+	mainPlan: PaidSubscriptionPlan,
+): string | null {
+	const chosenOptionNum = Number(chosenAmount);
+	if (!chosenAmount && !isOtherAmountSelected) {
+		return 'Please make a selection';
+	} else if (chosenOptionNum === currentAmount) {
+		return 'You have selected the same amount as you currently contribute';
+	} else if (!chosenAmount || isNaN(chosenOptionNum)) {
+		return 'There is a problem with the amount you have selected, please make sure it is a valid amount';
+	} else if (!isNaN(chosenOptionNum) && chosenOptionNum < minAmount) {
+		return `There is a minimum ${
+			mainPlan.billingPeriod
+		}ly contribution amount of ${mainPlan.currency}${minAmount.toFixed(
+			2,
+		)} ${mainPlan.currencyISO}`;
+	} else if (!isNaN(chosenOptionNum) && chosenOptionNum > maxAmount) {
+		return `There is a maximum ${
+			mainPlan.billingPeriod
+		}ly contribution amount of ${mainPlan.currency}${maxAmount.toFixed(
+			2,
+		)} ${mainPlan.currencyISO}`;
+	}
+	return null;
+}
 
 export const UpgradeSupportAmountForm = () => {
 	const upgradeSupportContext = useContext(
 		UpgradeSupportContext,
 	) as UpgradeSupportInterface;
 
+	const priceConfig = (supporterPlusPriceConfigByCountryGroup[
+		upgradeSupportContext.mainPlan.currencyISO as CurrencyIso
+	] || supporterPlusPriceConfigByCountryGroup.international)[
+		calculateMonthlyOrAnnualFromBillingPeriod(
+			upgradeSupportContext.mainPlan.billingPeriod,
+		)
+	];
+
+	const amountLabel = (amount: number) => {
+		return `${upgradeSupportContext.mainPlan.currency}${amount} a ${upgradeSupportContext.mainPlan.billingPeriod}`;
+	};
 	const currentAmount = upgradeSupportContext.mainPlan.price / 100;
+	const mainPlan = upgradeSupportContext.mainPlan;
+
+	const otherAmountLabel = `Choose an amount (${upgradeSupportContext.mainPlan.currency} per ${upgradeSupportContext.mainPlan.billingPeriod})`;
+
+	const [selectedValue, setSelectedValue] = useState<number | null>(null);
+
+	const [isOtherAmountSelected, setIsOtherAmountSelected] =
+		useState<boolean>(false);
+
+	const [hasInteractedWithOtherAmount, setHasInteractedWithOtherAmount] =
+		useState<boolean>(false);
+
+	const [hasSubmitted] = useState<boolean>(false);
+
+	const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+	const defaultOtherAmount = priceConfig.minAmount;
+
+	const [otherAmount, setOtherAmount] = useState<number | null>(
+		defaultOtherAmount,
+	);
+	const chosenAmount = isOtherAmountSelected ? otherAmount : selectedValue;
+
+	const shouldShowOtherAmountErrorMessage =
+		hasInteractedWithOtherAmount || hasSubmitted;
+
+	useEffect(() => {
+		if (otherAmount !== defaultOtherAmount) {
+			setHasInteractedWithOtherAmount(true);
+		}
+	}, [otherAmount]);
+
+	useEffect(() => {
+		const newErrorMessage = validateChoice(
+			currentAmount,
+			chosenAmount,
+			priceConfig.minAmount,
+			priceConfig.maxAmount,
+			isOtherAmountSelected,
+			mainPlan,
+		);
+		setErrorMessage(newErrorMessage);
+	}, [otherAmount, selectedValue]);
 
 	return (
 		<>
@@ -27,9 +122,9 @@ export const UpgradeSupportAmountForm = () => {
 					${textSans.medium()};
 				`}
 			>
-				<InfoIconDark />
-				You're currently supporting{' '}
-				{upgradeSupportContext.mainPlan.currency} {currentAmount}
+				<InfoIconDark /> You're currently supporting{' '}
+				{upgradeSupportContext.mainPlan.currency}
+				{currentAmount} per{' '}
 				{upgradeSupportContext.mainPlan.billingPeriod}.
 				<dl />
 				<ChoiceCardGroup
@@ -39,34 +134,69 @@ export const UpgradeSupportAmountForm = () => {
 					columns={2}
 				>
 					<>
-						<ChoiceCard
-							id={`amount-other`}
-							value="£15"
-							label="£15"
-						/>
-						<ChoiceCard
-							id={`amount-other`}
-							value="£12"
-							label="£12"
-						/>
-						<ChoiceCard
-							id={`amount-other`}
-							value="£10"
-							label="£10"
-						/>
+						{suggestedAmounts(currentAmount).map((amount) => (
+							<ChoiceCard
+								id={`amount-${amount}`}
+								key={amount}
+								value={amount.toString()}
+								label={amountLabel(amount)}
+								checked={selectedValue === amount}
+								onChange={() => {
+									setSelectedValue(amount);
+									setIsOtherAmountSelected(false);
+								}}
+							/>
+						))}
+
 						<ChoiceCard
 							id={`amount-other`}
 							value="Choose your amount"
 							label="Choose your amount"
+							checked={isOtherAmountSelected}
+							onChange={() => {
+								setIsOtherAmountSelected(true);
+								setSelectedValue(null);
+							}}
 						/>
 					</>
 				</ChoiceCardGroup>
+				{isOtherAmountSelected && (
+					<div
+						css={css`
+							margin-top: ${space[3]}px;
+						`}
+					>
+						<TextInput
+							label={otherAmountLabel}
+							error={
+								(shouldShowOtherAmountErrorMessage &&
+									errorMessage) ||
+								undefined
+							}
+							type="number"
+							value={otherAmount?.toString() || ''}
+							onChange={(event) =>
+								setOtherAmount(
+									event.target.value
+										? Number(event.target.value)
+										: null,
+								)
+							}
+						/>
+					</div>
+				)}
 				<div
 					css={css`
-						max-width: 500px;
+						margin-bottom: ${space[5]}px;
+						padding: ${space[3]}px ${space[5]}px;
+						${textSans.medium()};
 					`}
-				></div>
-				<Button>Continue with XYZ</Button>
+				>
+					<BenefitsSection
+						benefits={benefitsConfiguration['contributions']}
+					/>
+				</div>
+				<Button>Continue XYZ</Button>
 			</div>
 		</>
 	);

--- a/client/components/mma/upgrade/UpgradeSupportContainer.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportContainer.tsx
@@ -1,0 +1,82 @@
+import type { Context, ReactNode } from 'react';
+import { createContext } from 'react';
+import { Navigate, Outlet } from 'react-router';
+import type {
+	MembersDataApiResponse,
+	PaidSubscriptionPlan,
+} from '../../../../shared/productResponse';
+import { getMainPlan, isProduct } from '../../../../shared/productResponse';
+import { PRODUCT_TYPES } from '../../../../shared/productTypes';
+import {
+	LoadingState,
+	useAsyncLoader,
+} from '../../../utilities/hooks/useAsyncLoader';
+import { createProductDetailFetcher } from '../../../utilities/productUtils';
+import { GenericErrorScreen } from '../../shared/GenericErrorScreen';
+import { NAV_LINKS } from '../../shared/nav/NavConfig';
+import { PageContainer } from '../Page';
+import { JsonResponseHandler } from '../shared/asyncComponents/DefaultApiResponseHandler';
+import { DefaultLoadingView } from '../shared/asyncComponents/DefaultLoadingView';
+
+export interface UpgradeSupportInterface {
+	mainPlan: PaidSubscriptionPlan;
+}
+
+export const UpgradeSupportContext: Context<UpgradeSupportInterface | {}> =
+	createContext({});
+
+const UpgradeSupportPageContainer = ({ children }: { children: ReactNode }) => {
+	return (
+		<PageContainer
+			selectedNavItem={NAV_LINKS.accountOverview}
+			pageTitle={'Select your new support'}
+		>
+			{children}
+		</PageContainer>
+	);
+};
+
+export const UpgradeSupportContainer = () => {
+	const request = createProductDetailFetcher(
+		PRODUCT_TYPES.contributions.allProductsProductTypeFilterString,
+	);
+
+	const { data, loadingState } = useAsyncLoader<MembersDataApiResponse>(
+		request,
+		JsonResponseHandler,
+	);
+
+	if (loadingState == LoadingState.HasError) {
+		return (
+			<UpgradeSupportPageContainer>
+				<GenericErrorScreen />
+			</UpgradeSupportPageContainer>
+		);
+	}
+	if (loadingState == LoadingState.IsLoading) {
+		return (
+			<UpgradeSupportPageContainer>
+				<DefaultLoadingView loadingMessage="Loading your contribution details..." />
+			</UpgradeSupportPageContainer>
+		);
+	}
+
+	if (data == null || data.products.length == 0) {
+		return <Navigate to="/" />;
+	}
+
+	const contribution = data.products.filter(isProduct)[0];
+	const mainPlan = getMainPlan(contribution.subscription);
+
+	return (
+		<UpgradeSupportPageContainer>
+			<UpgradeSupportContext.Provider
+				value={{
+					mainPlan,
+				}}
+			>
+				<Outlet />
+			</UpgradeSupportContext.Provider>
+		</UpgradeSupportPageContainer>
+	);
+};


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
First iteration of the new screen to support the RC users to increase their contribution amount. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
This will a url accessible only via an email but can be viewed via **/upgrade-support**
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
Landing on the screen
![image](https://github.com/guardian/manage-frontend/assets/115992455/68fee4c1-90f7-4147-b8a9-5a5bb66dc271)

Selecting an amount (above threshold)
<img width="913" alt="image" src="https://github.com/guardian/manage-frontend/assets/115992455/67d3d03d-660b-4a09-a983-855ea60b7e20">

Selecting Choose your amount
<img width="913" alt="image" src="https://github.com/guardian/manage-frontend/assets/115992455/d0f4fad8-1f4c-4b0a-982d-fea103a70a8e">

Entering in same amount as currently contributing
![image](https://github.com/guardian/manage-frontend/assets/115992455/ad449fb9-d34a-4189-865b-b29713629187)

Entering amount below threshold 
![image](https://github.com/guardian/manage-frontend/assets/115992455/a7d859d0-723b-4661-bf3d-a8e7c9bb385b)

Entering 0 
![image](https://github.com/guardian/manage-frontend/assets/115992455/4b1fbd77-ca57-4b6c-955c-449a0673a9e4)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
