### PR TITLE
National Delivery - Block Delivery Issues page from allowing you to change address

### DIFF
--- a/client/components/mma/delivery/address/DeliveryAddressForm.tsx
+++ b/client/components/mma/delivery/address/DeliveryAddressForm.tsx
@@ -27,6 +27,7 @@ import { Input } from '../../../shared/Input';
 import { NAV_LINKS } from '../../../shared/nav/NavConfig';
 import { COUNTRIES } from '../../identity/models';
 import { InfoIconDark } from '../../shared/assets/InfoIconDark';
+import { CallCentrePrompt } from '../../shared/CallCentrePrompt';
 import { InfoSection } from '../../shared/InfoSection';
 import type { ProductDescriptionListKeyValue } from '../../shared/ProductDescriptionListTable';
 import { ProductDescriptionListTable } from '../../shared/ProductDescriptionListTable';
@@ -420,8 +421,6 @@ export const DeliveryAddressUpdate = (props: WithProductType<ProductType>) => {
 	const [formErrors, setFormErrors] = useState({ isValid: false });
 	const contactIdToArrayOfProductDetailAndProductType =
 		useContext(ContactIdContext);
-	const [showTopCallCentreNumbers, setTopCallCentreNumbersVisibility] =
-		useState<boolean>(false);
 
 	const subHeadingCss = `
 		border-top: 1px solid ${palette.neutral['86']};
@@ -439,59 +438,22 @@ export const DeliveryAddressUpdate = (props: WithProductType<ProductType>) => {
 	)
 		.flatMap(flattenEquivalent)
 		.some(({ productDetail }) => {
-			return GROUPED_PRODUCT_TYPES.subscriptions
-				.mapGroupedToSpecific(productDetail)
-				.productType === 'nationaldelivery';
+			return (
+				GROUPED_PRODUCT_TYPES.subscriptions.mapGroupedToSpecific(
+					productDetail,
+				).productType === 'nationaldelivery'
+			);
 		});
 
 	if (hasNationalDelivery) {
 		return (
-			<>
-				<p
-					css={css`
-						display: block;
-						${textSans.medium()};
-						border: 4px solid ${palette.brand['500']};
-						padding: ${space[5]}px ${space[5]}px ${space[5]}px 49px;
-						margin-top: 12px;
-						position: relative;
-						${from.tablet} {
-							display: inline-block;
-							vertical-align: top;
-							width: calc(100% - (30ch + ${space[3]}px + 2px));
-						}
-					`}
-				>
-					<i
-						css={css`
-							width: 17px;
-							height: 17px;
-							position: absolute;
-							top: ${space[5]}px;
-							left: ${space[5]}px;
-						`}
-					>
-						<InfoIconDark fillColor={palette.brand[500]} />
-					</i>
-					Changed address? Please{' '}
-					<span
-						css={css`
-							cursor: pointer;
-							color: ${palette.brand[500]};
-							text-decoration: underline;
-						`}
-						onClick={() =>
-							setTopCallCentreNumbersVisibility(
-								!showTopCallCentreNumbers,
-							)
-						}
-					>
-						call our customer support team
-					</span>{' '}
-					to update your delivery details.
-				</p>
-				{showTopCallCentreNumbers && <CallCentreEmailAndNumbers />}
-			</>
+			<div
+				css={css`
+					margin-top: ${space[3]}px;
+				`}
+			>
+				<CallCentrePrompt />
+			</div>
 		);
 	}
 

--- a/client/components/mma/delivery/records/ReadOnlyAddressDisplay.tsx
+++ b/client/components/mma/delivery/records/ReadOnlyAddressDisplay.tsx
@@ -6,7 +6,7 @@ import type { DeliveryAddress } from '../../../../../shared/productResponse';
 import { DeliveryAddressDisplay } from '../address/DeliveryAddressDisplay';
 
 interface ReadOnlyAddressDisplayProps {
-	showEditButton?: true;
+	showEditButton?: boolean;
 	editButtonCallback?: () => void;
 	address: DeliveryAddress;
 	instructions?: string;

--- a/client/components/mma/shared/CallCentrePrompt.stories.tsx
+++ b/client/components/mma/shared/CallCentrePrompt.stories.tsx
@@ -1,0 +1,11 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import { CallCentrePrompt } from './CallCentrePrompt';
+
+export default {
+	component: CallCentrePrompt,
+	title: 'Components/CallCentrePrompt',
+} as Meta<typeof CallCentrePrompt>;
+
+export const Default: StoryFn<typeof CallCentrePrompt> = () => {
+	return <CallCentrePrompt />;
+};

--- a/client/components/mma/shared/CallCentrePrompt.tsx
+++ b/client/components/mma/shared/CallCentrePrompt.tsx
@@ -1,0 +1,33 @@
+import { ButtonLink, Stack } from '@guardian/source-react-components';
+import { InfoSummary } from '@guardian/source-react-components-development-kitchen';
+import { useState } from 'react';
+import { CallCentreEmailAndNumbers } from '@/client/components/shared/CallCenterEmailAndNumbers';
+
+export const CallCentrePrompt = () => {
+	const [showCallCentreNumbers, setCallCentreNumbersVisibility] =
+		useState<boolean>(false);
+
+	return (
+		<Stack space={3}>
+			<InfoSummary
+				message="Changed address?"
+				context={
+					<>
+						Please{' '}
+						<ButtonLink
+							onClick={() =>
+								setCallCentreNumbersVisibility(
+									!showCallCentreNumbers,
+								)
+							}
+						>
+							call our customer support team
+						</ButtonLink>{' '}
+						to update your delivery details.
+					</>
+				}
+			/>
+			{showCallCentreNumbers && <CallCentreEmailAndNumbers />}
+		</Stack>
+	);
+};


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Block "National Delivery" subscribers from changing their address, we have not built any functionality to allow choosing a new delivery provider so users are directed to call the call centre.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

With a National Delivery product
Go to Manage subscription 
 -> Click Manage delivery history
     -> Report a problem
         -> See Step 3
         -> See CSR prompt 

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

National Delivery
![image](https://github.com/guardian/manage-frontend/assets/114918544/a15b356d-5a71-46cf-af26-9d72784cfcb5)

Other Print Subscription AND National Delivery
![image](https://github.com/guardian/manage-frontend/assets/114918544/4f3f3f4d-b177-4b12-8133-32d69e60e390)
After click:
![image](https://github.com/guardian/manage-frontend/assets/114918544/36930487-e638-4c94-b8ef-3bd893a14db3)


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
