### PR TITLE
Update storybook tests

### DIFF
--- a/client/components/helpCentre/HelpCentre.stories.tsx
+++ b/client/components/helpCentre/HelpCentre.stories.tsx
@@ -1,6 +1,6 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { rest } from 'msw';
-import { ReactRouterDecorator } from '../../../.storybook/ReactRouterDecorator';
+import { ReactRouterDecorator } from '@/.storybook/ReactRouterDecorator';
 import { HelpCenterContentWrapper } from './HelpCenterContentWrapper';
 import { HelpCentre } from './HelpCentre';
 
@@ -11,9 +11,9 @@ export default {
 	parameters: {
 		layout: 'fullscreen',
 	},
-} as ComponentMeta<typeof HelpCentre>;
+} as Meta<typeof HelpCentre>;
 
-export const Default: ComponentStory<typeof HelpCentre> = () => {
+export const Default: StoryFn<typeof HelpCentre> = () => {
 	return (
 		<HelpCenterContentWrapper knownIssues={[]}>
 			<HelpCentre />
@@ -29,7 +29,7 @@ Default.parameters = {
 	],
 };
 
-export const WithKnownIssue: ComponentStory<typeof HelpCentre> = () => {
+export const WithKnownIssue: StoryFn<typeof HelpCentre> = () => {
 	const knownIssue = [
 		{
 			date: '20 Jan 2022 12:00',

--- a/client/components/helpCentre/HelpCentreArticle.stories.tsx
+++ b/client/components/helpCentre/HelpCentreArticle.stories.tsx
@@ -1,6 +1,6 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { rest } from 'msw';
-import { ReactRouterDecorator } from '../../../.storybook/ReactRouterDecorator';
+import { ReactRouterDecorator } from '@/.storybook/ReactRouterDecorator';
 import { SectionContent } from '../shared/SectionContent';
 import { SectionHeader } from '../shared/SectionHeader';
 import { HelpCentreArticle } from './HelpCentreArticle';
@@ -15,7 +15,7 @@ export default {
 			viewports: [320, 1300],
 		},
 	},
-} as ComponentMeta<typeof HelpCentreArticle>;
+} as Meta<typeof HelpCentreArticle>;
 
 const articleContent = {
 	title: 'I need to pause my delivery',
@@ -40,7 +40,7 @@ const articleContent = {
 	],
 };
 
-export const Default: ComponentStory<typeof HelpCentreArticle> = () => {
+export const Default: StoryFn<typeof HelpCentreArticle> = () => {
 	return (
 		<>
 			<SectionHeader title="How can we help you?" pageHasNav={true} />

--- a/client/components/helpCentre/HelpCentrePhoneNumbers.stories.tsx
+++ b/client/components/helpCentre/HelpCentrePhoneNumbers.stories.tsx
@@ -1,4 +1,4 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { HelpCentrePhoneNumbersProps } from './HelpCentrePhoneNumbers';
 import { HelpCentrePhoneNumbers } from './HelpCentrePhoneNumbers';
 
@@ -13,9 +13,9 @@ export default {
 			viewports: [320, 1300],
 		},
 	},
-} as ComponentMeta<typeof HelpCentrePhoneNumbers>;
+} as Meta<typeof HelpCentrePhoneNumbers>;
 
-const Template: ComponentStory<typeof HelpCentrePhoneNumbers> = (
+const Template: StoryFn<typeof HelpCentrePhoneNumbers> = (
 	args: HelpCentrePhoneNumbersProps,
 ) => <HelpCentrePhoneNumbers {...args} />;
 

--- a/client/components/helpCentre/HelpCentreTopic.stories.tsx
+++ b/client/components/helpCentre/HelpCentreTopic.stories.tsx
@@ -1,6 +1,6 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { rest } from 'msw';
-import { ReactRouterDecorator } from '../../../.storybook/ReactRouterDecorator';
+import { ReactRouterDecorator } from '@/.storybook/ReactRouterDecorator';
 import { SectionContent } from '../shared/SectionContent';
 import { SectionHeader } from '../shared/SectionHeader';
 import { HelpCentreTopic } from './HelpCentreTopic';
@@ -12,7 +12,7 @@ export default {
 	parameters: {
 		layout: 'fullscreen',
 	},
-} as ComponentMeta<typeof HelpCentreTopic>;
+} as Meta<typeof HelpCentreTopic>;
 
 const topicContent = {
 	path: 'delivery',
@@ -33,7 +33,7 @@ const topicContent = {
 	],
 };
 
-export const Default: ComponentStory<typeof HelpCentreTopic> = () => {
+export const Default: StoryFn<typeof HelpCentreTopic> = () => {
 	return (
 		<>
 			<SectionHeader title="How can we help you?" pageHasNav={true} />

--- a/client/components/helpCentre/contactUs/ContactUs.stories.tsx
+++ b/client/components/helpCentre/contactUs/ContactUs.stories.tsx
@@ -1,6 +1,6 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { rest } from 'msw';
-import { ReactRouterDecorator } from '../../../../.storybook/ReactRouterDecorator';
+import { ReactRouterDecorator } from '@/.storybook/ReactRouterDecorator';
 import { SectionContent } from '../../shared/SectionContent';
 import { SectionHeader } from '../../shared/SectionHeader';
 import { KnownIssues } from '../KnownIssues';
@@ -13,9 +13,9 @@ export default {
 	parameters: {
 		layout: 'fullscreen',
 	},
-} as ComponentMeta<typeof ContactUs>;
+} as Meta<typeof ContactUs>;
 
-export const Default: ComponentStory<typeof ContactUs> = () => {
+export const Default: StoryFn<typeof ContactUs> = () => {
 	return (
 		<>
 			<SectionHeader title="Need to contact us?" />
@@ -42,7 +42,7 @@ const knownIssue = [
 	},
 ];
 
-export const WithKnownIssue: ComponentStory<typeof ContactUs> = () => {
+export const WithKnownIssue: StoryFn<typeof ContactUs> = () => {
 	return (
 		<>
 			<SectionHeader title="Need to contact us?" />
@@ -62,7 +62,7 @@ WithKnownIssue.parameters = {
 	],
 };
 
-export const TopicSelected: ComponentStory<typeof ContactUs> = () => (
+export const TopicSelected: StoryFn<typeof ContactUs> = () => (
 	<>
 		<SectionHeader title="Need to contact us?" />
 		<KnownIssues issues={[]} />

--- a/client/components/mma/billing/Billing.stories.tsx
+++ b/client/components/mma/billing/Billing.stories.tsx
@@ -1,7 +1,7 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { rest } from 'msw';
-import { ReactRouterDecorator } from '../../../../.storybook/ReactRouterDecorator';
-import { featureSwitches } from '../../../../shared/featureSwitches';
+import { ReactRouterDecorator } from '@/.storybook/ReactRouterDecorator';
+import { featureSwitches } from '@/shared/featureSwitches';
 import {
 	InAppPurchase,
 	InAppPurchaseAndroid,
@@ -25,9 +25,9 @@ export default {
 	parameters: {
 		layout: 'fullscreen',
 	},
-} as ComponentMeta<typeof Billing>;
+} as Meta<typeof Billing>;
 
-export const NoSubscription: ComponentStory<typeof Billing> = () => {
+export const NoSubscription: StoryFn<typeof Billing> = () => {
 	return <Billing />;
 };
 
@@ -53,7 +53,7 @@ NoSubscription.parameters = {
 	],
 };
 
-export const WithSubscriptions: ComponentStory<typeof Billing> = () => {
+export const WithSubscriptions: StoryFn<typeof Billing> = () => {
 	featureSwitches['appSubscriptions'] = true;
 
 	return <Billing />;

--- a/client/components/mma/cancel/Cancellation.stories.tsx
+++ b/client/components/mma/cancel/Cancellation.stories.tsx
@@ -1,7 +1,7 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { rest } from 'msw';
-import { ReactRouterDecorator } from '../../../../.storybook/ReactRouterDecorator';
-import { PRODUCT_TYPES } from '../../../../shared/productTypes';
+import { ReactRouterDecorator } from '@/.storybook/ReactRouterDecorator';
+import { PRODUCT_TYPES } from '@/shared/productTypes';
 import {
 	contributionCancelled,
 	contributionPaidByPayPal,
@@ -30,15 +30,13 @@ export default {
 			container: <CancellationContainer productType={contributions} />,
 		},
 	},
-} as ComponentMeta<typeof CancellationContainer>;
+} as Meta<typeof CancellationContainer>;
 
-export const SelectReason: ComponentStory<
-	typeof CancellationReasonSelection
-> = () => {
+export const SelectReason: StoryFn<typeof CancellationReasonSelection> = () => {
 	return <CancellationReasonSelection />;
 };
 
-export const ContactCustomerService: ComponentStory<
+export const ContactCustomerService: StoryFn<
 	typeof CancellationReasonSelection
 > = () => <CancellationReasonSelection />;
 
@@ -51,7 +49,7 @@ ContactCustomerService.parameters = {
 	},
 };
 
-export const Review: ComponentStory<typeof CancellationContainer> = () => {
+export const Review: StoryFn<typeof CancellationContainer> = () => {
 	return <CancellationReasonReview />;
 };
 
@@ -70,9 +68,7 @@ Review.parameters = {
 	},
 };
 
-export const Confirmation: ComponentStory<
-	typeof CancellationContainer
-> = () => {
+export const Confirmation: StoryFn<typeof CancellationContainer> = () => {
 	// @ts-expect-error set identity details email in the window
 	window.guardian = { identityDetails: { email: 'test' } };
 

--- a/client/components/mma/cancelReminders/CancelReminders.stories.tsx
+++ b/client/components/mma/cancelReminders/CancelReminders.stories.tsx
@@ -1,6 +1,6 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { Meta , StoryFn } from '@storybook/react';
 import { rest } from 'msw';
-import { ReactRouterDecorator } from '../../../../.storybook/ReactRouterDecorator';
+import { ReactRouterDecorator } from '@/.storybook/ReactRouterDecorator';
 import { CancelReminders } from './CancelReminders';
 
 export default {
@@ -14,9 +14,9 @@ export default {
 			path: 'cancel-reminders/:reminderCode',
 		},
 	},
-} as ComponentMeta<typeof CancelReminders>;
+} as Meta<typeof CancelReminders>;
 
-export const Error: ComponentStory<typeof CancelReminders> = () => {
+export const Error: StoryFn<typeof CancelReminders> = () => {
 	return <CancelReminders />;
 };
 
@@ -28,7 +28,7 @@ Error.parameters = {
 	],
 };
 
-export const Success: ComponentStory<typeof CancelReminders> = () => {
+export const Success: StoryFn<typeof CancelReminders> = () => {
 	return <CancelReminders />;
 };
 

--- a/client/components/mma/dataPrivacy/DataPrivacy.stories.tsx
+++ b/client/components/mma/dataPrivacy/DataPrivacy.stories.tsx
@@ -1,6 +1,6 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { Meta , StoryFn } from '@storybook/react';
 import { rest } from 'msw';
-import { ReactRouterDecorator } from '../../../../.storybook/ReactRouterDecorator';
+import { ReactRouterDecorator } from '@/.storybook/ReactRouterDecorator';
 import { consents } from '../../../fixtures/consents';
 import { user } from '../../../fixtures/user';
 import { DataPrivacy } from './DataPrivacy';
@@ -12,9 +12,9 @@ export default {
 	parameters: {
 		layout: 'fullscreen',
 	},
-} as ComponentMeta<typeof DataPrivacy>;
+} as Meta<typeof DataPrivacy>;
 
-export const Default: ComponentStory<typeof DataPrivacy> = () => {
+export const Default: StoryFn<typeof DataPrivacy> = () => {
 	return <DataPrivacy />;
 };
 

--- a/client/components/mma/delivery/address/DeliveryAddress.stories.tsx
+++ b/client/components/mma/delivery/address/DeliveryAddress.stories.tsx
@@ -1,9 +1,9 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { Meta , StoryFn } from '@storybook/react';
 import { rest } from 'msw';
-import { ReactRouterDecorator } from '../../../../../.storybook/ReactRouterDecorator';
-import { PRODUCT_TYPES } from '../../../../../shared/productTypes';
-import { toMembersDataApiResponse } from '../../../../fixtures/mdapiResponse';
-import { guardianWeeklyPaidByCard } from '../../../../fixtures/productBuilder/testProducts';
+import { ReactRouterDecorator } from '@/.storybook/ReactRouterDecorator';
+import { toMembersDataApiResponse } from '@/client/fixtures/mdapiResponse';
+import { guardianWeeklyPaidByCard } from '@/client/fixtures/productBuilder/testProducts';
+import { PRODUCT_TYPES } from '@/shared/productTypes';
 import { DeliveryAddressChangeContainer } from './DeliveryAddressChangeContainer';
 import { DeliveryAddressConfirmation } from './DeliveryAddressConfirmation';
 import { DeliveryAddressUpdate } from './DeliveryAddressForm';
@@ -32,21 +32,19 @@ export default {
 			}),
 		],
 	},
-} as ComponentMeta<typeof DeliveryAddressChangeContainer>;
+} as Meta<typeof DeliveryAddressChangeContainer>;
 
-export const UpdateDeliveryAddress: ComponentStory<
+export const UpdateDeliveryAddress: StoryFn<
 	typeof DeliveryAddressUpdate
 > = () => {
 	return <DeliveryAddressUpdate productType={PRODUCT_TYPES.guardianweekly} />;
 };
 
-export const Review: ComponentStory<typeof DeliveryAddressReview> = () => {
+export const Review: StoryFn<typeof DeliveryAddressReview> = () => {
 	return <DeliveryAddressReview productType={PRODUCT_TYPES.guardianweekly} />;
 };
 
-export const Confirmation: ComponentStory<
-	typeof DeliveryAddressConfirmation
-> = () => {
+export const Confirmation: StoryFn<typeof DeliveryAddressConfirmation> = () => {
 	return (
 		<DeliveryAddressConfirmation
 			productType={PRODUCT_TYPES.guardianweekly}

--- a/client/components/mma/help/Help.stories.tsx
+++ b/client/components/mma/help/Help.stories.tsx
@@ -1,5 +1,5 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
-import { ReactRouterDecorator } from '../../../../.storybook/ReactRouterDecorator';
+import type { Meta , StoryFn } from '@storybook/react';
+import { ReactRouterDecorator } from '@/.storybook/ReactRouterDecorator';
 import { Help } from './Help';
 
 export default {
@@ -12,6 +12,6 @@ export default {
 			viewports: [320, 1300],
 		},
 	},
-} as ComponentMeta<typeof Help>;
+} as Meta<typeof Help>;
 
-export const Default: ComponentStory<typeof Help> = () => <Help />;
+export const Default: StoryFn<typeof Help> = () => <Help />;

--- a/client/components/mma/holiday/Holiday.stories.tsx
+++ b/client/components/mma/holiday/Holiday.stories.tsx
@@ -1,7 +1,7 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { Meta , StoryFn } from '@storybook/react';
 import { rest } from 'msw';
-import { ReactRouterDecorator } from '../../../../.storybook/ReactRouterDecorator';
-import { PRODUCT_TYPES } from '../../../../shared/productTypes';
+import { ReactRouterDecorator } from '@/.storybook/ReactRouterDecorator';
+import { PRODUCT_TYPES } from '@/shared/productTypes';
 import { existingHolidays } from '../../../fixtures/holidays';
 import { toMembersDataApiResponse } from '../../../fixtures/mdapiResponse';
 import { guardianWeeklyPaidByCard } from '../../../fixtures/productBuilder/testProducts';
@@ -29,9 +29,9 @@ export default {
 			),
 		},
 	},
-} as ComponentMeta<typeof HolidayStopsContainer>;
+} as Meta<typeof HolidayStopsContainer>;
 
-export const Manage: ComponentStory<typeof HolidaysOverview> = () => {
+export const Manage: StoryFn<typeof HolidaysOverview> = () => {
 	return <HolidaysOverview />;
 };
 
@@ -48,7 +48,7 @@ Manage.parameters = {
 	],
 };
 
-export const Create: ComponentStory<typeof HolidayDateChooser> = () => {
+export const Create: StoryFn<typeof HolidayDateChooser> = () => {
 	return <HolidayDateChooser />;
 };
 

--- a/client/components/mma/identity/emailAndMarketing/EmailAndMarketing.stories.tsx
+++ b/client/components/mma/identity/emailAndMarketing/EmailAndMarketing.stories.tsx
@@ -1,19 +1,19 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { Meta , StoryFn } from '@storybook/react';
 import { rest } from 'msw';
-import { ReactRouterDecorator } from '../../../../../.storybook/ReactRouterDecorator';
-import { featureSwitches } from '../../../../../shared/featureSwitches';
-import { consents } from '../../../../fixtures/consents';
-import { InAppPurchase } from '../../../../fixtures/inAppPurchase';
-import { toMembersDataApiResponse } from '../../../../fixtures/mdapiResponse';
-import { newsletters } from '../../../../fixtures/newsletters';
-import { newsletterSubscriptions } from '../../../../fixtures/newsletterSubscriptions';
+import { ReactRouterDecorator } from '@/.storybook/ReactRouterDecorator';
+import { consents } from '@/client/fixtures/consents';
+import { InAppPurchase } from '@/client/fixtures/inAppPurchase';
+import { toMembersDataApiResponse } from '@/client/fixtures/mdapiResponse';
+import { newsletters } from '@/client/fixtures/newsletters';
+import { newsletterSubscriptions } from '@/client/fixtures/newsletterSubscriptions';
 import {
 	digitalPackPaidByDirectDebit,
 	guardianWeeklyPaidByCard,
 	newspaperVoucherPaidByPaypal,
-} from '../../../../fixtures/productBuilder/testProducts';
-import { singleContributionsAPIResponse } from '../../../../fixtures/singleContribution';
-import { user } from '../../../../fixtures/user';
+} from '@/client/fixtures/productBuilder/testProducts';
+import { singleContributionsAPIResponse } from '@/client/fixtures/singleContribution';
+import { user } from '@/client/fixtures/user';
+import { featureSwitches } from '@/shared/featureSwitches';
 import { EmailAndMarketing } from './EmailAndMarketing';
 
 export default {
@@ -23,9 +23,9 @@ export default {
 	parameters: {
 		layout: 'fullscreen',
 	},
-} as ComponentMeta<typeof EmailAndMarketing>;
+} as Meta<typeof EmailAndMarketing>;
 
-export const Default: ComponentStory<typeof EmailAndMarketing> = () => {
+export const Default: StoryFn<typeof EmailAndMarketing> = () => {
 	return <EmailAndMarketing />;
 };
 
@@ -66,7 +66,7 @@ Default.parameters = {
 	],
 };
 
-export const WithNoProducts: ComponentStory<typeof EmailAndMarketing> = () => {
+export const WithNoProducts: StoryFn<typeof EmailAndMarketing> = () => {
 	return <EmailAndMarketing />;
 };
 
@@ -99,7 +99,7 @@ WithNoProducts.parameters = {
 	],
 };
 
-export const WithIAP: ComponentStory<typeof EmailAndMarketing> = () => {
+export const WithIAP: StoryFn<typeof EmailAndMarketing> = () => {
 	featureSwitches['appSubscriptions'] = true;
 
 	return <EmailAndMarketing />;
@@ -134,9 +134,7 @@ WithIAP.parameters = {
 	],
 };
 
-export const WithSingleContribution: ComponentStory<
-	typeof EmailAndMarketing
-> = () => {
+export const WithSingleContribution: StoryFn<typeof EmailAndMarketing> = () => {
 	featureSwitches['singleContributions'] = true;
 
 	return <EmailAndMarketing />;

--- a/client/components/mma/identity/publicProfile/PublicProfile.stories.tsx
+++ b/client/components/mma/identity/publicProfile/PublicProfile.stories.tsx
@@ -1,7 +1,7 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { Meta , StoryFn } from '@storybook/react';
 import { rest } from 'msw';
-import { ReactRouterDecorator } from '../../../../../.storybook/ReactRouterDecorator';
-import { user } from '../../../../fixtures/user';
+import { ReactRouterDecorator } from '@/.storybook/ReactRouterDecorator';
+import { user } from '@/client/fixtures/user';
 import { PublicProfile } from './PublicProfile';
 
 export default {
@@ -11,9 +11,9 @@ export default {
 	parameters: {
 		layout: 'fullscreen',
 	},
-} as ComponentMeta<typeof PublicProfile>;
+} as Meta<typeof PublicProfile>;
 
-export const Default: ComponentStory<typeof PublicProfile> = () => {
+export const Default: StoryFn<typeof PublicProfile> = () => {
 	return <PublicProfile />;
 };
 

--- a/client/components/mma/identity/settings/Settings.stories.tsx
+++ b/client/components/mma/identity/settings/Settings.stories.tsx
@@ -1,7 +1,7 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { Meta , StoryFn } from '@storybook/react';
 import { rest } from 'msw';
-import { ReactRouterDecorator } from '../../../../../.storybook/ReactRouterDecorator';
-import { user } from '../../../../fixtures/user';
+import { ReactRouterDecorator } from '@/.storybook/ReactRouterDecorator';
+import { user } from '@/client/fixtures/user';
 import { Settings } from './Settings';
 
 export default {
@@ -11,9 +11,9 @@ export default {
 	parameters: {
 		layout: 'fullscreen',
 	},
-} as ComponentMeta<typeof Settings>;
+} as Meta<typeof Settings>;
 
-export const Default: ComponentStory<typeof Settings> = () => {
+export const Default: StoryFn<typeof Settings> = () => {
 	return <Settings />;
 };
 

--- a/client/components/mma/maintenance/Maintenance.stories.tsx
+++ b/client/components/mma/maintenance/Maintenance.stories.tsx
@@ -1,4 +1,4 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { Meta , StoryFn } from '@storybook/react';
 import { Maintenance } from './Maintenance';
 
 export default {
@@ -7,8 +7,6 @@ export default {
 	parameters: {
 		layout: 'fullscreen',
 	},
-} as ComponentMeta<typeof Maintenance>;
+} as Meta<typeof Maintenance>;
 
-export const Default: ComponentStory<typeof Maintenance> = () => (
-	<Maintenance />
-);
+export const Default: StoryFn<typeof Maintenance> = () => <Maintenance />;

--- a/client/components/mma/paymentUpdate/UpdatePayment.stories.tsx
+++ b/client/components/mma/paymentUpdate/UpdatePayment.stories.tsx
@@ -1,6 +1,6 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
-import { ReactRouterDecorator } from '../../../../.storybook/ReactRouterDecorator';
-import { PRODUCT_TYPES } from '../../../../shared/productTypes';
+import type { Meta , StoryFn } from '@storybook/react';
+import { ReactRouterDecorator } from '@/.storybook/ReactRouterDecorator';
+import { PRODUCT_TYPES } from '@/shared/productTypes';
 import {
 	guardianWeeklyExpiredCard,
 	guardianWeeklyPaidByCard,
@@ -13,7 +13,7 @@ export default {
 	component: PaymentDetailUpdateContainer,
 	title: 'Pages/UpdatePayment',
 	decorators: [ReactRouterDecorator],
-} as ComponentMeta<typeof PaymentDetailUpdateContainer>;
+} as Meta<typeof PaymentDetailUpdateContainer>;
 
 const setSiteKey = () => {
 	// @ts-expect-error set the recaptcha key in the window for the recaptcha to render
@@ -22,9 +22,7 @@ const setSiteKey = () => {
 	};
 };
 
-export const GuardianWeeklyCard: ComponentStory<
-	typeof PaymentDetailUpdate
-> = () => {
+export const GuardianWeeklyCard: StoryFn<typeof PaymentDetailUpdate> = () => {
 	setSiteKey();
 	return <PaymentDetailUpdate productType={PRODUCT_TYPES.guardianweekly} />;
 };
@@ -42,7 +40,7 @@ GuardianWeeklyCard.parameters = {
 	},
 };
 
-export const NewspaperVoucherPaypal: ComponentStory<
+export const NewspaperVoucherPaypal: StoryFn<
 	typeof PaymentDetailUpdate
 > = () => {
 	setSiteKey();
@@ -60,7 +58,7 @@ NewspaperVoucherPaypal.parameters = {
 	},
 };
 
-export const GuardianWeeklyExpiredCard: ComponentStory<
+export const GuardianWeeklyExpiredCard: StoryFn<
 	typeof PaymentDetailUpdate
 > = () => {
 	setSiteKey();

--- a/client/components/mma/shared/BasicProductInfoTable.stories.tsx
+++ b/client/components/mma/shared/BasicProductInfoTable.stories.tsx
@@ -1,14 +1,14 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
-import { GROUPED_PRODUCT_TYPES } from '../../../../shared/productTypes';
+import type { Meta, StoryFn } from '@storybook/react';
+import { GROUPED_PRODUCT_TYPES } from '@/shared/productTypes';
 import { newspaperVoucherPaidByPaypal } from '../../../fixtures/productBuilder/testProducts';
 import { BasicProductInfoTable } from './BasicProductInfoTable';
 
 export default {
 	title: 'Components/BasicProductInfoTable',
 	component: BasicProductInfoTable,
-} as ComponentMeta<typeof BasicProductInfoTable>;
+} as Meta<typeof BasicProductInfoTable>;
 
-export const Default: ComponentStory<typeof BasicProductInfoTable> = () => (
+export const Default: StoryFn<typeof BasicProductInfoTable> = () => (
 	<BasicProductInfoTable
 		groupedProductType={GROUPED_PRODUCT_TYPES.subscriptions}
 		productDetail={newspaperVoucherPaidByPaypal()}

--- a/client/components/mma/shared/Button.stories.tsx
+++ b/client/components/mma/shared/Button.stories.tsx
@@ -1,5 +1,5 @@
 import { brand } from '@guardian/source-foundations';
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { ButtonProps } from './Buttons';
 import { Button } from './Buttons';
 
@@ -59,9 +59,9 @@ export default {
 			control: { type: 'inline-radio' },
 		},
 	},
-} as ComponentMeta<typeof Button>;
+} as Meta<typeof Button>;
 
-const Template: ComponentStory<typeof Button> = (args: ButtonProps) => (
+const Template: StoryFn<typeof Button> = (args: ButtonProps) => (
 	<Button {...args} />
 );
 

--- a/client/components/mma/shared/Checkbox.stories.tsx
+++ b/client/components/mma/shared/Checkbox.stories.tsx
@@ -1,4 +1,4 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { CheckboxProps } from './Checkbox';
 import { Checkbox } from './Checkbox';
 
@@ -21,9 +21,9 @@ export default {
 			control: { type: 'color' },
 		},
 	},
-} as ComponentMeta<typeof Checkbox>;
+} as Meta<typeof Checkbox>;
 
-const Template: ComponentStory<typeof Checkbox> = (args: CheckboxProps) => (
+const Template: StoryFn<typeof Checkbox> = (args: CheckboxProps) => (
 	<Checkbox {...args} />
 );
 

--- a/client/components/mma/shared/DateInput.stories.tsx
+++ b/client/components/mma/shared/DateInput.stories.tsx
@@ -1,4 +1,4 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { DateInputProps } from './DateInput';
 import { DateInput } from './DateInput';
 
@@ -17,9 +17,9 @@ export default {
 			},
 		},
 	},
-} as ComponentMeta<typeof DateInput>;
+} as Meta<typeof DateInput>;
 
-const Template: ComponentStory<typeof DateInput> = (args: DateInputProps) => {
+const Template: StoryFn<typeof DateInput> = (args: DateInputProps) => {
 	args.date = new Date(args.date);
 	return <DateInput {...args} />;
 };

--- a/client/components/mma/shared/DatePicker.stories.tsx
+++ b/client/components/mma/shared/DatePicker.stories.tsx
@@ -1,4 +1,4 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { DatePickerProps } from './DatePicker';
 import { DatePicker } from './DatePicker';
 
@@ -16,9 +16,9 @@ export default {
 		issueKeyword: 'Issue',
 		existingDates: [],
 	},
-} as ComponentMeta<typeof DatePicker>;
+} as Meta<typeof DatePicker>;
 
-const Template: ComponentStory<typeof DatePicker> = (args: DatePickerProps) => {
+const Template: StoryFn<typeof DatePicker> = (args: DatePickerProps) => {
 	return <DatePicker {...args} />;
 };
 

--- a/client/components/mma/shared/LinkButton.stories.tsx
+++ b/client/components/mma/shared/LinkButton.stories.tsx
@@ -1,6 +1,6 @@
 import { brand, neutral } from '@guardian/source-foundations';
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
-import { ReactRouterDecorator } from '../../../../.storybook/ReactRouterDecorator';
+import type { Meta, StoryFn } from '@storybook/react';
+import { ReactRouterDecorator } from '@/.storybook/ReactRouterDecorator';
 import type { LinkButtonProps } from './Buttons';
 import { LinkButton } from './Buttons';
 
@@ -62,9 +62,9 @@ export default {
 			control: { type: 'inline-radio' },
 		},
 	},
-} as ComponentMeta<typeof LinkButton>;
+} as Meta<typeof LinkButton>;
 
-const Template: ComponentStory<typeof LinkButton> = (args: LinkButtonProps) => (
+const Template: StoryFn<typeof LinkButton> = (args: LinkButtonProps) => (
 	<LinkButton {...args} />
 );
 

--- a/client/components/mma/shared/OverlayLoader.stories.tsx
+++ b/client/components/mma/shared/OverlayLoader.stories.tsx
@@ -1,4 +1,4 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { OverlayLoaderProps } from './OverlayLoader';
 import { OverlayLoader } from './OverlayLoader';
 
@@ -11,10 +11,10 @@ export default {
 	args: {
 		message: 'Updating payment details...',
 	},
-} as ComponentMeta<typeof OverlayLoader>;
+} as Meta<typeof OverlayLoader>;
 
-const Template: ComponentStory<typeof OverlayLoader> = (
-	args: OverlayLoaderProps,
-) => <OverlayLoader {...args} />;
+const Template: StoryFn<typeof OverlayLoader> = (args: OverlayLoaderProps) => (
+	<OverlayLoader {...args} />
+);
 
 export const Default = Template.bind({});

--- a/client/components/mma/shared/ProgressIndicator.stories.tsx
+++ b/client/components/mma/shared/ProgressIndicator.stories.tsx
@@ -1,4 +1,4 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { ProgressIndicator } from './ProgressIndicator';
 import { ProgressStepper } from './ProgressStepper';
 
@@ -8,9 +8,9 @@ export default {
 	parameters: {
 		layout: 'fullscreen',
 	},
-} as ComponentMeta<typeof ProgressStepper>;
+} as Meta<typeof ProgressStepper>;
 
-export const Default: ComponentStory<typeof ProgressStepper> = () => {
+export const Default: StoryFn<typeof ProgressStepper> = () => {
 	return (
 		<>
 			<ProgressStepper
@@ -41,7 +41,7 @@ export const Default: ComponentStory<typeof ProgressStepper> = () => {
 	);
 };
 
-export const OldVersion: ComponentStory<typeof ProgressIndicator> = () => {
+export const OldVersion: StoryFn<typeof ProgressIndicator> = () => {
 	return (
 		<ProgressIndicator
 			steps={[

--- a/client/components/shared/CallCentreNumbers.stories.tsx
+++ b/client/components/shared/CallCentreNumbers.stories.tsx
@@ -1,4 +1,4 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { CallCentreNumbersProps } from './CallCentreNumbers';
 import { CallCentreNumbers } from './CallCentreNumbers';
 
@@ -8,9 +8,9 @@ export default {
 	args: {
 		prefixText: '',
 	},
-} as ComponentMeta<typeof CallCentreNumbers>;
+} as Meta<typeof CallCentreNumbers>;
 
-const Template: ComponentStory<typeof CallCentreNumbers> = (
+const Template: StoryFn<typeof CallCentreNumbers> = (
 	args: CallCentreNumbersProps,
 ) => {
 	return <CallCentreNumbers {...args} />;

--- a/client/components/shared/ExpanderButton.stories.tsx
+++ b/client/components/shared/ExpanderButton.stories.tsx
@@ -1,13 +1,13 @@
 import { css } from '@emotion/react';
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { ExpanderButton } from './ExpanderButton';
 
 export default {
 	title: 'Components/ExpanderButton',
 	component: ExpanderButton,
-} as ComponentMeta<typeof ExpanderButton>;
+} as Meta<typeof ExpanderButton>;
 
-export const Default: ComponentStory<typeof ExpanderButton> = () => (
+export const Default: StoryFn<typeof ExpanderButton> = () => (
 	<ExpanderButton buttonLabel="2 issues">
 		<ul
 			css={css`

--- a/client/components/shared/ExpanderButton.tsx
+++ b/client/components/shared/ExpanderButton.tsx
@@ -45,7 +45,7 @@ export const expanderButtonCss =
 			color: isExpanded ? highlightColour : mainColour,
 		});
 
-interface ExpanderButtonProps {
+export interface ExpanderButtonProps {
 	buttonLabel: string | React.ReactElement;
 	children: React.ReactElement | React.ReactElement[];
 }

--- a/client/components/shared/FormError.stories.tsx
+++ b/client/components/shared/FormError.stories.tsx
@@ -1,4 +1,4 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { FormErrorProps } from './FormError';
 import { FormError } from './FormError';
 
@@ -11,9 +11,9 @@ export default {
 			'Please try again or if the problem persists please contact Customer Service',
 		],
 	},
-} as ComponentMeta<typeof FormError>;
+} as Meta<typeof FormError>;
 
-const Template: ComponentStory<typeof FormError> = (args: FormErrorProps) => {
+const Template: StoryFn<typeof FormError> = (args: FormErrorProps) => {
 	return <FormError {...args} />;
 };
 

--- a/client/components/shared/Header.stories.tsx
+++ b/client/components/shared/Header.stories.tsx
@@ -1,5 +1,5 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
-import { ReactRouterDecorator } from '../../../.storybook/ReactRouterDecorator';
+import type { Meta, StoryFn } from '@storybook/react';
+import { ReactRouterDecorator } from '@/.storybook/ReactRouterDecorator';
 import type { HeaderProps } from './Header';
 import { Header } from './Header';
 
@@ -19,9 +19,9 @@ export default {
 			control: { type: 'select' },
 		},
 	},
-} as ComponentMeta<typeof Header>;
+} as Meta<typeof Header>;
 
-const Template: ComponentStory<typeof Header> = (args: HeaderProps) => (
+const Template: StoryFn<typeof Header> = (args: HeaderProps) => (
 	<Header {...args} />
 );
 

--- a/client/components/shared/Main.stories.tsx
+++ b/client/components/shared/Main.stories.tsx
@@ -1,5 +1,5 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
-import { ReactRouterDecorator } from '../../../.storybook/ReactRouterDecorator';
+import type { Meta, StoryFn } from '@storybook/react';
+import { ReactRouterDecorator } from '@/.storybook/ReactRouterDecorator';
 import type { MainProps } from './Main';
 import { Main } from './Main';
 
@@ -21,9 +21,9 @@ export default {
 			control: { type: 'select' },
 		},
 	},
-} as ComponentMeta<typeof Main>;
+} as Meta<typeof Main>;
 
-const Template: ComponentStory<typeof Main> = (args: MainProps) => (
+const Template: StoryFn<typeof Main> = (args: MainProps) => (
 	<Main {...args}>
 		<h1>Main content</h1>
 	</Main>

--- a/client/components/shared/Spinner.stories.tsx
+++ b/client/components/shared/Spinner.stories.tsx
@@ -1,4 +1,4 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { LoadingProps } from './Spinner';
 import { Spinner } from './Spinner';
 
@@ -21,9 +21,9 @@ export default {
 			control: { type: 'inline-radio' },
 		},
 	},
-} as ComponentMeta<typeof Spinner>;
+} as Meta<typeof Spinner>;
 
-const Template: ComponentStory<typeof Spinner> = (args: LoadingProps) => (
+const Template: StoryFn<typeof Spinner> = (args: LoadingProps) => (
 	<Spinner {...args} />
 );
 

--- a/client/components/shared/SupportTheGuardianButton.stories.tsx
+++ b/client/components/shared/SupportTheGuardianButton.stories.tsx
@@ -1,30 +1,30 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { SupportTheGuardianButton } from './SupportTheGuardianButton';
 
 export default {
 	title: 'Components/SupportTheGuardianButton',
 	component: SupportTheGuardianButton,
-} as ComponentMeta<typeof SupportTheGuardianButton>;
+} as Meta<typeof SupportTheGuardianButton>;
 
-export const Default: ComponentStory<typeof SupportTheGuardianButton> = () => (
+export const Default: StoryFn<typeof SupportTheGuardianButton> = () => (
 	<SupportTheGuardianButton supportReferer="storybook" />
 );
 
-export const WithSmallSize: ComponentStory<
-	typeof SupportTheGuardianButton
-> = () => <SupportTheGuardianButton supportReferer="storybook" size="small" />;
+export const WithSmallSize: StoryFn<typeof SupportTheGuardianButton> = () => (
+	<SupportTheGuardianButton supportReferer="storybook" size="small" />
+);
 
-export const WithBrandTheme: ComponentStory<
-	typeof SupportTheGuardianButton
-> = () => <SupportTheGuardianButton supportReferer="storybook" theme="brand" />;
+export const WithBrandTheme: StoryFn<typeof SupportTheGuardianButton> = () => (
+	<SupportTheGuardianButton supportReferer="storybook" theme="brand" />
+);
 
-export const WithBrandAltTheme: ComponentStory<
+export const WithBrandAltTheme: StoryFn<
 	typeof SupportTheGuardianButton
 > = () => (
 	<SupportTheGuardianButton supportReferer="storybook" theme="brandAlt" />
 );
 
-export const WithAlternateButtonText: ComponentStory<
+export const WithAlternateButtonText: StoryFn<
 	typeof SupportTheGuardianButton
 > = () => (
 	<SupportTheGuardianButton

--- a/client/components/shared/WithStandardTopMargin.stories.tsx
+++ b/client/components/shared/WithStandardTopMargin.stories.tsx
@@ -1,13 +1,13 @@
 import { css } from '@emotion/react';
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { WithStandardTopMargin } from './WithStandardTopMargin';
 
 export default {
 	title: 'Components/WithStandardTopMargin',
 	component: WithStandardTopMargin,
-} as ComponentMeta<typeof WithStandardTopMargin>;
+} as Meta<typeof WithStandardTopMargin>;
 
-export const Default: ComponentStory<typeof WithStandardTopMargin> = () => (
+export const Default: StoryFn<typeof WithStandardTopMargin> = () => (
 	<div
 		css={css`
 			outline: 1px dotted red;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
A number of storybook components were using deprecated imports ComponentMeta and ComponentStory this PR updates those tests to use Meta and StoryFn. Also shortens many imports.

Fixed error on ExpanderButton storybook by setting ExpanderButtonProps to export
![image](https://github.com/guardian/manage-frontend/assets/115992455/2b40b8ca-41fd-47d9-ac67-5e5672d36e6d)
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Check that storybook tests are unchanged
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
