### PR TITLE
Upgrade Support - Copy Changes

### DIFF
--- a/client/components/mma/shared/benefits/BenefitsConfiguration.ts
+++ b/client/components/mma/shared/benefits/BenefitsConfiguration.ts
@@ -59,7 +59,7 @@ export function getUpgradeBenefits(
 	const isUnavailable = supportProduct === 'contributions';
 	return [
 		{
-			name: 'Fierce independent journalism',
+			name: 'More impactful funding of journalism',
 		},
 		{
 			name: 'A regular supporter newsletter',

--- a/client/components/mma/upgrade/ConfirmForm.tsx
+++ b/client/components/mma/upgrade/ConfirmForm.tsx
@@ -110,7 +110,7 @@ const WhatHappensNext = ({
 							</strong>
 							<br />
 							You can start enjoying your exclusive extras
-							straight away
+							straight away.
 						</span>
 					</li>
 					<li>

--- a/client/components/mma/upgrade/ConfirmForm.tsx
+++ b/client/components/mma/upgrade/ConfirmForm.tsx
@@ -262,6 +262,7 @@ export const ConfirmForm = ({
 
 	const currencySymbol = mainPlan.currency;
 	const aboveThreshold = chosenAmount >= threshold;
+	const previousPrice = mainPlan.price / 100;
 
 	const [shouldShowRoundUp] = useState<boolean>(
 		!aboveThreshold && suggestedAmounts.includes(threshold),
@@ -328,6 +329,8 @@ export const ConfirmForm = ({
 		}
 	};
 
+	const increaseText = chosenAmount > previousPrice ? 'increase' : 'change';
+
 	return (
 		<Stack space={4}>
 			<section
@@ -339,7 +342,7 @@ export const ConfirmForm = ({
 				`}
 			>
 				<Heading sansSerif level="3" borderless>
-					2. Confirm support increase
+					2. Confirm support {increaseText}
 				</Heading>
 				<div
 					css={css`
@@ -367,7 +370,7 @@ export const ConfirmForm = ({
 					subscription={subscription}
 					nextPaymentDate={nextPaymentDate}
 					chosenAmount={chosenAmount}
-					alreadyPayingAboveThreshold={mainPlan.price >= threshold}
+					alreadyPayingAboveThreshold={previousPrice >= threshold}
 				/>
 			)}
 			<section css={buttonContainerCss}>
@@ -377,7 +380,7 @@ export const ConfirmForm = ({
 						onClick={confirmOnClick}
 						isLoading={isConfirmationLoading}
 					>
-						Confirm increase to {currencySymbol}
+						Confirm {increaseText} to {currencySymbol}
 						{chosenAmount}/{mainPlan.billingPeriod}
 					</Button>
 				</ThemeProvider>

--- a/client/components/mma/upgrade/ConfirmForm.tsx
+++ b/client/components/mma/upgrade/ConfirmForm.tsx
@@ -191,7 +191,7 @@ const RoundUp = ({
 							: palette.neutral[20]};
 					`}
 				>
-					Round up to unlock all benefits ({currencySymbol}
+					Round up to unlock extras ({currencySymbol}
 					{thresholdAmount}/{billingPeriod})
 				</div>
 				<div
@@ -348,7 +348,7 @@ export const ConfirmForm = ({
 				>
 					You've selected to support {currencySymbol}
 					{chosenAmount} per {mainPlan.billingPeriod}
-					{aboveThreshold ? ', which unlocks all benefits' : ''}.
+					{aboveThreshold ? ', which unlocks extras' : ''}.
 				</div>
 			</section>
 			{shouldShowRoundUp && (

--- a/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
@@ -196,7 +196,7 @@ export const UpgradeSupportAmountForm = ({
 						>
 							<TextInput
 								label={otherAmountLabel}
-								supporting={`Support ${currencySymbol}${threshold}/${mainPlan.billingPeriod} or more to unlock all benefits.`}
+								supporting={`Support ${currencySymbol}${threshold}/${mainPlan.billingPeriod} or more to unlock extras.`}
 								error={
 									(hasInteractedWithOtherAmount &&
 										errorMessage) ||

--- a/client/components/mma/upgrade/UpgradeSupportSwitchThankYou.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportSwitchThankYou.tsx
@@ -132,7 +132,7 @@ export const UpgradeSupportSwitchThankYou = () => {
 									billingPeriod,
 								).toLowerCase()}{' '}
 								payment will be {currency}
-								{chosenAmount}
+								{chosenAmount}.
 							</div>
 						</Heading>
 						<Heading

--- a/client/components/mma/upgrade/UpgradeSupportSwitchThankYou.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportSwitchThankYou.tsx
@@ -63,6 +63,9 @@ export const UpgradeSupportSwitchThankYou = () => {
 		upgradeSupportContext.mainPlan.chargedThrough ?? undefined,
 	).dateStr(DATE_FNS_LONG_OUTPUT_FORMAT);
 
+	const increasedText =
+		chosenAmount > previousPrice ? 'increased' : 'changed';
+
 	return (
 		<>
 			<section
@@ -90,7 +93,7 @@ export const UpgradeSupportSwitchThankYou = () => {
 							margin-bottom: 32px;
 						`}
 					>
-						You’ve increased your support from {currency}
+						You’ve {increasedText} your support from {currency}
 						{previousPrice} to {currency}
 						{chosenAmount} per {billingPeriod}.
 					</div>

--- a/client/components/mma/upgrade/UpgradeSupportThankYou.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportThankYou.tsx
@@ -60,6 +60,9 @@ export const UpgradeSupportThankYou = () => {
 		upgradeSupportContext.mainPlan.chargedThrough ?? undefined,
 	).dateStr(DATE_FNS_LONG_OUTPUT_FORMAT);
 
+	const increasedText =
+		chosenAmount > previousPrice ? 'increased' : 'changed';
+
 	return (
 		<>
 			<section
@@ -87,7 +90,7 @@ export const UpgradeSupportThankYou = () => {
 							margin-bottom: 32px;
 						`}
 					>
-						You’ve increased your support from {currency}
+						You’ve {increasedText} your support from {currency}
 						{previousPrice} to {currency}
 						{chosenAmount} per {billingPeriod}.
 					</div>

--- a/client/components/mma/upgrade/UpgradeSupportThankYou.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportThankYou.tsx
@@ -47,7 +47,6 @@ export const UpgradeSupportThankYou = () => {
 
 	const location = useLocation();
 	const routerState = location.state as UpgradeRouterState;
-	const amountPayableToday = routerState?.amountPayableToday.toFixed(2);
 	const chosenAmount = routerState?.chosenAmount.toFixed(2);
 
 	const currency = upgradeSupportContext.mainPlan.currency;
@@ -117,15 +116,10 @@ export const UpgradeSupportThankYou = () => {
 						>
 							<li>
 								<SvgCalendar size="medium" />
-								<span css={iconTextCss}>
-									Your billing date has changed
-								</span>
+								<span css={iconTextCss}>Your billing date</span>
 							</li>
 							<p css={withMarginParagraphCss}>
-								Your first billing date is today and you will be
-								charged {currency}
-								{amountPayableToday}. From {nextBillingDate},
-								your ongoing{' '}
+								From {nextBillingDate}, your ongoing{' '}
 								{calculateMonthlyOrAnnualFromBillingPeriod(
 									billingPeriod,
 								).toLowerCase()}{' '}

--- a/client/components/mma/upgrade/UpgradeSupportThankYou.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportThankYou.tsx
@@ -130,7 +130,7 @@ export const UpgradeSupportThankYou = () => {
 									billingPeriod,
 								).toLowerCase()}{' '}
 								payment will be {currency}
-								{chosenAmount}{' '}
+								{chosenAmount}.
 							</p>
 						</Heading>
 					</ul>

--- a/client/components/shared/productSwitch/SwitchPaymentInfo.tsx
+++ b/client/components/shared/productSwitch/SwitchPaymentInfo.tsx
@@ -44,7 +44,7 @@ export const SwitchPaymentInfo = ({
 				`We won't charge you today, as your current payment covers you for the rest of the ${billingPeriod}.`}{' '}
 			After this, from {nextPaymentDate}, your new {monthlyOrAnnual}{' '}
 			payment will be {currencySymbol}
-			{formatAmount(supporterPlusPurchaseAmount)}
+			{formatAmount(supporterPlusPurchaseAmount)}.
 		</>
 	);
 };


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Change the copy after review:

- Update first checkpoint to “More impactful funding of journalism”
- Add full stops to the body copy in the What Happens Next component. Do not add a full stop if the sentence ends with an email.
- Update “all benefits” to “extras”

- RC thank you page: update Your billing date copy. The billing date doesn't change
- Change "increase" to "change" if it's a decrease

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://github.com/guardian/manage-frontend/assets/114918544/1a77e14e-8cff-4980-818b-d99f2ea8561d)
![image](https://github.com/guardian/manage-frontend/assets/114918544/7ea49004-5007-411c-aa2e-f1b597963ba3)

RC to RC
Before
![image](https://github.com/guardian/manage-frontend/assets/114918544/a3273104-8eb2-4ebb-99f8-6b4840be5425)
After
![image](https://github.com/guardian/manage-frontend/assets/114918544/0922ba66-3925-41c0-a0c0-2522480bd012)


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
