### PR TITLE
Upgrade support - value page fixes

### DIFF
--- a/client/components/mma/shared/benefits/BenefitsCard.tsx
+++ b/client/components/mma/shared/benefits/BenefitsCard.tsx
@@ -8,11 +8,17 @@ const UpgradeBenefit = ({ benefit }: { benefit: ProductBenefit }) => {
 	return (
 		<li css={benefit.isUnavailable ? unavailableBenefitsCss : ''}>
 			{benefit.isUnavailable ? (
-				<SvgCrossRound isAnnouncedByScreenReader size="small" />
+				<SvgCrossRound isAnnouncedByScreenReader size="medium" />
 			) : (
-				<SvgTickRound isAnnouncedByScreenReader size="small" />
+				<SvgTickRound isAnnouncedByScreenReader size="medium" />
 			)}
-			<span>{benefit.name}</span>
+			<span
+				css={css`
+					padding-top: ${space[1]}px;
+				`}
+			>
+				{benefit.name}
+			</span>
 		</li>
 	);
 };

--- a/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
@@ -85,15 +85,6 @@ interface UpgradeSupportAmountFormProps {
 	suggestedAmounts: number[];
 }
 
-function addScrollEventListener() {
-	document.addEventListener('wheel', function (_) {
-		const inputElement = document.activeElement as HTMLInputElement;
-		if (inputElement.type === 'number') {
-			inputElement.blur();
-		}
-	});
-}
-
 export const UpgradeSupportAmountForm = ({
 	chosenAmount,
 	setChosenAmount,
@@ -153,8 +144,6 @@ export const UpgradeSupportAmountForm = ({
 
 		setErrorMessage(newErrorMessage);
 	}, [otherAmountSelected, chosenAmount]);
-
-	addScrollEventListener();
 
 	return (
 		<>
@@ -216,6 +205,7 @@ export const UpgradeSupportAmountForm = ({
 								type="number"
 								width={30}
 								value={otherAmountSelected?.toString() || ''}
+								onWheel={(event) => event.currentTarget.blur()}
 								onChange={(event) => {
 									setChosenAmount(
 										event.target.value

--- a/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportAmountForm.tsx
@@ -85,6 +85,15 @@ interface UpgradeSupportAmountFormProps {
 	suggestedAmounts: number[];
 }
 
+function addScrollEventListener() {
+	document.addEventListener('wheel', function (_) {
+		const inputElement = document.activeElement as HTMLInputElement;
+		if (inputElement.type === 'number') {
+			inputElement.blur();
+		}
+	});
+}
+
 export const UpgradeSupportAmountForm = ({
 	chosenAmount,
 	setChosenAmount,
@@ -144,6 +153,8 @@ export const UpgradeSupportAmountForm = ({
 
 		setErrorMessage(newErrorMessage);
 	}, [otherAmountSelected, chosenAmount]);
+
+	addScrollEventListener();
 
 	return (
 		<>
@@ -240,9 +251,7 @@ export const UpgradeSupportAmountForm = ({
 									<Button
 										cssOverrides={buttonCentredCss}
 										onClick={() => {
-											setContinuedToConfirmation(
-												true
-											);
+											setContinuedToConfirmation(true);
 											scrollToConfirmChange();
 										}}
 									>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Fixes two issues on the first upgrade-support page:

1.  Icon size should be 20px
2. Prevent scrolling within input box

(from Rob)
![image](https://github.com/guardian/manage-frontend/assets/114918544/e08f7726-f317-47bf-92ed-ec162d0f965f)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

1. Visual check
2. Click "other" amount, click within text box, try to scroll (box becomes unfocused)

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
