### PR TITLE
Add Cypress Tests for National Delivery Address Blocking

### DIFF
--- a/client/components/mma/delivery/address/DeliveryAddressForm.tsx
+++ b/client/components/mma/delivery/address/DeliveryAddressForm.tsx
@@ -437,12 +437,8 @@ export const DeliveryAddressUpdate = (props: WithProductType<ProductType>) => {
 		contactIdToArrayOfProductDetailAndProductType,
 	)
 		.flatMap(flattenEquivalent)
-		.some(({ productDetail }) => {
-			return (
-				GROUPED_PRODUCT_TYPES.subscriptions.mapGroupedToSpecific(
-					productDetail,
-				).productType === 'nationaldelivery'
-			);
+		.some(({ productType }) => {
+			return productType.productType === 'nationaldelivery';
 		});
 
 	if (hasNationalDelivery) {

--- a/client/components/mma/delivery/records/DeliveryAddressStep.tsx
+++ b/client/components/mma/delivery/records/DeliveryAddressStep.tsx
@@ -191,12 +191,8 @@ export const DeliveryAddressStep = (props: DeliveryAddressStepProps) => {
 			contactIdToArrayOfProductDetailAndProductType,
 		)
 			.flatMap(flattenEquivalent)
-			.some(({ productDetail }) => {
-				return (
-					GROUPED_PRODUCT_TYPES.subscriptions.mapGroupedToSpecific(
-						productDetail,
-					).productType === 'nationaldelivery'
-				);
+			.some(({ productType }) => {
+				return productType.productType === 'nationaldelivery';
 			});
 
 		if (hasNationalDelivery) {

--- a/client/fixtures/productBuilder/baseProducts.ts
+++ b/client/fixtures/productBuilder/baseProducts.ts
@@ -383,6 +383,72 @@ export function baseHomeDelivery(): ProductDetail {
 	};
 }
 
+export function baseNationalDelivery(): ProductDetail {
+	return {
+		mmaCategory: 'subscriptions',
+		tier: 'Newspaper - National Delivery',
+		isPaidTier: true,
+		selfServiceCancellation: {
+			isAllowed: false,
+			shouldDisplayEmail: false,
+			phoneRegionsToDisplay: ['UK & ROW'],
+		},
+		joinDate: '2021-12-15',
+		optIn: true,
+		subscription: {
+			contactId: '0039E00001KA26BQAT',
+			deliveryAddress: {
+				addressLine1: 'Kings Place',
+				addressLine2: '90 York Way',
+				town: 'Derby',
+				postcode: 'DE10FD',
+				country: 'United Kingdom',
+			},
+			safeToUpdatePaymentMethod: true,
+			start: '2021-12-24',
+			end: '2022-12-15',
+			nextPaymentPrice: 3250,
+			nextPaymentDate: '2021-12-24',
+			lastPaymentDate: null,
+			chargedThroughDate: null,
+			renewalDate: '2022-12-15',
+			anniversaryDate: '2022-12-24',
+			cancelledAt: false,
+			subscriberId: 'A-S00293857',
+			subscriptionId: 'A-S00293857',
+			trialLength: -37,
+			autoRenew: true,
+			currentPlans: [
+				{
+					name: 'Everyday',
+					start: '2021-12-24',
+					end: '2022-12-15',
+					shouldBeVisible: true,
+					chargedThrough: null,
+					price: 3250,
+					currency: '£',
+					currencyISO: 'GBP',
+					billingPeriod: 'month',
+					daysOfWeek: [
+						'Monday',
+						'Tuesday',
+						'Wednesday',
+						'Thursday',
+						'Friday',
+						'Saturday',
+						'Sunday',
+					],
+				},
+			],
+			futurePlans: [],
+			readerType: 'Direct',
+			accountId: '8ad0965d7dbcc507017dbe20afd33ac4',
+			deliveryAddressChangeEffectiveDate: '2022-02-11',
+		},
+		isTestUser: false,
+	};
+}
+
 export function baseSupporterPlus(): ProductDetail {
 	return {
 		mmaCategory: 'recurringSupport',

--- a/client/fixtures/productBuilder/testProducts.ts
+++ b/client/fixtures/productBuilder/testProducts.ts
@@ -6,6 +6,7 @@ import {
 	baseGuardianWeekly,
 	baseHomeDelivery,
 	baseMembership,
+	baseNationalDelivery,
 	baseSupporterPlus,
 } from './baseProducts';
 import { cards, ProductBuilder } from './productBuilder';
@@ -130,6 +131,12 @@ export function newspaperVoucherPaidByPaypal(email?: string) {
 
 export function homeDelivery() {
 	return new ProductBuilder(baseHomeDelivery())
+		.payByCard()
+		.getProductDetailObject();
+}
+
+export function nationalDelivery() {
+	return new ProductBuilder(baseNationalDelivery())
 		.payByCard()
 		.getProductDetailObject();
 }

--- a/cypress/e2e/parallel-4/deliveryRecords.cy.ts
+++ b/cypress/e2e/parallel-4/deliveryRecords.cy.ts
@@ -22,11 +22,6 @@ describe('Delivery records', () => {
 	beforeEach(() => {
 		signInAndAcceptCookies();
 
-		cy.intercept('GET', '/api/me/mma?productType=HomeDelivery', {
-			statusCode: 200,
-			body: toMembersDataApiResponse(nationalDelivery()),
-		}).as('national_product_detail');
-
 		cy.intercept('GET', '/api/me/mma?productType=Weekly', {
 			statusCode: 200,
 			body: toMembersDataApiResponse(guardianWeeklyPaidByCard()),
@@ -358,7 +353,13 @@ describe('Delivery records', () => {
 	});
 
 	it('does not allow you to update National delivery address before reporting a problem', () => {
+		cy.intercept('GET', '/api/me/mma?productType=HomeDelivery', {
+			statusCode: 200,
+			body: toMembersDataApiResponse(nationalDelivery()),
+		}).as('national_product_detail');
+
 		cy.visit('/delivery/nationaldelivery/records');
+
 		cy.wait('@national_product_detail');
 		cy.wait('@delivery_records');
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds Cypress tests for National Delivery address updates being disabled. A small refactoring of the check to do this is included in the PR.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Cypress tests pass. 
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
