### PR TITLE
Block address update for national delivery

### DIFF
--- a/client/components/mma/delivery/address/DeliveryAddressForm.tsx
+++ b/client/components/mma/delivery/address/DeliveryAddressForm.tsx
@@ -107,6 +107,8 @@ const Form = (props: FormProps) => {
 			return `${friendlyProductName}`;
 		});
 
+	console.log(subscriptionsNames);
+
 	const handleFormSubmit = (e: FormEvent) => {
 		e.preventDefault();
 
@@ -137,106 +139,334 @@ const Form = (props: FormProps) => {
 		}
 	};
 
+	const hasNationalDelivery = Object.values(
+		contactIdToArrayOfProductDetailAndProductType,
+	)
+		.flatMap(flattenEquivalent)
+		.map(({ productDetail }) => {
+			const hasProducts = GROUPED_PRODUCT_TYPES.subscriptions
+				.mapGroupedToSpecific(productDetail)
+				.productType.includes('national delivery');
+			return `${hasProducts}`;
+		});
+
 	return (
 		<>
-			<form action="#" onSubmit={handleFormSubmit}>
-				<fieldset
-					css={{
-						border: `1px solid ${neutral['86']}`,
-						padding: '48px 14px 14px',
-						position: 'relative',
-						marginBottom: `${space[5]}px`,
-						label: {
-							marginTop: `${space[3]}px`,
-						},
-					}}
-				>
-					<legend
-						css={css`
-							width: 100%;
-							position: absolute;
-							top: 0;
-							left: 0;
-							padding: 0 14px;
-							${textSans.medium()};
-							font-weight: bold;
-							line-height: 48px;
-							background-color: ${neutral['97']};
-							border-bottom: 1px solid ${neutral['86']};
-						`}
-					>
-						Delivery address
-						{props.productType.delivery
-							?.enableDeliveryInstructionsUpdate &&
-							' and instructions'}
-					</legend>
-					<Input
-						label={'Address line 1'}
-						width={30}
-						value={addressStateObject.addressLine1}
-						changeSetState={addressSetStateObject.setAddressLine1}
-						inErrorState={
-							props.formStatus === formStates.VALIDATION_ERROR &&
-							!props.formErrors.addressLine1?.isValid
-						}
-						errorMessage={props.formErrors.addressLine1?.message}
-					/>
-					<Input
-						label="Address line 2"
-						width={30}
-						value={addressStateObject.addressLine2 || ''}
-						changeSetState={addressSetStateObject.setAddressLine2}
-						optional={true}
-					/>
-					<Input
-						label="Town or City"
-						width={30}
-						value={addressStateObject.town || ''}
-						changeSetState={addressSetStateObject.setTown}
-						inErrorState={
-							props.formStatus === formStates.VALIDATION_ERROR &&
-							!props.formErrors.town?.isValid
-						}
-						errorMessage={props.formErrors.town?.message}
-					/>
-					<Input
-						label="County or State"
-						width={30}
-						value={addressStateObject.region || ''}
-						optional={true}
-						changeSetState={addressSetStateObject.setRegion}
-					/>
-					<Input
-						label="Postcode/Zipcode"
-						width={11}
-						value={addressStateObject.postcode}
-						changeSetState={addressSetStateObject.setPostcode}
-						inErrorState={
-							props.formStatus === formStates.VALIDATION_ERROR &&
-							!props.formErrors.postcode?.isValid
-						}
-						errorMessage={props.formErrors.postcode?.message}
-					/>
-					<Select
-						label={'Country'}
-						options={COUNTRIES.map((country) => {
-							return {
-								name: country.name,
-								value: country.name,
-							};
-						})}
-						width={30}
-						additionalCSS={css`
-							margin-top: 14px;
-						`}
-						value={addressStateObject.country}
-						changeSetState={addressSetStateObject.setCountry}
-						inErrorState={
-							props.formStatus === formStates.VALIDATION_ERROR &&
-							!props.formErrors.country?.isValid
-						}
-						errorMessage={props.formErrors.country?.message}
-					/>
+			{!hasNationalDelivery && (
+				<>
+					<form action="#" onSubmit={handleFormSubmit}>
+						<fieldset
+							css={{
+								border: `1px solid ${neutral['86']}`,
+								padding: '48px 14px 14px',
+								position: 'relative',
+								marginBottom: `${space[5]}px`,
+								label: {
+									marginTop: `${space[3]}px`,
+								},
+							}}
+						>
+							<legend
+								css={css`
+									width: 100%;
+									position: absolute;
+									top: 0;
+									left: 0;
+									padding: 0 14px;
+									${textSans.medium()};
+									font-weight: bold;
+									line-height: 48px;
+									background-color: ${neutral['97']};
+									border-bottom: 1px solid ${neutral['86']};
+								`}
+							>
+								Delivery address
+								{props.productType.delivery
+									?.enableDeliveryInstructionsUpdate &&
+									' and instructions'}
+							</legend>
+							<Input
+								label={'Address line 1'}
+								width={30}
+								value={addressStateObject.addressLine1}
+								changeSetState={
+									addressSetStateObject.setAddressLine1
+								}
+								inErrorState={
+									props.formStatus ===
+										formStates.VALIDATION_ERROR &&
+									!props.formErrors.addressLine1?.isValid
+								}
+								errorMessage={
+									props.formErrors.addressLine1?.message
+								}
+							/>
+							<Input
+								label="Address line 2"
+								width={30}
+								value={addressStateObject.addressLine2 || ''}
+								changeSetState={
+									addressSetStateObject.setAddressLine2
+								}
+								optional={true}
+							/>
+							<Input
+								label="Town or City"
+								width={30}
+								value={addressStateObject.town || ''}
+								changeSetState={addressSetStateObject.setTown}
+								inErrorState={
+									props.formStatus ===
+										formStates.VALIDATION_ERROR &&
+									!props.formErrors.town?.isValid
+								}
+								errorMessage={props.formErrors.town?.message}
+							/>
+							<Input
+								label="County or State"
+								width={30}
+								value={addressStateObject.region || ''}
+								optional={true}
+								changeSetState={addressSetStateObject.setRegion}
+							/>
+							<Input
+								label="Postcode/Zipcode"
+								width={11}
+								value={addressStateObject.postcode}
+								changeSetState={
+									addressSetStateObject.setPostcode
+								}
+								inErrorState={
+									props.formStatus ===
+										formStates.VALIDATION_ERROR &&
+									!props.formErrors.postcode?.isValid
+								}
+								errorMessage={
+									props.formErrors.postcode?.message
+								}
+							/>
+							<Select
+								label={'Country'}
+								options={COUNTRIES.map((country) => {
+									return {
+										name: country.name,
+										value: country.name,
+									};
+								})}
+								width={30}
+								additionalCSS={css`
+									margin-top: 14px;
+								`}
+								value={addressStateObject.country}
+								changeSetState={
+									addressSetStateObject.setCountry
+								}
+								inErrorState={
+									props.formStatus ===
+										formStates.VALIDATION_ERROR &&
+									!props.formErrors.country?.isValid
+								}
+								errorMessage={props.formErrors.country?.message}
+							/>
+							{props.productType.delivery
+								?.enableDeliveryInstructionsUpdate && (
+								<label
+									css={css`
+										display: block;
+										color: ${neutral['7']};
+										${textSans.medium()};
+										font-weight: bold;
+									`}
+								>
+									Instructions
+									<div>
+										<div
+											css={css`
+												display: inline-block;
+												vertical-align: top;
+												margin-top: 4px;
+												width: 100%;
+												max-width: 30ch;
+											`}
+										>
+											<textarea
+												id="delivery-instructions"
+												name="instructions"
+												rows={2}
+												maxLength={250}
+												value={
+													addressStateObject.instructions
+												}
+												onChange={(
+													e: ChangeEvent<HTMLTextAreaElement>,
+												) => {
+													addressSetStateObject.setInstructions(
+														e.target.value,
+													);
+													setInstructionsRemainingCharacters(
+														250 -
+															e.target.value
+																.length,
+													);
+												}}
+												css={css`
+													width: 100%;
+													border: 2px solid
+														${neutral['60']};
+													padding: 12px;
+													resize: vertical;
+													${textSans.medium()};
+												`}
+											/>
+											<span
+												css={css`
+													display: block;
+													text-align: right;
+													${textSans.small()};
+													color: ${neutral[46]};
+												`}
+											>
+												{
+													instructionsRemainingCharacters
+												}{' '}
+												characters remaining
+											</span>
+										</div>
+										<p
+											css={css`
+												display: block;
+												${textSans.medium()};
+												border: 4px solid ${brand[500]};
+												padding: ${space[5]}px
+													${space[5]}px ${space[5]}px
+													49px;
+												margin: ${space[3]}px 0;
+												position: relative;
+												${from.tablet} {
+													display: inline-block;
+													vertical-align: top;
+													margin: 2px 0 ${space[3]}px
+														${space[3]}px;
+													width: calc(
+														100% -
+															(
+																30ch +
+																	${space[3]}px +
+																	2px
+															)
+													);
+												}
+											`}
+										>
+											<i
+												css={css`
+													width: 17px;
+													height: 17px;
+													position: absolute;
+													top: ${space[5]}px;
+													left: ${space[5]}px;
+												`}
+											>
+												<InfoIconDark
+													fillColor={brand[500]}
+												/>
+											</i>
+											Delivery instructions are only
+											applicable for newspaper deliveries.
+											They do not apply to Guardian
+											Weekly.
+										</p>
+									</div>
+								</label>
+							)}
+						</fieldset>
+						<CheckboxGroup
+							name="instructions-checkbox"
+							error={
+								props.formStatus ===
+									formStates.VALIDATION_ERROR &&
+								!acknowledgementChecked
+									? 'Please indicate that you understand which subscriptions this change will affect.'
+									: undefined
+							}
+						>
+							<Checkbox
+								value="acknowledged"
+								label="I understand that this address change will affect the following subscriptions"
+								checked={acknowledgementChecked}
+								onChange={(
+									e: ChangeEvent<HTMLInputElement>,
+								) => {
+									setAcknowledgementState(e.target.checked);
+								}}
+							/>
+						</CheckboxGroup>
+						{props.warning && (
+							<ProductDescriptionListTable
+								content={props.warning}
+								seperateEachRow
+							/>
+						)}
+						<div
+							css={css`
+								margin-top: ${space[5]}px;
+								* {
+									display: inline-block;
+								}
+								${from.tablet} {
+									margin-top: ${space[6]}px;
+								}
+							`}
+						>
+							<Button type="submit">Review details</Button>
+							<Link
+								to={NAV_LINKS.accountOverview.link}
+								css={css`
+									${textSans.medium()};
+									font-weight: bold;
+									margin-left: 22px;
+									color: ${brand[400]};
+								`}
+							>
+								Cancel
+							</Link>
+						</div>
+					</form>
+
+					<Stack space={5}>
+						<p
+							css={css`
+								${textSans.medium()};
+								margin: ${space[12]}px 0 0;
+								color: ${neutral[46]};
+							`}
+						>
+							If you need separate delivery addresses for each of
+							your subscriptions, please{' '}
+							<span
+								css={css`
+									cursor: pointer;
+									color: ${brand[500]};
+									text-decoration: underline;
+								`}
+								onClick={() =>
+									setTopCallCentreNumbersVisibility(
+										!showTopCallCentreNumbers,
+									)
+								}
+							>
+								contact us
+							</span>
+							.
+						</p>
+						{showTopCallCentreNumbers && (
+							<CallCentreEmailAndNumbers />
+						)}
+					</Stack>
+				</>
+			)}
+			{hasNationalDelivery && (
+				<>
 					{props.productType.delivery
 						?.enableDeliveryInstructionsUpdate && (
 						<label
@@ -294,169 +524,58 @@ const Form = (props: FormProps) => {
 										characters remaining
 									</span>
 								</div>
-								<p
-									css={css`
-										display: block;
-										${textSans.medium()};
-										border: 4px solid ${brand[500]};
-										padding: ${space[5]}px ${space[5]}px
-											${space[5]}px 49px;
-										margin: ${space[3]}px 0;
-										position: relative;
-										${from.tablet} {
-											display: inline-block;
-											vertical-align: top;
-											margin: 2px 0 ${space[3]}px
-												${space[3]}px;
-											width: calc(
-												100% -
-													(30ch + ${space[3]}px + 2px)
-											);
-										}
-									`}
-								>
-									<i
-										css={css`
-											width: 17px;
-											height: 17px;
-											position: absolute;
-											top: ${space[5]}px;
-											left: ${space[5]}px;
-										`}
-									>
-										<InfoIconDark fillColor={brand[500]} />
-									</i>
-									Delivery instructions are only applicable
-									for newspaper deliveries. They do not apply
-									to Guardian Weekly.
-								</p>
 							</div>
 						</label>
 					)}
-				</fieldset>
-				<CheckboxGroup
-					name="instructions-checkbox"
-					error={
-						props.formStatus === formStates.VALIDATION_ERROR &&
-						!acknowledgementChecked
-							? 'Please indicate that you understand which subscriptions this change will affect.'
-							: undefined
-					}
-				>
-					<Checkbox
-						value="acknowledged"
-						label="I understand that this address change will affect the following subscriptions"
-						checked={acknowledgementChecked}
-						onChange={(e: ChangeEvent<HTMLInputElement>) => {
-							setAcknowledgementState(e.target.checked);
-						}}
-					/>
-				</CheckboxGroup>
-				{props.warning && (
-					<ProductDescriptionListTable
-						content={props.warning}
-						seperateEachRow
-					/>
-				)}
-				<div
-					css={css`
-						margin-top: ${space[5]}px;
-						* {
-							display: inline-block;
-						}
-						${from.tablet} {
-							margin-top: ${space[6]}px;
-						}
-					`}
-				>
-					<Button type="submit">Review details</Button>
-					<Link
-						to={NAV_LINKS.accountOverview.link}
+					<p
 						css={css`
+							display: block;
 							${textSans.medium()};
-							font-weight: bold;
-							margin-left: 22px;
-							color: ${brand[400]};
+							border: 4px solid ${brand[500]};
+							padding: ${space[5]}px ${space[5]}px ${space[5]}px
+								49px;
+							margin: ${space[3]}px 0;
+							position: relative;
+							${from.tablet} {
+								display: inline-block;
+								vertical-align: top;
+								margin: 2px 0 ${space[3]}px ${space[3]}px;
+								width: calc(
+									100% - (30ch + ${space[3]}px + 2px)
+								);
+							}
 						`}
 					>
-						Cancel
-					</Link>
-				</div>
-			</form>
-
-			<Stack space={5}>
-				<p
-					css={css`
-						${textSans.medium()};
-						margin: ${space[12]}px 0 0;
-						color: ${neutral[46]};
-					`}
-				>
-					If you need separate delivery addresses for each of your
-					subscriptions, please{' '}
-					<span
-						css={css`
-							cursor: pointer;
-							color: ${brand[500]};
-							text-decoration: underline;
-						`}
-						onClick={() =>
-							setTopCallCentreNumbersVisibility(
-								!showTopCallCentreNumbers,
-							)
-						}
-					>
-						contact us
-					</span>
-					.
-				</p>
-				{showTopCallCentreNumbers && <CallCentreEmailAndNumbers />}
-			</Stack>
-
-			<p
-				css={css`
-					display: block;
-					${textSans.medium()};
-					border: 4px solid ${brand[500]};
-					padding: ${space[5]}px ${space[5]}px ${space[5]}px 49px;
-					margin: ${space[3]}px 0;
-					position: relative;
-					${from.tablet} {
-						display: inline-block;
-						vertical-align: top;
-						margin: 2px 0 ${space[3]}px ${space[3]}px;
-						width: calc(100% - (30ch + ${space[3]}px + 2px));
-					}
-				`}
-			>
-				<i
-					css={css`
-						width: 17px;
-						height: 17px;
-						position: absolute;
-						top: ${space[5]}px;
-						left: ${space[5]}px;
-					`}
-				>
-					<InfoIconDark fillColor={brand[500]} />
-				</i>
-				Changed address? Please{' '}
-				<span
-					css={css`
-						cursor: pointer;
-						color: ${brand[500]};
-						text-decoration: underline;
-					`}
-					onClick={() =>
-						setTopCallCentreNumbersVisibility(
-							!showTopCallCentreNumbers,
-						)
-					}
-				>
-					call our customer support team
-				</span>
-				to update your delivery details.
-			</p>
+						<i
+							css={css`
+								width: 17px;
+								height: 17px;
+								position: absolute;
+								top: ${space[5]}px;
+								left: ${space[5]}px;
+							`}
+						>
+							<InfoIconDark fillColor={brand[500]} />
+						</i>
+						Changed address? Please{' '}
+						<span
+							css={css`
+								cursor: pointer;
+								color: ${brand[500]};
+								text-decoration: underline;
+							`}
+							onClick={() =>
+								setTopCallCentreNumbersVisibility(
+									!showTopCallCentreNumbers,
+								)
+							}
+						>
+							call our customer support team
+						</span>
+						to update your delivery details.
+					</p>
+				</>
+			)}
 		</>
 	);
 };

--- a/client/components/mma/delivery/address/DeliveryAddressForm.tsx
+++ b/client/components/mma/delivery/address/DeliveryAddressForm.tsx
@@ -4,6 +4,7 @@ import {
 	from,
 	headline,
 	neutral,
+	palette,
 	space,
 	textSans,
 	until,
@@ -106,8 +107,6 @@ const Form = (props: FormProps) => {
 				.friendlyName();
 			return `${friendlyProductName}`;
 		});
-
-	console.log(subscriptionsNames);
 
 	const handleFormSubmit = (e: FormEvent) => {
 		e.preventDefault();
@@ -467,79 +466,18 @@ const Form = (props: FormProps) => {
 			)}
 			{hasNationalDelivery && (
 				<>
-					{props.productType.delivery
-						?.enableDeliveryInstructionsUpdate && (
-						<label
-							css={css`
-								display: block;
-								color: ${neutral['7']};
-								${textSans.medium()};
-								font-weight: bold;
-							`}
-						>
-							Instructions
-							<div>
-								<div
-									css={css`
-										display: inline-block;
-										vertical-align: top;
-										margin-top: 4px;
-										width: 100%;
-										max-width: 30ch;
-									`}
-								>
-									<textarea
-										id="delivery-instructions"
-										name="instructions"
-										rows={2}
-										maxLength={250}
-										value={addressStateObject.instructions}
-										onChange={(
-											e: ChangeEvent<HTMLTextAreaElement>,
-										) => {
-											addressSetStateObject.setInstructions(
-												e.target.value,
-											);
-											setInstructionsRemainingCharacters(
-												250 - e.target.value.length,
-											);
-										}}
-										css={css`
-											width: 100%;
-											border: 2px solid ${neutral['60']};
-											padding: 12px;
-											resize: vertical;
-											${textSans.medium()};
-										`}
-									/>
-									<span
-										css={css`
-											display: block;
-											text-align: right;
-											${textSans.small()};
-											color: ${neutral[46]};
-										`}
-									>
-										{instructionsRemainingCharacters}{' '}
-										characters remaining
-									</span>
-								</div>
-							</div>
-						</label>
-					)}
 					<p
 						css={css`
 							display: block;
 							${textSans.medium()};
-							border: 4px solid ${brand[500]};
+							border: 4px solid ${palette.brand['500']};
 							padding: ${space[5]}px ${space[5]}px ${space[5]}px
 								49px;
-							margin: ${space[3]}px 0;
+							margin-top: 12px;
 							position: relative;
 							${from.tablet} {
 								display: inline-block;
 								vertical-align: top;
-								margin: 2px 0 ${space[3]}px ${space[3]}px;
 								width: calc(
 									100% - (30ch + ${space[3]}px + 2px)
 								);
@@ -574,6 +512,7 @@ const Form = (props: FormProps) => {
 						</span>
 						to update your delivery details.
 					</p>
+					{showTopCallCentreNumbers && <CallCentreEmailAndNumbers />}
 				</>
 			)}
 		</>
@@ -597,18 +536,31 @@ export const DeliveryAddressUpdate = (props: WithProductType<ProductType>) => {
 		};
 	`;
 
+	const hasNationalDelivery = Object.values(
+		contactIdToArrayOfProductDetailAndProductType,
+	)
+		.flatMap(flattenEquivalent)
+		.map(({ productDetail }) => {
+			const hasProducts = GROUPED_PRODUCT_TYPES.subscriptions
+				.mapGroupedToSpecific(productDetail)
+				.productType.includes('national delivery');
+			return `${hasProducts}`;
+		});
+
 	return (
 		<>
-			<ProgressIndicator
-				steps={[
-					{ title: 'Update', isCurrentStep: true },
-					{ title: 'Review' },
-					{ title: 'Confirmation' },
-				]}
-				additionalCSS={css`
-					margin-top: ${space[5]}px;
-				`}
-			/>
+			{!hasNationalDelivery && (
+				<ProgressIndicator
+					steps={[
+						{ title: 'Update', isCurrentStep: true },
+						{ title: 'Review' },
+						{ title: 'Confirmation' },
+					]}
+					additionalCSS={css`
+						margin-top: ${space[5]}px;
+					`}
+				/>
+			)}
 			<h2
 				css={css`
 					${subHeadingCss}

--- a/client/components/mma/delivery/address/DeliveryAddressForm.tsx
+++ b/client/components/mma/delivery/address/DeliveryAddressForm.tsx
@@ -1,9 +1,7 @@
 import { css } from '@emotion/react';
 import {
-	brand,
 	from,
 	headline,
-	neutral,
 	palette,
 	space,
 	textSans,
@@ -18,14 +16,11 @@ import {
 import type { ChangeEvent, Dispatch, FormEvent, SetStateAction } from 'react';
 import { useContext, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import type { DeliveryAddress } from '../../../../../shared/productResponse';
-import type {
-	ProductType,
-	WithProductType,
-} from '../../../../../shared/productTypes';
-import { GROUPED_PRODUCT_TYPES } from '../../../../../shared/productTypes';
-import { addressChangeAffectedInfo } from '../../../../utilities/deliveryAddress';
-import { flattenEquivalent } from '../../../../utilities/utils';
+import { addressChangeAffectedInfo } from '@/client/utilities/deliveryAddress';
+import { flattenEquivalent } from '@/client/utilities/utils';
+import type { DeliveryAddress } from '@/shared/productResponse';
+import type { ProductType, WithProductType } from '@/shared/productTypes';
+import { GROUPED_PRODUCT_TYPES } from '@/shared/productTypes';
 import { CallCentreEmailAndNumbers } from '../../../shared/CallCenterEmailAndNumbers';
 import { CallCentreNumbers } from '../../../shared/CallCentreNumbers';
 import { Input } from '../../../shared/Input';
@@ -156,7 +151,7 @@ const Form = (props: FormProps) => {
 					<form action="#" onSubmit={handleFormSubmit}>
 						<fieldset
 							css={{
-								border: `1px solid ${neutral['86']}`,
+								border: `1px solid ${palette.neutral['86']}`,
 								padding: '48px 14px 14px',
 								position: 'relative',
 								marginBottom: `${space[5]}px`,
@@ -175,8 +170,9 @@ const Form = (props: FormProps) => {
 									${textSans.medium()};
 									font-weight: bold;
 									line-height: 48px;
-									background-color: ${neutral['97']};
-									border-bottom: 1px solid ${neutral['86']};
+									background-color: ${palette.neutral['97']};
+									border-bottom: 1px solid
+										${palette.neutral['86']};
 								`}
 							>
 								Delivery address
@@ -272,7 +268,7 @@ const Form = (props: FormProps) => {
 								<label
 									css={css`
 										display: block;
-										color: ${neutral['7']};
+										color: ${palette.neutral['7']};
 										${textSans.medium()};
 										font-weight: bold;
 									`}
@@ -311,7 +307,7 @@ const Form = (props: FormProps) => {
 												css={css`
 													width: 100%;
 													border: 2px solid
-														${neutral['60']};
+														${palette.neutral['60']};
 													padding: 12px;
 													resize: vertical;
 													${textSans.medium()};
@@ -322,7 +318,8 @@ const Form = (props: FormProps) => {
 													display: block;
 													text-align: right;
 													${textSans.small()};
-													color: ${neutral[46]};
+													color: ${palette
+														.neutral[46]};
 												`}
 											>
 												{
@@ -335,7 +332,8 @@ const Form = (props: FormProps) => {
 											css={css`
 												display: block;
 												${textSans.medium()};
-												border: 4px solid ${brand[500]};
+												border: 4px solid
+													${palette.brand[500]};
 												padding: ${space[5]}px
 													${space[5]}px ${space[5]}px
 													49px;
@@ -367,7 +365,9 @@ const Form = (props: FormProps) => {
 												`}
 											>
 												<InfoIconDark
-													fillColor={brand[500]}
+													fillColor={
+														palette.brand[500]
+													}
 												/>
 											</i>
 											Delivery instructions are only
@@ -424,7 +424,7 @@ const Form = (props: FormProps) => {
 									${textSans.medium()};
 									font-weight: bold;
 									margin-left: 22px;
-									color: ${brand[400]};
+									color: ${palette.brand[400]};
 								`}
 							>
 								Cancel
@@ -437,7 +437,7 @@ const Form = (props: FormProps) => {
 							css={css`
 								${textSans.medium()};
 								margin: ${space[12]}px 0 0;
-								color: ${neutral[46]};
+								color: ${palette.neutral[46]};
 							`}
 						>
 							If you need separate delivery addresses for each of
@@ -445,7 +445,7 @@ const Form = (props: FormProps) => {
 							<span
 								css={css`
 									cursor: pointer;
-									color: ${brand[500]};
+									color: ${palette.brand[500]};
 									text-decoration: underline;
 								`}
 								onClick={() =>
@@ -493,13 +493,13 @@ const Form = (props: FormProps) => {
 								left: ${space[5]}px;
 							`}
 						>
-							<InfoIconDark fillColor={brand[500]} />
+							<InfoIconDark fillColor={palette.brand[500]} />
 						</i>
 						Changed address? Please{' '}
 						<span
 							css={css`
 								cursor: pointer;
-								color: ${brand[500]};
+								color: ${palette.brand[500]};
 								text-decoration: underline;
 							`}
 							onClick={() =>
@@ -526,7 +526,7 @@ export const DeliveryAddressUpdate = (props: WithProductType<ProductType>) => {
 		useContext(ContactIdContext);
 
 	const subHeadingCss = `
-		border-top: 1px solid ${neutral['86']};
+		border-top: 1px solid ${palette.neutral['86']};
 		${headline.small()};
 		font-weight: bold;
 		margin-top: 50px;

--- a/client/components/mma/delivery/address/DeliveryAddressForm.tsx
+++ b/client/components/mma/delivery/address/DeliveryAddressForm.tsx
@@ -412,6 +412,51 @@ const Form = (props: FormProps) => {
 				</p>
 				{showTopCallCentreNumbers && <CallCentreEmailAndNumbers />}
 			</Stack>
+
+			<p
+				css={css`
+					display: block;
+					${textSans.medium()};
+					border: 4px solid ${brand[500]};
+					padding: ${space[5]}px ${space[5]}px ${space[5]}px 49px;
+					margin: ${space[3]}px 0;
+					position: relative;
+					${from.tablet} {
+						display: inline-block;
+						vertical-align: top;
+						margin: 2px 0 ${space[3]}px ${space[3]}px;
+						width: calc(100% - (30ch + ${space[3]}px + 2px));
+					}
+				`}
+			>
+				<i
+					css={css`
+						width: 17px;
+						height: 17px;
+						position: absolute;
+						top: ${space[5]}px;
+						left: ${space[5]}px;
+					`}
+				>
+					<InfoIconDark fillColor={brand[500]} />
+				</i>
+				Changed address? Please{' '}
+				<span
+					css={css`
+						cursor: pointer;
+						color: ${brand[500]};
+						text-decoration: underline;
+					`}
+					onClick={() =>
+						setTopCallCentreNumbersVisibility(
+							!showTopCallCentreNumbers,
+						)
+					}
+				>
+					call our customer support team
+				</span>
+				to update your delivery details.
+			</p>
 		</>
 	);
 };

--- a/client/components/mma/delivery/address/DeliveryAddressForm.tsx
+++ b/client/components/mma/delivery/address/DeliveryAddressForm.tsx
@@ -487,7 +487,7 @@ export const DeliveryAddressUpdate = (props: WithProductType<ProductType>) => {
 						}
 					>
 						call our customer support team
-					</span>
+					</span>{' '}
 					to update your delivery details.
 				</p>
 				{showTopCallCentreNumbers && <CallCentreEmailAndNumbers />}

--- a/client/components/mma/delivery/address/DeliveryAddressForm.tsx
+++ b/client/components/mma/delivery/address/DeliveryAddressForm.tsx
@@ -439,15 +439,10 @@ export const DeliveryAddressUpdate = (props: WithProductType<ProductType>) => {
 	)
 		.flatMap(flattenEquivalent)
 		.some(({ productDetail }) => {
-			console.log(productDetail);
 			return GROUPED_PRODUCT_TYPES.subscriptions
 				.mapGroupedToSpecific(productDetail)
 				.productType.includes('nationaldelivery');
 		});
-
-	console.log(contactIdToArrayOfProductDetailAndProductType);
-
-	console.log(hasNationalDelivery);
 
 	if (hasNationalDelivery) {
 		return (

--- a/client/components/mma/delivery/address/DeliveryAddressForm.tsx
+++ b/client/components/mma/delivery/address/DeliveryAddressForm.tsx
@@ -441,7 +441,7 @@ export const DeliveryAddressUpdate = (props: WithProductType<ProductType>) => {
 		.some(({ productDetail }) => {
 			return GROUPED_PRODUCT_TYPES.subscriptions
 				.mapGroupedToSpecific(productDetail)
-				.productType.includes('nationaldelivery');
+				.productType === 'nationaldelivery';
 		});
 
 	if (hasNationalDelivery) {

--- a/client/components/mma/delivery/address/DeliveryAddressForm.tsx
+++ b/client/components/mma/delivery/address/DeliveryAddressForm.tsx
@@ -28,8 +28,8 @@ import { NAV_LINKS } from '../../../shared/nav/NavConfig';
 import { COUNTRIES } from '../../identity/models';
 import { InfoIconDark } from '../../shared/assets/InfoIconDark';
 import { InfoSection } from '../../shared/InfoSection';
-import { ProductDescriptionListTable } from '../../shared/ProductDescriptionListTable';
 import type { ProductDescriptionListKeyValue } from '../../shared/ProductDescriptionListTable';
+import { ProductDescriptionListTable } from '../../shared/ProductDescriptionListTable';
 import { ProgressIndicator } from '../../shared/ProgressIndicator';
 import type { AddressSetStateObject } from './DeliveryAddressFormContext';
 import {
@@ -438,12 +438,16 @@ export const DeliveryAddressUpdate = (props: WithProductType<ProductType>) => {
 		contactIdToArrayOfProductDetailAndProductType,
 	)
 		.flatMap(flattenEquivalent)
-		.map(({ productDetail }) => {
-			const hasProducts = GROUPED_PRODUCT_TYPES.subscriptions
+		.some(({ productDetail }) => {
+			console.log(productDetail);
+			return GROUPED_PRODUCT_TYPES.subscriptions
 				.mapGroupedToSpecific(productDetail)
-				.productType.includes('national delivery');
-			return `${hasProducts}`;
+				.productType.includes('nationaldelivery');
 		});
+
+	console.log(contactIdToArrayOfProductDetailAndProductType);
+
+	console.log(hasNationalDelivery);
 
 	if (hasNationalDelivery) {
 		return (

--- a/client/components/mma/delivery/address/DeliveryAddressForm.tsx
+++ b/client/components/mma/delivery/address/DeliveryAddressForm.tsx
@@ -133,388 +133,284 @@ const Form = (props: FormProps) => {
 		}
 	};
 
-	const hasNationalDelivery = Object.values(
-		contactIdToArrayOfProductDetailAndProductType,
-	)
-		.flatMap(flattenEquivalent)
-		.map(({ productDetail }) => {
-			const hasProducts = GROUPED_PRODUCT_TYPES.subscriptions
-				.mapGroupedToSpecific(productDetail)
-				.productType.includes('national delivery');
-			return `${hasProducts}`;
-		});
-
 	return (
 		<>
-			{!hasNationalDelivery && (
-				<>
-					<form action="#" onSubmit={handleFormSubmit}>
-						<fieldset
-							css={{
-								border: `1px solid ${palette.neutral['86']}`,
-								padding: '48px 14px 14px',
-								position: 'relative',
-								marginBottom: `${space[5]}px`,
-								label: {
-									marginTop: `${space[3]}px`,
-								},
-							}}
-						>
-							<legend
-								css={css`
-									width: 100%;
-									position: absolute;
-									top: 0;
-									left: 0;
-									padding: 0 14px;
-									${textSans.medium()};
-									font-weight: bold;
-									line-height: 48px;
-									background-color: ${palette.neutral['97']};
-									border-bottom: 1px solid
-										${palette.neutral['86']};
-								`}
-							>
-								Delivery address
-								{props.productType.delivery
-									?.enableDeliveryInstructionsUpdate &&
-									' and instructions'}
-							</legend>
-							<Input
-								label={'Address line 1'}
-								width={30}
-								value={addressStateObject.addressLine1}
-								changeSetState={
-									addressSetStateObject.setAddressLine1
-								}
-								inErrorState={
-									props.formStatus ===
-										formStates.VALIDATION_ERROR &&
-									!props.formErrors.addressLine1?.isValid
-								}
-								errorMessage={
-									props.formErrors.addressLine1?.message
-								}
-							/>
-							<Input
-								label="Address line 2"
-								width={30}
-								value={addressStateObject.addressLine2 || ''}
-								changeSetState={
-									addressSetStateObject.setAddressLine2
-								}
-								optional={true}
-							/>
-							<Input
-								label="Town or City"
-								width={30}
-								value={addressStateObject.town || ''}
-								changeSetState={addressSetStateObject.setTown}
-								inErrorState={
-									props.formStatus ===
-										formStates.VALIDATION_ERROR &&
-									!props.formErrors.town?.isValid
-								}
-								errorMessage={props.formErrors.town?.message}
-							/>
-							<Input
-								label="County or State"
-								width={30}
-								value={addressStateObject.region || ''}
-								optional={true}
-								changeSetState={addressSetStateObject.setRegion}
-							/>
-							<Input
-								label="Postcode/Zipcode"
-								width={11}
-								value={addressStateObject.postcode}
-								changeSetState={
-									addressSetStateObject.setPostcode
-								}
-								inErrorState={
-									props.formStatus ===
-										formStates.VALIDATION_ERROR &&
-									!props.formErrors.postcode?.isValid
-								}
-								errorMessage={
-									props.formErrors.postcode?.message
-								}
-							/>
-							<Select
-								label={'Country'}
-								options={COUNTRIES.map((country) => {
-									return {
-										name: country.name,
-										value: country.name,
-									};
-								})}
-								width={30}
-								additionalCSS={css`
-									margin-top: 14px;
-								`}
-								value={addressStateObject.country}
-								changeSetState={
-									addressSetStateObject.setCountry
-								}
-								inErrorState={
-									props.formStatus ===
-										formStates.VALIDATION_ERROR &&
-									!props.formErrors.country?.isValid
-								}
-								errorMessage={props.formErrors.country?.message}
-							/>
-							{props.productType.delivery
-								?.enableDeliveryInstructionsUpdate && (
-								<label
-									css={css`
-										display: block;
-										color: ${palette.neutral['7']};
-										${textSans.medium()};
-										font-weight: bold;
-									`}
-								>
-									Instructions
-									<div>
-										<div
-											css={css`
-												display: inline-block;
-												vertical-align: top;
-												margin-top: 4px;
-												width: 100%;
-												max-width: 30ch;
-											`}
-										>
-											<textarea
-												id="delivery-instructions"
-												name="instructions"
-												rows={2}
-												maxLength={250}
-												value={
-													addressStateObject.instructions
-												}
-												onChange={(
-													e: ChangeEvent<HTMLTextAreaElement>,
-												) => {
-													addressSetStateObject.setInstructions(
-														e.target.value,
-													);
-													setInstructionsRemainingCharacters(
-														250 -
-															e.target.value
-																.length,
-													);
-												}}
-												css={css`
-													width: 100%;
-													border: 2px solid
-														${palette.neutral['60']};
-													padding: 12px;
-													resize: vertical;
-													${textSans.medium()};
-												`}
-											/>
-											<span
-												css={css`
-													display: block;
-													text-align: right;
-													${textSans.small()};
-													color: ${palette
-														.neutral[46]};
-												`}
-											>
-												{
-													instructionsRemainingCharacters
-												}{' '}
-												characters remaining
-											</span>
-										</div>
-										<p
-											css={css`
-												display: block;
-												${textSans.medium()};
-												border: 4px solid
-													${palette.brand[500]};
-												padding: ${space[5]}px
-													${space[5]}px ${space[5]}px
-													49px;
-												margin: ${space[3]}px 0;
-												position: relative;
-												${from.tablet} {
-													display: inline-block;
-													vertical-align: top;
-													margin: 2px 0 ${space[3]}px
-														${space[3]}px;
-													width: calc(
-														100% -
-															(
-																30ch +
-																	${space[3]}px +
-																	2px
-															)
-													);
-												}
-											`}
-										>
-											<i
-												css={css`
-													width: 17px;
-													height: 17px;
-													position: absolute;
-													top: ${space[5]}px;
-													left: ${space[5]}px;
-												`}
-											>
-												<InfoIconDark
-													fillColor={
-														palette.brand[500]
-													}
-												/>
-											</i>
-											Delivery instructions are only
-											applicable for newspaper deliveries.
-											They do not apply to Guardian
-											Weekly.
-										</p>
-									</div>
-								</label>
-							)}
-						</fieldset>
-						<CheckboxGroup
-							name="instructions-checkbox"
-							error={
-								props.formStatus ===
-									formStates.VALIDATION_ERROR &&
-								!acknowledgementChecked
-									? 'Please indicate that you understand which subscriptions this change will affect.'
-									: undefined
-							}
-						>
-							<Checkbox
-								value="acknowledged"
-								label="I understand that this address change will affect the following subscriptions"
-								checked={acknowledgementChecked}
-								onChange={(
-									e: ChangeEvent<HTMLInputElement>,
-								) => {
-									setAcknowledgementState(e.target.checked);
-								}}
-							/>
-						</CheckboxGroup>
-						{props.warning && (
-							<ProductDescriptionListTable
-								content={props.warning}
-								seperateEachRow
-							/>
-						)}
-						<div
-							css={css`
-								margin-top: ${space[5]}px;
-								* {
-									display: inline-block;
-								}
-								${from.tablet} {
-									margin-top: ${space[6]}px;
-								}
-							`}
-						>
-							<Button type="submit">Review details</Button>
-							<Link
-								to={NAV_LINKS.accountOverview.link}
-								css={css`
-									${textSans.medium()};
-									font-weight: bold;
-									margin-left: 22px;
-									color: ${palette.brand[400]};
-								`}
-							>
-								Cancel
-							</Link>
-						</div>
-					</form>
-
-					<Stack space={5}>
-						<p
-							css={css`
-								${textSans.medium()};
-								margin: ${space[12]}px 0 0;
-								color: ${palette.neutral[46]};
-							`}
-						>
-							If you need separate delivery addresses for each of
-							your subscriptions, please{' '}
-							<span
-								css={css`
-									cursor: pointer;
-									color: ${palette.brand[500]};
-									text-decoration: underline;
-								`}
-								onClick={() =>
-									setTopCallCentreNumbersVisibility(
-										!showTopCallCentreNumbers,
-									)
-								}
-							>
-								contact us
-							</span>
-							.
-						</p>
-						{showTopCallCentreNumbers && (
-							<CallCentreEmailAndNumbers />
-						)}
-					</Stack>
-				</>
-			)}
-			{hasNationalDelivery && (
-				<>
-					<p
+			<form action="#" onSubmit={handleFormSubmit}>
+				<fieldset
+					css={{
+						border: `1px solid ${palette.neutral['86']}`,
+						padding: '48px 14px 14px',
+						position: 'relative',
+						marginBottom: `${space[5]}px`,
+						label: {
+							marginTop: `${space[3]}px`,
+						},
+					}}
+				>
+					<legend
 						css={css`
-							display: block;
+							width: 100%;
+							position: absolute;
+							top: 0;
+							left: 0;
+							padding: 0 14px;
 							${textSans.medium()};
-							border: 4px solid ${palette.brand['500']};
-							padding: ${space[5]}px ${space[5]}px ${space[5]}px
-								49px;
-							margin-top: 12px;
-							position: relative;
-							${from.tablet} {
-								display: inline-block;
-								vertical-align: top;
-								width: calc(
-									100% - (30ch + ${space[3]}px + 2px)
-								);
-							}
+							font-weight: bold;
+							line-height: 48px;
+							background-color: ${palette.neutral['97']};
+							border-bottom: 1px solid ${palette.neutral['86']};
 						`}
 					>
-						<i
+						Delivery address
+						{props.productType.delivery
+							?.enableDeliveryInstructionsUpdate &&
+							' and instructions'}
+					</legend>
+					<Input
+						label={'Address line 1'}
+						width={30}
+						value={addressStateObject.addressLine1}
+						changeSetState={addressSetStateObject.setAddressLine1}
+						inErrorState={
+							props.formStatus === formStates.VALIDATION_ERROR &&
+							!props.formErrors.addressLine1?.isValid
+						}
+						errorMessage={props.formErrors.addressLine1?.message}
+					/>
+					<Input
+						label="Address line 2"
+						width={30}
+						value={addressStateObject.addressLine2 || ''}
+						changeSetState={addressSetStateObject.setAddressLine2}
+						optional={true}
+					/>
+					<Input
+						label="Town or City"
+						width={30}
+						value={addressStateObject.town || ''}
+						changeSetState={addressSetStateObject.setTown}
+						inErrorState={
+							props.formStatus === formStates.VALIDATION_ERROR &&
+							!props.formErrors.town?.isValid
+						}
+						errorMessage={props.formErrors.town?.message}
+					/>
+					<Input
+						label="County or State"
+						width={30}
+						value={addressStateObject.region || ''}
+						optional={true}
+						changeSetState={addressSetStateObject.setRegion}
+					/>
+					<Input
+						label="Postcode/Zipcode"
+						width={11}
+						value={addressStateObject.postcode}
+						changeSetState={addressSetStateObject.setPostcode}
+						inErrorState={
+							props.formStatus === formStates.VALIDATION_ERROR &&
+							!props.formErrors.postcode?.isValid
+						}
+						errorMessage={props.formErrors.postcode?.message}
+					/>
+					<Select
+						label={'Country'}
+						options={COUNTRIES.map((country) => {
+							return {
+								name: country.name,
+								value: country.name,
+							};
+						})}
+						width={30}
+						additionalCSS={css`
+							margin-top: 14px;
+						`}
+						value={addressStateObject.country}
+						changeSetState={addressSetStateObject.setCountry}
+						inErrorState={
+							props.formStatus === formStates.VALIDATION_ERROR &&
+							!props.formErrors.country?.isValid
+						}
+						errorMessage={props.formErrors.country?.message}
+					/>
+					{props.productType.delivery
+						?.enableDeliveryInstructionsUpdate && (
+						<label
 							css={css`
-								width: 17px;
-								height: 17px;
-								position: absolute;
-								top: ${space[5]}px;
-								left: ${space[5]}px;
+								display: block;
+								color: ${palette.neutral['7']};
+								${textSans.medium()};
+								font-weight: bold;
 							`}
 						>
-							<InfoIconDark fillColor={palette.brand[500]} />
-						</i>
-						Changed address? Please{' '}
-						<span
-							css={css`
-								cursor: pointer;
-								color: ${palette.brand[500]};
-								text-decoration: underline;
-							`}
-							onClick={() =>
-								setTopCallCentreNumbersVisibility(
-									!showTopCallCentreNumbers,
-								)
-							}
-						>
-							call our customer support team
-						</span>
-						to update your delivery details.
-					</p>
-					{showTopCallCentreNumbers && <CallCentreEmailAndNumbers />}
-				</>
-			)}
+							Instructions
+							<div>
+								<div
+									css={css`
+										display: inline-block;
+										vertical-align: top;
+										margin-top: 4px;
+										width: 100%;
+										max-width: 30ch;
+									`}
+								>
+									<textarea
+										id="delivery-instructions"
+										name="instructions"
+										rows={2}
+										maxLength={250}
+										value={addressStateObject.instructions}
+										onChange={(
+											e: ChangeEvent<HTMLTextAreaElement>,
+										) => {
+											addressSetStateObject.setInstructions(
+												e.target.value,
+											);
+											setInstructionsRemainingCharacters(
+												250 - e.target.value.length,
+											);
+										}}
+										css={css`
+											width: 100%;
+											border: 2px solid
+												${palette.neutral['60']};
+											padding: 12px;
+											resize: vertical;
+											${textSans.medium()};
+										`}
+									/>
+									<span
+										css={css`
+											display: block;
+											text-align: right;
+											${textSans.small()};
+											color: ${palette.neutral[46]};
+										`}
+									>
+										{instructionsRemainingCharacters}{' '}
+										characters remaining
+									</span>
+								</div>
+								<p
+									css={css`
+										display: block;
+										${textSans.medium()};
+										border: 4px solid ${palette.brand[500]};
+										padding: ${space[5]}px ${space[5]}px
+											${space[5]}px 49px;
+										margin: ${space[3]}px 0;
+										position: relative;
+										${from.tablet} {
+											display: inline-block;
+											vertical-align: top;
+											margin: 2px 0 ${space[3]}px
+												${space[3]}px;
+											width: calc(
+												100% -
+													(30ch + ${space[3]}px + 2px)
+											);
+										}
+									`}
+								>
+									<i
+										css={css`
+											width: 17px;
+											height: 17px;
+											position: absolute;
+											top: ${space[5]}px;
+											left: ${space[5]}px;
+										`}
+									>
+										<InfoIconDark
+											fillColor={palette.brand[500]}
+										/>
+									</i>
+									Delivery instructions are only applicable
+									for newspaper deliveries. They do not apply
+									to Guardian Weekly.
+								</p>
+							</div>
+						</label>
+					)}
+				</fieldset>
+				<CheckboxGroup
+					name="instructions-checkbox"
+					error={
+						props.formStatus === formStates.VALIDATION_ERROR &&
+						!acknowledgementChecked
+							? 'Please indicate that you understand which subscriptions this change will affect.'
+							: undefined
+					}
+				>
+					<Checkbox
+						value="acknowledged"
+						label="I understand that this address change will affect the following subscriptions"
+						checked={acknowledgementChecked}
+						onChange={(e: ChangeEvent<HTMLInputElement>) => {
+							setAcknowledgementState(e.target.checked);
+						}}
+					/>
+				</CheckboxGroup>
+				{props.warning && (
+					<ProductDescriptionListTable
+						content={props.warning}
+						seperateEachRow
+					/>
+				)}
+				<div
+					css={css`
+						margin-top: ${space[5]}px;
+						* {
+							display: inline-block;
+						}
+						${from.tablet} {
+							margin-top: ${space[6]}px;
+						}
+					`}
+				>
+					<Button type="submit">Review details</Button>
+					<Link
+						to={NAV_LINKS.accountOverview.link}
+						css={css`
+							${textSans.medium()};
+							font-weight: bold;
+							margin-left: 22px;
+							color: ${palette.brand[400]};
+						`}
+					>
+						Cancel
+					</Link>
+				</div>
+			</form>
+
+			<Stack space={5}>
+				<p
+					css={css`
+						${textSans.medium()};
+						margin: ${space[12]}px 0 0;
+						color: ${palette.neutral[46]};
+					`}
+				>
+					If you need separate delivery addresses for each of your
+					subscriptions, please{' '}
+					<span
+						css={css`
+							cursor: pointer;
+							color: ${palette.brand[500]};
+							text-decoration: underline;
+						`}
+						onClick={() =>
+							setTopCallCentreNumbersVisibility(
+								!showTopCallCentreNumbers,
+							)
+						}
+					>
+						contact us
+					</span>
+					.
+				</p>
+				{showTopCallCentreNumbers && <CallCentreEmailAndNumbers />}
+			</Stack>
 		</>
 	);
 };
@@ -524,6 +420,8 @@ export const DeliveryAddressUpdate = (props: WithProductType<ProductType>) => {
 	const [formErrors, setFormErrors] = useState({ isValid: false });
 	const contactIdToArrayOfProductDetailAndProductType =
 		useContext(ContactIdContext);
+	const [showTopCallCentreNumbers, setTopCallCentreNumbersVisibility] =
+		useState<boolean>(false);
 
 	const subHeadingCss = `
 		border-top: 1px solid ${palette.neutral['86']};
@@ -546,6 +444,57 @@ export const DeliveryAddressUpdate = (props: WithProductType<ProductType>) => {
 				.productType.includes('national delivery');
 			return `${hasProducts}`;
 		});
+
+	if (hasNationalDelivery) {
+		return (
+			<>
+				<p
+					css={css`
+						display: block;
+						${textSans.medium()};
+						border: 4px solid ${palette.brand['500']};
+						padding: ${space[5]}px ${space[5]}px ${space[5]}px 49px;
+						margin-top: 12px;
+						position: relative;
+						${from.tablet} {
+							display: inline-block;
+							vertical-align: top;
+							width: calc(100% - (30ch + ${space[3]}px + 2px));
+						}
+					`}
+				>
+					<i
+						css={css`
+							width: 17px;
+							height: 17px;
+							position: absolute;
+							top: ${space[5]}px;
+							left: ${space[5]}px;
+						`}
+					>
+						<InfoIconDark fillColor={palette.brand[500]} />
+					</i>
+					Changed address? Please{' '}
+					<span
+						css={css`
+							cursor: pointer;
+							color: ${palette.brand[500]};
+							text-decoration: underline;
+						`}
+						onClick={() =>
+							setTopCallCentreNumbersVisibility(
+								!showTopCallCentreNumbers,
+							)
+						}
+					>
+						call our customer support team
+					</span>
+					to update your delivery details.
+				</p>
+				{showTopCallCentreNumbers && <CallCentreEmailAndNumbers />}
+			</>
+		);
+	}
 
 	return (
 		<>

--- a/client/components/mma/delivery/address/DeliveryAddressForm.tsx
+++ b/client/components/mma/delivery/address/DeliveryAddressForm.tsx
@@ -498,18 +498,16 @@ export const DeliveryAddressUpdate = (props: WithProductType<ProductType>) => {
 
 	return (
 		<>
-			{!hasNationalDelivery && (
-				<ProgressIndicator
-					steps={[
-						{ title: 'Update', isCurrentStep: true },
-						{ title: 'Review' },
-						{ title: 'Confirmation' },
-					]}
-					additionalCSS={css`
-						margin-top: ${space[5]}px;
-					`}
-				/>
-			)}
+			<ProgressIndicator
+				steps={[
+					{ title: 'Update', isCurrentStep: true },
+					{ title: 'Review' },
+					{ title: 'Confirmation' },
+				]}
+				additionalCSS={css`
+					margin-top: ${space[5]}px;
+				`}
+			/>
 			<h2
 				css={css`
 					${subHeadingCss}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
We currently don't have the capability to allow users with national deliveries to update their addresses via MMA. This change no longer shows the address form and  displays a new message to call the CSR team if you want to change addresses.

This change also prevents users who may have any other delivery as well as a national delivery product from updating their address.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
On MMA with a national delivery product -> click manage subscription -> click manage delivery address you should see the new message displayed asking you to call a CSR to update your address.

On MMA with a home delivery product (as well a national delivery) -> click manage subscription -> click manage delivery address you should see the new message displayed asking you to call a CSR to update your address.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
National delivery product 
![image](https://github.com/guardian/manage-frontend/assets/115992455/d81ddb4a-eb8d-4101-8a51-a76a83dcf30a)

Home delivery with also an active sub
![image](https://github.com/guardian/manage-frontend/assets/115992455/52fb608a-ba7a-4c35-b228-93623e87ccc0)

Only home delivery on account 🎉
![image](https://github.com/guardian/manage-frontend/assets/115992455/ab6e1a67-0358-4b87-82da-43b0dfd59c63)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
