### PR TITLE
Small design changes from Rob

### DIFF
--- a/client/components/mma/upgrade/ConfirmForm.tsx
+++ b/client/components/mma/upgrade/ConfirmForm.tsx
@@ -385,7 +385,7 @@ export const ConfirmForm = ({
 				>
 					You've selected to support {currencySymbol}
 					{formatAmount(chosenAmount)} per {mainPlan.billingPeriod}
-					{aboveThreshold ? ', which unlocks extras' : ''}.
+					{aboveThreshold ? ', which unlocks all extras' : ''}.
 				</div>
 			</section>
 			{shouldShowRoundUp && (

--- a/client/components/mma/upgrade/UpgradeSupportStyles.ts
+++ b/client/components/mma/upgrade/UpgradeSupportStyles.ts
@@ -3,6 +3,9 @@ import { from, palette, textSans } from '@guardian/source-foundations';
 
 export const linkCss = css`
 	${textSans.medium()};
+	a {
+		color: ${palette.brand[400]};
+	}
 	color: ${palette.brand[400]};
 	font-weight: 700;
 	text-decoration-line: underline;

--- a/client/components/mma/upgrade/UpgradeSupportSwitchThankYou.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportSwitchThankYou.tsx
@@ -171,9 +171,9 @@ export const UpgradeSupportSwitchThankYou = () => {
 									Enjoy your new extras
 								</strong>
 								<br />
-								To access your exclusive extras on our website
-								and app, please sign in. It takes less than a
-								minute.
+								Your new support plan starts today. It may take
+								up to an hour for your full app access to become
+								available.
 							</span>
 						</li>
 					</ul>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Minor tweaks:

- Adding 'all' into sentence about extras on ConfirmForm.tsx
- Changed colour of 'Back to Account Overview' link to match design
- Changes wording in Extras benefits on UpgradeSupportSwitchThankYou.tsx to match design

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
![image](https://github.com/guardian/manage-frontend/assets/115992455/5f336666-efde-423b-828f-7b92f26fc35f)

![image](https://github.com/guardian/manage-frontend/assets/115992455/8f5e4523-9944-4c54-a941-76acb9666fa0)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
