### PR TITLE
Upgrade - RC Roundup

### DIFF
--- a/client/components/mma/upgrade/ConfirmForm.tsx
+++ b/client/components/mma/upgrade/ConfirmForm.tsx
@@ -127,9 +127,11 @@ const WhatHappensNext = ({
 
 const RoundUp = ({
 	setChosenAmount,
+	thresholdAmount,
 	chosenAmountPreRoundup,
 }: {
 	setChosenAmount: Dispatch<SetStateAction<number | null>>;
+	thresholdAmount: number;
 	chosenAmountPreRoundup: number;
 }) => {
 	const [hasRoundedUp, setHasRoundedUp] = useState<boolean>(false);
@@ -143,7 +145,9 @@ const RoundUp = ({
 						const toggleRoundUp = !hasRoundedUp;
 						setHasRoundedUp(toggleRoundUp);
 						setChosenAmount(
-							toggleRoundUp ? 10 : chosenAmountPreRoundup,
+							toggleRoundUp
+								? thresholdAmount
+								: chosenAmountPreRoundup,
 						);
 					}}
 				>
@@ -274,6 +278,7 @@ export const ConfirmForm = ({
 			{shouldShowRoundUp && (
 				<RoundUp
 					setChosenAmount={setChosenAmount}
+					thresholdAmount={threshold}
 					chosenAmountPreRoundup={chosenAmountPreRoundup}
 				/>
 			)}

--- a/client/components/mma/upgrade/ConfirmForm.tsx
+++ b/client/components/mma/upgrade/ConfirmForm.tsx
@@ -194,11 +194,13 @@ const productSwitchType: ProductSwitchType =
 interface ConfirmFormProps {
 	chosenAmount: number;
 	setChosenAmount: Dispatch<SetStateAction<number | null>>;
+	suggestedAmounts: number[];
 }
 
 export const ConfirmForm = ({
 	chosenAmount,
 	setChosenAmount,
+	suggestedAmounts,
 }: ConfirmFormProps) => {
 	const { mainPlan, subscription } = useContext(
 		UpgradeSupportContext,
@@ -211,8 +213,13 @@ export const ConfirmForm = ({
 		mainPlan.billingPeriod as 'month' | 'year',
 	);
 	const aboveThreshold = chosenAmount >= threshold;
-	const [shouldShowRoundUp] = useState<boolean>(!aboveThreshold);
+
+	const [shouldShowRoundUp] = useState<boolean>(
+		!aboveThreshold && suggestedAmounts.includes(threshold),
+	);
+
 	const [chosenAmountPreRoundup] = useState<number>(chosenAmount);
+
 	const [isConfirmationLoading, setIsConfirmationLoading] =
 		useState<boolean>(false);
 

--- a/client/components/mma/upgrade/UpgradeSupport.tsx
+++ b/client/components/mma/upgrade/UpgradeSupport.tsx
@@ -47,6 +47,7 @@ export const UpgradeSupport = () => {
 						<ConfirmForm
 							chosenAmount={chosenAmount}
 							setChosenAmount={setChosenAmount}
+							suggestedAmounts={suggestedAmounts}
 						/>
 					)}
 				</Stack>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR makes two changes.

1. Roundup to the currency specific threshold (eg if GBP roundup to 10, if USD roundup to 13)
2. Hide round up if threshold is not one of suggested amounts (since we cannot highlight it)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Don't show roundup if amount to round up to is not present
![image](https://github.com/guardian/manage-frontend/assets/114918544/f5db11b3-4289-48be-8c17-d6ac6d7d31f2)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
