### PR TITLE
One product-move-api preview call in upgrade journey

### DIFF
--- a/client/components/mma/upgrade/ConfirmForm.tsx
+++ b/client/components/mma/upgrade/ConfirmForm.tsx
@@ -16,11 +16,13 @@ import type {
 } from '../../../../shared/productResponse';
 import type { PreviewResponse } from '../../../../shared/productSwitchTypes';
 import { fetchWithDefaultParameters } from '../../../utilities/fetch';
+import { LoadingState } from '../../../utilities/hooks/useAsyncLoader';
 import {
 	calculateAmountPayableToday,
 	calculateCheckChargeAmountBeforeUpdate,
 } from '../../../utilities/productMovePreview';
 import { productMoveFetch } from '../../../utilities/productUtils';
+import { GenericErrorScreen } from '../../shared/GenericErrorScreen';
 import { DefaultLoadingView } from '../shared/asyncComponents/DefaultLoadingView';
 import { Heading } from '../shared/Heading';
 import { PaymentDetails } from '../shared/PaymentDetails';
@@ -176,6 +178,7 @@ interface ConfirmFormProps {
 	threshold: number;
 	suggestedAmounts: number[];
 	previewResponse: PreviewResponse | null;
+	previewLoadingState: LoadingState;
 }
 
 export const ConfirmForm = ({
@@ -184,6 +187,7 @@ export const ConfirmForm = ({
 	threshold,
 	suggestedAmounts,
 	previewResponse,
+	previewLoadingState,
 }: ConfirmFormProps) => {
 	const { mainPlan, subscription } = useContext(
 		UpgradeSupportContext,
@@ -202,10 +206,17 @@ export const ConfirmForm = ({
 	const [isConfirmationLoading, setIsConfirmationLoading] =
 		useState<boolean>(false);
 
-	if (previewResponse === null) {
+	if (previewLoadingState === LoadingState.IsLoading) {
 		return (
 			<DefaultLoadingView loadingMessage="Loading your payment details..." />
 		);
+	}
+
+	if (
+		previewLoadingState === LoadingState.HasError ||
+		previewResponse === null
+	) {
+		return <GenericErrorScreen />;
 	}
 
 	const amountPayableToday = calculateAmountPayableToday(

--- a/client/components/mma/upgrade/ConfirmForm.tsx
+++ b/client/components/mma/upgrade/ConfirmForm.tsx
@@ -12,7 +12,6 @@ import { useContext, useState } from 'react';
 import { useNavigate } from 'react-router';
 import type { Subscription } from '../../../../shared/productResponse';
 import type { PreviewResponse } from '../../../../shared/productSwitchTypes';
-import { contributionPaidByCard } from '../../../fixtures/productBuilder/testProducts';
 import type { CurrencyIso } from '../../../utilities/currencyIso';
 import { fetchWithDefaultParameters } from '../../../utilities/fetch';
 import { productMoveFetch } from '../../../utilities/productUtils';
@@ -70,10 +69,10 @@ const listWithDividersCss = css`
 `;
 
 const WhatHappensNext = ({
-	contributionPriceDisplay,
+	firstPaymentDisplay,
 	subscription,
 }: {
-	contributionPriceDisplay: string;
+	firstPaymentDisplay: string;
 	subscription: Subscription;
 }) => {
 	return (
@@ -95,7 +94,7 @@ const WhatHappensNext = ({
 						<span>
 							<strong>
 								Your first payment will be just{' '}
-								{contributionPriceDisplay}
+								{firstPaymentDisplay}
 							</strong>
 							<br />
 							We will charge you...
@@ -195,7 +194,12 @@ export const ConfirmForm = ({
 	const [isConfirmationLoading, setIsConfirmationLoading] =
 		useState<boolean>(false);
 
-	const checkChargeAmount = false; //todo
+	const checkChargeAmount = false; //todo calculate this
+
+	//ToDo: a more elegant loading option
+	const firstPaymentDisplay = `${mainPlan.currency}${
+		previewResponse?.amountPayableToday ?? 'loading'
+	}`;
 
 	const confirmOnClick = async () => {
 		if (isConfirmationLoading) {
@@ -237,8 +241,8 @@ export const ConfirmForm = ({
 			)}
 			{aboveThreshold && (
 				<WhatHappensNext
-					contributionPriceDisplay={`${previewResponse?.amountPayableToday}`}
-					subscription={contributionPaidByCard().subscription}
+					firstPaymentDisplay={firstPaymentDisplay}
+					subscription={subscription}
 				/>
 			)}
 			<section>

--- a/client/components/mma/upgrade/UpgradeSupport.tsx
+++ b/client/components/mma/upgrade/UpgradeSupport.tsx
@@ -3,9 +3,13 @@ import { headline, space, textSans, until } from '@guardian/source-foundations';
 import { Stack } from '@guardian/source-react-components';
 import { useContext, useState } from 'react';
 import type { PreviewResponse } from '../../../../shared/productSwitchTypes';
+import type { CurrencyIso } from '../../../utilities/currencyIso';
 import { useAsyncLoader } from '../../../utilities/hooks/useAsyncLoader';
 import { productMoveFetch } from '../../../utilities/productUtils';
-import { getSuggestedAmountsFromMainPlan } from '../../../utilities/supporterPlusPricing';
+import {
+	getBenefitsThreshold,
+	getSuggestedAmountsFromMainPlan,
+} from '../../../utilities/supporterPlusPricing';
 import { JsonResponseHandler } from '../shared/asyncComponents/DefaultApiResponseHandler';
 import { ConfirmForm } from './ConfirmForm';
 import { UpgradeSupportAmountForm } from './UpgradeSupportAmountForm';
@@ -26,11 +30,17 @@ export const UpgradeSupport = () => {
 		useState<boolean>(false);
 
 	const currentAmount = mainPlan.price / 100;
+	const threshold = getBenefitsThreshold(
+		mainPlan.currencyISO as CurrencyIso,
+		mainPlan.billingPeriod as 'month' | 'year',
+	);
+
+	// ToDo: what should we do if there is an error - some kind of retry logic? Or just show error screen instead of perpetual loading
 	const { data: previewResponse } = useAsyncLoader<PreviewResponse>(
 		() =>
 			productMoveFetch(
 				subscription.subscriptionId,
-				10,
+				threshold,
 				'recurring-contribution-to-supporter-plus',
 				false,
 				true,
@@ -81,6 +91,7 @@ export const UpgradeSupport = () => {
 					{continuedToConfirmation && chosenAmount && (
 						<ConfirmForm
 							chosenAmount={chosenAmount}
+							threshold={threshold}
 							setChosenAmount={setChosenAmount}
 							suggestedAmounts={suggestedAmounts}
 							previewResponse={previewResponse}

--- a/client/components/mma/upgrade/UpgradeSupport.tsx
+++ b/client/components/mma/upgrade/UpgradeSupport.tsx
@@ -1,7 +1,9 @@
 import { css } from '@emotion/react';
 import { headline, space, textSans, until } from '@guardian/source-foundations';
 import { Stack } from '@guardian/source-react-components';
-import { useContext, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
+import type { PreviewResponse } from '../../../../shared/productSwitchTypes';
+import { productMoveFetch } from '../../../utilities/productUtils';
 import { getSuggestedAmountsFromMainPlan } from '../../../utilities/supporterPlusPricing';
 import { ConfirmForm } from './ConfirmForm';
 import { UpgradeSupportAmountForm } from './UpgradeSupportAmountForm';
@@ -68,6 +70,7 @@ export const UpgradeSupport = () => {
 							chosenAmount={chosenAmount}
 							setChosenAmount={setChosenAmount}
 							suggestedAmounts={suggestedAmounts}
+							previewResponse={previewResponse}
 						/>
 					)}
 				</Stack>

--- a/client/components/mma/upgrade/UpgradeSupport.tsx
+++ b/client/components/mma/upgrade/UpgradeSupport.tsx
@@ -1,17 +1,19 @@
 import { css } from '@emotion/react';
 import { headline, space, textSans, until } from '@guardian/source-foundations';
 import { Stack } from '@guardian/source-react-components';
-import { useContext, useEffect, useState } from 'react';
+import { useContext, useState } from 'react';
 import type { PreviewResponse } from '../../../../shared/productSwitchTypes';
+import { useAsyncLoader } from '../../../utilities/hooks/useAsyncLoader';
 import { productMoveFetch } from '../../../utilities/productUtils';
 import { getSuggestedAmountsFromMainPlan } from '../../../utilities/supporterPlusPricing';
+import { JsonResponseHandler } from '../shared/asyncComponents/DefaultApiResponseHandler';
 import { ConfirmForm } from './ConfirmForm';
 import { UpgradeSupportAmountForm } from './UpgradeSupportAmountForm';
 import type { UpgradeSupportInterface } from './UpgradeSupportContainer';
 import { UpgradeSupportContext } from './UpgradeSupportContainer';
 
 export const UpgradeSupport = () => {
-	const { mainPlan } = useContext(
+	const { mainPlan, subscription } = useContext(
 		UpgradeSupportContext,
 	) as UpgradeSupportInterface;
 
@@ -24,6 +26,17 @@ export const UpgradeSupport = () => {
 		useState<boolean>(false);
 
 	const currentAmount = mainPlan.price / 100;
+	const { data: previewResponse } = useAsyncLoader<PreviewResponse>(
+		() =>
+			productMoveFetch(
+				subscription.subscriptionId,
+				10,
+				'recurring-contribution-to-supporter-plus',
+				false,
+				true,
+			),
+		JsonResponseHandler,
+	);
 
 	return (
 		<>

--- a/client/components/mma/upgrade/UpgradeSupport.tsx
+++ b/client/components/mma/upgrade/UpgradeSupport.tsx
@@ -35,18 +35,18 @@ export const UpgradeSupport = () => {
 		mainPlan.billingPeriod as 'month' | 'year',
 	);
 
-	// ToDo: what should we do if there is an error - some kind of retry logic? Or just show error screen instead of perpetual loading
-	const { data: previewResponse } = useAsyncLoader<PreviewResponse>(
-		() =>
-			productMoveFetch(
-				subscription.subscriptionId,
-				threshold,
-				'recurring-contribution-to-supporter-plus',
-				false,
-				true,
-			),
-		JsonResponseHandler,
-	);
+	const { data: previewResponse, loadingState: previewLoadingState } =
+		useAsyncLoader<PreviewResponse>(
+			() =>
+				productMoveFetch(
+					subscription.subscriptionId,
+					threshold,
+					'recurring-contribution-to-supporter-plus',
+					false,
+					true,
+				),
+			JsonResponseHandler,
+		);
 
 	return (
 		<>
@@ -95,6 +95,7 @@ export const UpgradeSupport = () => {
 							setChosenAmount={setChosenAmount}
 							suggestedAmounts={suggestedAmounts}
 							previewResponse={previewResponse}
+							previewLoadingState={previewLoadingState}
 						/>
 					)}
 				</Stack>

--- a/client/utilities/productMovePreview.ts
+++ b/client/utilities/productMovePreview.ts
@@ -1,0 +1,22 @@
+// These functions are client side versions of logic performed in the product-move-api to render preview details
+// They are duplicated here to avoid making many api calls if a user selects different amounts that require preview
+
+/**
+ * calculate the amount a user will pay at the time they switch product
+ */
+export function calculateAmountPayableToday(
+	userChosenAmount: number,
+	contributionRefundAmount: number,
+): number {
+	// contributionRefundAmount will be a negative number (eg if the refund is £5 the param will be -5)
+	return userChosenAmount - -1 * contributionRefundAmount;
+}
+
+/**
+ * calculate param to pass to non-preview call to check whether the amount is less than the minimum Stripe charge
+ */
+export function calculateCheckChargeAmountBeforeUpdate(
+	amountPayableToday: number,
+): boolean {
+	return amountPayableToday > 0 && amountPayableToday < 0.5;
+}

--- a/client/utilities/productMovePreview.ts
+++ b/client/utilities/productMovePreview.ts
@@ -9,7 +9,7 @@ export function calculateAmountPayableToday(
 	contributionRefundAmount: number,
 ): number {
 	// contributionRefundAmount will be a negative number (eg if the refund is £5 the param will be -5)
-	return userChosenAmount - -1 * contributionRefundAmount;
+	return userChosenAmount - Math.abs(contributionRefundAmount);
 }
 
 /**

--- a/client/utilities/productUtils.ts
+++ b/client/utilities/productUtils.ts
@@ -20,7 +20,7 @@ export const shouldHaveHolidayStopsFlow = (
 
 export const productMoveFetch = (
 	subscriptionId: string,
-	chosenAmount: number,
+	price: number,
 	productSwitchType: ProductSwitchType,
 	checkChargeAmountBeforeUpdate: boolean,
 	preview: boolean,
@@ -28,7 +28,7 @@ export const productMoveFetch = (
 	fetch(`/api/product-move/${productSwitchType}/${subscriptionId}`, {
 		method: 'POST',
 		body: JSON.stringify({
-			price: chosenAmount,
+			price,
 			preview,
 			checkChargeAmountBeforeUpdate,
 		}),

--- a/client/utilities/productUtils.ts
+++ b/client/utilities/productUtils.ts
@@ -3,6 +3,7 @@ import {
 	X_GU_ID_FORWARDED_SCOPE,
 } from '../../shared/identity';
 import type { ProductDetail } from '../../shared/productResponse';
+import type { ProductSwitchType } from '../../shared/productSwitchTypes';
 import type {
 	AllProductsProductTypeFilterString,
 	ProductType,
@@ -16,6 +17,25 @@ import { fetchWithDefaultParameters } from './fetch';
 export const shouldHaveHolidayStopsFlow = (
 	productType: ProductType,
 ): productType is ProductTypeWithHolidayStopsFlow => !!productType.holidayStops;
+
+export const productMoveFetch = (
+	subscriptionId: string,
+	chosenAmount: number,
+	productSwitchType: ProductSwitchType,
+	checkChargeAmountBeforeUpdate: boolean,
+	preview: boolean,
+) =>
+	fetch(`/api/product-move/${productSwitchType}/${subscriptionId}`, {
+		method: 'POST',
+		body: JSON.stringify({
+			price: chosenAmount,
+			preview,
+			checkChargeAmountBeforeUpdate,
+		}),
+		headers: {
+			'Content-Type': 'application/json',
+		},
+	});
 
 export const createProductDetailFetcher =
 	(

--- a/cypress/integration/parallel-2/upgradeSupport.spec.ts
+++ b/cypress/integration/parallel-2/upgradeSupport.spec.ts
@@ -24,7 +24,7 @@ describe('upgrade support', () => {
 		}).as('product_move');
 	});
 
-	it('upgrades contribution to supporter plus', () => {
+	it('resets when a different amount is clicked, upgrades contribution to supporter plus, only calls product-move preview once', () => {
 		cy.visit('/upgrade-support');
 
 		cy.findByText(/Increase your support/).should('exist');
@@ -37,31 +37,7 @@ describe('upgrade support', () => {
 
 		cy.findByText(/Confirm change/).should('exist');
 
-		cy.findByRole('button', {
-			name: /Confirm support change/,
-		}).click();
-
-		cy.wait('@product_move');
-
-		cy.findByText(/Your new support/).should('exist');
-
-		cy.get('@mdapi_get_contribution.all').should('have.length', 1);
-		cy.get('@product_move.all').should('have.length', 2);
-	});
-
-	it('resets when a different amount is clicked, only calls product-move preview once', () => {
-		cy.visit('/upgrade-support');
-
-		cy.findByText(/Increase your support/).should('exist');
-
-		cy.findByRole('button', {
-			name: /Continue with/,
-		}).click();
-
-		cy.wait('@product_move');
-
-		cy.findByText(/Confirm change/).should('exist');
-
+		// ToDo: make it more explicit what amount we're choosing once amounts confirmed
 		cy.get(
 			'[data-cy="contribution-amount-choices"] label:nth-of-type(2)',
 		).click();

--- a/cypress/integration/parallel-2/upgradeSupport.spec.ts
+++ b/cypress/integration/parallel-2/upgradeSupport.spec.ts
@@ -1,0 +1,86 @@
+import { toMembersDataApiResponse } from '../../../client/fixtures/mdapiResponse';
+import {
+	contributionPaidByCard,
+	contributionPaidByPayPal,
+} from '../../../client/fixtures/productBuilder/testProducts';
+import { productMovePreviewResponse } from '../../../client/fixtures/productMove';
+import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
+
+describe('upgrade support', () => {
+	beforeEach(() => {
+		signInAndAcceptCookies();
+
+		cy.intercept('GET', '/api/me/mma?productType=Contribution', {
+			statusCode: 200,
+			body: toMembersDataApiResponse(
+				contributionPaidByCard(),
+				contributionPaidByPayPal(),
+			),
+		}).as('mdapi_get_contribution');
+
+		cy.intercept('POST', '/api/product-move/**', {
+			statusCode: 200,
+			body: productMovePreviewResponse,
+		}).as('product_move');
+	});
+
+	it('upgrades contribution to supporter plus', () => {
+		cy.visit('/upgrade-support');
+
+		cy.findByText(/Increase your support/).should('exist');
+
+		cy.findByRole('button', {
+			name: /Continue with/,
+		}).click();
+
+		cy.wait('@product_move');
+
+		cy.findByText(/Confirm change/).should('exist');
+
+		cy.findByRole('button', {
+			name: /Confirm support change/,
+		}).click();
+
+		cy.wait('@product_move');
+
+		cy.findByText(/Your new support/).should('exist');
+
+		cy.get('@mdapi_get_contribution.all').should('have.length', 1);
+		cy.get('@product_move.all').should('have.length', 2);
+	});
+
+	it('resets when a different amount is clicked, only calls product-move preview once', () => {
+		cy.visit('/upgrade-support');
+
+		cy.findByText(/Increase your support/).should('exist');
+
+		cy.findByRole('button', {
+			name: /Continue with/,
+		}).click();
+
+		cy.wait('@product_move');
+
+		cy.findByText(/Confirm change/).should('exist');
+
+		cy.get(
+			'[data-cy="contribution-amount-choices"] label:nth-of-type(2)',
+		).click();
+
+		cy.findByText(/Confirm change/).should('not.exist');
+
+		cy.findByRole('button', {
+			name: /Continue with/,
+		}).click();
+
+		cy.findByRole('button', {
+			name: /Confirm support change/,
+		}).click();
+
+		cy.wait('@product_move');
+
+		cy.findByText(/Your new support/).should('exist');
+
+		cy.get('@mdapi_get_contribution.all').should('have.length', 1);
+		cy.get('@product_move.all').should('have.length', 2);
+	});
+});

--- a/shared/productSwitchTypes.ts
+++ b/shared/productSwitchTypes.ts
@@ -5,6 +5,7 @@ export type ProductSwitchType =
 export interface PreviewResponse {
 	amountPayableToday: number;
 	supporterPlusPurchaseAmount: number;
+	contributionRefundAmount: number;
 	nextPaymentDate: string;
 	checkChargeAmountBeforeUpdate: boolean;
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Refactors the upgrade journey to only call the `product-move-api` preview once. It uses the refund amount from the response to calculate the amount payable today. This change also puts the api call in the parent component of where it was previously (from `ConfirmForm` into `UpgradeSupport`), meaning it happens when the component first renders not when the `Continue` button is clicked

In effect we are calculating two response variables that are normally determined [in the product-move-api](https://github.com/guardian/support-service-lambdas/blob/main/handlers/product-move-api/src/main/scala/com/gu/productmove/switchtype/RecurringContributionToSupporterPlus.scala) on the client side instead

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

1. Go to `/upgrade-support`.
2. In network tab see api call to fetch preview info
3. Select an amount 
4. Continue
5. See amount payable today
6. Select a different amount
7. See new amount payable today

This PR also adds a Cypress test that counts the number of api calls.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

- The server side and client side could become out of sync if a change is performed and not duplicated 
- Inaccurate information could be passed to the server side if the client makes an error

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Loading details if a user clicks Continue before the preview call finishes
<img width="1728" alt="image" src="https://github.com/guardian/manage-frontend/assets/114918544/fc5726ce-2ee7-49f7-85aa-cbe8355cde45">

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
