### PR TITLE
Select your support step 2 - not switching product v1

### DIFF
--- a/client/components/mma/shared/SupporterPlusTsAndCs.tsx
+++ b/client/components/mma/shared/SupporterPlusTsAndCs.tsx
@@ -1,0 +1,94 @@
+import { css } from '@emotion/react';
+import { space, textSans } from '@guardian/source-foundations';
+import { Link } from 'react-router-dom';
+import { calculateMonthlyOrAnnualFromBillingPeriod } from '../../../../shared/productTypes';
+import {
+	convertCurrencyToSymbol,
+	isCurrencyIso,
+} from '../../../utilities/currencyIso';
+import { getBenefitsThreshold } from '../../../utilities/supporterPlusPricing';
+import { formatAmount } from '../../../utilities/utils';
+
+const smallPrintCss = css`
+	${textSans.xxsmall()};
+	margin-top: 0;
+	margin-bottom: 0;
+	color: #606060;
+	> a {
+		color: inherit;
+		text-decoration: underline;
+	}
+	& + & {
+		margin-top: ${space[1]}px;
+	}
+`;
+
+export const SupporterPlusTsAndCs = ({
+	currencyISO,
+	billingPeriod,
+}: {
+	currencyISO: string;
+	billingPeriod: string;
+}) => {
+	if (!isCurrencyIso(currencyISO)) {
+		throw new Error('Invalid currency');
+	}
+
+	const currencySymbol = convertCurrencyToSymbol(currencyISO);
+	const monthlyOrAnnual =
+		calculateMonthlyOrAnnualFromBillingPeriod(billingPeriod);
+	const monthlyThreshold = getBenefitsThreshold(currencyISO, 'Monthly');
+	const annualThreshold = getBenefitsThreshold(currencyISO, 'Annual');
+
+	return (
+		<>
+			<p css={smallPrintCss}>
+				If you pay at least {currencySymbol}
+				{formatAmount(monthlyThreshold)} per month or {currencySymbol}
+				{formatAmount(annualThreshold)} per year, you will receive the
+				Supporter Plus benefits on a subscription basis. If you pay more
+				than {currencySymbol}
+				{formatAmount(
+					monthlyOrAnnual === 'Annual'
+						? annualThreshold
+						: monthlyThreshold,
+				)}{' '}
+				per {billingPeriod}, these additional amounts will be separate{' '}
+				{monthlyOrAnnual.toLowerCase()} voluntary financial
+				contributions to the Guardian. The Supporter Plus subscription
+				and any contributions will auto-renew each {billingPeriod}. You
+				will be charged the subscription and contribution amounts using
+				your chosen payment method at each renewal unless you cancel.
+				You can cancel your subscription or change your contributions at
+				any time before your next renewal date. If you cancel within 14
+				days of taking out a Supporter Plus subscription, you’ll receive
+				a full refund (including of any contributions) and your
+				subscription and any contribution will stop immediately.
+				Cancellation of your subscription (which will also cancel any
+				contribution) or cancellation of your contribution made after 14
+				days will take effect at the end of your current{' '}
+				{monthlyOrAnnual.toLowerCase()} payment period. To cancel,{' '}
+				<Link to="/recurringsupport">go to Manage My Account</Link> or{' '}
+				<a href="https://www.theguardian.com/info/2022/oct/28/the-guardian-supporter-plus-terms-and-conditions">
+					see our Terms
+				</a>
+				.
+			</p>
+			<p css={smallPrintCss}>
+				By proceeding, you are agreeing to our{' '}
+				<a href="https://www.theguardian.com/info/2022/oct/28/the-guardian-supporter-plus-terms-and-conditions">
+					Terms and Conditions
+				</a>
+				.
+			</p>
+			<p css={smallPrintCss}>
+				To find out what personal data we collect and how we use it,
+				please visit our{' '}
+				<a href="https://www.theguardian.com/help/privacy-policy">
+					Privacy Policy
+				</a>
+				.
+			</p>
+		</>
+	);
+};

--- a/client/components/mma/switch/review/SwitchReview.tsx
+++ b/client/components/mma/switch/review/SwitchReview.tsx
@@ -26,6 +26,7 @@ import { BenefitsToggle } from '../../shared/benefits/BenefitsToggle';
 import { Card } from '../../shared/Card';
 import { Heading } from '../../shared/Heading';
 import { PaymentDetails } from '../../shared/PaymentDetails';
+import { SupporterPlusTsAndCs } from '../../shared/SupporterPlusTsAndCs';
 import type {
 	SwitchContextInterface,
 	SwitchRouterState,
@@ -41,7 +42,6 @@ import {
 	listWithDividersCss,
 	productTitleCss,
 	sectionSpacing,
-	smallPrintCss,
 } from '../SwitchStyles';
 
 const SwitchErrorContext = (props: { PaymentFailure: boolean }) =>
@@ -131,12 +131,8 @@ export const SwitchReview = () => {
 
 	const inPaymentFailure = !!contributionToSwitch.alertText;
 
-	const {
-		monthlyThreshold,
-		annualThreshold,
-		thresholdForBillingPeriod: threshold,
-		isAboveThreshold,
-	} = thresholds;
+	const { thresholdForBillingPeriod: threshold, isAboveThreshold } =
+		thresholds;
 
 	const newAmount = Math.max(threshold, mainPlan.price / 100);
 
@@ -377,57 +373,10 @@ export const SwitchReview = () => {
 				</section>
 			)}
 			<section css={sectionSpacing}>
-				<p css={smallPrintCss}>
-					If you pay at least {mainPlan.currency}
-					{formatAmount(monthlyThreshold)} per month or{' '}
-					{mainPlan.currency}
-					{formatAmount(annualThreshold)} per year, you will receive
-					the Supporter Plus benefits on a subscription basis. If you
-					pay more than {mainPlan.currency}
-					{formatAmount(
-						monthlyOrAnnual === 'Annual'
-							? annualThreshold
-							: monthlyThreshold,
-					)}{' '}
-					per {mainPlan.billingPeriod}, these additional amounts will
-					be separate {monthlyOrAnnual.toLowerCase()} voluntary
-					financial contributions to the Guardian. The Supporter Plus
-					subscription and any contributions will auto-renew each{' '}
-					{mainPlan.billingPeriod}. You will be charged the
-					subscription and contribution amounts using your chosen
-					payment method at each renewal unless you cancel. You can
-					cancel your subscription or change your contributions at any
-					time before your next renewal date. If you cancel within 14
-					days of taking out a Supporter Plus subscription, you’ll
-					receive a full refund (including of any contributions) and
-					your subscription and any contribution will stop
-					immediately. Cancellation of your subscription (which will
-					also cancel any contribution) or cancellation of your
-					contribution made after 14 days will take effect at the end
-					of your current {monthlyOrAnnual.toLowerCase()} payment
-					period. To cancel,{' '}
-					<Link to="/recurringsupport">go to Manage My Account</Link>{' '}
-					or{' '}
-					<a href="https://www.theguardian.com/info/2022/oct/28/the-guardian-supporter-plus-terms-and-conditions">
-						see our Terms
-					</a>
-					.
-				</p>
-				<p css={smallPrintCss}>
-					By proceeding, you are agreeing to our{' '}
-					<a href="https://www.theguardian.com/info/2022/oct/28/the-guardian-supporter-plus-terms-and-conditions">
-						Terms and Conditions
-					</a>
-					.
-				</p>
-				<p css={smallPrintCss}>
-					To find out what personal data we collect and how we use it,
-					please visit our{' '}
-					<a href="https://www.theguardian.com/help/privacy-policy">
-						Privacy Policy
-					</a>
-					.
-				</p>
+				<SupporterPlusTsAndCs
+					currencyISO={mainPlan.currencyISO}
+					billingPeriod={mainPlan.billingPeriod}
+				/>
 			</section>
 		</>
 	);

--- a/client/components/mma/upgrade/ConfirmForm.tsx
+++ b/client/components/mma/upgrade/ConfirmForm.tsx
@@ -8,11 +8,14 @@ import {
 	SvgReload,
 } from '@guardian/source-react-components';
 import type { Dispatch, SetStateAction } from 'react';
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 import type { Subscription } from '../../../../shared/productResponse';
 import { contributionPaidByCard } from '../../../fixtures/productBuilder/testProducts';
 import { Heading } from '../shared/Heading';
 import { PaymentDetails } from '../shared/PaymentDetails';
+import { SupporterPlusTsAndCs } from '../shared/SupporterPlusTsAndCs';
+import type { UpgradeSupportInterface } from './UpgradeSupportContainer';
+import { UpgradeSupportContext } from './UpgradeSupportContainer';
 
 const iconListCss = css`
 	${textSans.medium()};
@@ -111,20 +114,22 @@ const RoundUp = ({
 	const [hasRoundedUp, setHasRoundedUp] = useState<boolean>(false);
 
 	return (
-		<section>
-			Want to unlock extras etc?
-			<Button
-				onClick={() => {
-					const toggleRoundUp = !hasRoundedUp;
-					setHasRoundedUp(toggleRoundUp);
-					setChosenAmount(
-						toggleRoundUp ? 10 : chosenAmountPreRoundup,
-					);
-				}}
-			>
-				{hasRoundedUp ? 'Rounded up' : 'Round up'}
-			</Button>
-		</section>
+		<Stack space={2}>
+			<p>Want to unlock all extras?</p>
+			<section>
+				<Button
+					onClick={() => {
+						const toggleRoundUp = !hasRoundedUp;
+						setHasRoundedUp(toggleRoundUp);
+						setChosenAmount(
+							toggleRoundUp ? 10 : chosenAmountPreRoundup,
+						);
+					}}
+				>
+					{hasRoundedUp ? 'Rounded up' : 'Round up'}
+				</Button>
+			</section>
+		</Stack>
 	);
 };
 
@@ -139,28 +144,40 @@ export const ConfirmForm = ({
 	setChosenAmount,
 	threshold,
 }: ConfirmFormProps) => {
+	const { mainPlan } = useContext(
+		UpgradeSupportContext,
+	) as UpgradeSupportInterface;
+
 	const aboveThreshold = chosenAmount >= threshold;
 	const [shouldShowRoundUp] = useState<boolean>(!aboveThreshold);
 	const [chosenAmountPreRoundup] = useState<number>(chosenAmount);
 
 	return (
-		<Stack>
+		<Stack space={2}>
 			<Heading>2. Confirm change</Heading>
+			{shouldShowRoundUp && (
+				<RoundUp
+					setChosenAmount={setChosenAmount}
+					chosenAmountPreRoundup={chosenAmountPreRoundup}
+				/>
+			)}
+			{aboveThreshold && (
+				<WhatHappensNext
+					contributionPriceDisplay=""
+					subscription={contributionPaidByCard().subscription}
+				/>
+			)}
 			<section>
-				{shouldShowRoundUp && (
-					<RoundUp
-						setChosenAmount={setChosenAmount}
-						chosenAmountPreRoundup={chosenAmountPreRoundup}
-					/>
-				)}
-				{aboveThreshold && (
-					<WhatHappensNext
-						contributionPriceDisplay=""
-						subscription={contributionPaidByCard().subscription}
-					/>
-				)}
 				<Button>Confirm support change</Button>
 			</section>
+			{aboveThreshold && (
+				<section>
+					<SupporterPlusTsAndCs
+						currencyISO={mainPlan.currencyISO}
+						billingPeriod={mainPlan.billingPeriod}
+					/>{' '}
+				</section>
+			)}
 		</Stack>
 	);
 };

--- a/client/components/mma/upgrade/ConfirmForm.tsx
+++ b/client/components/mma/upgrade/ConfirmForm.tsx
@@ -1,0 +1,166 @@
+import { css } from '@emotion/react';
+import { from, palette, space, textSans } from '@guardian/source-foundations';
+import {
+	Button,
+	Stack,
+	SvgClock,
+	SvgCreditCard,
+	SvgReload,
+} from '@guardian/source-react-components';
+import type { Dispatch, SetStateAction } from 'react';
+import { useState } from 'react';
+import type { Subscription } from '../../../../shared/productResponse';
+import { contributionPaidByCard } from '../../../fixtures/productBuilder/testProducts';
+import { Heading } from '../shared/Heading';
+import { PaymentDetails } from '../shared/PaymentDetails';
+
+const iconListCss = css`
+	${textSans.medium()};
+	list-style: none;
+	padding: 0;
+	margin-bottom: 0;
+
+	li + li {
+		margin-top: ${space[2]}px;
+		${from.tablet} {
+			margin-top: ${space[3]}px;
+		}
+	}
+
+	li {
+		display: flex;
+		margin-left: -4px;
+		align-items: flex-start;
+
+		> svg {
+			flex-shrink: 0;
+			margin-right: 8px;
+			fill: currentColor;
+		}
+	}
+`;
+
+const listWithDividersCss = css`
+	li + li {
+		> svg {
+			padding-top: ${space[2]}px;
+			${from.tablet} {
+				padding-top: ${space[3]}px;
+			}
+		}
+		> span {
+			flex-grow: 1;
+			padding-top: ${space[2]}px;
+			border-top: 1px solid ${palette.neutral[86]};
+			min-width: 0;
+			${from.tablet} {
+				padding-top: ${space[3]}px;
+			}
+		}
+	}
+`;
+
+const WhatHappensNext = (props: {
+	contributionPriceDisplay: string;
+	subscription: Subscription;
+}) => {
+	return (
+		<section>
+			<Stack space={4}>
+				<Heading sansSerif>What happens next?</Heading>
+				<ul css={[iconListCss, listWithDividersCss]}>
+					<li>
+						<SvgClock size="medium" />
+						<span>
+							<strong>Price change will happen today</strong>
+							<br />
+							You can start enjoying your exclusive extras
+							straight away
+						</span>
+					</li>
+					<li>
+						<SvgReload size="medium" />
+						<span>
+							<strong>Your first payment will be just £x</strong>
+							<br />
+							We will charge you...
+						</span>
+					</li>
+					<li>
+						<SvgCreditCard size="medium" />
+						<span data-qm-masking="blocklist">
+							<strong>Your payment method</strong>
+							<br />
+							The payment will be taken from{' '}
+							<PaymentDetails subscription={props.subscription} />
+						</span>
+					</li>
+				</ul>
+			</Stack>
+		</section>
+	);
+};
+
+const RoundUp = ({
+	setChosenAmount,
+	chosenAmountPreRoundup,
+}: {
+	setChosenAmount: Dispatch<SetStateAction<number>>;
+	chosenAmountPreRoundup: number;
+}) => {
+	const [hasRoundedUp, setHasRoundedUp] = useState<boolean>(false);
+
+	return (
+		<section>
+			Want to unlock extras etc?
+			<Button
+				onClick={() => {
+					const toggleRoundUp = !hasRoundedUp;
+					setHasRoundedUp(toggleRoundUp);
+					setChosenAmount(
+						toggleRoundUp ? 10 : chosenAmountPreRoundup,
+					);
+				}}
+			>
+				{hasRoundedUp ? 'Rounded up' : 'Round up'}
+			</Button>
+		</section>
+	);
+};
+
+interface ConfirmFormProps {
+	chosenAmount: number;
+	setChosenAmount: Dispatch<SetStateAction<number>>;
+	threshold: number;
+}
+
+export const ConfirmForm = ({
+	chosenAmount,
+	setChosenAmount,
+	threshold,
+}: ConfirmFormProps) => {
+	const aboveThreshold = chosenAmount >= threshold;
+	const [shouldShowRoundUp] = useState<boolean>(!aboveThreshold);
+	const [chosenAmountPreRoundup] = useState<number>(chosenAmount);
+
+	return (
+		<Stack>
+			<Heading>2. Confirm change</Heading>
+			<section>
+				{shouldShowRoundUp && (
+					<RoundUp
+						setChosenAmount={setChosenAmount}
+						chosenAmountPreRoundup={chosenAmountPreRoundup}
+					/>
+				)}
+				{aboveThreshold && (
+					<WhatHappensNext
+						contributionPriceDisplay=""
+						subscription={contributionPaidByCard().subscription}
+					/>
+				)}
+				<Button>Confirm support change</Button>
+			</section>
+		</Stack>
+	);
+};

--- a/client/components/mma/upgrade/UpgradeSupport.tsx
+++ b/client/components/mma/upgrade/UpgradeSupport.tsx
@@ -1,10 +1,14 @@
 import { css } from '@emotion/react';
 import { headline } from '@guardian/source-foundations';
 import { Stack } from '@guardian/source-react-components';
+import { useState } from 'react';
 import { sectionSpacing } from '../switch/SwitchStyles';
+import { ConfirmForm } from './ConfirmForm';
 import { UpgradeSupportAmountForm } from './UpgradeSupportAmountForm';
 
 export const UpgradeSupport = () => {
+	const [chosenAmount, setChosenAmount] = useState<number>(0);
+
 	return (
 		<>
 			<section css={sectionSpacing}>
@@ -18,6 +22,11 @@ export const UpgradeSupport = () => {
 						1. Increase your support
 					</h2>
 					<UpgradeSupportAmountForm />
+					<ConfirmForm
+						chosenAmount={chosenAmount}
+						setChosenAmount={setChosenAmount}
+						threshold={10}
+					/>
 				</Stack>
 			</section>
 		</>

--- a/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
@@ -76,13 +76,13 @@ export const UpgradeSupportAmountForm = () => {
 		UpgradeSupportContext,
 	) as UpgradeSupportInterface;
 
+	const monthlyOrAnnual = calculateMonthlyOrAnnualFromBillingPeriod(
+		upgradeSupportContext.mainPlan.billingPeriod,
+	);
+
 	const priceConfig = (supporterPlusPriceConfigByCountryGroup[
 		upgradeSupportContext.mainPlan.currencyISO as CurrencyIso
-	] || supporterPlusPriceConfigByCountryGroup.international)[
-		calculateMonthlyOrAnnualFromBillingPeriod(
-			upgradeSupportContext.mainPlan.billingPeriod,
-		)
-	];
+	] || supporterPlusPriceConfigByCountryGroup.international)[monthlyOrAnnual];
 
 	const amountLabel = (amount: number) => {
 		return `${upgradeSupportContext.mainPlan.currency}${amount} per ${upgradeSupportContext.mainPlan.billingPeriod}`;

--- a/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
@@ -111,9 +111,6 @@ export const UpgradeSupportAmountForm = () => {
 		defaultOtherAmount,
 	);
 	const chosenAmount = isOtherAmountSelected ? otherAmount : selectedValue;
-	const monthlyOrAnnual = calculateMonthlyOrAnnualFromBillingPeriod(
-		mainPlan.billingPeriod,
-	);
 
 	const shouldShowOtherAmountErrorMessage =
 		hasInteractedWithOtherAmount || hasSubmitted;

--- a/client/components/mma/upgrade/UpgradeSupportContainer.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportContainer.tsx
@@ -4,6 +4,7 @@ import { Navigate, Outlet } from 'react-router';
 import type {
 	MembersDataApiResponse,
 	PaidSubscriptionPlan,
+	Subscription,
 } from '../../../../shared/productResponse';
 import { getMainPlan, isProduct } from '../../../../shared/productResponse';
 import { PRODUCT_TYPES } from '../../../../shared/productTypes';
@@ -20,6 +21,7 @@ import { DefaultLoadingView } from '../shared/asyncComponents/DefaultLoadingView
 
 export interface UpgradeSupportInterface {
 	mainPlan: PaidSubscriptionPlan;
+	subscription: Subscription;
 	user?: MembersDataApiResponse;
 }
 
@@ -75,6 +77,7 @@ export const UpgradeSupportContainer = () => {
 			<UpgradeSupportContext.Provider
 				value={{
 					mainPlan,
+					subscription: contribution.subscription,
 					user,
 				}}
 			>

--- a/client/utilities/currencyIso.ts
+++ b/client/utilities/currencyIso.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
-export type CurrencyIso = 'GBP' | 'USD' | 'AUD' | 'EUR' | 'NZD' | 'CAD';
+const CurrencyIsos = ['GBP', 'USD', 'AUD', 'EUR', 'NZD', 'CAD'] as const;
+export type CurrencyIso = typeof CurrencyIsos[number];
 
 export type MembershipCurrencyIso = 'GBP' | 'USD' | 'AUD' | 'EUR' | 'CAD';
 
@@ -12,6 +13,10 @@ const currencySymbols: Record<CurrencyIso, string> = {
 	NZD: '$',
 	CAD: '$',
 };
+
+export function isCurrencyIso(currency: string): currency is CurrencyIso {
+	return CurrencyIsos.includes(currency as CurrencyIso);
+}
 
 export function convertCurrencyToSymbol(currency: string): string {
 	const symbol = currencySymbols[currency as CurrencyIso];


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a skeleton for step two of the upgrade support journey. A round up button with logic plus confirm button and `onClick` function.

Also refactors the Supporter + Ts and Cs to be generic across pages

https://trello.com/c/aUIKFe2H/4314-mma-upsell-select-your-support-step-2-rc-not-switching-product-first-designs

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Go to `/upgrade-support`, see new component

No UI regressions from refactoring Ts and Cs

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
![image](https://github.com/guardian/manage-frontend/assets/114918544/d6a68bcc-405c-4971-a99c-4b3ca1d5b9c4)
![image](https://github.com/guardian/manage-frontend/assets/114918544/dc4c22ed-90f6-403f-bf22-daea27435d68)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
