### PR TITLE
Upgrade Support - Use next payment date from preview response after switch

### DIFF
--- a/client/components/mma/upgrade/ConfirmForm.tsx
+++ b/client/components/mma/upgrade/ConfirmForm.tsx
@@ -318,6 +318,7 @@ export const ConfirmForm = ({
 		const routerState = {
 			chosenAmount,
 			amountPayableToday,
+			nextPaymentDate,
 			journeyCompleted: true,
 		} as UpgradeRouterState;
 

--- a/client/components/mma/upgrade/UpgradeSupport.stories.tsx
+++ b/client/components/mma/upgrade/UpgradeSupport.stories.tsx
@@ -19,6 +19,7 @@ export default {
 			state: {
 				amountPayableToday: 5.9,
 				chosenAmount: 9,
+				nextPaymentDate: '20 March',
 			},
 			container: <UpgradeSupportContainer />,
 		},

--- a/client/components/mma/upgrade/UpgradeSupportContainer.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportContainer.tsx
@@ -33,6 +33,7 @@ export interface UpgradeSupportInterface {
 export interface UpgradeRouterState {
 	chosenAmount: number;
 	amountPayableToday: number;
+	nextPaymentDate: string;
 	journeyCompleted: boolean;
 }
 

--- a/client/components/mma/upgrade/UpgradeSupportSwitchThankYou.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportSwitchThankYou.tsx
@@ -16,7 +16,6 @@ import {
 import { useContext } from 'react';
 import { useLocation } from 'react-router';
 import { formatAmount } from '@/client/utilities/utils';
-import { DATE_FNS_LONG_OUTPUT_FORMAT, parseDate } from '@/shared/dates';
 import { calculateMonthlyOrAnnualFromBillingPeriod } from '@/shared/productTypes';
 import {
 	buttonCentredCss,
@@ -51,14 +50,12 @@ export const UpgradeSupportSwitchThankYou = () => {
 	const routerState = location.state as UpgradeRouterState;
 	const amountPayableToday = routerState?.amountPayableToday;
 	const chosenAmount = routerState?.chosenAmount;
+	const nextPaymentDate = routerState?.nextPaymentDate;
+
 	const currency = upgradeSupportContext.mainPlan.currency;
 	const previousPrice = upgradeSupportContext.mainPlan.price / 100;
 	const billingPeriod = upgradeSupportContext.mainPlan.billingPeriod;
 	const userEmail = upgradeSupportContext.user?.email ?? '';
-
-	const nextBillingDate = parseDate(
-		upgradeSupportContext.mainPlan.chargedThrough ?? undefined,
-	).dateStr(DATE_FNS_LONG_OUTPUT_FORMAT);
 
 	const increasedText =
 		chosenAmount > previousPrice ? 'increased' : 'changed';
@@ -155,7 +152,7 @@ export const UpgradeSupportSwitchThankYou = () => {
 								Your first billing date is today and you will be
 								charged {currency}
 								{formatAmount(amountPayableToday)}. From{' '}
-								{nextBillingDate}, your ongoing{' '}
+								{nextPaymentDate}, your ongoing{' '}
 								{calculateMonthlyOrAnnualFromBillingPeriod(
 									billingPeriod,
 								).toLowerCase()}{' '}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Fixes a bug in the Switch Thank You page after upgrading to S+. The page was using the original billing date instead of the new one after switching (which comes from the product move preview response.)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Go to `/upgrade-support` and select above the threshold, see the next payment date 
![image](https://github.com/guardian/manage-frontend/assets/114918544/030293c7-8f97-440f-a1be-c456c7316380)

Confirm and see the **same date** on the thank you page (ignore the wrong charge in the screenshots they're from separate tests)

![image](https://github.com/guardian/manage-frontend/assets/114918544/befd303a-3387-4f3a-b0d5-3c9dc21bad2e)


<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
