### PR TITLE
Upgrade Support - Lift 'chosenAmount' state up and refactor

### DIFF
--- a/client/__tests__/supporterPlus.test.tsx
+++ b/client/__tests__/supporterPlus.test.tsx
@@ -1,4 +1,4 @@
-import { suggestedAmounts } from '../utilities/supporterPlusPricing';
+import { getSuggestedAmounts } from '../utilities/supporterPlusPricing';
 
 describe('suggested support amounts for monthly', () => {
 	it.each([
@@ -14,13 +14,13 @@ describe('suggested support amounts for monthly', () => {
 			expectedSecondAmount: number,
 			expectedThirdAmount: number,
 		) => {
-			expect(suggestedAmounts(currentAmount, 'Monthly')[0]).toEqual(
+			expect(getSuggestedAmounts(currentAmount, 'Monthly')[0]).toEqual(
 				expectedFirstAmount,
 			);
-			expect(suggestedAmounts(currentAmount, 'Monthly')[1]).toEqual(
+			expect(getSuggestedAmounts(currentAmount, 'Monthly')[1]).toEqual(
 				expectedSecondAmount,
 			);
-			expect(suggestedAmounts(currentAmount, 'Monthly')[2]).toEqual(
+			expect(getSuggestedAmounts(currentAmount, 'Monthly')[2]).toEqual(
 				expectedThirdAmount,
 			);
 		},
@@ -41,13 +41,13 @@ describe('suggested support amounts for annual', () => {
 			expectedSecondAmount: number,
 			expectedThirdAmount: number,
 		) => {
-			expect(suggestedAmounts(currentAmount, 'Annual')[0]).toEqual(
+			expect(getSuggestedAmounts(currentAmount, 'Annual')[0]).toEqual(
 				expectedFirstAmount,
 			);
-			expect(suggestedAmounts(currentAmount, 'Annual')[1]).toEqual(
+			expect(getSuggestedAmounts(currentAmount, 'Annual')[1]).toEqual(
 				expectedSecondAmount,
 			);
-			expect(suggestedAmounts(currentAmount, 'Annual')[2]).toEqual(
+			expect(getSuggestedAmounts(currentAmount, 'Annual')[2]).toEqual(
 				expectedThirdAmount,
 			);
 		},

--- a/client/components/mma/accountoverview/updateAmount/SupporterPlusUpdateAmountForm.tsx
+++ b/client/components/mma/accountoverview/updateAmount/SupporterPlusUpdateAmountForm.tsx
@@ -16,7 +16,7 @@ import { calculateMonthlyOrAnnualFromBillingPeriod } from '../../../../../shared
 import type { CurrencyIso } from '../../../../utilities/currencyIso';
 import { fetchWithDefaultParameters } from '../../../../utilities/fetch';
 import {
-	suggestedAmounts,
+	getSuggestedAmountsFromMainPlan,
 	supporterPlusPriceConfigByCountryGroup,
 } from '../../../../utilities/supporterPlusPricing';
 import { JsonResponseHandler } from '../../shared/asyncComponents/DefaultApiResponseHandler';
@@ -264,9 +264,8 @@ export const SupporterPlusUpdateAmountForm = (
 							columns={2}
 						>
 							<>
-								{suggestedAmounts(
-									props.currentAmount,
-									monthlyOrAnnual,
+								{getSuggestedAmountsFromMainPlan(
+									props.mainPlan,
 								).map((amount) => (
 									<ChoiceCard
 										id={`amount-${amount}`}

--- a/client/components/mma/upgrade/ConfirmForm.tsx
+++ b/client/components/mma/upgrade/ConfirmForm.tsx
@@ -112,7 +112,7 @@ const RoundUp = ({
 	setChosenAmount,
 	chosenAmountPreRoundup,
 }: {
-	setChosenAmount: Dispatch<SetStateAction<number>>;
+	setChosenAmount: Dispatch<SetStateAction<number | null>>;
 	chosenAmountPreRoundup: number;
 }) => {
 	const [hasRoundedUp, setHasRoundedUp] = useState<boolean>(false);
@@ -172,14 +172,12 @@ const productSwitchType: ProductSwitchType =
 
 interface ConfirmFormProps {
 	chosenAmount: number;
-	setChosenAmount: Dispatch<SetStateAction<number>>;
-	threshold: number;
+	setChosenAmount: Dispatch<SetStateAction<number | null>>;
 }
 
 export const ConfirmForm = ({
 	chosenAmount,
 	setChosenAmount,
-	threshold,
 }: ConfirmFormProps) => {
 	const { mainPlan, subscription } = useContext(
 		UpgradeSupportContext,
@@ -187,6 +185,7 @@ export const ConfirmForm = ({
 
 	const navigate = useNavigate();
 
+	const threshold = 10;
 	// todo get this from preview
 	const checkChargeAmountBeforeUpdate = false;
 	const aboveThreshold = chosenAmount >= threshold;

--- a/client/components/mma/upgrade/UpgradeSupport.tsx
+++ b/client/components/mma/upgrade/UpgradeSupport.tsx
@@ -1,13 +1,28 @@
 import { css } from '@emotion/react';
 import { headline } from '@guardian/source-foundations';
 import { Stack } from '@guardian/source-react-components';
-import { useState } from 'react';
+import { useContext, useState } from 'react';
+import { getSuggestedAmountsFromMainPlan } from '../../../utilities/supporterPlusPricing';
 import { sectionSpacing } from '../switch/SwitchStyles';
 import { ConfirmForm } from './ConfirmForm';
 import { UpgradeSupportAmountForm } from './UpgradeSupportAmountForm';
+import type { UpgradeSupportInterface } from './UpgradeSupportContainer';
+import { UpgradeSupportContext } from './UpgradeSupportContainer';
 
 export const UpgradeSupport = () => {
-	const [chosenAmount, setChosenAmount] = useState<number | null>(null);
+	const upgradeSupportContext = useContext(
+		UpgradeSupportContext,
+	) as UpgradeSupportInterface;
+
+	const suggestedAmounts = getSuggestedAmountsFromMainPlan(
+		upgradeSupportContext.mainPlan,
+	);
+
+	const [chosenAmount, setChosenAmount] = useState<number | null>(
+		suggestedAmounts[0],
+	);
+	const [continuedToConfirmation, setContinuedToConfirmation] =
+		useState<boolean>(false);
 
 	return (
 		<>
@@ -24,8 +39,11 @@ export const UpgradeSupport = () => {
 					<UpgradeSupportAmountForm
 						chosenAmount={chosenAmount}
 						setChosenAmount={setChosenAmount}
+						setContinuedToConfirmation={setContinuedToConfirmation}
+						continuedToConfirmation={continuedToConfirmation}
+						suggestedAmounts={suggestedAmounts}
 					/>
-					{chosenAmount && (
+					{continuedToConfirmation && chosenAmount && (
 						<ConfirmForm
 							chosenAmount={chosenAmount}
 							setChosenAmount={setChosenAmount}

--- a/client/components/mma/upgrade/UpgradeSupport.tsx
+++ b/client/components/mma/upgrade/UpgradeSupport.tsx
@@ -7,7 +7,7 @@ import { ConfirmForm } from './ConfirmForm';
 import { UpgradeSupportAmountForm } from './UpgradeSupportAmountForm';
 
 export const UpgradeSupport = () => {
-	const [chosenAmount, setChosenAmount] = useState<number>(0);
+	const [chosenAmount, setChosenAmount] = useState<number | null>(null);
 
 	return (
 		<>
@@ -21,12 +21,16 @@ export const UpgradeSupport = () => {
 					>
 						1. Increase your support
 					</h2>
-					<UpgradeSupportAmountForm />
-					<ConfirmForm
+					<UpgradeSupportAmountForm
 						chosenAmount={chosenAmount}
 						setChosenAmount={setChosenAmount}
-						threshold={10}
 					/>
+					{chosenAmount && (
+						<ConfirmForm
+							chosenAmount={chosenAmount}
+							setChosenAmount={setChosenAmount}
+						/>
+					)}
 				</Stack>
 			</section>
 		</>

--- a/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
@@ -166,7 +166,10 @@ export const UpgradeSupportAmountForm = ({
 								key={amount}
 								value={amount.toString()}
 								label={amountLabel(amount)}
-								checked={chosenAmount === amount}
+								checked={
+									chosenAmount === amount &&
+									!isOtherAmountSelected
+								}
 								onChange={() => {
 									setChosenAmount(amount);
 									setIsOtherAmountSelected(false);

--- a/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
@@ -7,6 +7,7 @@ import {
 	ChoiceCardGroup,
 	TextInput,
 } from '@guardian/source-react-components';
+import type { Dispatch, SetStateAction } from 'react';
 import { useContext, useEffect, useState } from 'react';
 import type { PaidSubscriptionPlan } from '../../../../shared/productResponse';
 import { calculateMonthlyOrAnnualFromBillingPeriod } from '../../../../shared/productTypes';
@@ -71,7 +72,15 @@ function displayRelevantBenefits(
 	}
 }
 
-export const UpgradeSupportAmountForm = () => {
+interface UpgradeSupportAmountFormProps {
+	chosenAmount: number | null;
+	setChosenAmount: Dispatch<SetStateAction<number | null>>;
+}
+
+export const UpgradeSupportAmountForm = ({
+	chosenAmount,
+	setChosenAmount,
+}: UpgradeSupportAmountFormProps) => {
 	const upgradeSupportContext = useContext(
 		UpgradeSupportContext,
 	) as UpgradeSupportInterface;
@@ -93,10 +102,13 @@ export const UpgradeSupportAmountForm = () => {
 
 	const otherAmountLabel = `Choose an amount (${upgradeSupportContext.mainPlan.currency} per ${upgradeSupportContext.mainPlan.billingPeriod})`;
 
-	const [selectedValue, setSelectedValue] = useState<number | null>(null);
-
 	const [isOtherAmountSelected, setIsOtherAmountSelected] =
 		useState<boolean>(false);
+
+	const defaultOtherAmount = priceConfig.minAmount;
+	const [otherAmountSelected, setOtherAmountSelected] = useState<
+		number | null
+	>(defaultOtherAmount);
 
 	const [hasInteractedWithOtherAmount, setHasInteractedWithOtherAmount] =
 		useState<boolean>(false);
@@ -105,21 +117,14 @@ export const UpgradeSupportAmountForm = () => {
 
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-	const defaultOtherAmount = priceConfig.minAmount;
-
-	const [otherAmount, setOtherAmount] = useState<number | null>(
-		defaultOtherAmount,
-	);
-	const chosenAmount = isOtherAmountSelected ? otherAmount : selectedValue;
-
 	const shouldShowOtherAmountErrorMessage =
 		hasInteractedWithOtherAmount || hasSubmitted;
 
 	useEffect(() => {
-		if (otherAmount !== defaultOtherAmount) {
+		if (otherAmountSelected !== defaultOtherAmount) {
 			setHasInteractedWithOtherAmount(true);
 		}
-	}, [otherAmount]);
+	}, [otherAmountSelected]);
 
 	useEffect(() => {
 		const newErrorMessage = validateChoice(
@@ -131,7 +136,7 @@ export const UpgradeSupportAmountForm = () => {
 			mainPlan,
 		);
 		setErrorMessage(newErrorMessage);
-	}, [otherAmount, selectedValue]);
+	}, [otherAmountSelected, chosenAmount]);
 
 	return (
 		<>
@@ -162,15 +167,14 @@ export const UpgradeSupportAmountForm = () => {
 									key={amount}
 									value={amount.toString()}
 									label={amountLabel(amount)}
-									checked={selectedValue === amount}
+									checked={chosenAmount === amount}
 									onChange={() => {
-										setSelectedValue(amount);
+										setChosenAmount(amount);
 										setIsOtherAmountSelected(false);
 									}}
 								/>
 							),
 						)}
-
 						<ChoiceCard
 							id={`amount-other`}
 							value="Choose your amount"
@@ -178,7 +182,7 @@ export const UpgradeSupportAmountForm = () => {
 							checked={isOtherAmountSelected}
 							onChange={() => {
 								setIsOtherAmountSelected(true);
-								setSelectedValue(null);
+								setChosenAmount(otherAmountSelected);
 							}}
 						/>
 					</>
@@ -200,14 +204,19 @@ export const UpgradeSupportAmountForm = () => {
 								undefined
 							}
 							type="number"
-							value={otherAmount?.toString() || ''}
-							onChange={(event) =>
-								setOtherAmount(
+							value={otherAmountSelected?.toString() || ''}
+							onChange={(event) => {
+								setChosenAmount(
 									event.target.value
 										? Number(event.target.value)
 										: null,
-								)
-							}
+								);
+								setOtherAmountSelected(
+									event.target.value
+										? Number(event.target.value)
+										: null,
+								);
+							}}
 						/>
 					</div>
 				)}

--- a/client/utilities/supporterPlusPricing.ts
+++ b/client/utilities/supporterPlusPricing.ts
@@ -1,3 +1,5 @@
+import type { PaidSubscriptionPlan } from '../../shared/productResponse';
+import { calculateMonthlyOrAnnualFromBillingPeriod } from '../../shared/productTypes';
 import type { CurrencyIso } from './currencyIso';
 
 type PriceConfig = {
@@ -49,13 +51,24 @@ export function getBenefitsThreshold(
 	return region[billingPeriod].minAmount;
 }
 
-export function suggestedAmounts(
+export function getSuggestedAmounts(
 	currentAmount: number,
 	monthlyOrAnnual: 'Monthly' | 'Annual',
 ) {
 	return monthlyOrAnnual === 'Monthly'
 		? suggestedAmountsMonthly(currentAmount)
 		: suggestedAmountsAnnual(currentAmount);
+}
+
+export function getSuggestedAmountsFromMainPlan(
+	mainPlan: PaidSubscriptionPlan,
+) {
+	const currentAmount = mainPlan.price / 100;
+	const monthlyOrAnnual = calculateMonthlyOrAnnualFromBillingPeriod(
+		mainPlan.billingPeriod,
+	);
+
+	return getSuggestedAmounts(currentAmount, monthlyOrAnnual);
 }
 
 function suggestedAmountsMonthly(currentAmount: number) {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Refactor the upgradeSupport components to use the same state for the amount a user chooses, as well as some other refactors. Hide the 'Continue' button after clicking and show the second step 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Go to `/upgrade-support` and select an amount, click 'Continue with x', see step 2 appear

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
