### PR TITLE
Check for 'patch' request in amend holiday stops cypress test

### DIFF
--- a/cypress/e2e/parallel-3/holidayStops.cy.ts
+++ b/cypress/e2e/parallel-3/holidayStops.cy.ts
@@ -41,6 +41,13 @@ describe('Holiday stops', () => {
 				message: 'success',
 			},
 		}).as('create_holiday_stop');
+
+		cy.intercept('PATCH', '/api/holidays/**', {
+			statusCode: 200,
+			body: {
+				message: 'success',
+			},
+		}).as('amend_holiday_stop');
 	});
 
 	it('can add a new holiday stop and add another', () => {
@@ -129,6 +136,10 @@ describe('Holiday stops', () => {
 
 		cy.get('@fetch_existing_holidays.all').should('have.length', 1);
 		cy.get('@product_detail.all').should('have.length', 1);
+
+		cy.findByText('Confirm').click();
+		cy.wait('@amend_holiday_stop');
+		cy.findByText('Your schedule has been set');
 	});
 
 	it('can delete an existing holiday stop from overview page', () => {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Update the "can amend an existing holiday stop from overview page" Cypress test to click the "Confirm" button and mock the `PATCH` request. This is a followup from #1225 which fixed the component to actually check the correct variable to choose `PATCH` 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Cypress tests pass in CI

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
