### PR TITLE
Upgrade Support - Add Error Handling for confirmation

### DIFF
--- a/client/components/mma/switch/review/SwitchReview.tsx
+++ b/client/components/mma/switch/review/SwitchReview.tsx
@@ -7,10 +7,9 @@ import {
 	SvgClock,
 	SvgCreditCard,
 } from '@guardian/source-react-components';
-import { ErrorSummary } from '@guardian/source-react-components-development-kitchen';
 import { useContext, useState } from 'react';
 import { Navigate, useLocation, useNavigate } from 'react-router';
-import { Link } from 'react-router-dom';
+import { SwitchErrorSummary } from '@/client/components/shared/productSwitch/SwitchErrorSummary';
 import { dateString } from '../../../../../shared/dates';
 import type {
 	PreviewResponse,
@@ -20,11 +19,6 @@ import {
 	buttonCentredCss,
 	buttonMutedCss,
 } from '../../../../styles/ButtonStyles';
-import {
-	errorSummaryBlockLinkCss,
-	errorSummaryLinkCss,
-	errorSummaryOverrideCss,
-} from '../../../../styles/ErrorStyles';
 import {
 	iconListCss,
 	listWithDividersCss,
@@ -51,31 +45,6 @@ import type {
 	SwitchRouterState,
 } from '../SwitchContainer';
 import { SwitchContext } from '../SwitchContainer';
-
-const SwitchErrorContext = (props: { PaymentFailure: boolean }) =>
-	props.PaymentFailure ? (
-		<>
-			Please update your payment details in order to change your support.
-			<Link
-				css={[errorSummaryLinkCss, errorSummaryBlockLinkCss]}
-				to="/payment/contributions"
-			>
-				Check your payment details
-			</Link>
-		</>
-	) : (
-		<>
-			Please ensure your payment details are correct. If the problem
-			persists get in touch at{' '}
-			<a
-				css={errorSummaryLinkCss}
-				href="mailto:customer.help@guardian.com"
-			>
-				customer.help@guardian.com
-			</a>
-			.
-		</>
-	);
 
 const newAmountCss = css`
 	${textSans.medium({ fontWeight: 'bold' })};
@@ -351,19 +320,7 @@ export const SwitchReview = () => {
 			</section>
 			{switchingError && (
 				<section css={sectionSpacing} id="productSwitchErrorMessage">
-					<ErrorSummary
-						message={
-							inPaymentFailure
-								? 'There is a problem with your payment method'
-								: 'We were unable to change your support'
-						}
-						context={
-							<SwitchErrorContext
-								PaymentFailure={inPaymentFailure}
-							/>
-						}
-						cssOverrides={errorSummaryOverrideCss}
-					/>
+					<SwitchErrorSummary inPaymentFailure={inPaymentFailure} />
 				</section>
 			)}
 			<section css={sectionSpacing}>

--- a/client/components/mma/upgrade/UpgradeSupportContainer.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportContainer.tsx
@@ -26,6 +26,7 @@ import { DefaultLoadingView } from '../shared/asyncComponents/DefaultLoadingView
 export interface UpgradeSupportInterface {
 	mainPlan: PaidSubscriptionPlan;
 	subscription: Subscription;
+	inPaymentFailure: boolean;
 	user?: MembersDataApiUser;
 }
 
@@ -93,6 +94,8 @@ export const UpgradeSupportContainer = () => {
 	const monthlyOrAnnual = calculateMonthlyOrAnnualFromBillingPeriod(
 		mainPlan.billingPeriod,
 	);
+
+	const inPaymentFailure = !!contribution.alertText;
 	const pageTitle = `Your ${monthlyOrAnnual.toLowerCase()} support`;
 
 	return (
@@ -101,6 +104,7 @@ export const UpgradeSupportContainer = () => {
 				value={{
 					mainPlan,
 					subscription: contribution.subscription,
+					inPaymentFailure,
 					user: data.user,
 				}}
 			>

--- a/client/components/shared/productSwitch/SwitchErrorSummary.tsx
+++ b/client/components/shared/productSwitch/SwitchErrorSummary.tsx
@@ -1,0 +1,52 @@
+import { ErrorSummary } from '@guardian/source-react-components-development-kitchen';
+import { Link } from 'react-router-dom';
+import {
+	errorSummaryBlockLinkCss,
+	errorSummaryLinkCss,
+	errorSummaryOverrideCss,
+} from '@/client/styles/ErrorStyles';
+
+const SwitchErrorContext = ({
+	inPaymentFailure,
+}: {
+	inPaymentFailure: boolean;
+}) =>
+	inPaymentFailure ? (
+		<>
+			Please update your payment details in order to change your support.
+			<Link
+				css={[errorSummaryLinkCss, errorSummaryBlockLinkCss]}
+				to="/payment/contributions"
+			>
+				Check your payment details
+			</Link>
+		</>
+	) : (
+		<>
+			Please ensure your payment details are correct. If the problem
+			persists get in touch at{' '}
+			<a
+				css={errorSummaryLinkCss}
+				href="mailto:customer.help@guardian.com"
+			>
+				customer.help@guardian.com
+			</a>
+			.
+		</>
+	);
+
+export const SwitchErrorSummary = ({
+	inPaymentFailure,
+}: {
+	inPaymentFailure: boolean;
+}) => (
+	<ErrorSummary
+		message={
+			inPaymentFailure
+				? 'There is a problem with your payment method'
+				: 'We were unable to change your support'
+		}
+		context={<SwitchErrorContext inPaymentFailure={inPaymentFailure} />}
+		cssOverrides={errorSummaryOverrideCss}
+	/>
+);

--- a/cypress/integration/parallel-2/upgradeSupport.spec.ts
+++ b/cypress/integration/parallel-2/upgradeSupport.spec.ts
@@ -37,7 +37,6 @@ describe('upgrade support', () => {
 
 		cy.findByText(/Confirm support increase/).should('exist');
 
-		// ToDo: make it more explicit what amount we're choosing once amounts confirmed
 		cy.get(
 			'[data-cy="contribution-amount-choices"] label:nth-of-type(2)',
 		).click();
@@ -58,5 +57,29 @@ describe('upgrade support', () => {
 
 		cy.get('@mdapi_get_contribution.all').should('have.length', 1);
 		cy.get('@product_move.all').should('have.length', 2);
+	});
+
+	it('shows an error message if switch fails', () => {
+		cy.visit('/upgrade-support');
+
+		cy.findByText(/Increase your support/).should('exist');
+		cy.wait('@product_move');
+
+		cy.intercept('POST', '/api/product-move/**', {
+			statusCode: 500,
+			body: {},
+		}).as('failed_product_move');
+
+		cy.findByRole('button', {
+			name: /Continue with/,
+		}).click();
+
+		cy.findByRole('button', {
+			name: /Confirm increase/,
+		}).click();
+
+		cy.wait('@failed_product_move');
+
+		cy.findByText('We were unable to change your support').should('exist');
 	});
 });


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds error handling for when an api call fails on a user confirming their change. This should show an error message. Refactors and reuses the switch error messaging from product switching journey.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

New Cypress test added for when switching fails

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://github.com/guardian/manage-frontend/assets/114918544/36534e92-157f-4975-8036-b36f304040e6)
![image](https://github.com/guardian/manage-frontend/assets/114918544/dcc34b64-657a-4b2b-90dd-79a3975b843f)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
