### PR TITLE
OAuth migration | Redirect to original URL on sign-in

### DIFF
--- a/client/components/shared/Header.tsx
+++ b/client/components/shared/Header.tsx
@@ -63,7 +63,7 @@ export const Header = ({ signInStatus, isHelpCentrePage }: HeaderProps) => {
 				)}
 				{signInStatus === 'signedOut' && (
 					<a
-						href={`/oauth/signin?returnUrl=${window.location.href}`}
+						href={`/oauth/signin?returnUrl=${window.location.pathname}`}
 						css={aCss}
 					>
 						Sign in

--- a/client/components/shared/Header.tsx
+++ b/client/components/shared/Header.tsx
@@ -5,6 +5,7 @@ import {
 	palette,
 	space,
 } from '@guardian/source-foundations';
+import { buildUrl } from '@/shared/urlUtils';
 import type { SignInStatus } from '../../utilities/signInStatus';
 import { TheGuardianLogo } from '../mma/shared/assets/TheGuardianLogo';
 import { DropdownNav } from './nav/DropdownNav';
@@ -63,7 +64,9 @@ export const Header = ({ signInStatus, isHelpCentrePage }: HeaderProps) => {
 				)}
 				{signInStatus === 'signedOut' && (
 					<a
-						href={`/oauth/signin?returnUrl=${window.location.pathname}`}
+						href={buildUrl('/oauth/signin', {
+							returnUrl: window.location.pathname,
+						})}
 						css={aCss}
 					>
 						Sign in

--- a/client/components/shared/Header.tsx
+++ b/client/components/shared/Header.tsx
@@ -62,7 +62,10 @@ export const Header = ({ signInStatus, isHelpCentrePage }: HeaderProps) => {
 					</div>
 				)}
 				{signInStatus === 'signedOut' && (
-					<a href={'/'} css={aCss}>
+					<a
+						href={`/oauth/signin?returnUrl=${window.location.href}`}
+						css={aCss}
+					>
 						Sign in
 					</a>
 				)}

--- a/server/routes/oauth.ts
+++ b/server/routes/oauth.ts
@@ -5,14 +5,13 @@ import { withIdentity } from '../middleware/identityMiddleware';
 const router = Router();
 
 // TODO: Change this to withOAuth from rk/oauth-migration
-router.get('/signin', withIdentity, (req: Request, res: Response) => {
+router.get('/signin', withIdentity, (_: Request, res: Response) => {
 	// This route essentially does nothing, but triggers the OAuth signin flow.
 	// It is used by 'Sign In' buttons on the frontend, which pass a 'returnUrl'
 	// query parameter to this route which is then handled by the middleware.
 
-	// If we've fallen through to here, we're signed in - redirect.
-	const returnUrl = (req.query.returnUrl as string) || '/';
-	res.redirect(returnUrl);
+	// If we've fallen through to here, we're already signed in.
+	res.redirect('/');
 });
 
 export { router };

--- a/server/routes/oauth.ts
+++ b/server/routes/oauth.ts
@@ -1,0 +1,18 @@
+import type { Request, Response } from 'express';
+import { Router } from 'express';
+import { withIdentity } from '../middleware/identityMiddleware';
+
+const router = Router();
+
+// TODO: Change this to withOAuth from rk/oauth-migration
+router.get('/signin', withIdentity, (req: Request, res: Response) => {
+	// This route essentially does nothing, but triggers the OAuth signin flow.
+	// It is used by 'Sign In' buttons on the frontend, which pass a 'returnUrl'
+	// query parameter to this route which is then handled by the middleware.
+
+	// If we've fallen through to here, we're signed in - redirect.
+	const returnUrl = (req.query.returnUrl as string) || '/';
+	res.redirect(returnUrl);
+});
+
+export { router };

--- a/shared/requiresSignin.ts
+++ b/shared/requiresSignin.ts
@@ -1,7 +1,7 @@
 import { normalize } from 'path'; // webpack polyfills this for the browser via node-polyfill-webpack-plugin
 
 // To avoid security vulnerabilities do not add public paths that do not end in a slash
-const publicPaths = [
+export const publicPaths = [
 	'/api/contact-us/',
 	'/api/known-issues/',
 	'/api/reminders/cancel/',

--- a/shared/urlUtils.ts
+++ b/shared/urlUtils.ts
@@ -1,0 +1,10 @@
+import { conf } from '@/server/config';
+
+export const buildUrl = (path: string, params: Record<string, string>) => {
+	const url = new URL(`https://manage.${conf.DOMAIN}${path}`);
+	Object.entries(params).forEach(([key, value]) => {
+		url.searchParams.append(key, value);
+	});
+	// Return only the path and query string
+	return url.href.replace(url.origin, '');
+};


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
