### PR TITLE
Upgrade Support - Step 2 (Second iteration)

### DIFF
--- a/client/components/mma/cancel/cancellationSaves/SwitchThankYou.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SwitchThankYou.tsx
@@ -21,7 +21,7 @@ import {
 	headingCss,
 	iconListCss,
 	sectionSpacing,
-	whatHappensNextCss,
+	whatHappensNextIconCss,
 } from '../../../../styles/GenericStyles';
 import { getOldMembershipPrice } from '../../../../utilities/membershipPriceRise';
 import { Heading } from '../../shared/Heading';
@@ -84,7 +84,7 @@ export const SwitchThankYou = () => {
 			<section css={sectionSpacing}>
 				<Stack space={4}>
 					<Heading sansSerif>What happens next?</Heading>
-					<ul css={[iconListCss, whatHappensNextCss]}>
+					<ul css={[iconListCss, whatHappensNextIconCss]}>
 						<li>
 							<SvgEnvelope size="medium" />
 							<span data-qm-masking="blocklist">

--- a/client/components/mma/shared/Heading.tsx
+++ b/client/components/mma/shared/Heading.tsx
@@ -13,12 +13,15 @@ interface HeadingProps {
 	cssOverrides?: SerializedStyles | SerializedStyles[];
 	level?: '1' | '2' | '3' | '4';
 	sansSerif?: boolean;
+	borderless?: boolean;
 }
 
 export const Heading = (props: HeadingProps) => {
-	const dividerStyles = css`
-		border-top: 1px solid ${palette.neutral[86]};
-	`;
+	const dividerStyles = props.borderless
+		? css``
+		: css`
+				border-top: 1px solid ${palette.neutral[86]};
+		  `;
 
 	const headingStyles = css`
 		${props.sansSerif

--- a/client/components/mma/switch/complete/SwitchComplete.tsx
+++ b/client/components/mma/switch/complete/SwitchComplete.tsx
@@ -22,7 +22,7 @@ import { buttonCentredCss } from '../../../../styles/ButtonStyles';
 import {
 	iconListCss,
 	sectionSpacing,
-	whatHappensNextCss,
+	whatHappensNextIconCss,
 } from '../../../../styles/GenericStyles';
 import { formatAmount } from '../../../../utilities/utils';
 import { Heading } from '../../shared/Heading';
@@ -190,7 +190,7 @@ const WhatHappensNext = (props: {
 	return (
 		<Stack space={4}>
 			<Heading sansSerif>What happens next?</Heading>
-			<ul css={[iconListCss, whatHappensNextCss]}>
+			<ul css={[iconListCss, whatHappensNextIconCss]}>
 				<li>
 					<SvgEnvelope size="medium" />
 					<span data-qm-masking="blocklist">

--- a/client/components/mma/switch/review/SwitchReview.tsx
+++ b/client/components/mma/switch/review/SwitchReview.tsx
@@ -37,6 +37,7 @@ import {
 } from '../../../../utilities/hooks/useAsyncLoader';
 import { formatAmount } from '../../../../utilities/utils';
 import { GenericErrorScreen } from '../../../shared/GenericErrorScreen';
+import { SwitchPaymentInfo } from '../../../shared/productSwitch/SwitchPaymentInfo';
 import { SwitchOffsetPaymentIcon } from '../../shared/assets/SwitchOffsetPaymentIcon';
 import { JsonResponseHandler } from '../../shared/asyncComponents/DefaultApiResponseHandler';
 import { DefaultLoadingView } from '../../shared/asyncComponents/DefaultLoadingView';
@@ -293,27 +294,20 @@ export const SwitchReview = () => {
 						>
 							<SwitchOffsetPaymentIcon size="medium" />
 							<span>
-								<strong>
-									{previewResponse.amountPayableToday > 0 &&
-										`Your first payment will be
-									${isAboveThreshold ? 'just' : ''}
-									${mainPlan.currency}${formatAmount(previewResponse.amountPayableToday)}`}
-									{previewResponse.amountPayableToday == 0 &&
-										"There's nothing extra to pay today"}
-								</strong>
-								<br />
-								{previewResponse.amountPayableToday > 0 &&
-									`We will charge you a smaller amount today, to
-								offset the payment you've already given us for
-								the rest of the ${mainPlan.billingPeriod}.`}
-								{previewResponse.amountPayableToday == 0 &&
-									`We won't charge you today, as your current payment covers you for the rest of the ${mainPlan.billingPeriod}.`}{' '}
-								After this, from {nextPaymentDate}, your new{' '}
-								{monthlyOrAnnual.toLowerCase()} payment will be{' '}
-								{mainPlan.currency}
-								{formatAmount(
-									previewResponse.supporterPlusPurchaseAmount,
-								)}
+								<SwitchPaymentInfo
+									amountPayableToday={
+										previewResponse.amountPayableToday
+									}
+									alreadyPayingAboveThreshold={
+										isAboveThreshold
+									}
+									currencySymbol={mainPlan.currency}
+									supporterPlusPurchaseAmount={
+										previewResponse.supporterPlusPurchaseAmount
+									}
+									billingPeriod={mainPlan.billingPeriod}
+									nextPaymentDate={nextPaymentDate}
+								/>
 							</span>
 						</li>
 						<li>

--- a/client/components/mma/upgrade/ConfirmForm.tsx
+++ b/client/components/mma/upgrade/ConfirmForm.tsx
@@ -1,7 +1,8 @@
-import { css } from '@emotion/react';
-import { palette, space, textSans } from '@guardian/source-foundations';
+import { css, ThemeProvider } from '@emotion/react';
+import { from, palette, space, textSans } from '@guardian/source-foundations';
 import {
 	Button,
+	buttonThemeReaderRevenueBrand,
 	Stack,
 	SvgClock,
 	SvgCreditCard,
@@ -53,7 +54,12 @@ const WhatHappensNext = ({
 	alreadyPayingAboveThreshold: boolean;
 }) => {
 	return (
-		<section>
+		<section
+			css={css`
+				border-bottom: 1px solid ${palette.neutral[86]};
+				padding-bottom: ${space[4] + space[1]}px;
+			`}
+		>
 			<Stack space={4}>
 				<div
 					css={css`
@@ -226,7 +232,6 @@ export const ConfirmForm = ({
 		chosenAmount,
 		previewResponse.contributionRefundAmount,
 	);
-	console.log();
 
 	const nextPaymentDate = dateString(
 		new Date(previewResponse.nextPaymentDate),
@@ -265,8 +270,14 @@ export const ConfirmForm = ({
 	};
 
 	return (
-		<Stack space={2}>
-			<section>
+		<Stack space={4}>
+			<section
+				css={css`
+					${from.tablet} {
+						padding-bottom: ${space[2]}px;
+					}
+				`}
+			>
 				<Heading sansSerif level="3" borderless>
 					2. Confirm support increase
 				</Heading>
@@ -294,12 +305,15 @@ export const ConfirmForm = ({
 				/>
 			)}
 			<section>
-				<Button
-					onClick={confirmOnClick}
-					isLoading={isConfirmationLoading}
-				>
-					Confirm support change
-				</Button>
+				<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
+					<Button
+						onClick={confirmOnClick}
+						isLoading={isConfirmationLoading}
+					>
+						Confirm increase to {currencySymbol}
+						{chosenAmount}/{mainPlan.billingPeriod}
+					</Button>
+				</ThemeProvider>
 			</section>
 			{aboveThreshold && (
 				<section>

--- a/client/components/mma/upgrade/ConfirmForm.tsx
+++ b/client/components/mma/upgrade/ConfirmForm.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { from, palette, space, textSans } from '@guardian/source-foundations';
+import { palette, space, textSans } from '@guardian/source-foundations';
 import {
 	Button,
 	Stack,
@@ -10,11 +10,17 @@ import {
 import type { Dispatch, SetStateAction } from 'react';
 import { useContext, useState } from 'react';
 import { useNavigate } from 'react-router';
+import { dateString } from '../../../../shared/dates';
 import type {
 	PaidSubscriptionPlan,
 	Subscription,
 } from '../../../../shared/productResponse';
 import type { PreviewResponse } from '../../../../shared/productSwitchTypes';
+import {
+	iconListCss,
+	listWithDividersCss,
+	whatHappensNextIconCss,
+} from '../../../styles/GenericStyles';
 import { fetchWithDefaultParameters } from '../../../utilities/fetch';
 import { LoadingState } from '../../../utilities/hooks/useAsyncLoader';
 import {
@@ -23,6 +29,7 @@ import {
 } from '../../../utilities/productMovePreview';
 import { productMoveFetch } from '../../../utilities/productUtils';
 import { GenericErrorScreen } from '../../shared/GenericErrorScreen';
+import { SwitchPaymentInfo } from '../../shared/productSwitch/SwitchPaymentInfo';
 import { DefaultLoadingView } from '../shared/asyncComponents/DefaultLoadingView';
 import { Heading } from '../shared/Heading';
 import { PaymentDetails } from '../shared/PaymentDetails';
@@ -30,72 +37,57 @@ import { SupporterPlusTsAndCs } from '../shared/SupporterPlusTsAndCs';
 import type { UpgradeSupportInterface } from './UpgradeSupportContainer';
 import { UpgradeSupportContext } from './UpgradeSupportContainer';
 
-const iconListCss = css`
-	${textSans.medium()};
-	list-style: none;
-	padding: 0;
-	margin-bottom: 0;
-
-	li + li {
-		margin-top: ${space[2]}px;
-		${from.tablet} {
-			margin-top: ${space[3]}px;
-		}
-	}
-
-	li {
-		display: flex;
-		margin-left: -4px;
-		align-items: flex-start;
-
-		> svg {
-			flex-shrink: 0;
-			margin-right: 8px;
-			fill: currentColor;
-		}
-	}
-`;
-
-const listWithDividersCss = css`
-	li + li {
-		> svg {
-			padding-top: ${space[2]}px;
-			${from.tablet} {
-				padding-top: ${space[3]}px;
-			}
-		}
-		> span {
-			flex-grow: 1;
-			padding-top: ${space[2]}px;
-			border-top: 1px solid ${palette.neutral[86]};
-			min-width: 0;
-			${from.tablet} {
-				padding-top: ${space[3]}px;
-			}
-		}
-	}
-`;
-
 const WhatHappensNext = ({
 	amountPayableToday,
 	mainPlan,
 	subscription,
+	nextPaymentDate,
+	chosenAmount,
+	alreadyPayingAboveThreshold,
 }: {
 	amountPayableToday: number;
 	mainPlan: PaidSubscriptionPlan;
 	subscription: Subscription;
+	nextPaymentDate: string;
+	chosenAmount: number;
+	alreadyPayingAboveThreshold: boolean;
 }) => {
-	const firstPaymentDisplay = `${mainPlan.currency}${amountPayableToday}`;
-
 	return (
 		<section>
 			<Stack space={4}>
-				<Heading sansSerif>What happens next?</Heading>
-				<ul css={[iconListCss, listWithDividersCss]}>
+				<div
+					css={css`
+						border-top: 1px solid ${palette.neutral[86]};
+						padding-bottom: ${space[1]}px;
+					`}
+				>
+					<h3
+						css={css`
+							${textSans.large({ fontWeight: 'bold' })};
+							padding-top: ${space[1]}px;
+							margin: 0;
+						`}
+					>
+						What happens next?
+					</h3>
+				</div>
+				<ul
+					css={[
+						iconListCss,
+						listWithDividersCss,
+						whatHappensNextIconCss,
+					]}
+				>
 					<li>
 						<SvgClock size="medium" />
 						<span>
-							<strong>Price change will happen today</strong>
+							<strong
+								css={css`
+									padding-bottom: ${space[1]}px;
+								`}
+							>
+								Price change will happen today
+							</strong>
 							<br />
 							You can start enjoying your exclusive extras
 							straight away
@@ -104,18 +96,28 @@ const WhatHappensNext = ({
 					<li>
 						<SvgReload size="medium" />
 						<span>
-							<strong>
-								Your first payment will be just{' '}
-								{firstPaymentDisplay}
-							</strong>
-							<br />
-							We will charge you...
+							<SwitchPaymentInfo
+								amountPayableToday={amountPayableToday}
+								alreadyPayingAboveThreshold={
+									alreadyPayingAboveThreshold
+								}
+								currencySymbol={mainPlan.currency}
+								supporterPlusPurchaseAmount={chosenAmount}
+								billingPeriod={mainPlan.billingPeriod}
+								nextPaymentDate={nextPaymentDate}
+							/>
 						</span>
 					</li>
 					<li>
 						<SvgCreditCard size="medium" />
 						<span data-qm-masking="blocklist">
-							<strong>Your payment method</strong>
+							<strong
+								css={css`
+									padding-bottom: ${space[1]}px;
+								`}
+							>
+								Your payment method
+							</strong>
 							<br />
 							The payment will be taken from{' '}
 							<PaymentDetails subscription={subscription} />
@@ -195,6 +197,7 @@ export const ConfirmForm = ({
 
 	const navigate = useNavigate();
 
+	const currencySymbol = mainPlan.currency;
 	const aboveThreshold = chosenAmount >= threshold;
 
 	const [shouldShowRoundUp] = useState<boolean>(
@@ -223,6 +226,13 @@ export const ConfirmForm = ({
 		chosenAmount,
 		previewResponse.contributionRefundAmount,
 	);
+	console.log();
+
+	const nextPaymentDate = dateString(
+		new Date(previewResponse.nextPaymentDate),
+		'd MMMM',
+	);
+
 	const checkChargeAmount =
 		calculateCheckChargeAmountBeforeUpdate(amountPayableToday);
 
@@ -256,7 +266,16 @@ export const ConfirmForm = ({
 
 	return (
 		<Stack space={2}>
-			<Heading>2. Confirm change</Heading>
+			<section>
+				<Heading sansSerif level="3" borderless>
+					2. Confirm support increase
+				</Heading>
+				<div>
+					You've selected to support {currencySymbol}
+					{chosenAmount} per {mainPlan.billingPeriod}
+					{aboveThreshold ? ', which unlocks all benefits' : ''}.
+				</div>
+			</section>
 			{shouldShowRoundUp && (
 				<RoundUp
 					setChosenAmount={setChosenAmount}
@@ -269,6 +288,9 @@ export const ConfirmForm = ({
 					amountPayableToday={amountPayableToday}
 					mainPlan={mainPlan}
 					subscription={subscription}
+					nextPaymentDate={nextPaymentDate}
+					chosenAmount={chosenAmount}
+					alreadyPayingAboveThreshold={mainPlan.price >= threshold}
 				/>
 			)}
 			<section>

--- a/client/components/mma/upgrade/ConfirmForm.tsx
+++ b/client/components/mma/upgrade/ConfirmForm.tsx
@@ -18,6 +18,10 @@ import type {
 } from '../../../../shared/productResponse';
 import type { PreviewResponse } from '../../../../shared/productSwitchTypes';
 import {
+	buttonCentredCss,
+	buttonContainerCss,
+} from '../../../styles/ButtonStyles';
+import {
 	iconListCss,
 	listWithDividersCss,
 	whatHappensNextIconCss,
@@ -304,9 +308,10 @@ export const ConfirmForm = ({
 					alreadyPayingAboveThreshold={mainPlan.price >= threshold}
 				/>
 			)}
-			<section>
+			<section css={buttonContainerCss}>
 				<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
 					<Button
+						cssOverrides={buttonCentredCss}
 						onClick={confirmOnClick}
 						isLoading={isConfirmationLoading}
 					>

--- a/client/components/mma/upgrade/ConfirmForm.tsx
+++ b/client/components/mma/upgrade/ConfirmForm.tsx
@@ -285,7 +285,11 @@ export const ConfirmForm = ({
 				<Heading sansSerif level="3" borderless>
 					2. Confirm support increase
 				</Heading>
-				<div>
+				<div
+					css={css`
+						${textSans.medium()}
+					`}
+				>
 					You've selected to support {currencySymbol}
 					{chosenAmount} per {mainPlan.billingPeriod}
 					{aboveThreshold ? ', which unlocks all benefits' : ''}.

--- a/client/components/mma/upgrade/UpgradeSupport.stories.tsx
+++ b/client/components/mma/upgrade/UpgradeSupport.stories.tsx
@@ -3,6 +3,7 @@ import { rest } from 'msw';
 import { ReactRouterDecorator } from '../../../../.storybook/ReactRouterDecorator';
 import { toMembersDataApiResponse } from '../../../fixtures/mdapiResponse';
 import { contributionPaidByCard } from '../../../fixtures/productBuilder/testProducts';
+import { productMovePreviewResponse } from '../../../fixtures/productMove';
 import { UpgradeSupport } from './UpgradeSupport';
 import { UpgradeSupportContainer } from './UpgradeSupportContainer';
 import { UpgradeSupportSwitchThankYou } from './UpgradeSupportSwitchThankYou';
@@ -24,6 +25,9 @@ export default {
 						toMembersDataApiResponse(contributionPaidByCard()),
 					),
 				);
+			}),
+			rest.post('/api/product-move/*', (_req, res, ctx) => {
+				return res(ctx.json(productMovePreviewResponse));
 			}),
 		],
 	},

--- a/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
@@ -1,5 +1,5 @@
 import { css, ThemeProvider } from '@emotion/react';
-import { space, textSans, until } from '@guardian/source-foundations';
+import { space } from '@guardian/source-foundations';
 import {
 	Button,
 	buttonThemeReaderRevenueBrand,
@@ -19,6 +19,7 @@ import type { ContributionInterval } from '../../../utilities/contributionsAmoun
 import { contributionAmountsLookup } from '../../../utilities/contributionsAmount';
 import { UpgradeBenefitsCard } from '../shared/benefits/BenefitsCard';
 import { getUpgradeBenefits } from '../shared/benefits/BenefitsConfiguration';
+import { Heading } from '../shared/Heading';
 import type { UpgradeSupportInterface } from './UpgradeSupportContainer';
 import { UpgradeSupportContext } from './UpgradeSupportContainer';
 
@@ -136,17 +137,9 @@ export const UpgradeSupportAmountForm = ({
 	return (
 		<>
 			<div>
-				<h3
-					css={css`
-						${textSans.xlarge({ fontWeight: 'bold' })};
-						${until.tablet} {
-							${textSans.large({ fontWeight: 'bold' })};
-						}
-						margin: 0;
-					`}
-				>
+				<Heading sansSerif level="3" borderless>
 					1. Choose your new amount
-				</h3>
+				</Heading>
 				<Stack space={4}>
 					<ChoiceCardGroup
 						cssOverrides={twoColumnChoiceCardMobile}

--- a/client/components/mma/upgrade/UpgradeSupportSwitchThankYou.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportSwitchThankYou.tsx
@@ -16,7 +16,7 @@ import {
 	headingCss,
 	iconListCss,
 	sectionSpacing,
-	whatHappensNextCss,
+	whatHappensNextIconCss,
 } from '../../../styles/GenericStyles';
 import {
 	signInContentContainerCss,
@@ -49,7 +49,7 @@ export const UpgradeSupportSwitchThankYou = () => {
 			</section>
 			<section css={sectionSpacing}>
 				<Heading sansSerif>What happens next?</Heading>
-				<ul css={[iconListCss, whatHappensNextCss]}>
+				<ul css={[iconListCss, whatHappensNextIconCss]}>
 					<li>
 						<SvgEnvelope size="medium" />
 						<span data-qm-masking="blocklist">

--- a/client/components/mma/upgrade/UpgradeSupportThankYou.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportThankYou.tsx
@@ -19,7 +19,7 @@ import {
 	headingCss,
 	iconListCss,
 	sectionSpacing,
-	whatHappensNextCss,
+	whatHappensNextIconCss,
 } from '../../../styles/GenericStyles';
 import { Heading } from '../shared/Heading';
 import type { UpgradeSupportInterface } from './UpgradeSupportContainer';
@@ -55,7 +55,7 @@ export const UpgradeSupportThankYou = () => {
 			<section css={sectionSpacing}>
 				<Stack space={4}>
 					<Heading sansSerif>What happens next?</Heading>
-					<ul css={[iconListCss, whatHappensNextCss]}>
+					<ul css={[iconListCss, whatHappensNextIconCss]}>
 						<li>
 							<SvgEnvelope size="medium" />
 							<span data-qm-masking="blocklist">

--- a/client/components/shared/productSwitch/SwitchPaymentInfo.tsx
+++ b/client/components/shared/productSwitch/SwitchPaymentInfo.tsx
@@ -1,0 +1,50 @@
+import { css } from '@emotion/react';
+import { space } from '@guardian/source-foundations';
+import { calculateMonthlyOrAnnualFromBillingPeriod } from '../../../../shared/productTypes';
+import { formatAmount } from '../../../utilities/utils';
+
+export const SwitchPaymentInfo = ({
+	amountPayableToday,
+	alreadyPayingAboveThreshold,
+	currencySymbol,
+	supporterPlusPurchaseAmount,
+	billingPeriod,
+	nextPaymentDate,
+}: {
+	amountPayableToday: number;
+	alreadyPayingAboveThreshold: boolean;
+	currencySymbol: string;
+	supporterPlusPurchaseAmount: number;
+	billingPeriod: string;
+	nextPaymentDate: string;
+}) => {
+	const monthlyOrAnnual =
+		calculateMonthlyOrAnnualFromBillingPeriod(billingPeriod).toLowerCase();
+
+	return (
+		<>
+			<strong
+				css={css`
+					padding-bottom: ${space[1]}px;
+				`}
+			>
+				{amountPayableToday > 0 &&
+					`Your first payment will be
+									${alreadyPayingAboveThreshold ? 'just' : ''}
+									${currencySymbol}${formatAmount(amountPayableToday)}`}
+				{amountPayableToday == 0 &&
+					"There's nothing extra to pay today"}
+			</strong>
+			<br />
+			{amountPayableToday > 0 &&
+				`We will charge you a smaller amount today, to
+								offset the payment you've already given us for
+								the rest of the ${billingPeriod}.`}
+			{amountPayableToday == 0 &&
+				`We won't charge you today, as your current payment covers you for the rest of the ${billingPeriod}.`}{' '}
+			After this, from {nextPaymentDate}, your new {monthlyOrAnnual}{' '}
+			payment will be {currencySymbol}
+			{formatAmount(supporterPlusPurchaseAmount)}
+		</>
+	);
+};

--- a/client/fixtures/productMove.ts
+++ b/client/fixtures/productMove.ts
@@ -1,6 +1,9 @@
-export const productMovePreviewResponse = {
+import type { PreviewResponse } from '../../shared/productSwitchTypes';
+
+export const productMovePreviewResponse: PreviewResponse = {
 	amountPayableToday: 5.0,
 	supporterPlusPurchaseAmount: 10.0,
+	contributionRefundAmount: -5,
 	nextPaymentDate: '2023-03-20',
 	checkChargeAmountBeforeUpdate: false,
 };

--- a/client/styles/GenericStyles.ts
+++ b/client/styles/GenericStyles.ts
@@ -28,7 +28,7 @@ export const headingCss = css`
 	}
 `;
 
-export const whatHappensNextCss = css`
+export const whatHappensNextIconCss = css`
 	li > svg {
 		fill: ${palette.brand[500]};
 	}

--- a/cypress/integration/parallel-2/upgradeSupport.spec.ts
+++ b/cypress/integration/parallel-2/upgradeSupport.spec.ts
@@ -49,7 +49,7 @@ describe('upgrade support', () => {
 		}).click();
 
 		cy.findByRole('button', {
-			name: /Confirm support change/,
+			name: /Confirm support increase/,
 		}).click();
 
 		cy.wait('@product_move');

--- a/cypress/integration/parallel-2/upgradeSupport.spec.ts
+++ b/cypress/integration/parallel-2/upgradeSupport.spec.ts
@@ -35,21 +35,21 @@ describe('upgrade support', () => {
 
 		cy.wait('@product_move');
 
-		cy.findByText(/Confirm change/).should('exist');
+		cy.findByText(/Confirm support increase/).should('exist');
 
 		// ToDo: make it more explicit what amount we're choosing once amounts confirmed
 		cy.get(
 			'[data-cy="contribution-amount-choices"] label:nth-of-type(2)',
 		).click();
 
-		cy.findByText(/Confirm change/).should('not.exist');
+		cy.findByText(/Confirm support increase/).should('not.exist');
 
 		cy.findByRole('button', {
 			name: /Continue with/,
 		}).click();
 
 		cy.findByRole('button', {
-			name: /Confirm support increase/,
+			name: /Confirm increase/,
 		}).click();
 
 		cy.wait('@product_move');


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Implement final designs ([figma](https://www.figma.com/file/BAqeBncOfn51nXxk9zrFxe/Upsell?node-id=1438%3A29057&mode=dev)) of the second step upgrade support journey - when a user switches to supporter plus.

Refactors the product switch journey to use the same info about next payment dates, for reuse. Also adds a borderless heading style

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

See storybook or go to `/upgrade-support`, choose an amount above the S+ threshold and click 'Continue with x'

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://github.com/guardian/manage-frontend/assets/114918544/1410ec9e-ff8e-4c4f-b944-76b3bacffeed)

![image](https://github.com/guardian/manage-frontend/assets/114918544/56503a94-3e83-4982-86c7-aad72c274fef)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
