### PR TITLE
Build fix 

### DIFF
--- a/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
@@ -111,6 +111,9 @@ export const UpgradeSupportAmountForm = () => {
 		defaultOtherAmount,
 	);
 	const chosenAmount = isOtherAmountSelected ? otherAmount : selectedValue;
+	const monthlyOrAnnual = calculateMonthlyOrAnnualFromBillingPeriod(
+		mainPlan.billingPeriod,
+	);
 
 	const shouldShowOtherAmountErrorMessage =
 		hasInteractedWithOtherAmount || hasSubmitted;
@@ -155,19 +158,21 @@ export const UpgradeSupportAmountForm = () => {
 					columns={2}
 				>
 					<>
-						{suggestedAmounts(currentAmount).map((amount) => (
-							<ChoiceCard
-								id={`amount-${amount}`}
-								key={amount}
-								value={amount.toString()}
-								label={amountLabel(amount)}
-								checked={selectedValue === amount}
-								onChange={() => {
-									setSelectedValue(amount);
-									setIsOtherAmountSelected(false);
-								}}
-							/>
-						))}
+						{suggestedAmounts(currentAmount, monthlyOrAnnual).map(
+							(amount) => (
+								<ChoiceCard
+									id={`amount-${amount}`}
+									key={amount}
+									value={amount.toString()}
+									label={amountLabel(amount)}
+									checked={selectedValue === amount}
+									onChange={() => {
+										setSelectedValue(amount);
+										setIsOtherAmountSelected(false);
+									}}
+								/>
+							),
+						)}
 
 						<ChoiceCard
 							id={`amount-other`}


### PR DESCRIPTION
Fix for type error on main build which was caused by a missing parameter being passed into a function

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
