### PR TITLE
Fix Holiday Stops Amend

### DIFF
--- a/client/components/mma/holiday/HolidayReview.tsx
+++ b/client/components/mma/holiday/HolidayReview.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { space, until } from '@guardian/source-foundations';
 import { Button, InlineError } from '@guardian/source-react-components';
 import { useContext, useState } from 'react';
-import { Link, Navigate, useLocation, useNavigate } from 'react-router-dom';
+import { Link, Navigate, useLocation } from 'react-router-dom';
 import type { DateRange } from '../../../../shared/dates';
 import { DATE_FNS_INPUT_FORMAT, dateString } from '../../../../shared/dates';
 import type { ProductDetail } from '../../../../shared/productResponse';
@@ -95,10 +95,8 @@ export const HolidayReview = () => {
 		publicationsImpacted,
 		holidayStopResponse,
 		existingHolidayStopToAmend,
-		setExistingHolidayStopToAmend,
 	} = useContext(HolidayStopsContext) as HolidayStopsContextInterface;
 
-	const navigate = useNavigate();
 	const location = useLocation();
 	const routerState = location.state as HolidayStopsRouterState;
 
@@ -217,7 +215,7 @@ export const HolidayReview = () => {
 						css={[
 							buttonBarCss,
 							{
-								justifyContent: 'space-between',
+								justifyContent: 'flex-end',
 								marginTop: '20px',
 								[until.mobileMedium]: {
 									flexDirection: 'column',
@@ -227,36 +225,10 @@ export const HolidayReview = () => {
 						]}
 					>
 						<div
-							css={{
-								marginTop: '20px',
-								alignSelf: 'flex-start',
-							}}
-						>
-							<Button
-								onClick={() => {
-									setExistingHolidayStopToAmend({
-										dateRange: selectedRange,
-										publicationsImpacted,
-										mutabilityFlags: {
-											isEndDateEditable: true,
-											isFullyMutable: true,
-										},
-									});
-									navigate('../amend', {
-										state: routerState,
-									});
-								}}
-								priority="secondary"
-							>
-								Amend
-							</Button>
-						</div>
-						<div
 							css={[
 								buttonBarCss,
 								{
 									marginTop: '20px',
-									alignSelf: 'flex-end',
 								},
 							]}
 						>

--- a/client/components/mma/holiday/HolidayReview.tsx
+++ b/client/components/mma/holiday/HolidayReview.tsx
@@ -21,9 +21,9 @@ import {
 } from './HolidayQuestionsModal';
 import type {
 	CreateOrAmendHolidayStopsResponse,
+	GetHolidayStopsResponse,
 	HolidayStopDetail,
 	HolidayStopRequest,
-	ReloadableGetHolidayStopsResponse,
 } from './HolidayStopApi';
 import {
 	CreateOrAmendHolidayStopsAsyncLoader,
@@ -42,7 +42,7 @@ const getPerformCreateOrAmendFetcher =
 		selectedRange: DateRange,
 		subscriptionName: string,
 		isTestUser: boolean,
-		existingHolidayStopToAmend?: HolidayStopRequest,
+		existingHolidayStopToAmend: HolidayStopRequest | null,
 	) =>
 	() =>
 		fetchWithDefaultParameters(
@@ -94,6 +94,7 @@ export const HolidayReview = () => {
 		selectedRange,
 		publicationsImpacted,
 		holidayStopResponse,
+		existingHolidayStopToAmend,
 		setExistingHolidayStopToAmend,
 	} = useContext(HolidayStopsContext) as HolidayStopsContextInterface;
 
@@ -102,7 +103,7 @@ export const HolidayReview = () => {
 	const routerState = location.state as HolidayStopsRouterState;
 
 	const buildActualRenderer = (
-		holidayStopsResponse: ReloadableGetHolidayStopsResponse,
+		holidayStopsResponse: GetHolidayStopsResponse,
 		productDetail: ProductDetail,
 		selectedRange: DateRange,
 		publicationsImpacted: HolidayStopDetail[],
@@ -189,7 +190,7 @@ export const HolidayReview = () => {
 								selectedRange,
 								productDetail.subscription.subscriptionId,
 								productDetail.isTestUser,
-								holidayStopsResponse.existingHolidayStopToAmend,
+								existingHolidayStopToAmend,
 							)}
 							render={(_: CreateOrAmendHolidayStopsResponse) => (
 								<Navigate
@@ -198,12 +199,12 @@ export const HolidayReview = () => {
 								/>
 							)}
 							errorRender={getRenderCreateOrAmendError(
-								holidayStopsResponse.existingHolidayStopToAmend
+								existingHolidayStopToAmend
 									? 'amending'
 									: 'creating',
 							)}
 							loadingMessage={`${
-								holidayStopsResponse.existingHolidayStopToAmend
+								existingHolidayStopToAmend
 									? 'Amending'
 									: 'Creating'
 							} your suspension...`}

--- a/client/components/mma/holiday/HolidayStopApi.ts
+++ b/client/components/mma/holiday/HolidayStopApi.ts
@@ -81,11 +81,6 @@ export interface GetHolidayStopsResponse {
 	existing: HolidayStopRequest[];
 }
 
-export interface ReloadableGetHolidayStopsResponse
-	extends GetHolidayStopsResponse {
-	existingHolidayStopToAmend?: HolidayStopRequest;
-}
-
 interface RawGetHolidayStopsResponse {
 	issueSpecifics: Array<{
 		issueDayOfWeek: number;
@@ -134,8 +129,8 @@ export interface CreateOrAmendHolidayStopsResponse {
 export class CreateOrAmendHolidayStopsAsyncLoader extends AsyncLoader<CreateOrAmendHolidayStopsResponse> {}
 
 export function isHolidayStopsResponse(
-	data: ReloadableGetHolidayStopsResponse | {} | undefined,
-): data is ReloadableGetHolidayStopsResponse {
+	data: GetHolidayStopsResponse | {} | undefined,
+): data is GetHolidayStopsResponse {
 	return !!data && data.hasOwnProperty('existing');
 }
 

--- a/cypress/e2e/parallel-3/holidayStops.cy.ts
+++ b/cypress/e2e/parallel-3/holidayStops.cy.ts
@@ -78,45 +78,6 @@ describe('Holiday stops', () => {
 		cy.get('@create_holiday_stop.all').should('have.length', 1);
 	});
 
-	it('can amend a non-confirmed holiday stop', () => {
-		cy.visit('/suspend/guardianweekly');
-		cy.wait('@fetch_existing_holidays');
-		cy.wait('@product_detail');
-		cy.get('[data-cy="create-suspension-cta"] button').click();
-
-		// Selects 09/02/2022 - 11/02/2022
-		cy.get('[data-cy="date-picker"] div').eq(9).click();
-		cy.get('[data-cy="date-picker"] div').eq(11).click();
-		cy.wait('@fetch_potential_holidays');
-		cy.findByText('Review details').click();
-
-		cy.findByText('Amend').click();
-
-		cy.findByText('Choose the dates you will be away').should('exist');
-		cy.findByText('Please select your new dates...').should('exist');
-		cy.get('[aria-label="day"]').eq(0).should('have.value', '9');
-		cy.get('[aria-label="month"]').eq(0).should('have.value', '2');
-		cy.get('[aria-label="year"]').eq(0).should('have.value', '2022');
-		cy.get('[aria-label="day"]').eq(1).should('have.value', '11');
-		cy.get('[aria-label="month"]').eq(1).should('have.value', '2');
-		cy.get('[aria-label="year"]').eq(1).should('have.value', '2022');
-
-		cy.get('[data-cy="date-picker"] div').eq(16).click();
-		cy.get('[data-cy="date-picker"] div').eq(18).click();
-		cy.wait('@fetch_potential_holidays');
-
-		// Selects 16/02/2022 - 18/02/2022
-		cy.get('[aria-label="day"]').eq(0).should('have.value', '16');
-		cy.get('[aria-label="day"]').eq(1).should('have.value', '18');
-
-		// Total issues suspended
-		cy.get('[data-cy="suspension-issue-count"]').eq(0).contains('1 issue');
-
-		cy.get('@fetch_existing_holidays.all').should('have.length', 1);
-		cy.get('@product_detail.all').should('have.length', 1);
-		cy.get('@fetch_potential_holidays.all').should('have.length', 2);
-	});
-
 	it('can not create a holiday stop for date range when there are no deliveries', () => {
 		cy.intercept('GET', '/api/holidays/*/potential?*', {
 			statusCode: 200,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Fix amending an existing holiday stop - this was not checking the correct value and therefore calling the api with a `POST` instead of a `PATCH` request. 

Fix a secondary bug when amending a non-confirmed holiday stop. The wrong dates were being set when this button was clicked, which made the holiday stop to amend appear as an existing suspension. (See image below.) This PR removes the second Amend button.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

With a newspaper delivery product, click Manage suspensions, click "Amend", pick dates, click "Confirm", see loading message "Amending...", do not see error.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Before
![image](https://github.com/guardian/manage-frontend/assets/114918544/ceb29fa7-d1bb-457e-a423-e2d33e113273)
Bug after pressing "Amend" on review page, the existing suspension should not appear as that is what is being amended
![image](https://github.com/guardian/manage-frontend/assets/114918544/7af54234-1abd-4c46-ac9f-b66944d459b6)

After
<img width="853" alt="image" src="https://github.com/guardian/manage-frontend/assets/114918544/4f5e9375-0e9c-4d0e-97cb-72d444240bc1">

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
