### PR TITLE
Add National Delivery as a product type

### DIFF
--- a/client/components/mma/accountoverview/ProductCardConfiguration.ts
+++ b/client/components/mma/accountoverview/ProductCardConfiguration.ts
@@ -61,6 +61,9 @@ export const productCardConfiguration: {
 	homedelivery: {
 		colour: productColour.newspaper,
 	},
+	nationaldelivery: {
+		colour: productColour.newspaper,
+	},
 	voucher: {
 		colour: productColour.newspaper,
 	},

--- a/client/components/mma/shared/benefits/BenefitsConfiguration.ts
+++ b/client/components/mma/shared/benefits/BenefitsConfiguration.ts
@@ -47,6 +47,7 @@ export const benefitsConfiguration: {
 	digitalvoucher: [],
 	newspaper: [],
 	homedelivery: [],
+	nationaldelivery: [],
 	voucher: [],
 	guardianweekly: [],
 	guardianpatron: [],

--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -68,8 +68,7 @@ router.get(
 				response.json(mdapiResponse);
 			})
 			.catch((error) => {
-				const errorMessage =
-					"Unexpected error when augmenting members-data-api response with 'deliveryAddressChangeEffectiveDate'";
+				const errorMessage = `Unexpected error when augmenting members-data-api response with 'deliveryAddressChangeEffectiveDate' error message was ${error}`;
 				log.error(errorMessage, error);
 				Sentry.captureMessage(errorMessage);
 				response.json(augmentedWithTestUser); // fallback to sending the response augmented with just isTestUser

--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -38,7 +38,6 @@ type ProductFriendlyName =
 	| 'newspaper voucher subscription'
 	| 'newspaper subscription card'
 	| 'newspaper home delivery subscription'
-	| 'newspaper national delivery subscription'
 	| 'digital subscription'
 	| 'monthly + extras'
 	| 'annual + extras'
@@ -53,6 +52,7 @@ type ProductUrlPart =
 	| 'voucher'
 	| 'subscriptioncard'
 	| 'homedelivery'
+	| 'nationaldelivery'
 	| 'digital'
 	| 'support'
 	| 'guardianweekly'
@@ -449,12 +449,12 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 	},
 	nationaldelivery: {
 		productTitle: calculateProductTitle('Newspaper Delivery'),
-		friendlyName: () => 'newspaper national delivery subscription',
-		shortFriendlyName: 'newspaper national delivery',
+		friendlyName: () => 'newspaper home delivery subscription',
+		shortFriendlyName: 'newspaper home delivery',
 		productType: 'nationaldelivery',
 		groupedProductType: 'subscriptions',
-		allProductsProductTypeFilterString: 'HomeDelivery', // Is this right?
-		urlPart: 'homedelivery', // Is this right?
+		allProductsProductTypeFilterString: 'HomeDelivery',
+		urlPart: 'nationaldelivery',
 		getOphanProductType: () => 'PRINT_SUBSCRIPTION',
 		productPageNewsletterIDs: [FRONT_PAGE_NEWSLETTER_ID],
 		softOptInIDs: [

--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -38,6 +38,7 @@ type ProductFriendlyName =
 	| 'newspaper voucher subscription'
 	| 'newspaper subscription card'
 	| 'newspaper home delivery subscription'
+	| 'newspaper national delivery subscription'
 	| 'digital subscription'
 	| 'monthly + extras'
 	| 'annual + extras'
@@ -263,6 +264,7 @@ export type ProductTypeKeys =
 	| 'contributions'
 	| 'newspaper'
 	| 'homedelivery'
+	| 'nationaldelivery'
 	| 'voucher'
 	| 'digitalvoucher'
 	| 'guardianweekly'
@@ -443,6 +445,46 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 		},
 		fulfilmentDateCalculator: {
 			productFilenamePart: 'Newspaper - Home Delivery',
+		},
+	},
+	nationaldelivery: {
+		productTitle: calculateProductTitle('Newspaper Delivery'),
+		friendlyName: () => 'newspaper national delivery subscription',
+		shortFriendlyName: 'newspaper national delivery',
+		productType: 'nationaldelivery',
+		groupedProductType: 'subscriptions',
+		allProductsProductTypeFilterString: 'HomeDelivery', // Is this right?
+		urlPart: 'homedelivery', // Is this right?
+		getOphanProductType: () => 'PRINT_SUBSCRIPTION',
+		productPageNewsletterIDs: [FRONT_PAGE_NEWSLETTER_ID],
+		softOptInIDs: [
+			SoftOptInIDs.SupportOnboarding,
+			SoftOptInIDs.SubscriberPreview,
+			SoftOptInIDs.SimilarProducts,
+			SoftOptInIDs.SupporterNewsletter,
+		],
+		holidayStops: {
+			issueKeyword: 'paper',
+		},
+		delivery: {
+			showAddress: showDeliveryAddressCheck,
+			enableDeliveryInstructionsUpdate: true,
+			records: {
+				productNameForProblemReport: 'National Delivery',
+				showDeliveryInstructions: true,
+				numberOfProblemRecordsToShow: 14,
+				contactUserOnExistingProblemReport: true,
+				availableProblemTypes: [
+					{
+						label: 'Instructions Not Followed',
+						messageIsMandatory: true,
+					},
+					...commonDeliveryProblemTypes,
+				],
+			},
+		},
+		fulfilmentDateCalculator: {
+			productFilenamePart: 'Newspaper - National Delivery',
 		},
 	},
 	voucher: {
@@ -723,6 +765,8 @@ export const GROUPED_PRODUCT_TYPES: {
 			if (productDetail.tier === 'Digital Pack') {
 				return PRODUCT_TYPES.digipack;
 			} else if (productDetail.tier === 'Newspaper Delivery') {
+				return PRODUCT_TYPES.homedelivery;
+			} else if (productDetail.tier === 'Newspaper - National Delivery') {
 				return PRODUCT_TYPES.homedelivery;
 			} else if (productDetail.tier === 'Newspaper Voucher') {
 				return PRODUCT_TYPES.voucher;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
[This change to members-data-api](https://github.com/guardian/members-data-api/pull/1036) makes National Delivery subs appear in the `user-attributes/me/mma` endpoint used by manage-frontend. This breaks manage however because National Delivery is not defined as a product so the site doesn't know how to display it.

This PR fixes that issue.