### PR TITLE
Add QM masking tag throughout MMA (and tiny import tidy up)

### DIFF
--- a/client/components/mma/accountoverview/CancelledProductCard.tsx
+++ b/client/components/mma/accountoverview/CancelledProductCard.tsx
@@ -1,9 +1,9 @@
 import { css } from '@emotion/react';
 import { LinkButton, Stack } from '@guardian/source-react-components';
 import { InfoSummary } from '@guardian/source-react-components-development-kitchen';
-import { parseDate } from '../../../../shared/dates';
-import type { CancelledProductDetail } from '../../../../shared/productResponse';
-import { GROUPED_PRODUCT_TYPES } from '../../../../shared/productTypes';
+import { parseDate } from '@/shared/dates';
+import type { CancelledProductDetail } from '@/shared/productResponse';
+import { GROUPED_PRODUCT_TYPES } from '@/shared/productTypes';
 import { wideButtonLayoutCss } from '../../../styles/ButtonStyles';
 import { trackEvent } from '../../../utilities/analytics';
 import { Card } from '../shared/Card';
@@ -53,7 +53,7 @@ export const CancelledProductCard = ({
 											? 'Supporter ID'
 											: 'Subscription ID'}
 									</dt>
-									<dd>
+									<dd data-qm-masking="blocklist">
 										{
 											productDetail.subscription
 												.subscriptionId

--- a/client/components/mma/accountoverview/EmptyAccountOverview.tsx
+++ b/client/components/mma/accountoverview/EmptyAccountOverview.tsx
@@ -1,8 +1,7 @@
 import { css } from '@emotion/react';
 import {
-	brand,
 	headline,
-	neutral,
+	palette,
 	space,
 	textSans,
 	until,
@@ -26,7 +25,7 @@ export const EmptyAccountOverview = () => {
 			<h2
 				css={css`
 					margin-top: 50px;
-					border-top: 1px solid ${neutral['86']};
+					border-top: 1px solid ${palette.neutral['86']};
 					${headline.small()};
 					font-weight: bold;
 					${until.tablet} {
@@ -50,8 +49,8 @@ export const EmptyAccountOverview = () => {
 			<dl
 				css={css`
 					${textSans.medium()}
-					background-color: ${neutral[97]};
-					border: 1px solid ${neutral[86]};
+					background-color: ${palette.neutral[97]};
+					border: 1px solid ${palette.neutral[86]};
 					margin: 30px 0 0 0;
 					padding: ${space[5]}px;
 				`}
@@ -105,7 +104,7 @@ export const EmptyAccountOverview = () => {
 						left: 0;
 					`}
 				>
-					<InfoIconDark fillColor={brand[500]} />
+					<InfoIconDark fillColor={palette.brand[500]} />
 				</i>
 				<p
 					css={css`
@@ -121,7 +120,7 @@ export const EmptyAccountOverview = () => {
 					<span
 						css={css`
 							cursor: pointer;
-							color: ${brand[500]};
+							color: ${palette.brand[500]};
 							text-decoration: underline;
 						`}
 						onClick={() =>

--- a/client/components/mma/accountoverview/EmptyAccountOverview.tsx
+++ b/client/components/mma/accountoverview/EmptyAccountOverview.tsx
@@ -74,6 +74,7 @@ export const EmptyAccountOverview = () => {
 						display: inline-block;
 						overflow-wrap: anywhere;
 					`}
+					data-qm-masking="blocklist"
 				>
 					{userEmailAddress}
 				</dd>

--- a/client/components/mma/accountoverview/PersonalisedHeader.tsx
+++ b/client/components/mma/accountoverview/PersonalisedHeader.tsx
@@ -1,10 +1,10 @@
 import { css } from '@emotion/react';
 import { headline, space } from '@guardian/source-foundations';
 import { min } from 'date-fns';
-import { dateString } from '../../../../shared/dates';
-import type { MPAPIResponse } from '../../../../shared/mpapiResponse';
-import type { MembersDataApiResponse } from '../../../../shared/productResponse';
-import { isProduct } from '../../../../shared/productResponse';
+import { dateString } from '@/shared/dates';
+import type { MPAPIResponse } from '@/shared/mpapiResponse';
+import type { MembersDataApiResponse } from '@/shared/productResponse';
+import { isProduct } from '@/shared/productResponse';
 
 interface PersonalisedHeaderProps {
 	mdapiResponse: MembersDataApiResponse;
@@ -57,6 +57,7 @@ export const PersonalisedHeader = ({
 					${headline.large({ fontWeight: 'bold' })};
 					margin-bottom: 0;
 				`}
+				data-qm-masking="blocklist"
 			>
 				{calculateTimeOfDay()}, {userDetails.firstName ?? 'supporter'}
 			</h2>

--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -12,18 +12,18 @@ import {
 	cancellationFormatDate,
 	DATE_FNS_LONG_OUTPUT_FORMAT,
 	parseDate,
-} from '../../../../shared/dates';
+} from '@/shared/dates';
 import type {
 	MembersDataApiUser,
 	PaidSubscriptionPlan,
 	ProductDetail,
 	Subscription,
-} from '../../../../shared/productResponse';
-import { getMainPlan, isGift } from '../../../../shared/productResponse';
+} from '@/shared/productResponse';
+import { getMainPlan, isGift } from '@/shared/productResponse';
 import {
 	calculateSupporterPlusTitle,
 	GROUPED_PRODUCT_TYPES,
-} from '../../../../shared/productTypes';
+} from '@/shared/productTypes';
 import { wideButtonLayoutCss } from '../../../styles/ButtonStyles';
 import { trackEvent } from '../../../utilities/analytics';
 import { ErrorIcon } from '../shared/assets/ErrorIcon';
@@ -54,6 +54,7 @@ const PaymentMethod = ({
 		css={css`
 			${textSans.medium()};
 		`}
+		data-qm-masking="blocklist"
 	>
 		{subscription.card && (
 			<CardDisplay
@@ -220,7 +221,7 @@ export const ProductCard = ({
 											? 'Supporter ID'
 											: 'Subscription ID'}
 									</dt>
-									<dd>
+									<dd data-qm-masking="blocklist">
 										{
 											productDetail.subscription
 												.subscriptionId

--- a/client/components/mma/billing/InvoicesTable.tsx
+++ b/client/components/mma/billing/InvoicesTable.tsx
@@ -1,9 +1,8 @@
 import { css } from '@emotion/react';
 import {
-	brand,
 	from,
 	headline,
-	neutral,
+	palette,
 	space,
 	textSans,
 	until,
@@ -92,7 +91,7 @@ export const InvoicesTable = (props: InvoicesTableProps) => {
 	const tableCss2 = css`
 		display: block;
 		width: 100%;
-		border: 1px solid ${neutral[86]};
+		border: 1px solid ${palette.neutral[86]};
 		${from.tablet} {
 			display: table;
 		}
@@ -115,8 +114,8 @@ export const InvoicesTable = (props: InvoicesTableProps) => {
 	const invoiceYearSelectCss = css`
 		display: none;
 		padding: ${space[3]}px;
-		background-color: ${neutral[97]};
-		border-bottom: 1px solid ${neutral[86]};
+		background-color: ${palette.neutral[97]};
+		border-bottom: 1px solid ${palette.neutral[86]};
 		${from.tablet} {
 			display: table-cell;
 			padding: ${space[5]}px ${space[5]}px ${space[5]}px 0;
@@ -127,8 +126,8 @@ export const InvoicesTable = (props: InvoicesTableProps) => {
 		display: table-cell;
 		${headline.xxsmall({ fontWeight: 'bold' })};
 		padding: ${space[5]}px;
-		background-color: ${neutral[97]};
-		border-bottom: 1px solid ${neutral[86]};
+		background-color: ${palette.neutral[97]};
+		border-bottom: 1px solid ${palette.neutral[86]};
 		${until.tablet} {
 			margin: 0;
 			padding: ${space[3]}px;
@@ -169,7 +168,7 @@ export const InvoicesTable = (props: InvoicesTableProps) => {
 		padding: ${space[3]}px ${space[3]}px 0;
 		:last-of-type {
 			${until.tablet} {
-				border-bottom: 1px solid ${neutral[86]};
+				border-bottom: 1px solid ${palette.neutral[86]};
 			}
 			padding: ${space[3]}px;
 		}
@@ -185,9 +184,9 @@ export const InvoicesTable = (props: InvoicesTableProps) => {
 			width: auto;
 			padding: ${space[5]}px;
 			margin: 0;
-			border-top: 1px solid ${neutral[86]};
+			border-top: 1px solid ${palette.neutral[86]};
 			background-color: ${rowIndex % 2 === 0
-				? neutral[97]
+				? palette.neutral[97]
 				: 'transparent'};
 			:before {
 				display: none;
@@ -206,7 +205,7 @@ export const InvoicesTable = (props: InvoicesTableProps) => {
 	`;
 
 	const invoiceLinkCss = css`
-		color: ${brand[400]};
+		color: ${palette.brand[400]};
 		font-weight: bold;
 	`;
 
@@ -225,8 +224,8 @@ export const InvoicesTable = (props: InvoicesTableProps) => {
 						<div
 							css={css`
 								display: none;
-								background-color: ${neutral[97]};
-								border-bottom: 1px solid ${neutral[86]};
+								background-color: ${palette.neutral[97]};
+								border-bottom: 1px solid ${palette.neutral[86]};
 								${from.tablet} {
 									display: table-cell;
 								}
@@ -235,8 +234,8 @@ export const InvoicesTable = (props: InvoicesTableProps) => {
 						<div
 							css={css`
 								display: none;
-								background-color: ${neutral[97]};
-								border-bottom: 1px solid ${neutral[86]};
+								background-color: ${palette.neutral[97]};
+								border-bottom: 1px solid ${palette.neutral[86]};
 								${from.tablet} {
 									display: table-cell;
 								}

--- a/client/components/mma/billing/InvoicesTable.tsx
+++ b/client/components/mma/billing/InvoicesTable.tsx
@@ -9,8 +9,8 @@ import {
 	until,
 } from '@guardian/source-foundations';
 import { useState } from 'react';
-import { parseDate } from '../../../../shared/dates';
-import type { InvoiceDataApiItem } from '../../../../shared/productResponse';
+import { parseDate } from '@/shared/dates';
+import type { InvoiceDataApiItem } from '@/shared/productResponse';
 import { trackEvent } from '../../../utilities/analytics';
 import { DownloadIcon } from '../shared/assets/DownloadIcon';
 import { CardDisplay } from '../shared/CardDisplay';
@@ -281,7 +281,10 @@ export const InvoicesTable = (props: InvoicesTableProps) => {
 										{parseDate(tableRow.date).dateStr()}
 									</div>
 									<div css={tdCss2(index, tableHeadings[1])}>
-										<div css={paymentDetailsHolderCss}>
+										<div
+											css={paymentDetailsHolderCss}
+											data-qm-masking="blocklist"
+										>
 											{tableRow.cardType &&
 												tableRow.last4 && (
 													<CardDisplay

--- a/client/components/mma/delivery/address/DeliveryAddressDisplay.tsx
+++ b/client/components/mma/delivery/address/DeliveryAddressDisplay.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { textSans } from '@guardian/source-foundations';
-import type { DeliveryAddress } from '../../../../../shared/productResponse';
+import type { DeliveryAddress } from '@/shared/productResponse';
 import { COUNTRIES } from '../../identity/models';
 
 export const DeliveryAddressDisplay = (props: DeliveryAddress) => {

--- a/client/components/mma/delivery/address/DeliveryAddressDisplay.tsx
+++ b/client/components/mma/delivery/address/DeliveryAddressDisplay.tsx
@@ -15,6 +15,7 @@ export const DeliveryAddressDisplay = (props: DeliveryAddress) => {
 				}
 				${textSans.medium()}
 			`}
+			data-qm-masking="blocklist"
 		>
 			<span>{props.addressLine1}</span>
 			{props.addressLine2 && <span>{props.addressLine2}</span>}

--- a/client/components/mma/delivery/address/Select.tsx
+++ b/client/components/mma/delivery/address/Select.tsx
@@ -35,6 +35,7 @@ export const Select = (props: SelectProps) => (
 			${textSans.medium()} ${props.additionalCSS};
 			font-weight: bold;
 		`}
+		data-qm-masking="blocklist"
 	>
 		{props.label}
 		{props.inErrorState && (

--- a/client/components/mma/delivery/address/Select.tsx
+++ b/client/components/mma/delivery/address/Select.tsx
@@ -1,11 +1,6 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import {
-	error,
-	focusHalo,
-	neutral,
-	textSans,
-} from '@guardian/source-foundations';
+import { focusHalo, palette, textSans } from '@guardian/source-foundations';
 import type * as React from 'react';
 import { ErrorIcon } from '../../shared/assets/ErrorIcon';
 
@@ -31,7 +26,7 @@ export const Select = (props: SelectProps) => (
 	<label
 		css={css`
 			display: block;
-			color: ${neutral['7']};
+			color: ${palette.neutral['7']};
 			${textSans.medium()} ${props.additionalCSS};
 			font-weight: bold;
 		`}
@@ -42,7 +37,7 @@ export const Select = (props: SelectProps) => (
 			<span
 				css={css`
 					display: block;
-					color: ${error[400]};
+					color: ${palette.error[400]};
 				`}
 			>
 				<ErrorIcon />
@@ -62,17 +57,19 @@ export const Select = (props: SelectProps) => (
 				width: 100%;
 				max-width: ${props.width}ch;
 				${textSans.medium()}
-				color: ${neutral['7']};
+				color: ${palette.neutral['7']};
 				box-sizing: border-box;
 				margin-top: 4px;
 				padding: 8px 0 8px 4px;
 				border: ${props.inErrorState ? 4 : 2}px solid
-					${props.inErrorState ? error[400] : neutral['60']};
+					${props.inErrorState
+						? palette.error[400]
+						: palette.neutral['60']};
 				&:focus {
 					${focusHalo};
 				}
 				& option {
-					line-height: '40px';
+					line-height: 40px;
 					font-size: 1.0625rem;
 				}
 			`}

--- a/client/components/mma/delivery/records/DeliveryRecordCard.tsx
+++ b/client/components/mma/delivery/records/DeliveryRecordCard.tsx
@@ -2,8 +2,8 @@ import { css } from '@emotion/react';
 import { from, neutral, space, textSans } from '@guardian/source-foundations';
 import { Checkbox, CheckboxGroup } from '@guardian/source-react-components';
 import type { FormEvent } from 'react';
-import { dateIsAfter, parseDate } from '../../../../../shared/dates';
-import type { DeliveryRecordApiItem } from '../../../../../shared/productResponse';
+import { dateIsAfter, parseDate } from '@/shared/dates';
+import type { DeliveryRecordApiItem } from '@/shared/productResponse';
 import { DeliveryRecordInstructions } from './DeliveryRecordInstructions';
 import { PageStatus } from './DeliveryRecords';
 import { RecordAddress } from './DeliveryRecordsAddress';
@@ -157,6 +157,7 @@ export const DeliveryRecordCard = (props: DeliveryRecordCardProps) => {
 					css={css`
 						${ddCss}
 					`}
+					data-qm-masking="blocklist"
 				>
 					{props.deliveryRecord.addressLine1 &&
 					!props.deliveryRecord.hasHolidayStop ? (

--- a/client/components/mma/delivery/records/DeliveryRecordCard.tsx
+++ b/client/components/mma/delivery/records/DeliveryRecordCard.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { from, neutral, space, textSans } from '@guardian/source-foundations';
+import { from, palette, space, textSans } from '@guardian/source-foundations';
 import { Checkbox, CheckboxGroup } from '@guardian/source-react-components';
 import type { FormEvent } from 'react';
 import { dateIsAfter, parseDate } from '@/shared/dates';
@@ -49,7 +49,7 @@ export const DeliveryRecordCard = (props: DeliveryRecordCardProps) => {
 	return (
 		<dl
 			css={css`
-				border: 1px solid ${neutral['86']};
+				border: 1px solid ${palette.neutral['86']};
 				margin: 0;
 				padding: ${space[3]}px;
 				${props.pageStatus === PageStatus.ReportIssueStep2 &&
@@ -75,7 +75,7 @@ export const DeliveryRecordCard = (props: DeliveryRecordCardProps) => {
 						left: 0;
 						height: 100%;
 						padding: 0 ${space[3]}px;
-						border-right: 1px solid ${neutral['86']};
+						border-right: 1px solid ${palette.neutral['86']};
 						${from.tablet} {
 							padding: 0 18px;
 						}
@@ -251,7 +251,7 @@ export const DeliveryRecordCard = (props: DeliveryRecordCardProps) => {
 							{props.deliveryRecord.credit.invoiceDate && (
 								<p
 									css={css`
-										color: ${neutral['60']};
+										color: ${palette.neutral['60']};
 										margin: 0;
 										${from.tablet} {
 											display: inline-block;

--- a/client/components/mma/delivery/records/DeliveryRecordsProblemConfirmation.tsx
+++ b/client/components/mma/delivery/records/DeliveryRecordsProblemConfirmation.tsx
@@ -1,9 +1,8 @@
 import { css } from '@emotion/react';
 import {
-	brand,
 	from,
 	headline,
-	neutral,
+	palette,
 	space,
 	textSans,
 	until,
@@ -123,7 +122,7 @@ const DeliveryRecordsProblemConfirmationFC = (
 			/>
 			<h2
 				css={css`
-					border-top: 1px solid ${neutral['86']};
+					border-top: 1px solid ${palette.neutral['86']};
 					${headline.small()};
 					font-weight: bold;
 					${until.tablet} {
@@ -148,7 +147,7 @@ const DeliveryRecordsProblemConfirmationFC = (
 					margin: ${space[3]}px 0;
 					padding: ${space[3]}px ${space[3]}px ${space[3]}px
 						${space[3] * 2 + 17}px;
-					background-color: ${neutral[97]};
+					background-color: ${palette.neutral[97]};
 					${textSans.small()};
 					${from.tablet} {
 						margin: ${space[5]}px 0;
@@ -162,7 +161,7 @@ const DeliveryRecordsProblemConfirmationFC = (
 						left: ${space[3]}px;
 					`}
 				>
-					<InfoIconDark fillColor={brand[500]} />
+					<InfoIconDark fillColor={palette.brand[500]} />
 				</i>
 				{deliveryProblemCredit?.showCredit
 					? `Thank you for reporting your delivery problem${
@@ -182,7 +181,7 @@ const DeliveryRecordsProblemConfirmationFC = (
 			</span>
 			<section
 				css={css`
-					border: 1px solid ${neutral['86']};
+					border: 1px solid ${palette.neutral['86']};
 					margin-bottom: ${deliveryAddressContext.address &&
 					deliveryAddressContext.productsAffected &&
 					deliveryAddressContext.productsAffected?.length > 0
@@ -194,8 +193,8 @@ const DeliveryRecordsProblemConfirmationFC = (
 					css={css`
 						margin: 0;
 						padding: 14px ${space[3]}px;
-						background-color: ${neutral['97']};
-						border-bottom: 1px solid ${neutral['86']};
+						background-color: ${palette.neutral['97']};
+						border-bottom: 1px solid ${palette.neutral['86']};
 						${textSans.medium({ fontWeight: 'bold' })};
 						${from.tablet} {
 							padding: 14px ${space[5]}px;
@@ -322,7 +321,7 @@ const DeliveryRecordsProblemConfirmationFC = (
 							${textSans.medium()};
 							padding: ${space[5]}px;
 							margin: ${space[5]}px;
-							background-color: ${neutral['97']};
+							background-color: ${palette.neutral['97']};
 						`}
 					>
 						<div
@@ -376,7 +375,7 @@ const DeliveryRecordsProblemConfirmationFC = (
 				deliveryAddressContext.productsAffected?.length > 0 && (
 					<section
 						css={css`
-							border: 1px solid ${neutral['86']};
+							border: 1px solid ${palette.neutral['86']};
 							margin-bottom: ${space[9]}px;
 						`}
 					>
@@ -384,8 +383,9 @@ const DeliveryRecordsProblemConfirmationFC = (
 							css={css`
 								margin: 0;
 								padding: 14px ${space[3]}px;
-								background-color: ${neutral['97']};
-								border-bottom: 1px solid ${neutral['86']};
+								background-color: ${palette.neutral['97']};
+								border-bottom: 1px solid
+									${palette.neutral['86']};
 								${textSans.medium({ fontWeight: 'bold' })};
 								${from.tablet} {
 									padding: 14px ${space[5]}px;

--- a/client/components/mma/delivery/records/DeliveryRecordsProblemConfirmation.tsx
+++ b/client/components/mma/delivery/records/DeliveryRecordsProblemConfirmation.tsx
@@ -11,16 +11,13 @@ import {
 import { LinkButton } from '@guardian/source-react-components';
 import { useContext } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
-import {
-	DATE_FNS_SHORT_OUTPUT_FORMAT,
-	dateString,
-} from '../../../../../shared/dates';
+import { DATE_FNS_SHORT_OUTPUT_FORMAT, dateString } from '@/shared/dates';
 import type {
 	DeliveryRecordApiItem,
 	PaidSubscriptionPlan,
 	Subscription,
-} from '../../../../../shared/productResponse';
-import { getMainPlan } from '../../../../../shared/productResponse';
+} from '@/shared/productResponse';
+import { getMainPlan } from '@/shared/productResponse';
 import { NAV_LINKS } from '../../../shared/nav/NavConfig';
 import { InfoIconDark } from '../../shared/assets/InfoIconDark';
 import { ProductDescriptionListTable } from '../../shared/ProductDescriptionListTable';
@@ -242,7 +239,9 @@ const DeliveryRecordsProblemConfirmationFC = (
 					</div>
 					<div>
 						<dt css={dtCss}>Subscription ID:</dt>
-						<dd css={ddCss}>{props.subscriptionId}</dd>
+						<dd css={ddCss} data-qm-masking="blocklist">
+							{props.subscriptionId}
+						</dd>
 					</div>
 					<div>
 						<dt css={dtCss}>Product:</dt>

--- a/client/components/mma/delivery/records/DeliveryRecordsProblemReview.tsx
+++ b/client/components/mma/delivery/records/DeliveryRecordsProblemReview.tsx
@@ -12,15 +12,12 @@ import { Button, Stack } from '@guardian/source-react-components';
 import { capitalize } from 'lodash';
 import { useContext, useState } from 'react';
 import { Navigate, useLocation, useNavigate } from 'react-router-dom';
-import { parseDate } from '../../../../../shared/dates';
+import { parseDate } from '@/shared/dates';
 import type {
 	DeliveryRecordApiItem,
 	PaidSubscriptionPlan,
-} from '../../../../../shared/productResponse';
-import {
-	getMainPlan,
-	isPaidSubscriptionPlan,
-} from '../../../../../shared/productResponse';
+} from '@/shared/productResponse';
+import { getMainPlan, isPaidSubscriptionPlan } from '@/shared/productResponse';
 import { CallCentreEmailAndNumbers } from '../../../shared/CallCenterEmailAndNumbers';
 import type {
 	PotentialHolidayStopsResponse,
@@ -288,6 +285,7 @@ const DeliveryRecordsProblemReviewFC = (
 							css={css`
 								${ddCss}
 							`}
+							data-qm-masking="blocklist"
 						>
 							{subscription.subscriptionId}
 						</dd>
@@ -315,6 +313,7 @@ const DeliveryRecordsProblemReviewFC = (
 							css={css`
 								${ddCss}
 							`}
+							data-qm-masking="blocklist"
 						>
 							{productName}
 						</dd>

--- a/client/components/mma/delivery/records/DeliveryRecordsProblemReview.tsx
+++ b/client/components/mma/delivery/records/DeliveryRecordsProblemReview.tsx
@@ -312,7 +312,6 @@ const DeliveryRecordsProblemReviewFC = (
 							css={css`
 								${ddCss}
 							`}
-							data-qm-masking="blocklist"
 						>
 							{productName}
 						</dd>

--- a/client/components/mma/delivery/records/DeliveryRecordsProblemReview.tsx
+++ b/client/components/mma/delivery/records/DeliveryRecordsProblemReview.tsx
@@ -1,9 +1,8 @@
 import { css } from '@emotion/react';
 import {
-	brand,
 	from,
 	headline,
-	neutral,
+	palette,
 	space,
 	textSans,
 	until,
@@ -226,7 +225,7 @@ const DeliveryRecordsProblemReviewFC = (
 			/>
 			<h2
 				css={css`
-					border-top: 1px solid ${neutral['86']};
+					border-top: 1px solid ${palette.neutral['86']};
 					${headline.small({ fontWeight: 'bold' })};
 					${until.tablet} {
 						font-size: 1.25rem;
@@ -238,15 +237,15 @@ const DeliveryRecordsProblemReviewFC = (
 			</h2>
 			<section
 				css={css`
-					border: 1px solid ${neutral['86']};
+					border: 1px solid ${palette.neutral['86']};
 				`}
 			>
 				<h2
 					css={css`
 						margin: 0;
 						padding: ${space[3]}px;
-						background-color: ${neutral['97']};
-						border-bottom: 1px solid ${neutral['86']};
+						background-color: ${palette.neutral['97']};
+						border-bottom: 1px solid ${palette.neutral['86']};
 						${textSans.medium({ fontWeight: 'bold' })};
 						${from.tablet} {
 							padding: ${space[3]}px ${space[5]}px;
@@ -458,7 +457,7 @@ const DeliveryRecordsProblemReviewFC = (
 									left: 0;
 								`}
 							>
-								<InfoIconDark fillColor={brand[500]} />
+								<InfoIconDark fillColor={palette.brand[500]} />
 							</i>
 							We apologise for any inconvenience caused and will
 							credit you the amount shown below once you submit
@@ -467,7 +466,7 @@ const DeliveryRecordsProblemReviewFC = (
 							satisfied with this outcome please{' '}
 							<span
 								css={css`
-									color: ${brand[500]};
+									color: ${palette.brand[500]};
 									text-decoration: underline;
 									cursor: pointer;
 								`}
@@ -486,7 +485,7 @@ const DeliveryRecordsProblemReviewFC = (
 								${textSans.medium()};
 								padding: ${space[3]}px;
 								margin: ${space[3]}px;
-								background-color: ${neutral['97']};
+								background-color: ${palette.neutral['97']};
 								${from.tablet} {
 									padding: ${space[5]}px;
 									margin: ${space[5]}px;
@@ -581,7 +580,7 @@ const DeliveryRecordsProblemReviewFC = (
 									left: 0;
 								`}
 							>
-								<InfoIconDark fillColor={brand[500]} />
+								<InfoIconDark fillColor={palette.brand[500]} />
 							</i>
 							Once you submit your report, your case will be
 							marked as high priority. Our customer service team
@@ -625,7 +624,7 @@ const DeliveryRecordsProblemReviewFC = (
 						font-weight: bold;
 						margin-left: 22px;
 						padding: 0;
-						color: ${brand[400]};
+						color: ${palette.brand[400]};
 						:hover {
 							background-color: transparent;
 						}
@@ -646,14 +645,14 @@ const DeliveryRecordsProblemReviewFC = (
 					css={css`
 						${textSans.medium()};
 						margin: ${space[6]}px 0 0;
-						color: ${neutral[46]};
+						color: ${palette.neutral[46]};
 					`}
 				>
 					If your delivery is not shown above, or you’d like to talk
 					to someone,{' '}
 					<span
 						css={css`
-							color: ${brand[500]};
+							color: ${palette.brand[500]};
 							text-decoration: underline;
 							cursor: pointer;
 						`}

--- a/client/components/mma/delivery/records/ProductDetailsTable.tsx
+++ b/client/components/mma/delivery/records/ProductDetailsTable.tsx
@@ -90,11 +90,11 @@ export const ProductDetailsTable = (props: ProductDetailsTableProps) => {
 			<dl css={dlCss}>
 				<div>
 					<dt>Product:</dt>
-					<dd>{props.productName}</dd>
+					<dd data-qm-masking="blocklist">{props.productName}</dd>
 				</div>
 				<div>
 					<dt>Subscription ID:</dt>
-					<dd>{props.subscriptionId}</dd>
+					<dd data-qm-masking="blocklist">{props.subscriptionId}</dd>
 				</div>
 			</dl>
 		</div>

--- a/client/components/mma/delivery/records/ProductDetailsTable.tsx
+++ b/client/components/mma/delivery/records/ProductDetailsTable.tsx
@@ -1,11 +1,5 @@
 import { css } from '@emotion/react';
-import {
-	brand,
-	from,
-	neutral,
-	space,
-	textSans,
-} from '@guardian/source-foundations';
+import { from, palette, space, textSans } from '@guardian/source-foundations';
 import { GiftIcon } from '../../shared/assets/GiftIcon';
 
 interface ProductDetailsTableProps {
@@ -55,7 +49,7 @@ export const ProductDetailsTable = (props: ProductDetailsTableProps) => {
 	return (
 		<div
 			css={css`
-				border: 1px solid ${neutral[86]};
+				border: 1px solid ${palette.neutral[86]};
 			`}
 		>
 			<h2
@@ -64,8 +58,8 @@ export const ProductDetailsTable = (props: ProductDetailsTableProps) => {
 					font-weight: bold;
 					padding: ${space[3]}px;
 					margin: 0;
-					background-color: ${brand[400]};
-					color: ${neutral[100]};
+					background-color: ${palette.brand[400]};
+					color: ${palette.neutral[100]};
 					position: relative;
 					${from.tablet} {
 						font-size: 20px;

--- a/client/components/mma/delivery/records/ProductDetailsTable.tsx
+++ b/client/components/mma/delivery/records/ProductDetailsTable.tsx
@@ -84,7 +84,7 @@ export const ProductDetailsTable = (props: ProductDetailsTableProps) => {
 			<dl css={dlCss}>
 				<div>
 					<dt>Product:</dt>
-					<dd data-qm-masking="blocklist">{props.productName}</dd>
+					<dd>{props.productName}</dd>
 				</div>
 				<div>
 					<dt>Subscription ID:</dt>

--- a/client/components/mma/identity/emailAndMarketing/EmailSettingsSection.tsx
+++ b/client/components/mma/identity/emailAndMarketing/EmailSettingsSection.tsx
@@ -1,6 +1,6 @@
 import { palette } from '@guardian/source-foundations';
 import type { FC } from 'react';
-import { sans } from '../../../../styles/fonts';
+import { sans } from '@/client/styles/fonts';
 import { Button } from '../../shared/Buttons';
 import { IdentityLocations } from '../IdentityLocations';
 import { PageSection } from '../PageSection';
@@ -50,7 +50,7 @@ export const EmailSettingsSection: FC<EmailSettingsSectionProps> = (props) => {
 		<PageSection title={'Email settings'}>
 			<p css={{ ...text, marginBottom: '8px' }}>
 				You are receiving newsletters, notifications and all other
-				emails to <strong>{email}</strong>
+				emails to <strong data-qm-masking="blocklist">{email}</strong>
 			</p>
 			<p css={{ ...text, marginBottom: '2px' }}>
 				<a css={linkCss} href={IdentityLocations.CHANGE_EMAIL}>

--- a/client/components/mma/identity/form/FormField.tsx
+++ b/client/components/mma/identity/form/FormField.tsx
@@ -73,7 +73,7 @@ export const FormSelectField = <T,>(props: FormSelectProps<T>) => {
 			label={props.label}
 			formikProps={props.formikProps}
 		>
-			<Field component="select" name={name}>
+			<Field component="select" name={name} data-qm-masking="blocklist">
 				<option disabled={firstOptionDisabled} value="">
 					{firstOptionLabel}
 				</option>
@@ -90,7 +90,7 @@ const getInputFieldOfType = (type: string) => {
 			label={props.label}
 			formikProps={props.formikProps}
 		>
-			<Field type={type} />
+			<Field type={type} data-qm-masking="blocklist" />
 		</FormField>
 	);
 };

--- a/client/components/mma/identity/publicProfile/ProfileFormSection.tsx
+++ b/client/components/mma/identity/publicProfile/ProfileFormSection.tsx
@@ -45,7 +45,11 @@ const fieldSetCss = {
 
 const ProfileForm = (props: FormikProps<User> & ProfileFormSectionProps) => (
 	<Form>
-		<fieldset css={fieldSetCss} disabled={props.isSubmitting}>
+		<fieldset
+			css={fieldSetCss}
+			disabled={props.isSubmitting}
+			data-qm-masking="blocklist"
+		>
 			{usernameInput(props)}
 			<Button
 				disabled={props.isSubmitting}

--- a/client/components/mma/paymentUpdate/CurrentPaymentDetail.tsx
+++ b/client/components/mma/paymentUpdate/CurrentPaymentDetail.tsx
@@ -7,9 +7,9 @@ import {
 	until,
 } from '@guardian/source-foundations';
 import { InlineError } from '@guardian/source-react-components';
-import type { ProductDetail } from '../../../../shared/productResponse';
-import { getMainPlan } from '../../../../shared/productResponse';
-import { GROUPED_PRODUCT_TYPES } from '../../../../shared/productTypes';
+import type { ProductDetail } from '@/shared/productResponse';
+import { getMainPlan } from '@/shared/productResponse';
+import { GROUPED_PRODUCT_TYPES } from '@/shared/productTypes';
 import { PaypalLogo } from '../shared/assets/PaypalLogo';
 import { CardDisplay } from '../shared/CardDisplay';
 import {
@@ -143,7 +143,7 @@ export const CurrentPaymentDetails = (props: ProductDetail) => {
 						<>
 							<ul css={keyValuePairCss}>
 								<li css={keyCss}>Payment method</li>
-								<li css={valueCss}>
+								<li css={valueCss} data-qm-masking="blocklist">
 									{subscription.card && (
 										<CardDisplay
 											inErrorState={hasPaymentFailure}
@@ -225,6 +225,7 @@ export const CurrentPaymentDetails = (props: ProductDetail) => {
 								)}
 							</span>
 							<span
+								data-qm-masking="blocklist"
 								css={css`
 									${valueCss};
 									color: ${hasPaymentFailure

--- a/client/components/mma/paymentUpdate/CurrentPaymentDetail.tsx
+++ b/client/components/mma/paymentUpdate/CurrentPaymentDetail.tsx
@@ -7,9 +7,9 @@ import {
 	until,
 } from '@guardian/source-foundations';
 import { InlineError } from '@guardian/source-react-components';
-import type { ProductDetail } from '@/shared/productResponse';
-import { getMainPlan } from '@/shared/productResponse';
-import { GROUPED_PRODUCT_TYPES } from '@/shared/productTypes';
+import type { ProductDetail } from '../../../../shared/productResponse';
+import { getMainPlan } from '../../../../shared/productResponse';
+import { GROUPED_PRODUCT_TYPES } from '../../../../shared/productTypes';
 import { PaypalLogo } from '../shared/assets/PaypalLogo';
 import { CardDisplay } from '../shared/CardDisplay';
 import {

--- a/client/components/mma/paymentUpdate/card/FlexCardElement.tsx
+++ b/client/components/mma/paymentUpdate/card/FlexCardElement.tsx
@@ -7,7 +7,7 @@ import {
 } from '@stripe/react-stripe-js';
 import type { StripeElementBase } from '@stripe/stripe-js';
 import type { Dispatch, SetStateAction } from 'react';
-import { sans } from '../../../../styles/fonts';
+import { sans } from '@/client/styles/fonts';
 import { FieldWrapper } from '../FieldWrapper';
 import { getLogos, PaymentMethod } from '../PaymentDetailUpdate';
 
@@ -80,22 +80,26 @@ export const FlexCardElement = (props: FlexCardElementProps) => (
 				`}
 			>
 				<FieldWrapper width="50%" label="Expiry Date">
-					<CardExpiryElement
-						options={{
-							style: baseStyle,
-							placeholder: 'MM/YY',
-						}}
-						onReady={props.setCardExpiryElement}
-					/>
+					<span data-qm-masking="blocklist">
+						<CardExpiryElement
+							options={{
+								style: baseStyle,
+								placeholder: 'MM/YY',
+							}}
+							onReady={props.setCardExpiryElement}
+						/>
+					</span>
 				</FieldWrapper>
 				<FieldWrapper width="50%" label="CVC">
-					<CardCvcElement
-						options={{
-							style: baseStyle,
-							placeholder: '123',
-						}}
-						onReady={props.setCardCVCElement}
-					/>
+					<span data-qm-masking="blocklist">
+						<CardCvcElement
+							options={{
+								style: baseStyle,
+								placeholder: '123',
+							}}
+							onReady={props.setCardCVCElement}
+						/>
+					</span>
 				</FieldWrapper>
 			</div>
 		</div>

--- a/client/components/mma/paymentUpdate/card/FlexCardElement.tsx
+++ b/client/components/mma/paymentUpdate/card/FlexCardElement.tsx
@@ -59,13 +59,15 @@ export const FlexCardElement = (props: FlexCardElementProps) => (
 				label="Card Number"
 				cornerHint={numberCornerHint()}
 			>
-				<CardNumberElement
-					options={{
-						style: baseStyle,
-						placeholder: '•••• •••• •••• ••••',
-					}}
-					onReady={props.setCardNumberElement}
-				/>
+				<span data-qm-masking="blocklist">
+					<CardNumberElement
+						options={{
+							style: baseStyle,
+							placeholder: '•••• •••• •••• ••••',
+						}}
+						onReady={props.setCardNumberElement}
+					/>
+				</span>
 			</FieldWrapper>
 			<div
 				css={css`

--- a/client/components/mma/paymentUpdate/card/FlexCardElement.tsx
+++ b/client/components/mma/paymentUpdate/card/FlexCardElement.tsx
@@ -7,7 +7,7 @@ import {
 } from '@stripe/react-stripe-js';
 import type { StripeElementBase } from '@stripe/stripe-js';
 import type { Dispatch, SetStateAction } from 'react';
-import { sans } from '@/client/styles/fonts';
+import { sans } from '../../../../styles/fonts';
 import { FieldWrapper } from '../FieldWrapper';
 import { getLogos, PaymentMethod } from '../PaymentDetailUpdate';
 

--- a/client/components/mma/paymentUpdate/dd/DirectDebitInputForm.tsx
+++ b/client/components/mma/paymentUpdate/dd/DirectDebitInputForm.tsx
@@ -8,8 +8,8 @@ import {
 import { ErrorSummary } from '@guardian/source-react-components-development-kitchen';
 import { useState } from 'react';
 import type * as React from 'react';
-import { sans } from '../../../../styles/fonts';
-import { processResponse } from '../../../../utilities/utils';
+import { sans } from '@/client/styles/fonts';
+import { processResponse } from '@/client/utilities/utils';
 import { cleanSortCode } from '../../shared/DirectDebitDisplay';
 import { FieldWrapper } from '../FieldWrapper';
 import type { NewPaymentMethodDetail } from '../NewPaymentMethodDetail';
@@ -147,6 +147,7 @@ export const DirectDebitInputForm = (props: DirectDebitUpdateFormProps) => {
 				}
 			>
 				<input
+					data-qm-masking="blocklist"
 					type="text"
 					css={inputBoxBaseStyle}
 					placeholder="First Name Surname"
@@ -174,6 +175,7 @@ export const DirectDebitInputForm = (props: DirectDebitUpdateFormProps) => {
 					}
 				>
 					<input
+						data-qm-masking="blocklist"
 						type="text"
 						pattern="[0-9]{2}[\-\s]?[0-9]{2}[\-\s]?[0-9]{2}"
 						title="Sort Code must contain 6 numbers (optionally separated by a - or space)"
@@ -191,6 +193,7 @@ export const DirectDebitInputForm = (props: DirectDebitUpdateFormProps) => {
 					}
 				>
 					<input
+						data-qm-masking="blocklist"
 						type="text"
 						pattern="[0-9]{7,}"
 						css={{ ...bulletsStyling, ...inputBoxBaseStyle }}

--- a/client/components/mma/paymentUpdate/dd/DirectDebitInputForm.tsx
+++ b/client/components/mma/paymentUpdate/dd/DirectDebitInputForm.tsx
@@ -8,8 +8,8 @@ import {
 import { ErrorSummary } from '@guardian/source-react-components-development-kitchen';
 import { useState } from 'react';
 import type * as React from 'react';
-import { sans } from '@/client/styles/fonts';
-import { processResponse } from '@/client/utilities/utils';
+import { sans } from '../../../../styles/fonts';
+import { processResponse } from '../../../../utilities/utils';
 import { cleanSortCode } from '../../shared/DirectDebitDisplay';
 import { FieldWrapper } from '../FieldWrapper';
 import type { NewPaymentMethodDetail } from '../NewPaymentMethodDetail';

--- a/client/components/mma/shared/ProductDescriptionListTable.tsx
+++ b/client/components/mma/shared/ProductDescriptionListTable.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import {
 	from,
 	headline,
-	neutral,
+	palette,
 	space,
 	textSans,
 	until,
@@ -59,7 +59,7 @@ export const ProductDescriptionListTable = (
 		${headline.xxsmall({ fontWeight: 'bold' })};
 		margin: 0;
 		padding: ${space[3]}px ${space[5]}px;
-		background-color: ${neutral[97]};
+		background-color: ${palette.neutral[97]};
 		${until.tablet} {
 			font-size: 1.0625rem;
 			line-height: 1.6;
@@ -121,7 +121,7 @@ export const ProductDescriptionListTable = (
 		<div
 			css={css`
 				${textSans.medium()};
-				border: 1px solid ${props.borderColour || neutral[20]};
+				border: 1px solid ${props.borderColour || palette.neutral[20]};
 				display: flex;
 				flex-wrap: wrap;
 				margin: ${space[5]}px 0;
@@ -161,17 +161,19 @@ export const ProductDescriptionListTable = (
 							margin: 0;
 							background-color: ${showAlternativeTableRowBgColours &&
 							currentRow % 2 === (props.tableHeading ? 1 : 0)
-								? neutral[97]
+								? palette.neutral[97]
 								: 'transparent'};
 							border-bottom: ${!isLastTableRow && !isFirstCollum
 									? `1px solid ${
-											props.borderColour || neutral[20]
+											props.borderColour ||
+											palette.neutral[20]
 									  };`
 									: 'none;'}
 								${from.tablet} {
 								border-bottom: ${!isLastTableRow
 									? `1px solid ${
-											props.borderColour || neutral[20]
+											props.borderColour ||
+											palette.neutral[20]
 									  }`
 									: 'none'};
 								width: ${tableEntry.spanTwoCols ||

--- a/client/components/mma/shared/ProductDescriptionListTable.tsx
+++ b/client/components/mma/shared/ProductDescriptionListTable.tsx
@@ -200,7 +200,10 @@ export const ProductDescriptionListTable = (
 						<dt css={tableEntryTitleCss(!!tableEntry.spanTwoCols)}>
 							{tableEntry.title}
 						</dt>
-						<dd css={tableValueCss(!!tableEntry.spanTwoCols)}>
+						<dd
+							css={tableValueCss(!!tableEntry.spanTwoCols)}
+							data-qm-masking="blocklist"
+						>
 							{tableEntry.value}
 						</dd>
 					</dl>

--- a/client/components/shared/Input.tsx
+++ b/client/components/shared/Input.tsx
@@ -1,11 +1,6 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import {
-	error,
-	focusHalo,
-	neutral,
-	textSans,
-} from '@guardian/source-foundations';
+import { focusHalo, palette, textSans } from '@guardian/source-foundations';
 import { useEffect, useRef } from 'react';
 import type * as React from 'react';
 import { ErrorIcon } from '../mma/shared/assets/ErrorIcon';
@@ -45,7 +40,7 @@ export const Input = (props: InputProps) => {
 		<label
 			css={css`
 				display: block;
-				color: ${neutral['7']};
+				color: ${palette.neutral['7']};
 				${textSans.medium()};
 				font-weight: bold;
 				${props.additionalCss}
@@ -58,7 +53,7 @@ export const Input = (props: InputProps) => {
 					css={css`
 						font-style: italic;
 						font-weight: normal;
-						color: ${neutral['46']};
+						color: ${palette.neutral['46']};
 					`}
 				>
 					{' '}
@@ -70,7 +65,7 @@ export const Input = (props: InputProps) => {
 					css={css`
 						display: block;
 						font-weight: normal;
-						color: ${neutral['46']};
+						color: ${palette.neutral['46']};
 						max-width: ${props.width}ch;
 					`}
 				>
@@ -82,7 +77,7 @@ export const Input = (props: InputProps) => {
 					css={css`
 						display: block;
 						font-weight: normal;
-						color: ${error[400]};
+						color: ${palette.error[400]};
 					`}
 				>
 					<ErrorIcon
@@ -134,12 +129,14 @@ export const Input = (props: InputProps) => {
 						max-width: ${props.width}ch;
 						height: 44px;
 						${textSans.medium()}
-						color: ${neutral['7']};
+						color: ${palette.neutral['7']};
 						margin-top: 4px;
 						padding: 0 8px;
-						background-color: ${neutral['100']};
+						background-color: ${palette.neutral['100']};
 						border: ${props.inErrorState ? 4 : 2}px solid
-							${props.inErrorState ? error[400] : neutral['60']};
+							${props.inErrorState
+								? palette.error[400]
+								: palette.neutral['60']};
 						${props.prefixValue &&
 						`
             margin-left: calc(-${props.prefixValue.length}ch + 4px);

--- a/client/components/shared/Input.tsx
+++ b/client/components/shared/Input.tsx
@@ -50,6 +50,7 @@ export const Input = (props: InputProps) => {
 				font-weight: bold;
 				${props.additionalCss}
 			`}
+			data-qm-masking="blocklist"
 		>
 			{props.label}
 			{props.optional && (


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This adds the QM masking tag `data-qm-masking="blocklist"` to fields within MMA which contain PII. We are doing this so when sessions are captured at QM any PII is masked and therefore not captured by the recorded sessions.

This PR also includes some tidy up to imports by shortening the paths and upgrading any deprecated imports to use the correct ones.
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Check screens on Storybook or local/CODE and any areas of PII should have the masked tag visible in the inspector
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
PII may be exposed and captured on QM, however this will be tested on CODE by QM to ensure that all areas are covered.
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
