### PR TITLE
Upgrade Support - add preview api call

### DIFF
--- a/client/components/mma/accountoverview/updateAmount/SupporterPlusUpdateAmountForm.tsx
+++ b/client/components/mma/accountoverview/updateAmount/SupporterPlusUpdateAmountForm.tsx
@@ -98,7 +98,7 @@ export const SupporterPlusUpdateAmountForm = (
 	const priceConfig = (supporterPlusPriceConfigByCountryGroup[
 		props.mainPlan.currencyISO as CurrencyIso
 	] || supporterPlusPriceConfigByCountryGroup.international)[
-		calculateMonthlyOrAnnualFromBillingPeriod(props.mainPlan.billingPeriod)
+		props.mainPlan.billingPeriod
 	];
 
 	const minPriceDisplay = `${props.mainPlan.currency}${priceConfig.minAmount}`;

--- a/client/components/mma/shared/SupporterPlusTsAndCs.tsx
+++ b/client/components/mma/shared/SupporterPlusTsAndCs.tsx
@@ -37,8 +37,8 @@ export const SupporterPlusTsAndCs = ({
 	const currencySymbol = convertCurrencyToSymbol(currencyISO);
 	const monthlyOrAnnual =
 		calculateMonthlyOrAnnualFromBillingPeriod(billingPeriod);
-	const monthlyThreshold = getBenefitsThreshold(currencyISO, 'Monthly');
-	const annualThreshold = getBenefitsThreshold(currencyISO, 'Annual');
+	const monthlyThreshold = getBenefitsThreshold(currencyISO, 'month');
+	const annualThreshold = getBenefitsThreshold(currencyISO, 'year');
 
 	return (
 		<>

--- a/client/components/mma/switch/SwitchContainer.tsx
+++ b/client/components/mma/switch/SwitchContainer.tsx
@@ -1,5 +1,5 @@
-import { createContext, useState } from 'react';
 import type { Context, ReactNode } from 'react';
+import { createContext, useState } from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router';
 import type {
 	MembersDataApiResponse,
@@ -185,11 +185,11 @@ function getThresholds(
 ): Thresholds {
 	const monthlyThreshold = getBenefitsThreshold(
 		mainPlan.currencyISO as CurrencyIso,
-		'Monthly',
+		'month',
 	);
 	const annualThreshold = getBenefitsThreshold(
 		mainPlan.currencyISO as CurrencyIso,
-		'Annual',
+		'year',
 	);
 	const thresholdForBillingPeriod = monthly
 		? monthlyThreshold

--- a/client/components/mma/switch/review/SwitchReview.tsx
+++ b/client/components/mma/switch/review/SwitchReview.tsx
@@ -12,7 +12,10 @@ import { useContext, useState } from 'react';
 import { Navigate, useLocation, useNavigate } from 'react-router';
 import { Link } from 'react-router-dom';
 import { dateString } from '../../../../../shared/dates';
-import type { ProductSwitchType } from '../../../../../shared/productSwitchTypes';
+import type {
+	PreviewResponse,
+	ProductSwitchType,
+} from '../../../../../shared/productSwitchTypes';
 import {
 	LoadingState,
 	useAsyncLoader,
@@ -104,13 +107,6 @@ const scrollToErrorMessage = () => {
 
 const productSwitchType: ProductSwitchType =
 	'recurring-contribution-to-supporter-plus';
-
-interface PreviewResponse {
-	amountPayableToday: number;
-	supporterPlusPurchaseAmount: number;
-	nextPaymentDate: string;
-	checkChargeAmountBeforeUpdate: boolean;
-}
 
 export const SwitchReview = () => {
 	const navigate = useNavigate();

--- a/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
@@ -219,6 +219,7 @@ export const UpgradeSupportAmountForm = ({
 										? Number(event.target.value)
 										: null,
 								);
+								setContinuedToConfirmation(false);
 							}}
 						/>
 					</div>

--- a/client/utilities/supporterPlusPricing.ts
+++ b/client/utilities/supporterPlusPricing.ts
@@ -12,38 +12,38 @@ export const supporterPlusPriceConfigByCountryGroup: Record<
 	Record<string, PriceConfig>
 > = {
 	GBP: {
-		Monthly: { minAmount: 10, maxAmount: 166 },
-		Annual: { minAmount: 95, maxAmount: 2000 },
+		month: { minAmount: 10, maxAmount: 166 },
+		year: { minAmount: 95, maxAmount: 2000 },
 	},
 	USD: {
-		Monthly: { minAmount: 13, maxAmount: 800 },
-		Annual: { minAmount: 120, maxAmount: 10000 },
+		month: { minAmount: 13, maxAmount: 800 },
+		year: { minAmount: 120, maxAmount: 10000 },
 	},
 	EUR: {
-		Monthly: { minAmount: 10, maxAmount: 166 },
-		Annual: { minAmount: 95, maxAmount: 2000 },
+		month: { minAmount: 10, maxAmount: 166 },
+		year: { minAmount: 95, maxAmount: 2000 },
 	},
 	AUD: {
-		Monthly: { minAmount: 17, maxAmount: 200 },
-		Annual: { minAmount: 160, maxAmount: 2000 },
+		month: { minAmount: 17, maxAmount: 200 },
+		year: { minAmount: 160, maxAmount: 2000 },
 	},
 	NZD: {
-		Monthly: { minAmount: 17, maxAmount: 200 },
-		Annual: { minAmount: 160, maxAmount: 2000 },
+		month: { minAmount: 17, maxAmount: 200 },
+		year: { minAmount: 160, maxAmount: 2000 },
 	},
 	CAD: {
-		Monthly: { minAmount: 13, maxAmount: 166 },
-		Annual: { minAmount: 120, maxAmount: 2000 },
+		month: { minAmount: 13, maxAmount: 166 },
+		year: { minAmount: 120, maxAmount: 2000 },
 	},
 	international: {
-		Monthly: { minAmount: 13, maxAmount: 166 },
-		Annual: { minAmount: 120, maxAmount: 2000 },
+		month: { minAmount: 13, maxAmount: 166 },
+		year: { minAmount: 120, maxAmount: 2000 },
 	},
 };
 
 export function getBenefitsThreshold(
 	currency: CurrencyIso,
-	billingPeriod: 'Monthly' | 'Annual',
+	billingPeriod: 'month' | 'year',
 ): number {
 	const region =
 		supporterPlusPriceConfigByCountryGroup[currency] ??

--- a/shared/productSwitchTypes.ts
+++ b/shared/productSwitchTypes.ts
@@ -1,3 +1,10 @@
 export type ProductSwitchType =
 	| 'to-recurring-contribution'
 	| 'recurring-contribution-to-supporter-plus';
+
+export interface PreviewResponse {
+	amountPayableToday: number;
+	supporterPlusPurchaseAmount: number;
+	nextPaymentDate: string;
+	checkChargeAmountBeforeUpdate: boolean;
+}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds the switch preview api call before showing step 2, to be able to render the payment amount.

The preview call is called every time the amount changes (with the threshold amount if a lower amount is chosen)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Go to '/upgrade-support`, click 'Continue with xx' - see Loading bar where step 2 (confirm) should be

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://github.com/guardian/manage-frontend/assets/114918544/c4dfd050-b1a4-4206-a836-d445f826d1df)


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
