### PR TITLE
bump consent management platform to 13.7.1 to fix babel traverse

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "@guardian/ab-core": "2.0.0",
     "@guardian/ab-react": "2.0.1",
     "@guardian/commercial-core": "5.4.5",
-    "@guardian/consent-management-platform": "13.6.1",
+    "@guardian/consent-management-platform": "13.7.1",
     "@guardian/libs": "15.7.1",
     "@guardian/source-foundations": "13.0.0",
     "@guardian/source-react-components": "16.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2048,10 +2048,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-5.4.5.tgz#2a2fa51b3c06e193f5ffb685a28ffc4b9788eeed"
   integrity sha512-06HK6V4fOpe9JSsV+hCzSgAmlSHSojTs0U7zEvDsfPCeGEWUjSrAsesmJ2EeM8oxpQZbNt8EL8Kxzn32QMCO4g==
 
-"@guardian/consent-management-platform@13.6.1":
-  version "13.6.1"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.6.1.tgz#528ed9193b1bd96e9f84964a5a1a080de43e29c1"
-  integrity sha512-5KQ4dZrqIBKuJCSJ/TTWXZ4F0WXY9ecpMnfOfvNIU9tXF1LAeT+LNv7hfV8eC5qMJskj2yvZZUi7hlwWD+Nq/A==
+"@guardian/consent-management-platform@13.7.1":
+  version "13.7.1"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.7.1.tgz#ba38f32de023775e615e79cfa97a3425f144eb89"
+  integrity sha512-BtUNkuCqd++A0Wkk9CA4kI95yVZJk1YMjPdppEnmq3cG/ros4ElXN4cNG7pWifeTR5cUtJflAiRRO4L5ewASpQ==
 
 "@guardian/eslint-config-typescript@1.0.11":
   version "1.0.11"


### PR DESCRIPTION
## What does this change?

This bumps the version of consent-management-platform from 13.6.1 to 13.7.1.
This updates the vendor list and includes fixes for critical vulnerabilities arising from babel/traverse.

## How to test

On code or prod, open in an incognito or guest mode window to pull up the consent management platform's cookie banner.  Accept all then open the browser's dev tools and, using `window.guCmpHotFix.cmp.version` check that the version number reflects the change here. 

## How can we measure success?

The correct version number.

## Have we considered potential risks?

If errors arise around the cookie banner, we may need to revert the version.

## Images

No UI changes

## Accessibility

No UX changes.