### PR TITLE
Use `CODE` over `DEV` for S3 content

### DIFF
--- a/server/awsIntegration.ts
+++ b/server/awsIntegration.ts
@@ -56,7 +56,7 @@ export const s3ConfigPromise =
 	(configPathPart: string) =>
 		s3FilePromise<ConfigInterface>(
 			'gu-reader-revenue-private',
-			`manage-frontend/${conf.STAGE}/${configPathPart}-${conf.STAGE}.json`,
+			`manage-frontend/${conf.API_STAGE}/${configPathPart}-${conf.API_STAGE}.json`,
 			...fieldNamesToValidate,
 		);
 

--- a/server/config.ts
+++ b/server/config.ts
@@ -1,5 +1,6 @@
 interface Config {
 	readonly STAGE: string;
+	readonly API_STAGE: 'PROD' | 'CODE';
 	readonly DOMAIN: string;
 	readonly API_DOMAIN: string;
 	readonly ENVIRONMENT: Environments;
@@ -37,6 +38,7 @@ const getDomain = () => {
 
 export const conf: Config = {
 	STAGE: stage || 'DEV',
+	API_STAGE: stage?.toUpperCase() === 'PROD' ? 'PROD' : 'CODE',
 	DOMAIN: getDomain(),
 	API_DOMAIN:
 		stage === 'PROD' ? 'guardianapis.com' : 'code.dev-guardianapis.com',

--- a/server/fulfilmentDateCalculatorReader.ts
+++ b/server/fulfilmentDateCalculatorReader.ts
@@ -17,10 +17,10 @@ const getDeliveryAddressChangeEffectiveDateForToday = async (
 ) => {
 	const datesByDayOfWeek =
 		await s3FilePromise<RawFulfilmentDateCalculatorDates>(
-			`fulfilment-date-calculator-${conf.STAGE.toLowerCase()}`,
+			`fulfilment-date-calculator-${conf.API_STAGE.toLowerCase()}`,
 			`${filenameProductPart}/${new Date()
 				.toISOString()
-				.substr(0, 10)}_${filenameProductPart}.json`,
+				.substring(0, 10)}_${filenameProductPart}.json`,
 			...daysOfWeek,
 		);
 	return (

--- a/server/helpCentreApi.ts
+++ b/server/helpCentreApi.ts
@@ -7,7 +7,7 @@ import { log } from './log';
 export const getArticleHandler = async (req: Request, res: Response) => {
 	const { article } = req.params;
 	const bucketName = 'manage-help-content';
-	const filePath = `${conf.STAGE}/articles/${article}.json`;
+	const filePath = `${conf.API_STAGE}/articles/${article}.json`;
 	s3FilePromise(bucketName, filePath)
 		.then((data) => {
 			if (!data) {
@@ -29,7 +29,7 @@ export const getArticleHandler = async (req: Request, res: Response) => {
 export const getTopicHandler = async (req: Request, res: Response) => {
 	const { topic } = req.params;
 	const bucketName = 'manage-help-content';
-	const filePath = `${conf.STAGE}/topics/${topic}.json`;
+	const filePath = `${conf.API_STAGE}/topics/${topic}.json`;
 	s3FilePromise(bucketName, filePath)
 		.then((data) => {
 			if (!data) {

--- a/server/recaptchaConfig.ts
+++ b/server/recaptchaConfig.ts
@@ -1,9 +1,12 @@
-import { s3ConfigPromise } from './awsIntegration';
+import { s3FilePromise } from './awsIntegration';
+import { conf } from './config';
 
 interface ReCaptchaKeys {
 	publicKey: string;
 	secretKey: string;
 }
 
-export const recaptchaConfigPromise =
-	s3ConfigPromise<ReCaptchaKeys>()('recaptcha');
+export const recaptchaConfigPromise = s3FilePromise<ReCaptchaKeys>(
+	'gu-reader-revenue-private',
+	`manage-frontend/${conf.STAGE}/recaptcha-${conf.STAGE}.json`,
+);

--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -282,7 +282,7 @@ router.get(
 
 router.get('/known-issues', async (_, response) => {
 	const bucketName = 'manage-help-content';
-	const filePath = `${conf.STAGE}/known-issues/knownIssuesConfig.json`;
+	const filePath = `${conf.API_STAGE}/known-issues/knownIssuesConfig.json`;
 	const data = await s3FilePromise(bucketName, filePath);
 	response.json(data || []);
 });

--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -71,7 +71,8 @@ router.get(
 				const errorMessage = `Unexpected error when augmenting members-data-api response with 'deliveryAddressChangeEffectiveDate' error message was ${error}`;
 				log.error(errorMessage, error);
 				Sentry.captureMessage(errorMessage);
-				response.json(augmentedWithTestUser); // fallback to sending the response augmented with just isTestUser
+				mdapiResponse.products = augmentedWithTestUser;
+				response.json(mdapiResponse); // fallback to sending the response augmented with just isTestUser
 			});
 	})(
 		'user-attributes/me/mma/:subscriptionName',

--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -71,8 +71,7 @@ router.get(
 				const errorMessage = `Unexpected error when augmenting members-data-api response with 'deliveryAddressChangeEffectiveDate' error message was ${error}`;
 				log.error(errorMessage, error);
 				Sentry.captureMessage(errorMessage);
-				mdapiResponse.products = augmentedWithTestUser;
-				response.json(mdapiResponse); // fallback to sending the response augmented with just isTestUser
+				response.json(augmentedWithTestUser); // fallback to sending the response augmented with just isTestUser
 			});
 	})(
 		'user-attributes/me/mma/:subscriptionName',

--- a/server/routes/core.ts
+++ b/server/routes/core.ts
@@ -62,7 +62,7 @@ router.get('/robots.txt', (_, res: Response) => {
 
 router.get('/sitemap.txt', async (_, res: Response) => {
 	const bucketName = 'manage-help-content';
-	const filePath = `${conf.STAGE}/sitemap.txt`;
+	const filePath = `${conf.API_STAGE}/sitemap.txt`;
 	s3TextFilePromise(bucketName, filePath)
 		.then((data) => {
 			if (!data) {

--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -767,7 +767,7 @@ export const GROUPED_PRODUCT_TYPES: {
 			} else if (productDetail.tier === 'Newspaper Delivery') {
 				return PRODUCT_TYPES.homedelivery;
 			} else if (productDetail.tier === 'Newspaper - National Delivery') {
-				return PRODUCT_TYPES.homedelivery;
+				return PRODUCT_TYPES.nationaldelivery;
 			} else if (productDetail.tier === 'Newspaper Voucher') {
 				return PRODUCT_TYPES.voucher;
 			} else if (

--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -767,7 +767,7 @@ export const GROUPED_PRODUCT_TYPES: {
 			} else if (productDetail.tier === 'Newspaper Delivery') {
 				return PRODUCT_TYPES.homedelivery;
 			} else if (productDetail.tier === 'Newspaper - National Delivery') {
-				return PRODUCT_TYPES.nationaldelivery;
+				return PRODUCT_TYPES.homedelivery;
 			} else if (productDetail.tier === 'Newspaper Voucher') {
 				return PRODUCT_TYPES.voucher;
 			} else if (


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR changes the stage that manage uses locally from `DEV` to `CODE` when looking at some files stored in S3. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Test locally that each S3 file promise still works:

- [x] Help Centre topics
- [x] Help Centre articles
- [ ] Help sitemap
- [x] Fulfilment date augment
- [x] Fetches keys for other apis

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
