### PR TITLE
Upsell: QM block email address on thank you pages

### DIFF
--- a/client/components/mma/upgrade/UpgradeSupportSwitchThankYou.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportSwitchThankYou.tsx
@@ -102,11 +102,12 @@ export const UpgradeSupportSwitchThankYou = () => {
 					<ul css={[iconListCss, whatHappensNextIconCss]}>
 						<li>
 							<SvgEnvelope size="medium" />
-							<span data-qm-masking="blocklist" css={iconTextCss}>
-								Check your email
-							</span>
+							<span css={iconTextCss}>Check your email</span>
 						</li>
-						<div css={withMarginParagraphCss}>
+						<div
+							css={withMarginParagraphCss}
+							data-qm-masking="blocklist"
+						>
 							You will receive a confirmation email to {userEmail}
 						</div>
 						<Heading

--- a/client/components/mma/upgrade/UpgradeSupportThankYou.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportThankYou.tsx
@@ -100,11 +100,12 @@ export const UpgradeSupportThankYou = () => {
 					<ul css={[iconListCss, whatHappensNextIconCss]}>
 						<li>
 							<SvgEnvelope size="medium" />
-							<span data-qm-masking="blocklist" css={iconTextCss}>
-								Check your email
-							</span>
+							<span css={iconTextCss}>Check your email</span>
 						</li>
-						<p css={withMarginParagraphCss}>
+						<p
+							css={withMarginParagraphCss}
+							data-qm-masking="blocklist"
+						>
 							You will receive a confirmation email to {userEmail}
 						</p>
 						<Heading


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Adding tag on email fields on the upsell thank you pages. Quantum metric (QM) check for the tag on their side and make sure that it is masked when capturing the sessions. We will get confirmation from QM that it has been blocked too before this is live.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Check on the thank you pages that you can see the masking tag like in the snapshots below:
![image](https://github.com/guardian/manage-frontend/assets/115992455/2f1053a2-a1b9-47ab-a1d3-bd4af31c24ef)

![image](https://github.com/guardian/manage-frontend/assets/115992455/0f8f2877-7f42-4d38-a656-a96ecdc63d63)

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
