### PR TITLE
Upgrade support - round up (final designs)

### DIFF
--- a/client/components/mma/upgrade/ConfirmForm.tsx
+++ b/client/components/mma/upgrade/ConfirmForm.tsx
@@ -170,7 +170,7 @@ const RoundUp = ({
 					padding: ${space[3]}px ${space[1]}px ${space[3]}px
 						${space[3]}px;
 				}
-				padding: ${space[3]}px ${space[2]}px ${space[3]}px ${space[3]}px;
+				padding: ${space[4]}px ${space[2]}px ${space[4]}px ${space[4]}px;
 				border-radius: 4px;
 				border: 1px solid ${palette.neutral[86]};
 				background: ${hasRoundedUp

--- a/client/components/mma/upgrade/ConfirmForm.tsx
+++ b/client/components/mma/upgrade/ConfirmForm.tsx
@@ -1,5 +1,11 @@
 import { css, ThemeProvider } from '@emotion/react';
-import { from, palette, space, textSans } from '@guardian/source-foundations';
+import {
+	from,
+	palette,
+	space,
+	textSans,
+	until,
+} from '@guardian/source-foundations';
 import {
 	Button,
 	buttonThemeReaderRevenueBrand,
@@ -8,6 +14,7 @@ import {
 	SvgCreditCard,
 	SvgReload,
 } from '@guardian/source-react-components';
+import { ToggleSwitch } from '@guardian/source-react-components-development-kitchen';
 import type { Dispatch, SetStateAction } from 'react';
 import { useContext, useState } from 'react';
 import { useNavigate } from 'react-router';
@@ -143,32 +150,69 @@ const RoundUp = ({
 	setChosenAmount,
 	thresholdAmount,
 	chosenAmountPreRoundup,
+	currencySymbol,
+	billingPeriod,
 }: {
 	setChosenAmount: Dispatch<SetStateAction<number | null>>;
 	thresholdAmount: number;
 	chosenAmountPreRoundup: number;
+	currencySymbol: string;
+	billingPeriod: string;
 }) => {
 	const [hasRoundedUp, setHasRoundedUp] = useState<boolean>(false);
 
 	return (
-		<Stack space={2}>
-			<p>Want to unlock all extras?</p>
-			<section>
-				<Button
-					onClick={() => {
-						const toggleRoundUp = !hasRoundedUp;
-						setHasRoundedUp(toggleRoundUp);
-						setChosenAmount(
-							toggleRoundUp
-								? thresholdAmount
-								: chosenAmountPreRoundup,
-						);
-					}}
+		<section
+			css={css`
+				display: flex;
+				justify-content: space-between;
+				${until.tablet} {
+					padding: ${space[3]}px ${space[1]}px ${space[3]}px
+						${space[3]}px;
+				}
+				padding: ${space[3]}px ${space[2]}px ${space[3]}px ${space[3]}px;
+				border-radius: 4px;
+				border: 1px solid ${palette.neutral[86]};
+				background: ${hasRoundedUp
+					? palette.neutral[97]
+					: palette.neutral[100]};
+			`}
+		>
+			<div>
+				<div
+					css={css`
+						${textSans.medium({ fontWeight: 'bold' })};
+						padding-right: ${space[4]}px;
+					`}
 				>
-					{hasRoundedUp ? 'Rounded up' : 'Round up'}
-				</Button>
-			</section>
-		</Stack>
+					Round up to unlock all benefits ({currencySymbol}
+					{thresholdAmount}/{billingPeriod})
+				</div>
+				<div
+					css={css`
+						${until.tablet} {
+							${textSans.small()};
+						}
+						${textSans.medium()};
+						color: ${palette.neutral[46]};
+					`}
+				>
+					Get unlimited app access, ad-free reading, and more.
+				</div>
+			</div>
+			<ToggleSwitch
+				checked={hasRoundedUp}
+				onClick={() => {
+					const toggleRoundUp = !hasRoundedUp;
+					setHasRoundedUp(toggleRoundUp);
+					setChosenAmount(
+						toggleRoundUp
+							? thresholdAmount
+							: chosenAmountPreRoundup,
+					);
+				}}
+			/>
+		</section>
 	);
 };
 
@@ -300,6 +344,8 @@ export const ConfirmForm = ({
 					setChosenAmount={setChosenAmount}
 					thresholdAmount={threshold}
 					chosenAmountPreRoundup={chosenAmountPreRoundup}
+					currencySymbol={currencySymbol}
+					billingPeriod={mainPlan.billingPeriod}
 				/>
 			)}
 			{aboveThreshold && (

--- a/client/components/mma/upgrade/ConfirmForm.tsx
+++ b/client/components/mma/upgrade/ConfirmForm.tsx
@@ -170,7 +170,7 @@ const RoundUp = ({
 					padding: ${space[3]}px ${space[1]}px ${space[3]}px
 						${space[3]}px;
 				}
-				padding: ${space[4]}px ${space[2]}px ${space[4]}px ${space[4]}px;
+				padding: ${space[3]}px ${space[2]}px ${space[3]}px ${space[4]}px;
 				border-radius: 4px;
 				border: 1px solid ${palette.neutral[86]};
 				background: ${hasRoundedUp
@@ -183,6 +183,9 @@ const RoundUp = ({
 					css={css`
 						${textSans.medium({ fontWeight: 'bold' })};
 						padding-right: ${space[4]}px;
+						color: ${hasRoundedUp
+							? palette.neutral[0]
+							: palette.neutral[20]};
 					`}
 				>
 					Round up to unlock all benefits ({currencySymbol}

--- a/client/components/mma/upgrade/UpgradeSupport.tsx
+++ b/client/components/mma/upgrade/UpgradeSupport.tsx
@@ -84,6 +84,7 @@ export const UpgradeSupport = () => {
 					<UpgradeSupportAmountForm
 						chosenAmount={chosenAmount}
 						setChosenAmount={setChosenAmount}
+						threshold={threshold}
 						setContinuedToConfirmation={setContinuedToConfirmation}
 						continuedToConfirmation={continuedToConfirmation}
 						suggestedAmounts={suggestedAmounts}
@@ -91,8 +92,8 @@ export const UpgradeSupport = () => {
 					{continuedToConfirmation && chosenAmount && (
 						<ConfirmForm
 							chosenAmount={chosenAmount}
-							threshold={threshold}
 							setChosenAmount={setChosenAmount}
+							threshold={threshold}
 							suggestedAmounts={suggestedAmounts}
 							previewResponse={previewResponse}
 							previewLoadingState={previewLoadingState}

--- a/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
@@ -74,6 +74,7 @@ function BenefitsDisplay({
 interface UpgradeSupportAmountFormProps {
 	chosenAmount: number | null;
 	setChosenAmount: Dispatch<SetStateAction<number | null>>;
+	threshold: number;
 	setContinuedToConfirmation: Dispatch<SetStateAction<boolean>>;
 	continuedToConfirmation: boolean;
 	suggestedAmounts: number[];
@@ -82,6 +83,7 @@ interface UpgradeSupportAmountFormProps {
 export const UpgradeSupportAmountForm = ({
 	chosenAmount,
 	setChosenAmount,
+	threshold,
 	setContinuedToConfirmation,
 	continuedToConfirmation,
 	suggestedAmounts,
@@ -90,7 +92,6 @@ export const UpgradeSupportAmountForm = ({
 		UpgradeSupportContext,
 	) as UpgradeSupportInterface;
 
-	const threshold = 10; // TODO
 	const priceConfig = (contributionAmountsLookup[mainPlan.currencyISO] ||
 		contributionAmountsLookup.international)[
 		mainPlan.billingPeriod as ContributionInterval


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Implement final designs from [figma](https://www.figma.com/file/BAqeBncOfn51nXxk9zrFxe/Upsell?node-id=1556%3A60600&mode=dev) for the Round Up component

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Go to `/upgrade-support`, with a contribution amount (eg £5) that has a suggested amount < the threshold (eg £10) and has the threshold as an option. See the Round Up component, toggle to round up and see the threshold amount become selected.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<img width="857" alt="image" src="https://github.com/guardian/manage-frontend/assets/114918544/1527583c-ebe0-44ed-834b-aada56f12276">
<img width="861" alt="image" src="https://github.com/guardian/manage-frontend/assets/114918544/86c5c1c6-5a9f-47c6-b4bb-7eb1fc5ec3fa">

<img width="364" alt="image" src="https://github.com/guardian/manage-frontend/assets/114918544/391ea3e9-6c1e-4526-9827-17429afb86a5">

<img width="370" alt="image" src="https://github.com/guardian/manage-frontend/assets/114918544/c7b2447a-1528-4a4e-aab8-4da2e7b71a4c">



<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
