### PR TITLE
Refactoring: Reused CSS moved into GenericStyles file

### DIFF
--- a/client/components/mma/accountoverview/CancelledProductCard.tsx
+++ b/client/components/mma/accountoverview/CancelledProductCard.tsx
@@ -10,8 +10,8 @@ import { productCardConfiguration } from './ProductCardConfiguration';
 import {
 	buttonLayoutCss,
 	keyValueCss,
+	productCardTitleCss,
 	productDetailLayoutCss,
-	productTitleCss,
 	sectionHeadingCss,
 } from './ProductCardStyles';
 
@@ -38,7 +38,7 @@ export const CancelledProductCard = ({
 			/>
 			<Card>
 				<Card.Header backgroundColor={cardConfig.colour}>
-					<h3 css={productTitleCss(cardConfig.invertText)}>
+					<h3 css={productCardTitleCss(cardConfig.invertText)}>
 						{specificProductType.productTitle()}
 					</h3>
 				</Card.Header>

--- a/client/components/mma/accountoverview/InAppPurchaseCard.tsx
+++ b/client/components/mma/accountoverview/InAppPurchaseCard.tsx
@@ -13,7 +13,10 @@ import {
 } from '../../../../shared/mpapiResponse';
 import { Card } from '../shared/Card';
 import { productColour } from './ProductCardConfiguration';
-import { productDetailLayoutCss, productTitleCss } from './ProductCardStyles';
+import {
+	productCardTitleCss,
+	productDetailLayoutCss,
+} from './ProductCardStyles';
 
 const summaryLinkCss = css`
 	color: currentColor;
@@ -60,7 +63,7 @@ export const InAppPurchaseCard = ({
 							: productColour.inAppPurchase
 					}
 				>
-					<h3 css={productTitleCss(!isPuzzleApp)}>
+					<h3 css={productCardTitleCss(!isPuzzleApp)}>
 						{capitalize(puzzleOrNews)} app
 					</h3>
 				</Card.Header>

--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -38,8 +38,8 @@ import { productCardConfiguration } from './ProductCardConfiguration';
 import {
 	buttonLayoutCss,
 	keyValueCss,
+	productCardTitleCss,
 	productDetailLayoutCss,
-	productTitleCss,
 	sectionHeadingCss,
 } from './ProductCardStyles';
 
@@ -188,7 +188,7 @@ export const ProductCard = ({
 			)}
 			<Card>
 				<Card.Header backgroundColor={cardConfig.colour}>
-					<h3 css={productTitleCss(cardConfig.invertText)}>
+					<h3 css={productCardTitleCss(cardConfig.invertText)}>
 						{productTitle}
 					</h3>
 					{isGifted && (

--- a/client/components/mma/accountoverview/ProductCardStyles.ts
+++ b/client/components/mma/accountoverview/ProductCardStyles.ts
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { from, headline, space, textSans } from '@guardian/source-foundations';
 import { textColour } from './ProductCardConfiguration';
 
-export const productTitleCss = (dark?: boolean) => css`
+export const productCardTitleCss = (dark?: boolean) => css`
 	${headline.xxsmall({ fontWeight: 'bold' })};
 	color: ${dark ? textColour.dark : textColour.light};
 	margin-top: 0;

--- a/client/components/mma/accountoverview/SingleContributionCard.tsx
+++ b/client/components/mma/accountoverview/SingleContributionCard.tsx
@@ -10,8 +10,8 @@ import { productColour } from './ProductCardConfiguration';
 import {
 	buttonLayoutCss,
 	keyValueCss,
+	productCardTitleCss,
 	productDetailLayoutCss,
-	productTitleCss,
 } from './ProductCardStyles';
 
 export const SingleContributionCard = ({
@@ -25,7 +25,7 @@ export const SingleContributionCard = ({
 		<Stack space={4}>
 			<Card>
 				<Card.Header backgroundColor={productColour.singleContribution}>
-					<h3 css={productTitleCss(true)}>Single Support</h3>
+					<h3 css={productCardTitleCss(true)}>Single Support</h3>
 				</Card.Header>
 				<Card.Section>
 					<div

--- a/client/components/mma/cancel/cancellationSaves/ContinueMembershipConfirmation.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ContinueMembershipConfirmation.tsx
@@ -6,13 +6,13 @@ import { useNavigate } from 'react-router';
 import { cancellationFormatDate } from '../../../../../shared/dates';
 import type { PaidSubscriptionPlan } from '../../../../../shared/productResponse';
 import { getMainPlan } from '../../../../../shared/productResponse';
+import { headingCss } from '../../../../styles/GenericStyles';
 import { getNewMembershipPrice } from '../../../../utilities/membershipPriceRise';
 import { ProgressStepper } from '../../shared/ProgressStepper';
 import type { CancellationContextInterface } from '../CancellationContainer';
 import { CancellationContext } from '../CancellationContainer';
 import {
 	buttonCentredCss,
-	headingCss,
 	paragraphListCss,
 	stackedButtonLeftLayoutCss,
 } from './SaveStyles';

--- a/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
@@ -10,6 +10,7 @@ import type {
 	ProductDetail,
 } from '../../../../../shared/productResponse';
 import { getMainPlan } from '../../../../../shared/productResponse';
+import { sectionSpacing } from '../../../../styles/GenericStyles';
 import type { CurrencyIso } from '../../../../utilities/currencyIso';
 import {
 	LoadingState,
@@ -23,7 +24,6 @@ import { GenericErrorScreen } from '../../../shared/GenericErrorScreen';
 import { JsonResponseHandler } from '../../shared/asyncComponents/DefaultApiResponseHandler';
 import { DefaultLoadingView } from '../../shared/asyncComponents/DefaultLoadingView';
 import { Heading } from '../../shared/Heading';
-import { sectionSpacing } from '../../switch/SwitchStyles';
 import type { CancellationContextInterface } from '../CancellationContainer';
 import { CancellationContext } from '../CancellationContainer';
 import { buttonLayoutCss, headingCss } from './SaveStyles';

--- a/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipCancellationLanding.tsx
@@ -10,7 +10,7 @@ import type {
 	ProductDetail,
 } from '../../../../../shared/productResponse';
 import { getMainPlan } from '../../../../../shared/productResponse';
-import { sectionSpacing } from '../../../../styles/GenericStyles';
+import { headingCss, sectionSpacing } from '../../../../styles/GenericStyles';
 import type { CurrencyIso } from '../../../../utilities/currencyIso';
 import {
 	LoadingState,
@@ -26,7 +26,7 @@ import { DefaultLoadingView } from '../../shared/asyncComponents/DefaultLoadingV
 import { Heading } from '../../shared/Heading';
 import type { CancellationContextInterface } from '../CancellationContainer';
 import { CancellationContext } from '../CancellationContainer';
-import { buttonLayoutCss, headingCss } from './SaveStyles';
+import { buttonLayoutCss } from './SaveStyles';
 
 function ineligibleForSave(
 	products: ProductDetail[],

--- a/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
@@ -20,6 +20,7 @@ import type { ProductSwitchType } from '../../../../../shared/productSwitchTypes
 import { calculateMonthlyOrAnnualFromBillingPeriod } from '../../../../../shared/productTypes';
 import {
 	iconListCss,
+	listWithDividersCss,
 	productTitleCss,
 	sectionSpacing,
 	smallPrintCss,
@@ -43,7 +44,6 @@ import {
 	buttonMutedCss,
 	errorSummaryLinkCss,
 	errorSummaryOverrideCss,
-	listWithDividersCss,
 	newAmountCss,
 	stackedButtonLayoutCss,
 	wideButtonCss,

--- a/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
@@ -18,7 +18,10 @@ import type {
 import { getMainPlan } from '../../../../../shared/productResponse';
 import type { ProductSwitchType } from '../../../../../shared/productSwitchTypes';
 import { calculateMonthlyOrAnnualFromBillingPeriod } from '../../../../../shared/productTypes';
-import { errorSummaryOverrideCss } from '../../../../styles/ErrorStyles';
+import {
+	errorSummaryLinkCss,
+	errorSummaryOverrideCss,
+} from '../../../../styles/ErrorStyles';
 import {
 	iconListCss,
 	listWithDividersCss,
@@ -43,7 +46,6 @@ import {
 import {
 	buttonCentredCss,
 	buttonMutedCss,
-	errorSummaryLinkCss,
 	newAmountCss,
 	stackedButtonLayoutCss,
 	wideButtonCss,

--- a/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
@@ -18,6 +18,7 @@ import type {
 import { getMainPlan } from '../../../../../shared/productResponse';
 import type { ProductSwitchType } from '../../../../../shared/productSwitchTypes';
 import { calculateMonthlyOrAnnualFromBillingPeriod } from '../../../../../shared/productTypes';
+import { sectionSpacing } from '../../../../styles/GenericStyles';
 import { getOldMembershipPrice } from '../../../../utilities/membershipPriceRise';
 import { JsonResponseHandler } from '../../shared/asyncComponents/DefaultApiResponseHandler';
 import { Card } from '../../shared/Card';
@@ -41,7 +42,6 @@ import {
 	listWithDividersCss,
 	newAmountCss,
 	productTitleCss,
-	sectionSpacing,
 	smallPrintCss,
 	stackedButtonLayoutCss,
 	wideButtonCss,

--- a/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
@@ -18,7 +18,7 @@ import type {
 import { getMainPlan } from '../../../../../shared/productResponse';
 import type { ProductSwitchType } from '../../../../../shared/productSwitchTypes';
 import { calculateMonthlyOrAnnualFromBillingPeriod } from '../../../../../shared/productTypes';
-import { sectionSpacing } from '../../../../styles/GenericStyles';
+import { iconListCss, sectionSpacing } from '../../../../styles/GenericStyles';
 import { getOldMembershipPrice } from '../../../../utilities/membershipPriceRise';
 import { JsonResponseHandler } from '../../shared/asyncComponents/DefaultApiResponseHandler';
 import { Card } from '../../shared/Card';
@@ -38,7 +38,6 @@ import {
 	buttonMutedCss,
 	errorSummaryLinkCss,
 	errorSummaryOverrideCss,
-	iconListCss,
 	listWithDividersCss,
 	newAmountCss,
 	productTitleCss,

--- a/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
@@ -18,6 +18,7 @@ import type {
 import { getMainPlan } from '../../../../../shared/productResponse';
 import type { ProductSwitchType } from '../../../../../shared/productSwitchTypes';
 import { calculateMonthlyOrAnnualFromBillingPeriod } from '../../../../../shared/productTypes';
+import { errorSummaryOverrideCss } from '../../../../styles/ErrorStyles';
 import {
 	iconListCss,
 	listWithDividersCss,
@@ -43,7 +44,6 @@ import {
 	buttonCentredCss,
 	buttonMutedCss,
 	errorSummaryLinkCss,
-	errorSummaryOverrideCss,
 	newAmountCss,
 	stackedButtonLayoutCss,
 	wideButtonCss,

--- a/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
@@ -18,7 +18,11 @@ import type {
 import { getMainPlan } from '../../../../../shared/productResponse';
 import type { ProductSwitchType } from '../../../../../shared/productSwitchTypes';
 import { calculateMonthlyOrAnnualFromBillingPeriod } from '../../../../../shared/productTypes';
-import { iconListCss, sectionSpacing } from '../../../../styles/GenericStyles';
+import {
+	iconListCss,
+	productTitleCss,
+	sectionSpacing,
+} from '../../../../styles/GenericStyles';
 import { getOldMembershipPrice } from '../../../../utilities/membershipPriceRise';
 import { JsonResponseHandler } from '../../shared/asyncComponents/DefaultApiResponseHandler';
 import { Card } from '../../shared/Card';
@@ -40,7 +44,6 @@ import {
 	errorSummaryOverrideCss,
 	listWithDividersCss,
 	newAmountCss,
-	productTitleCss,
 	smallPrintCss,
 	stackedButtonLayoutCss,
 	wideButtonCss,

--- a/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
+++ b/client/components/mma/cancel/cancellationSaves/MembershipSwitch.tsx
@@ -22,6 +22,7 @@ import {
 	iconListCss,
 	productTitleCss,
 	sectionSpacing,
+	smallPrintCss,
 } from '../../../../styles/GenericStyles';
 import { getOldMembershipPrice } from '../../../../utilities/membershipPriceRise';
 import { JsonResponseHandler } from '../../shared/asyncComponents/DefaultApiResponseHandler';
@@ -44,7 +45,6 @@ import {
 	errorSummaryOverrideCss,
 	listWithDividersCss,
 	newAmountCss,
-	smallPrintCss,
 	stackedButtonLayoutCss,
 	wideButtonCss,
 } from './SaveStyles';

--- a/client/components/mma/cancel/cancellationSaves/SaveOptions.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SaveOptions.tsx
@@ -16,7 +16,7 @@ import { Navigate, useLocation, useNavigate } from 'react-router';
 import type { PaidSubscriptionPlan } from '../../../../../shared/productResponse';
 import { getMainPlan } from '../../../../../shared/productResponse';
 import { calculateMonthlyOrAnnualFromBillingPeriod } from '../../../../../shared/productTypes';
-import { sectionSpacing } from '../../../../styles/GenericStyles';
+import { headingCss, sectionSpacing } from '../../../../styles/GenericStyles';
 import {
 	getNewMembershipPrice,
 	getOldMembershipPrice,
@@ -36,7 +36,6 @@ import {
 	buttonContainerCss,
 	cardHeaderDivCss,
 	cardSectionCss,
-	headingCss,
 	productSubtitleCss,
 	productTitleCss,
 } from './SaveStyles';

--- a/client/components/mma/cancel/cancellationSaves/SaveOptions.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SaveOptions.tsx
@@ -16,6 +16,7 @@ import { Navigate, useLocation, useNavigate } from 'react-router';
 import type { PaidSubscriptionPlan } from '../../../../../shared/productResponse';
 import { getMainPlan } from '../../../../../shared/productResponse';
 import { calculateMonthlyOrAnnualFromBillingPeriod } from '../../../../../shared/productTypes';
+import { sectionSpacing } from '../../../../styles/GenericStyles';
 import {
 	getNewMembershipPrice,
 	getOldMembershipPrice,
@@ -38,7 +39,6 @@ import {
 	headingCss,
 	productSubtitleCss,
 	productTitleCss,
-	sectionSpacing,
 } from './SaveStyles';
 
 const NewPriceIcon = () => {

--- a/client/components/mma/cancel/cancellationSaves/SaveOptions.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SaveOptions.tsx
@@ -16,7 +16,11 @@ import { Navigate, useLocation, useNavigate } from 'react-router';
 import type { PaidSubscriptionPlan } from '../../../../../shared/productResponse';
 import { getMainPlan } from '../../../../../shared/productResponse';
 import { calculateMonthlyOrAnnualFromBillingPeriod } from '../../../../../shared/productTypes';
-import { headingCss, sectionSpacing } from '../../../../styles/GenericStyles';
+import {
+	headingCss,
+	productTitleCss,
+	sectionSpacing,
+} from '../../../../styles/GenericStyles';
 import {
 	getNewMembershipPrice,
 	getOldMembershipPrice,
@@ -37,7 +41,6 @@ import {
 	cardHeaderDivCss,
 	cardSectionCss,
 	productSubtitleCss,
-	productTitleCss,
 } from './SaveStyles';
 
 const NewPriceIcon = () => {

--- a/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
+++ b/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
@@ -104,20 +104,6 @@ export const stackedButtonLeftLayoutCss = css`
 	}
 `;
 
-export const smallPrintCss = css`
-	${textSans.xxsmall()};
-	margin-top: 0;
-	margin-bottom: 0;
-	color: #606060;
-	> a {
-		color: inherit;
-		text-decoration: underline;
-	}
-	& + & {
-		margin-top: ${space[1]}px;
-	}
-`;
-
 export const productSubtitleCss = css`
 	${textSans.large({ fontWeight: 'bold' })};
 	color: ${palette.neutral[100]};

--- a/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
+++ b/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
@@ -117,11 +117,6 @@ export const wideButtonCss = css`
 	}
 `;
 
-export const errorSummaryLinkCss = css`
-	color: currentColor;
-	text-decoration: underline;
-`;
-
 export const paragraphListCss = css`
 	${textSans.medium()};
 	${from.tablet} {

--- a/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
+++ b/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
@@ -199,12 +199,6 @@ export const errorSummaryLinkCss = css`
 	text-decoration: underline;
 `;
 
-export const whatHappensNextCss = css`
-	li > svg {
-		fill: ${palette.brand[500]};
-	}
-`;
-
 export const paragraphListCss = css`
 	${textSans.medium()};
 	${from.tablet} {

--- a/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
+++ b/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
@@ -168,21 +168,6 @@ export const cardHeaderDivCss = css`
 	align-items: flex-end;
 `;
 
-export const headingCss = css`
-	${headline.xsmall({ fontWeight: 'bold' })};
-	margin-top: 0;
-	margin-bottom: 0;
-
-	${from.tablet} {
-		${headline.small({ fontWeight: 'bold' })};
-	}
-
-	span {
-		display: block;
-		color: ${palette.brand['500']};
-	}
-`;
-
 export const buttonContainerCss = css`
 	${until.tablet} {
 		display: flex;

--- a/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
+++ b/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
@@ -117,12 +117,6 @@ export const wideButtonCss = css`
 	}
 `;
 
-export const errorSummaryOverrideCss = css`
-	${until.tablet} {
-		border-radius: 6px;
-	}
-`;
-
 export const errorSummaryLinkCss = css`
 	color: currentColor;
 	text-decoration: underline;

--- a/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
+++ b/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
@@ -23,26 +23,6 @@ export const newAmountCss = css`
 	border-top: 1px solid ${palette.neutral[86]};
 `;
 
-export const listWithDividersCss = css`
-	li + li {
-		> svg {
-			padding-top: ${space[2]}px;
-			${from.tablet} {
-				padding-top: ${space[3]}px;
-			}
-		}
-		> span {
-			flex-grow: 1;
-			padding-top: ${space[2]}px;
-			border-top: 1px solid ${palette.neutral[86]};
-			min-width: 0;
-			${from.tablet} {
-				padding-top: ${space[3]}px;
-			}
-		}
-	}
-`;
-
 export const buttonCentredCss = css`
 	justify-content: center;
 `;

--- a/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
+++ b/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 import {
 	from,
-	headline,
 	palette,
 	space,
 	textSans,
@@ -13,16 +12,6 @@ export const cardSectionCss = css`
 	${from.tablet} {
 		padding-top: ${space[5]}px;
 		border-top: 1px solid ${palette.neutral[86]};
-	}
-`;
-
-export const productTitleCss = css`
-	${headline.xsmall({ fontWeight: 'bold' })};
-	color: ${palette.neutral[100]};
-	margin: 0;
-	max-width: 20ch;
-	${from.tablet} {
-		${headline.small({ fontWeight: 'bold' })};
 	}
 `;
 

--- a/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
+++ b/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
@@ -34,32 +34,6 @@ export const newAmountCss = css`
 	border-top: 1px solid ${palette.neutral[86]};
 `;
 
-export const iconListCss = css`
-	${textSans.medium()};
-	list-style: none;
-	padding: 0;
-	margin-bottom: 0;
-
-	li + li {
-		margin-top: ${space[2]}px;
-		${from.tablet} {
-			margin-top: ${space[3]}px;
-		}
-	}
-
-	li {
-		display: flex;
-		margin-left: -4px;
-		align-items: flex-start;
-
-		> svg {
-			flex-shrink: 0;
-			margin-right: 8px;
-			fill: currentColor;
-		}
-	}
-`;
-
 export const listWithDividersCss = css`
 	li + li {
 		> svg {

--- a/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
+++ b/client/components/mma/cancel/cancellationSaves/SaveStyles.ts
@@ -8,13 +8,6 @@ import {
 	until,
 } from '@guardian/source-foundations';
 
-export const sectionSpacing = css`
-	margin-top: ${space[6]}px;
-	${from.tablet} {
-		margin-top: ${space[9]}px;
-	}
-`;
-
 export const cardSectionCss = css`
 	margin-top: ${space[5]}px;
 	${from.tablet} {

--- a/client/components/mma/cancel/cancellationSaves/SelectReason.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SelectReason.tsx
@@ -23,6 +23,7 @@ import {
 	MDA_TEST_USER_HEADER,
 } from '../../../../../shared/productResponse';
 import type { ProductTypeWithCancellationFlow } from '../../../../../shared/productTypes';
+import { sectionSpacing } from '../../../../styles/GenericStyles';
 import { GenericErrorScreen } from '../../../shared/GenericErrorScreen';
 import { JsonResponseHandler } from '../../shared/asyncComponents/DefaultApiResponseHandler';
 import type {
@@ -36,7 +37,6 @@ import {
 	buttonCentredCss,
 	headingCss,
 	paragraphListCss,
-	sectionSpacing,
 	stackedButtonLayoutCss,
 	wideButtonCss,
 } from './SaveStyles';

--- a/client/components/mma/cancel/cancellationSaves/SelectReason.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SelectReason.tsx
@@ -23,7 +23,7 @@ import {
 	MDA_TEST_USER_HEADER,
 } from '../../../../../shared/productResponse';
 import type { ProductTypeWithCancellationFlow } from '../../../../../shared/productTypes';
-import { sectionSpacing } from '../../../../styles/GenericStyles';
+import { headingCss, sectionSpacing } from '../../../../styles/GenericStyles';
 import { GenericErrorScreen } from '../../../shared/GenericErrorScreen';
 import { JsonResponseHandler } from '../../shared/asyncComponents/DefaultApiResponseHandler';
 import type {
@@ -35,7 +35,6 @@ import type { CancellationReason } from '../cancellationReason';
 import { membershipCancellationReasons } from '../membership/MembershipCancellationReasons';
 import {
 	buttonCentredCss,
-	headingCss,
 	paragraphListCss,
 	stackedButtonLayoutCss,
 	wideButtonCss,

--- a/client/components/mma/cancel/cancellationSaves/SwitchThankYou.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SwitchThankYou.tsx
@@ -13,7 +13,7 @@ import {
 } from '../../../../../shared/dates';
 import type { PaidSubscriptionPlan } from '../../../../../shared/productResponse';
 import { getMainPlan } from '../../../../../shared/productResponse';
-import { sectionSpacing } from '../../../../styles/GenericStyles';
+import { headingCss, sectionSpacing } from '../../../../styles/GenericStyles';
 import { getOldMembershipPrice } from '../../../../utilities/membershipPriceRise';
 import { Heading } from '../../shared/Heading';
 import { iconListCss } from '../../switch/SwitchStyles';
@@ -28,7 +28,6 @@ import {
 } from '../CancellationContainer';
 import {
 	buttonCentredCss,
-	headingCss,
 	stackedButtonLayoutCss,
 	whatHappensNextCss,
 } from './SaveStyles';

--- a/client/components/mma/cancel/cancellationSaves/SwitchThankYou.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SwitchThankYou.tsx
@@ -15,12 +15,12 @@ import type { PaidSubscriptionPlan } from '../../../../../shared/productResponse
 import { getMainPlan } from '../../../../../shared/productResponse';
 import {
 	headingCss,
+	iconListCss,
 	sectionSpacing,
 	whatHappensNextCss,
 } from '../../../../styles/GenericStyles';
 import { getOldMembershipPrice } from '../../../../utilities/membershipPriceRise';
 import { Heading } from '../../shared/Heading';
-import { iconListCss } from '../../switch/SwitchStyles';
 import type {
 	CancellationContextInterface,
 	CancellationPageTitleInterface,

--- a/client/components/mma/cancel/cancellationSaves/SwitchThankYou.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SwitchThankYou.tsx
@@ -13,9 +13,10 @@ import {
 } from '../../../../../shared/dates';
 import type { PaidSubscriptionPlan } from '../../../../../shared/productResponse';
 import { getMainPlan } from '../../../../../shared/productResponse';
+import { sectionSpacing } from '../../../../styles/GenericStyles';
 import { getOldMembershipPrice } from '../../../../utilities/membershipPriceRise';
 import { Heading } from '../../shared/Heading';
-import { iconListCss, sectionSpacing } from '../../switch/SwitchStyles';
+import { iconListCss } from '../../switch/SwitchStyles';
 import type {
 	CancellationContextInterface,
 	CancellationPageTitleInterface,

--- a/client/components/mma/cancel/cancellationSaves/SwitchThankYou.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SwitchThankYou.tsx
@@ -13,7 +13,11 @@ import {
 } from '../../../../../shared/dates';
 import type { PaidSubscriptionPlan } from '../../../../../shared/productResponse';
 import { getMainPlan } from '../../../../../shared/productResponse';
-import { headingCss, sectionSpacing } from '../../../../styles/GenericStyles';
+import {
+	headingCss,
+	sectionSpacing,
+	whatHappensNextCss,
+} from '../../../../styles/GenericStyles';
 import { getOldMembershipPrice } from '../../../../utilities/membershipPriceRise';
 import { Heading } from '../../shared/Heading';
 import { iconListCss } from '../../switch/SwitchStyles';
@@ -26,11 +30,7 @@ import {
 	CancellationContext,
 	CancellationPageTitleContext,
 } from '../CancellationContainer';
-import {
-	buttonCentredCss,
-	stackedButtonLayoutCss,
-	whatHappensNextCss,
-} from './SaveStyles';
+import { buttonCentredCss, stackedButtonLayoutCss } from './SaveStyles';
 
 export const SwitchThankYou = () => {
 	const navigate = useNavigate();

--- a/client/components/mma/cancel/cancellationSaves/ValueOfSupport.tsx
+++ b/client/components/mma/cancel/cancellationSaves/ValueOfSupport.tsx
@@ -4,17 +4,14 @@ import { Button, Stack } from '@guardian/source-react-components';
 import { useContext } from 'react';
 import { Navigate, useLocation, useNavigate } from 'react-router';
 import { dateString } from '../../../../../shared/dates';
+import { headingCss } from '../../../../styles/GenericStyles';
 import { ProgressStepper } from '../../shared/ProgressStepper';
 import type {
 	CancellationContextInterface,
 	CancellationRouterState,
 } from '../CancellationContainer';
 import { CancellationContext } from '../CancellationContainer';
-import {
-	buttonCentredCss,
-	headingCss,
-	reverseStackedButtonLayoutCss,
-} from './SaveStyles';
+import { buttonCentredCss, reverseStackedButtonLayoutCss } from './SaveStyles';
 
 export const ValueOfSupport = () => {
 	const navigate = useNavigate();

--- a/client/components/mma/switch/SwitchStyles.ts
+++ b/client/components/mma/switch/SwitchStyles.ts
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { space, until } from '@guardian/source-foundations';
+import { until } from '@guardian/source-foundations';
 
 export const buttonCentredCss = css`
 	justify-content: center;
@@ -9,9 +9,4 @@ export const buttonMutedCss = css`
 	${until.tablet} {
 		border: none;
 	}
-`;
-
-export const errorSummaryBlockLinkCss = css`
-	display: block;
-	margin-top: ${space[3]}px;
 `;

--- a/client/components/mma/switch/SwitchStyles.ts
+++ b/client/components/mma/switch/SwitchStyles.ts
@@ -8,13 +8,6 @@ import {
 	until,
 } from '@guardian/source-foundations';
 
-export const sectionSpacing = css`
-	margin-top: ${space[6]}px;
-	${from.tablet} {
-		margin-top: ${space[9]}px;
-	}
-`;
-
 export const productTitleCss = css`
 	${headline.xsmall({ fontWeight: 'bold' })};
 	color: ${palette.neutral[100]};

--- a/client/components/mma/switch/SwitchStyles.ts
+++ b/client/components/mma/switch/SwitchStyles.ts
@@ -1,22 +1,11 @@
 import { css } from '@emotion/react';
 import {
 	from,
-	headline,
 	palette,
 	space,
 	textSans,
 	until,
 } from '@guardian/source-foundations';
-
-export const productTitleCss = css`
-	${headline.xsmall({ fontWeight: 'bold' })};
-	color: ${palette.neutral[100]};
-	margin: 0;
-	max-width: 20ch;
-	${from.tablet} {
-		${headline.small({ fontWeight: 'bold' })};
-	}
-`;
 
 export const smallPrintCss = css`
 	${textSans.xxsmall()};

--- a/client/components/mma/switch/SwitchStyles.ts
+++ b/client/components/mma/switch/SwitchStyles.ts
@@ -11,11 +11,6 @@ export const buttonMutedCss = css`
 	}
 `;
 
-export const errorSummaryLinkCss = css`
-	color: currentColor;
-	text-decoration: underline;
-`;
-
 export const errorSummaryBlockLinkCss = css`
 	display: block;
 	margin-top: ${space[3]}px;

--- a/client/components/mma/switch/SwitchStyles.ts
+++ b/client/components/mma/switch/SwitchStyles.ts
@@ -11,12 +11,6 @@ export const buttonMutedCss = css`
 	}
 `;
 
-export const errorSummaryOverrideCss = css`
-	${until.tablet} {
-		border-radius: 6px;
-	}
-`;
-
 export const errorSummaryLinkCss = css`
 	color: currentColor;
 	text-decoration: underline;

--- a/client/components/mma/switch/SwitchStyles.ts
+++ b/client/components/mma/switch/SwitchStyles.ts
@@ -32,32 +32,6 @@ export const smallPrintCss = css`
 	}
 `;
 
-export const iconListCss = css`
-	${textSans.medium()};
-	list-style: none;
-	padding: 0;
-	margin-bottom: 0;
-
-	li + li {
-		margin-top: ${space[2]}px;
-		${from.tablet} {
-			margin-top: ${space[3]}px;
-		}
-	}
-
-	li {
-		display: flex;
-		margin-left: -4px;
-		align-items: flex-start;
-
-		> svg {
-			flex-shrink: 0;
-			margin-right: 8px;
-			fill: currentColor;
-		}
-	}
-`;
-
 export const listWithDividersCss = css`
 	li + li {
 		> svg {

--- a/client/components/mma/switch/SwitchStyles.ts
+++ b/client/components/mma/switch/SwitchStyles.ts
@@ -1,25 +1,5 @@
 import { css } from '@emotion/react';
-import {
-	from,
-	palette,
-	space,
-	textSans,
-	until,
-} from '@guardian/source-foundations';
-
-export const smallPrintCss = css`
-	${textSans.xxsmall()};
-	margin-top: 0;
-	margin-bottom: 0;
-	color: #606060;
-	> a {
-		color: inherit;
-		text-decoration: underline;
-	}
-	& + & {
-		margin-top: ${space[1]}px;
-	}
-`;
+import { from, palette, space, until } from '@guardian/source-foundations';
 
 export const listWithDividersCss = css`
 	li + li {

--- a/client/components/mma/switch/SwitchStyles.ts
+++ b/client/components/mma/switch/SwitchStyles.ts
@@ -1,25 +1,5 @@
 import { css } from '@emotion/react';
-import { from, palette, space, until } from '@guardian/source-foundations';
-
-export const listWithDividersCss = css`
-	li + li {
-		> svg {
-			padding-top: ${space[2]}px;
-			${from.tablet} {
-				padding-top: ${space[3]}px;
-			}
-		}
-		> span {
-			flex-grow: 1;
-			padding-top: ${space[2]}px;
-			border-top: 1px solid ${palette.neutral[86]};
-			min-width: 0;
-			${from.tablet} {
-				padding-top: ${space[3]}px;
-			}
-		}
-	}
-`;
+import { space, until } from '@guardian/source-foundations';
 
 export const buttonCentredCss = css`
 	justify-content: center;

--- a/client/components/mma/switch/complete/SwitchComplete.tsx
+++ b/client/components/mma/switch/complete/SwitchComplete.tsx
@@ -18,7 +18,10 @@ import {
 import { useContext } from 'react';
 import { Navigate, useLocation } from 'react-router';
 import type { PaidSubscriptionPlan } from '../../../../../shared/productResponse';
-import { sectionSpacing } from '../../../../styles/GenericStyles';
+import {
+	sectionSpacing,
+	whatHappensNextCss,
+} from '../../../../styles/GenericStyles';
 import { formatAmount } from '../../../../utilities/utils';
 import { Heading } from '../../shared/Heading';
 import type {
@@ -173,12 +176,6 @@ const AppThankYouBanner = (props: {
 		</section>
 	);
 };
-
-const whatHappensNextCss = css`
-	li > svg {
-		fill: ${palette.brand[500]};
-	}
-`;
 
 const WhatHappensNext = (props: {
 	currency: string;

--- a/client/components/mma/switch/complete/SwitchComplete.tsx
+++ b/client/components/mma/switch/complete/SwitchComplete.tsx
@@ -19,6 +19,7 @@ import { useContext } from 'react';
 import { Navigate, useLocation } from 'react-router';
 import type { PaidSubscriptionPlan } from '../../../../../shared/productResponse';
 import {
+	iconListCss,
 	sectionSpacing,
 	whatHappensNextCss,
 } from '../../../../styles/GenericStyles';
@@ -29,7 +30,7 @@ import type {
 	SwitchRouterState,
 } from '../SwitchContainer';
 import { SwitchContext } from '../SwitchContainer';
-import { buttonCentredCss, iconListCss } from '../SwitchStyles';
+import { buttonCentredCss } from '../SwitchStyles';
 import { SwitchSignInImage } from './SwitchSignInImage';
 
 export const SwitchComplete = () => {

--- a/client/components/mma/switch/complete/SwitchComplete.tsx
+++ b/client/components/mma/switch/complete/SwitchComplete.tsx
@@ -18,6 +18,7 @@ import {
 import { useContext } from 'react';
 import { Navigate, useLocation } from 'react-router';
 import type { PaidSubscriptionPlan } from '../../../../../shared/productResponse';
+import { sectionSpacing } from '../../../../styles/GenericStyles';
 import { formatAmount } from '../../../../utilities/utils';
 import { Heading } from '../../shared/Heading';
 import type {
@@ -25,7 +26,7 @@ import type {
 	SwitchRouterState,
 } from '../SwitchContainer';
 import { SwitchContext } from '../SwitchContainer';
-import { buttonCentredCss, iconListCss, sectionSpacing } from '../SwitchStyles';
+import { buttonCentredCss, iconListCss } from '../SwitchStyles';
 import { SwitchSignInImage } from './SwitchSignInImage';
 
 export const SwitchComplete = () => {

--- a/client/components/mma/switch/options/SwitchOptions.tsx
+++ b/client/components/mma/switch/options/SwitchOptions.tsx
@@ -12,6 +12,7 @@ import { Link } from 'react-router-dom';
 import {
 	productTitleCss,
 	sectionSpacing,
+	smallPrintCss,
 } from '../../../../styles/GenericStyles';
 import { formatAmount } from '../../../../utilities/utils';
 import { supporterPlusSwitchBenefits } from '../../shared/benefits/BenefitsConfiguration';
@@ -28,7 +29,6 @@ import {
 	errorSummaryBlockLinkCss,
 	errorSummaryLinkCss,
 	errorSummaryOverrideCss,
-	smallPrintCss,
 } from '../SwitchStyles';
 
 const cardHeaderDivCss = css`

--- a/client/components/mma/switch/options/SwitchOptions.tsx
+++ b/client/components/mma/switch/options/SwitchOptions.tsx
@@ -9,7 +9,10 @@ import { ErrorSummary } from '@guardian/source-react-components-development-kitc
 import { useContext, useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { Link } from 'react-router-dom';
-import { errorSummaryOverrideCss } from '../../../../styles/ErrorStyles';
+import {
+	errorSummaryLinkCss,
+	errorSummaryOverrideCss,
+} from '../../../../styles/ErrorStyles';
 import {
 	productTitleCss,
 	sectionSpacing,
@@ -25,11 +28,7 @@ import type {
 	SwitchRouterState,
 } from '../SwitchContainer';
 import { SwitchContext } from '../SwitchContainer';
-import {
-	buttonCentredCss,
-	errorSummaryBlockLinkCss,
-	errorSummaryLinkCss,
-} from '../SwitchStyles';
+import { buttonCentredCss, errorSummaryBlockLinkCss } from '../SwitchStyles';
 
 const cardHeaderDivCss = css`
 	display: flex;

--- a/client/components/mma/switch/options/SwitchOptions.tsx
+++ b/client/components/mma/switch/options/SwitchOptions.tsx
@@ -9,6 +9,7 @@ import { ErrorSummary } from '@guardian/source-react-components-development-kitc
 import { useContext, useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { Link } from 'react-router-dom';
+import { errorSummaryOverrideCss } from '../../../../styles/ErrorStyles';
 import {
 	productTitleCss,
 	sectionSpacing,
@@ -28,7 +29,6 @@ import {
 	buttonCentredCss,
 	errorSummaryBlockLinkCss,
 	errorSummaryLinkCss,
-	errorSummaryOverrideCss,
 } from '../SwitchStyles';
 
 const cardHeaderDivCss = css`

--- a/client/components/mma/switch/options/SwitchOptions.tsx
+++ b/client/components/mma/switch/options/SwitchOptions.tsx
@@ -9,6 +9,7 @@ import { ErrorSummary } from '@guardian/source-react-components-development-kitc
 import { useContext, useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { Link } from 'react-router-dom';
+import { sectionSpacing } from '../../../../styles/GenericStyles';
 import { formatAmount } from '../../../../utilities/utils';
 import { supporterPlusSwitchBenefits } from '../../shared/benefits/BenefitsConfiguration';
 import { BenefitsSection } from '../../shared/benefits/BenefitsSection';
@@ -25,7 +26,6 @@ import {
 	errorSummaryLinkCss,
 	errorSummaryOverrideCss,
 	productTitleCss,
-	sectionSpacing,
 	smallPrintCss,
 } from '../SwitchStyles';
 

--- a/client/components/mma/switch/options/SwitchOptions.tsx
+++ b/client/components/mma/switch/options/SwitchOptions.tsx
@@ -10,6 +10,7 @@ import { useContext, useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { Link } from 'react-router-dom';
 import {
+	errorSummaryBlockLinkCss,
 	errorSummaryLinkCss,
 	errorSummaryOverrideCss,
 } from '../../../../styles/ErrorStyles';
@@ -28,7 +29,7 @@ import type {
 	SwitchRouterState,
 } from '../SwitchContainer';
 import { SwitchContext } from '../SwitchContainer';
-import { buttonCentredCss, errorSummaryBlockLinkCss } from '../SwitchStyles';
+import { buttonCentredCss } from '../SwitchStyles';
 
 const cardHeaderDivCss = css`
 	display: flex;

--- a/client/components/mma/switch/options/SwitchOptions.tsx
+++ b/client/components/mma/switch/options/SwitchOptions.tsx
@@ -9,7 +9,10 @@ import { ErrorSummary } from '@guardian/source-react-components-development-kitc
 import { useContext, useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { Link } from 'react-router-dom';
-import { sectionSpacing } from '../../../../styles/GenericStyles';
+import {
+	productTitleCss,
+	sectionSpacing,
+} from '../../../../styles/GenericStyles';
 import { formatAmount } from '../../../../utilities/utils';
 import { supporterPlusSwitchBenefits } from '../../shared/benefits/BenefitsConfiguration';
 import { BenefitsSection } from '../../shared/benefits/BenefitsSection';
@@ -25,7 +28,6 @@ import {
 	errorSummaryBlockLinkCss,
 	errorSummaryLinkCss,
 	errorSummaryOverrideCss,
-	productTitleCss,
 	smallPrintCss,
 } from '../SwitchStyles';
 

--- a/client/components/mma/switch/review/SwitchReview.tsx
+++ b/client/components/mma/switch/review/SwitchReview.tsx
@@ -13,7 +13,11 @@ import { Navigate, useLocation, useNavigate } from 'react-router';
 import { Link } from 'react-router-dom';
 import { dateString } from '../../../../../shared/dates';
 import type { ProductSwitchType } from '../../../../../shared/productSwitchTypes';
-import { iconListCss, sectionSpacing } from '../../../../styles/GenericStyles';
+import {
+	iconListCss,
+	productTitleCss,
+	sectionSpacing,
+} from '../../../../styles/GenericStyles';
 import {
 	LoadingState,
 	useAsyncLoader,
@@ -39,7 +43,6 @@ import {
 	errorSummaryLinkCss,
 	errorSummaryOverrideCss,
 	listWithDividersCss,
-	productTitleCss,
 	smallPrintCss,
 } from '../SwitchStyles';
 

--- a/client/components/mma/switch/review/SwitchReview.tsx
+++ b/client/components/mma/switch/review/SwitchReview.tsx
@@ -17,6 +17,7 @@ import {
 	iconListCss,
 	productTitleCss,
 	sectionSpacing,
+	smallPrintCss,
 } from '../../../../styles/GenericStyles';
 import {
 	LoadingState,
@@ -43,7 +44,6 @@ import {
 	errorSummaryLinkCss,
 	errorSummaryOverrideCss,
 	listWithDividersCss,
-	smallPrintCss,
 } from '../SwitchStyles';
 
 const SwitchErrorContext = (props: { PaymentFailure: boolean }) =>

--- a/client/components/mma/switch/review/SwitchReview.tsx
+++ b/client/components/mma/switch/review/SwitchReview.tsx
@@ -13,6 +13,7 @@ import { Navigate, useLocation, useNavigate } from 'react-router';
 import { Link } from 'react-router-dom';
 import { dateString } from '../../../../../shared/dates';
 import type { ProductSwitchType } from '../../../../../shared/productSwitchTypes';
+import { errorSummaryOverrideCss } from '../../../../styles/ErrorStyles';
 import {
 	iconListCss,
 	listWithDividersCss,
@@ -43,7 +44,6 @@ import {
 	buttonMutedCss,
 	errorSummaryBlockLinkCss,
 	errorSummaryLinkCss,
-	errorSummaryOverrideCss,
 } from '../SwitchStyles';
 
 const SwitchErrorContext = (props: { PaymentFailure: boolean }) =>

--- a/client/components/mma/switch/review/SwitchReview.tsx
+++ b/client/components/mma/switch/review/SwitchReview.tsx
@@ -13,6 +13,7 @@ import { Navigate, useLocation, useNavigate } from 'react-router';
 import { Link } from 'react-router-dom';
 import { dateString } from '../../../../../shared/dates';
 import type { ProductSwitchType } from '../../../../../shared/productSwitchTypes';
+import { sectionSpacing } from '../../../../styles/GenericStyles';
 import {
 	LoadingState,
 	useAsyncLoader,
@@ -40,7 +41,6 @@ import {
 	iconListCss,
 	listWithDividersCss,
 	productTitleCss,
-	sectionSpacing,
 	smallPrintCss,
 } from '../SwitchStyles';
 

--- a/client/components/mma/switch/review/SwitchReview.tsx
+++ b/client/components/mma/switch/review/SwitchReview.tsx
@@ -14,6 +14,7 @@ import { Link } from 'react-router-dom';
 import { dateString } from '../../../../../shared/dates';
 import type { ProductSwitchType } from '../../../../../shared/productSwitchTypes';
 import {
+	errorSummaryBlockLinkCss,
 	errorSummaryLinkCss,
 	errorSummaryOverrideCss,
 } from '../../../../styles/ErrorStyles';
@@ -42,11 +43,7 @@ import type {
 	SwitchRouterState,
 } from '../SwitchContainer';
 import { SwitchContext } from '../SwitchContainer';
-import {
-	buttonCentredCss,
-	buttonMutedCss,
-	errorSummaryBlockLinkCss,
-} from '../SwitchStyles';
+import { buttonCentredCss, buttonMutedCss } from '../SwitchStyles';
 
 const SwitchErrorContext = (props: { PaymentFailure: boolean }) =>
 	props.PaymentFailure ? (

--- a/client/components/mma/switch/review/SwitchReview.tsx
+++ b/client/components/mma/switch/review/SwitchReview.tsx
@@ -15,6 +15,7 @@ import { dateString } from '../../../../../shared/dates';
 import type { ProductSwitchType } from '../../../../../shared/productSwitchTypes';
 import {
 	iconListCss,
+	listWithDividersCss,
 	productTitleCss,
 	sectionSpacing,
 	smallPrintCss,
@@ -43,7 +44,6 @@ import {
 	errorSummaryBlockLinkCss,
 	errorSummaryLinkCss,
 	errorSummaryOverrideCss,
-	listWithDividersCss,
 } from '../SwitchStyles';
 
 const SwitchErrorContext = (props: { PaymentFailure: boolean }) =>

--- a/client/components/mma/switch/review/SwitchReview.tsx
+++ b/client/components/mma/switch/review/SwitchReview.tsx
@@ -13,7 +13,10 @@ import { Navigate, useLocation, useNavigate } from 'react-router';
 import { Link } from 'react-router-dom';
 import { dateString } from '../../../../../shared/dates';
 import type { ProductSwitchType } from '../../../../../shared/productSwitchTypes';
-import { errorSummaryOverrideCss } from '../../../../styles/ErrorStyles';
+import {
+	errorSummaryLinkCss,
+	errorSummaryOverrideCss,
+} from '../../../../styles/ErrorStyles';
 import {
 	iconListCss,
 	listWithDividersCss,
@@ -43,7 +46,6 @@ import {
 	buttonCentredCss,
 	buttonMutedCss,
 	errorSummaryBlockLinkCss,
-	errorSummaryLinkCss,
 } from '../SwitchStyles';
 
 const SwitchErrorContext = (props: { PaymentFailure: boolean }) =>

--- a/client/components/mma/switch/review/SwitchReview.tsx
+++ b/client/components/mma/switch/review/SwitchReview.tsx
@@ -13,7 +13,7 @@ import { Navigate, useLocation, useNavigate } from 'react-router';
 import { Link } from 'react-router-dom';
 import { dateString } from '../../../../../shared/dates';
 import type { ProductSwitchType } from '../../../../../shared/productSwitchTypes';
-import { sectionSpacing } from '../../../../styles/GenericStyles';
+import { iconListCss, sectionSpacing } from '../../../../styles/GenericStyles';
 import {
 	LoadingState,
 	useAsyncLoader,
@@ -38,7 +38,6 @@ import {
 	errorSummaryBlockLinkCss,
 	errorSummaryLinkCss,
 	errorSummaryOverrideCss,
-	iconListCss,
 	listWithDividersCss,
 	productTitleCss,
 	smallPrintCss,

--- a/client/components/mma/upgrade/UpgradeSupport.tsx
+++ b/client/components/mma/upgrade/UpgradeSupport.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { headline } from '@guardian/source-foundations';
 import { Stack } from '@guardian/source-react-components';
-import { sectionSpacing } from '../switch/SwitchStyles';
+import { sectionSpacing } from '../../../styles/GenericStyles';
 import { UpgradeSupportAmountForm } from './UpgradeSupportAmountForm';
 
 export const UpgradeSupport = () => {

--- a/client/components/mma/upgrade/UpgradeSupportSwitchThankYou.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportSwitchThankYou.tsx
@@ -8,7 +8,7 @@ import {
 } from '@guardian/source-react-components';
 import { useContext } from 'react';
 import { useNavigate } from 'react-router';
-import { sectionSpacing } from '../../../styles/GenericStyles';
+import { headingCss, sectionSpacing } from '../../../styles/GenericStyles';
 import {
 	signInContentContainerCss,
 	signInCss,
@@ -16,7 +16,6 @@ import {
 	signInParaCss,
 } from '../../shared/SignIn';
 import {
-	headingCss,
 	stackedButtonLayoutCss,
 	whatHappensNextCss,
 } from '../cancel/cancellationSaves/SaveStyles';

--- a/client/components/mma/upgrade/UpgradeSupportSwitchThankYou.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportSwitchThankYou.tsx
@@ -8,17 +8,18 @@ import {
 } from '@guardian/source-react-components';
 import { useContext } from 'react';
 import { useNavigate } from 'react-router';
-import { headingCss, sectionSpacing } from '../../../styles/GenericStyles';
+import {
+	headingCss,
+	sectionSpacing,
+	whatHappensNextCss,
+} from '../../../styles/GenericStyles';
 import {
 	signInContentContainerCss,
 	signInCss,
 	signInHeadingCss,
 	signInParaCss,
 } from '../../shared/SignIn';
-import {
-	stackedButtonLayoutCss,
-	whatHappensNextCss,
-} from '../cancel/cancellationSaves/SaveStyles';
+import { stackedButtonLayoutCss } from '../cancel/cancellationSaves/SaveStyles';
 import { Heading } from '../shared/Heading';
 import { SwitchSignInImage } from '../switch/complete/SwitchSignInImage';
 import { buttonCentredCss, iconListCss } from '../switch/SwitchStyles';

--- a/client/components/mma/upgrade/UpgradeSupportSwitchThankYou.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportSwitchThankYou.tsx
@@ -10,6 +10,7 @@ import { useContext } from 'react';
 import { useNavigate } from 'react-router';
 import {
 	headingCss,
+	iconListCss,
 	sectionSpacing,
 	whatHappensNextCss,
 } from '../../../styles/GenericStyles';
@@ -22,7 +23,7 @@ import {
 import { stackedButtonLayoutCss } from '../cancel/cancellationSaves/SaveStyles';
 import { Heading } from '../shared/Heading';
 import { SwitchSignInImage } from '../switch/complete/SwitchSignInImage';
-import { buttonCentredCss, iconListCss } from '../switch/SwitchStyles';
+import { buttonCentredCss } from '../switch/SwitchStyles';
 import type { UpgradeSupportInterface } from './UpgradeSupportContainer';
 import { UpgradeSupportContext } from './UpgradeSupportContainer';
 

--- a/client/components/mma/upgrade/UpgradeSupportSwitchThankYou.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportSwitchThankYou.tsx
@@ -8,8 +8,8 @@ import {
 } from '@guardian/source-react-components';
 import { useContext } from 'react';
 import { useNavigate } from 'react-router';
+import { sectionSpacing } from '../../../styles/GenericStyles';
 import {
-	sectionSpacing,
 	signInContentContainerCss,
 	signInCss,
 	signInHeadingCss,

--- a/client/components/shared/SignIn.tsx
+++ b/client/components/shared/SignIn.tsx
@@ -34,10 +34,3 @@ export const signInContentContainerCss = css`
 	padding: ${space[3]}px;
 	color: ${palette.neutral[100]};
 `;
-
-export const sectionSpacing = css`
-	margin-top: ${space[6]}px;
-	${from.tablet} {
-		margin-top: ${space[9]}px;
-	}
-`;

--- a/client/styles/ErrorStyles.ts
+++ b/client/styles/ErrorStyles.ts
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { until } from '@guardian/source-foundations';
+import { space, until } from '@guardian/source-foundations';
 
 export const errorSummaryOverrideCss = css`
 	${until.tablet} {
@@ -10,4 +10,9 @@ export const errorSummaryOverrideCss = css`
 export const errorSummaryLinkCss = css`
 	color: currentColor;
 	text-decoration: underline;
+`;
+
+export const errorSummaryBlockLinkCss = css`
+	display: block;
+	margin-top: ${space[3]}px;
 `;

--- a/client/styles/ErrorStyles.ts
+++ b/client/styles/ErrorStyles.ts
@@ -6,3 +6,8 @@ export const errorSummaryOverrideCss = css`
 		border-radius: 6px;
 	}
 `;
+
+export const errorSummaryLinkCss = css`
+	color: currentColor;
+	text-decoration: underline;
+`;

--- a/client/styles/ErrorStyles.ts
+++ b/client/styles/ErrorStyles.ts
@@ -1,0 +1,8 @@
+import { css } from '@emotion/react';
+import { until } from '@guardian/source-foundations';
+
+export const errorSummaryOverrideCss = css`
+	${until.tablet} {
+		border-radius: 6px;
+	}
+`;

--- a/client/styles/GenericStyles.ts
+++ b/client/styles/GenericStyles.ts
@@ -22,3 +22,9 @@ export const headingCss = css`
 		color: ${palette.brand['500']};
 	}
 `;
+
+export const whatHappensNextCss = css`
+	li > svg {
+		fill: ${palette.brand[500]};
+	}
+`;

--- a/client/styles/GenericStyles.ts
+++ b/client/styles/GenericStyles.ts
@@ -1,0 +1,9 @@
+import { css } from '@emotion/react';
+import { from, space } from '@guardian/source-foundations';
+
+export const sectionSpacing = css`
+	margin-top: ${space[6]}px;
+	${from.tablet} {
+		margin-top: ${space[9]}px;
+	}
+`;

--- a/client/styles/GenericStyles.ts
+++ b/client/styles/GenericStyles.ts
@@ -1,5 +1,11 @@
 import { css } from '@emotion/react';
-import { from, headline, palette, space } from '@guardian/source-foundations';
+import {
+	from,
+	headline,
+	palette,
+	space,
+	textSans,
+} from '@guardian/source-foundations';
 
 export const sectionSpacing = css`
 	margin-top: ${space[6]}px;
@@ -26,5 +32,31 @@ export const headingCss = css`
 export const whatHappensNextCss = css`
 	li > svg {
 		fill: ${palette.brand[500]};
+	}
+`;
+
+export const iconListCss = css`
+	${textSans.medium()};
+	list-style: none;
+	padding: 0;
+	margin-bottom: 0;
+
+	li + li {
+		margin-top: ${space[2]}px;
+		${from.tablet} {
+			margin-top: ${space[3]}px;
+		}
+	}
+
+	li {
+		display: flex;
+		margin-left: -4px;
+		align-items: flex-start;
+
+		> svg {
+			flex-shrink: 0;
+			margin-right: 8px;
+			fill: currentColor;
+		}
 	}
 `;

--- a/client/styles/GenericStyles.ts
+++ b/client/styles/GenericStyles.ts
@@ -70,3 +70,17 @@ export const productTitleCss = css`
 		${headline.small({ fontWeight: 'bold' })};
 	}
 `;
+
+export const smallPrintCss = css`
+	${textSans.xxsmall()};
+	margin-top: 0;
+	margin-bottom: 0;
+	color: #606060;
+	> a {
+		color: inherit;
+		text-decoration: underline;
+	}
+	& + & {
+		margin-top: ${space[1]}px;
+	}
+`;

--- a/client/styles/GenericStyles.ts
+++ b/client/styles/GenericStyles.ts
@@ -60,3 +60,13 @@ export const iconListCss = css`
 		}
 	}
 `;
+
+export const productTitleCss = css`
+	${headline.xsmall({ fontWeight: 'bold' })};
+	color: ${palette.neutral[100]};
+	margin: 0;
+	max-width: 20ch;
+	${from.tablet} {
+		${headline.small({ fontWeight: 'bold' })};
+	}
+`;

--- a/client/styles/GenericStyles.ts
+++ b/client/styles/GenericStyles.ts
@@ -1,9 +1,24 @@
 import { css } from '@emotion/react';
-import { from, space } from '@guardian/source-foundations';
+import { from, headline, palette, space } from '@guardian/source-foundations';
 
 export const sectionSpacing = css`
 	margin-top: ${space[6]}px;
 	${from.tablet} {
 		margin-top: ${space[9]}px;
+	}
+`;
+
+export const headingCss = css`
+	${headline.xsmall({ fontWeight: 'bold' })};
+	margin-top: 0;
+	margin-bottom: 0;
+
+	${from.tablet} {
+		${headline.small({ fontWeight: 'bold' })};
+	}
+
+	span {
+		display: block;
+		color: ${palette.brand['500']};
 	}
 `;

--- a/client/styles/GenericStyles.ts
+++ b/client/styles/GenericStyles.ts
@@ -84,3 +84,23 @@ export const smallPrintCss = css`
 		margin-top: ${space[1]}px;
 	}
 `;
+
+export const listWithDividersCss = css`
+	li + li {
+		> svg {
+			padding-top: ${space[2]}px;
+			${from.tablet} {
+				padding-top: ${space[3]}px;
+			}
+		}
+		> span {
+			flex-grow: 1;
+			padding-top: ${space[2]}px;
+			border-top: 1px solid ${palette.neutral[86]};
+			min-width: 0;
+			${from.tablet} {
+				padding-top: ${space[3]}px;
+			}
+		}
+	}
+`;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Refactoring of the CSS which is called multiple times in different style files into one generic file called GenericStyles. This includes:

- moving `sectionSpacing`
- moving `headingCss`
- moving `whatHappensNextCss`
- moving `iconListCss`
- moving `smallPrintCss`
- moving `listWithDividersCss`
- reimporting all references to the above from the GenericStyles file

Error CSS has been moved in their own styles file called ErrorStyles. This includes:
- moving `errorSummaryOverrideCss`
- moving `errorSummaryLinkCss`
- moving `errorSummaryBlockLinkCss`
- reimporting all references to the above from the GenericStyles file

Renaming `productTitleCss` to `productCardTitleCss` to keep it distinct from the other style css called ProductTitleCss

Button styles will be refactored as part of another PR. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
There should be no breaking changes and no UI changes
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
