### PR TITLE
Thank you no switch V1

### DIFF
--- a/client/components/mma/MMAPage.tsx
+++ b/client/components/mma/MMAPage.tsx
@@ -36,6 +36,7 @@ import { DeliveryAddressUpdate } from './delivery/address/DeliveryAddressForm';
 import { Maintenance } from './maintenance/Maintenance';
 import { MMAPageSkeleton } from './MMAPageSkeleton';
 import { UpgradeSupportContainer } from './upgrade/UpgradeSupportContainer';
+import { UpgradeSupportThankYou } from './upgrade/UpgradeSupportThankYou';
 
 const record = (event: any) => {
 	if (window.guardian?.ophan?.record) {
@@ -428,8 +429,12 @@ const MMARouter = () => {
 						>
 							<Route index element={<UpgradeSupport />} />
 							<Route
-								path={'thank-you'}
+								path={'switch-thank-you'}
 								element={<UpgradeSupportSwitchThankYou />}
+							/>
+							<Route
+								path={'thank-you'}
+								element={<UpgradeSupportThankYou />}
 							/>
 						</Route>
 						{[

--- a/client/components/mma/upgrade/UpgradeSupport.stories.tsx
+++ b/client/components/mma/upgrade/UpgradeSupport.stories.tsx
@@ -6,6 +6,7 @@ import { contributionPaidByCard } from '../../../fixtures/productBuilder/testPro
 import { UpgradeSupport } from './UpgradeSupport';
 import { UpgradeSupportContainer } from './UpgradeSupportContainer';
 import { UpgradeSupportSwitchThankYou } from './UpgradeSupportSwitchThankYou';
+import { UpgradeSupportThankYou } from './UpgradeSupportThankYou';
 
 export default {
 	title: 'Pages/UpgradeSupport',
@@ -36,4 +37,10 @@ export const UpgradeSupportSwitchThankYouPage: StoryFn<
 	typeof UpgradeSupportSwitchThankYou
 > = () => {
 	return <UpgradeSupportSwitchThankYou />;
+};
+
+export const UpgradeSupportThankYouPage: StoryFn<
+	typeof UpgradeSupportThankYou
+> = () => {
+	return <UpgradeSupportThankYou />;
 };

--- a/client/components/mma/upgrade/UpgradeSupportThankYou.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportThankYou.tsx
@@ -8,6 +8,10 @@ import {
 import { useContext } from 'react';
 import { useNavigate } from 'react-router';
 import {
+	DATE_FNS_LONG_OUTPUT_FORMAT,
+	parseDate,
+} from '../../../../shared/dates';
+import {
 	headingCss,
 	stackedButtonLeftLayoutCss,
 	whatHappensNextCss,
@@ -18,11 +22,8 @@ import {
 	iconListCss,
 	sectionSpacing,
 } from '../switch/SwitchStyles';
-import type {
-	UpgradeSupportInterface} from './UpgradeSupportContainer';
-import {
-	UpgradeSupportContext
-} from './UpgradeSupportContainer';
+import type { UpgradeSupportInterface } from './UpgradeSupportContainer';
+import { UpgradeSupportContext } from './UpgradeSupportContainer';
 
 export const UpgradeSupportThankYou = () => {
 	const upgradeSupportContext = useContext(
@@ -32,6 +33,13 @@ export const UpgradeSupportThankYou = () => {
 	const navigate = useNavigate();
 
 	const userEmailAddress = upgradeSupportContext.user;
+
+	const billingPeriod = upgradeSupportContext.mainPlan.billingPeriod;
+
+	const nextBillingDate = parseDate(
+		upgradeSupportContext.mainPlan.chargedThrough ?? undefined,
+	).dateStr(DATE_FNS_LONG_OUTPUT_FORMAT);
+
 	return (
 		<>
 			<section css={sectionSpacing}>
@@ -41,7 +49,7 @@ export const UpgradeSupportThankYou = () => {
 					</h2>
 				</Stack>
 				<Stack space={4}>
-					<h2 css={headingCss}>Your new support</h2>
+					<h2 css={headingCss}>Your new support /{billingPeriod}</h2>
 				</Stack>
 			</section>
 			<section css={sectionSpacing}>
@@ -59,7 +67,7 @@ export const UpgradeSupportThankYou = () => {
 							<SvgCalendar size="medium" />
 							<span>
 								This change will happen on your next billing
-								date of
+								date of {nextBillingDate}
 							</span>
 						</li>
 					</ul>

--- a/client/components/mma/upgrade/UpgradeSupportThankYou.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportThankYou.tsx
@@ -5,6 +5,7 @@ import {
 	SvgCalendar,
 	SvgEnvelope,
 } from '@guardian/source-react-components';
+import { useContext } from 'react';
 import { useNavigate } from 'react-router';
 import {
 	headingCss,
@@ -17,10 +18,20 @@ import {
 	iconListCss,
 	sectionSpacing,
 } from '../switch/SwitchStyles';
+import type {
+	UpgradeSupportInterface} from './UpgradeSupportContainer';
+import {
+	UpgradeSupportContext
+} from './UpgradeSupportContainer';
 
 export const UpgradeSupportThankYou = () => {
+	const upgradeSupportContext = useContext(
+		UpgradeSupportContext,
+	) as UpgradeSupportInterface;
+
 	const navigate = useNavigate();
 
+	const userEmailAddress = upgradeSupportContext.user;
 	return (
 		<>
 			<section css={sectionSpacing}>
@@ -41,6 +52,7 @@ export const UpgradeSupportThankYou = () => {
 							<SvgEnvelope size="medium" />
 							<span data-qm-masking="blocklist">
 								We will send a confirmation email to you at{' '}
+								<> {userEmailAddress} </>
 							</span>
 						</li>
 						<li>

--- a/client/components/mma/upgrade/UpgradeSupportThankYou.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportThankYou.tsx
@@ -1,0 +1,73 @@
+import {
+	Button,
+	LinkButton,
+	Stack,
+	SvgCalendar,
+	SvgEnvelope,
+} from '@guardian/source-react-components';
+import { useNavigate } from 'react-router';
+import {
+	headingCss,
+	stackedButtonLeftLayoutCss,
+	whatHappensNextCss,
+} from '../cancel/cancellationSaves/SaveStyles';
+import { Heading } from '../shared/Heading';
+import {
+	buttonCentredCss,
+	iconListCss,
+	sectionSpacing,
+} from '../switch/SwitchStyles';
+
+export const UpgradeSupportThankYou = () => {
+	const navigate = useNavigate();
+
+	return (
+		<>
+			<section css={sectionSpacing}>
+				<Stack space={4}>
+					<h2 css={headingCss}>
+						Thank you for your continued support.
+					</h2>
+				</Stack>
+				<Stack space={4}>
+					<h2 css={headingCss}>Your new support</h2>
+				</Stack>
+			</section>
+			<section css={sectionSpacing}>
+				<Stack space={4}>
+					<Heading sansSerif>What happens next?</Heading>
+					<ul css={[iconListCss, whatHappensNextCss]}>
+						<li>
+							<SvgEnvelope size="medium" />
+							<span data-qm-masking="blocklist">
+								We will send a confirmation email to you at{' '}
+							</span>
+						</li>
+						<li>
+							<SvgCalendar size="medium" />
+							<span>
+								This change will happen on your next billing
+								date of
+							</span>
+						</li>
+					</ul>
+				</Stack>
+			</section>
+			<div css={stackedButtonLeftLayoutCss}>
+				<Button
+					priority="tertiary"
+					onClick={() => navigate('/')}
+					cssOverrides={buttonCentredCss}
+				>
+					Back to my account
+				</Button>
+				<LinkButton
+					href="https://theguardian.com"
+					cssOverrides={buttonCentredCss}
+				>
+					Continue to the Guardian
+				</LinkButton>
+			</div>
+		</>
+	);
+};


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
New thank you screen for when a user upgrades their contribution amount and **does not** switch to S+. This is still a wip and this PR covers the first iteration of the designs.

This also changes the thank you page urls. When a users switches product they will see the `upgrade-support/switch-thank-you `page but in this case they will see the `upgrade-support/thank-you` page

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Locally head to `upgrade-support/thank-you` or check new scenario on storybook
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<img width="884" alt="image" src="https://github.com/guardian/manage-frontend/assets/115992455/fd13ad87-f35d-4532-b7cd-dcef3359bb65">

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
