### PR TITLE
Upgrade Journey- add mechanism to prevent going back

### DIFF
--- a/client/components/mma/upgrade/ConfirmForm.tsx
+++ b/client/components/mma/upgrade/ConfirmForm.tsx
@@ -316,6 +316,7 @@ export const ConfirmForm = ({
 		const routerState = {
 			chosenAmount,
 			amountPayableToday,
+			journeyCompleted: true,
 		} as UpgradeRouterState;
 
 		try {

--- a/cypress/integration/parallel-2/upgradeSupport.spec.ts
+++ b/cypress/integration/parallel-2/upgradeSupport.spec.ts
@@ -53,7 +53,7 @@ describe('upgrade support', () => {
 
 		cy.wait('@product_move');
 
-		cy.findByText(/Your monthly support/).should('exist');
+		cy.findByText(/Thank you/).should('exist');
 
 		cy.get('@mdapi_get_contribution.all').should('have.length', 1);
 		cy.get('@product_move.all').should('have.length', 2);
@@ -81,5 +81,29 @@ describe('upgrade support', () => {
 		cy.wait('@failed_product_move');
 
 		cy.findByText('We were unable to change your support').should('exist');
+	});
+
+	it('Does not allow user to navigate back to first page after completion', () => {
+		cy.visit('/upgrade-support');
+
+		cy.findByRole('button', {
+			name: /Continue with/,
+		}).click();
+
+		cy.wait('@product_move');
+
+		cy.findByText(/Confirm support increase/).should('exist');
+
+		cy.findByRole('button', {
+			name: /Confirm increase/,
+		}).click();
+
+		cy.wait('@product_move');
+
+		cy.findByText(/Thank you/).should('exist');
+
+		cy.go('back');
+
+		cy.findByRole('heading', { name: 'Account overview' }).should('exist');
 	});
 });


### PR DESCRIPTION

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

As with product switching and membership cancellation, we don't want people to press back in the browser and repeat their confirmation step (triggering an api call that will fail). To prevent this behaviour this PR adds a parameter in routerState that gets checked within the container

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Go to `/upgrade-support`, confirm change and on thank you page press browser back. Expect to see account overview.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
