### PR TITLE
Upgrade Support: Smooth scroll to confirmation step after clicking 'Continue with...'

### DIFF
--- a/client/components/mma/upgrade/ConfirmForm.tsx
+++ b/client/components/mma/upgrade/ConfirmForm.tsx
@@ -331,6 +331,7 @@ export const ConfirmForm = ({
 	return (
 		<Stack space={4}>
 			<section
+				id="confirm-change"
 				css={css`
 					${from.tablet} {
 						padding-bottom: ${space[2]}px;

--- a/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
@@ -17,11 +17,21 @@ import {
 import { twoColumnChoiceCardMobile } from '../../../styles/GenericStyles';
 import type { ContributionInterval } from '../../../utilities/contributionsAmount';
 import { contributionAmountsLookup } from '../../../utilities/contributionsAmount';
+import { waitForElement } from '../../../utilities/utils';
 import { UpgradeBenefitsCard } from '../shared/benefits/BenefitsCard';
 import { getUpgradeBenefits } from '../shared/benefits/BenefitsConfiguration';
 import { Heading } from '../shared/Heading';
 import type { UpgradeSupportInterface } from './UpgradeSupportContainer';
 import { UpgradeSupportContext } from './UpgradeSupportContainer';
+
+async function scrollToConfirmChange() {
+	const confirmElement = await waitForElement('#confirm-change');
+	confirmElement &&
+		confirmElement.scrollIntoView({
+			behavior: 'smooth',
+		});
+	parent.location.hash = 'confirm-change';
+}
 
 function validateChoice(
 	currentAmount: number,
@@ -225,11 +235,12 @@ export const UpgradeSupportAmountForm = ({
 							>
 								<Button
 									cssOverrides={buttonCentredCss}
-									onClick={() =>
+									onClick={() => {
 										setContinuedToConfirmation(
 											chosenAmount ? true : false,
-										)
-									}
+										);
+										scrollToConfirmChange();
+									}}
 								>
 									Continue with {currencySymbol}
 									{chosenAmount}/{mainPlan.billingPeriod}

--- a/client/utilities/utils.ts
+++ b/client/utilities/utils.ts
@@ -37,3 +37,23 @@ export const processResponse = <T>(resp: Response): Promise<T | null> => {
 
 	throw error;
 };
+
+export function waitForElement(selector: string): Promise<Element | null> {
+	return new Promise((resolve) => {
+		if (document.querySelector(selector)) {
+			return resolve(document.querySelector(selector));
+		}
+
+		const observer = new MutationObserver((_) => {
+			if (document.querySelector(selector)) {
+				observer.disconnect();
+				resolve(document.querySelector(selector));
+			}
+		});
+
+		observer.observe(document.body, {
+			childList: true,
+			subtree: true,
+		});
+	});
+}

--- a/client/utilities/utils.ts
+++ b/client/utilities/utils.ts
@@ -38,6 +38,7 @@ export const processResponse = <T>(resp: Response): Promise<T | null> => {
 	throw error;
 };
 
+// https://stackoverflow.com/a/61511955
 export function waitForElement(selector: string): Promise<Element | null> {
 	return new Promise((resolve) => {
 		if (document.querySelector(selector)) {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Within upgrade-support journey, adds a function to scroll smoothly to step 2 with id `confirm-change` and set a hash in the URL.

Also added a utility function to wait until an element is in the DOM and then get it (as step 2 will load async) that uses [Mutation Observer](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) to observe mutations. Based on [this stackoverflow answer](https://stackoverflow.com/a/61511955)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Manually: go to `/upgrade-support` and click "Continue with"

Automated: not sure

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Happy days:

https://github.com/guardian/manage-frontend/assets/114918544/da11bc90-79c6-442d-9cb4-d8bf09032767

Case where second step hasn't loaded yet: 

https://github.com/guardian/manage-frontend/assets/114918544/43f9d895-042b-4799-a95d-e5f16d195a1e

Mobile: 

https://github.com/guardian/manage-frontend/assets/114918544/d7456196-344f-4ac4-80bc-4ad02bb05151




<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
