### PR TITLE
Enable national delivery product

### DIFF
--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -71,7 +71,8 @@ router.get(
 				const errorMessage = `Unexpected error when augmenting members-data-api response with 'deliveryAddressChangeEffectiveDate' error message was ${error}`;
 				log.error(errorMessage, error);
 				Sentry.captureMessage(errorMessage);
-				response.json(augmentedWithTestUser); // fallback to sending the response augmented with just isTestUser
+				mdapiResponse.products = augmentedWithTestUser;
+				response.json(mdapiResponse); // fallback to sending the response augmented with just isTestUser
 			});
 	})(
 		'user-attributes/me/mma/:subscriptionName',

--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -767,7 +767,7 @@ export const GROUPED_PRODUCT_TYPES: {
 			} else if (productDetail.tier === 'Newspaper Delivery') {
 				return PRODUCT_TYPES.homedelivery;
 			} else if (productDetail.tier === 'Newspaper - National Delivery') {
-				return PRODUCT_TYPES.homedelivery;
+				return PRODUCT_TYPES.nationaldelivery;
 			} else if (productDetail.tier === 'Newspaper Voucher') {
 				return PRODUCT_TYPES.voucher;
 			} else if (


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Return the `nationaldelivery` product type when looking in config
Handle an error when augmenting MDAPI response so it doesn't return wrong shape of response

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Take out national delivery product, view account overview with no error and click `Manage subscription` and go to `/nationaldelivery`

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
