### PR TITLE
OAuth migration | Serverside Okta validation middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "git-revision-webpack-plugin": "3.0.6",
     "husky": "1.3.1",
     "jest": "29.7.0",
+    "jest-fetch-mock": "3.0.3",
     "lint-staged": "13.0.3",
     "mini-css-extract-plugin": "2.5.2",
     "mockdate": "3.0.5",
@@ -186,7 +187,8 @@
     "tslib": "2.6.2",
     "ua-parser-js": "1.0.34",
     "winston": "3.2.1",
-    "yup": "0.28.5"
+    "yup": "0.28.5",
+    "zod": "3.22.4"
   },
   "license": "UNLICENSED",
   "msw": {

--- a/server/__tests__/middleware/identityMiddleware.test.ts
+++ b/server/__tests__/middleware/identityMiddleware.test.ts
@@ -7,6 +7,8 @@ import type { Request, Response } from 'express';
 import { conf } from '@/server/config';
 import { authenticateWithOAuth } from '@/server/middleware/identityMiddleware';
 import * as oauth from '@/server/oauth';
+import type { Scopes } from '../../oauthConfig';
+import { oauthCookieOptions, scopes } from '../../oauthConfig';
 
 jest.mock('@/server/idapiConfig', () => ({
 	getConfig: () => ({
@@ -51,18 +53,18 @@ describe('authenticateWithOAuth middleware - route requires signin', () => {
 
 		expect(res.clearCookie).toHaveBeenCalledWith(
 			'GU_ACCESS_TOKEN',
-			oauth.oauthCookieOptions,
+			oauthCookieOptions,
 		);
 		expect(res.clearCookie).toHaveBeenCalledWith(
 			'GU_ID_TOKEN',
-			oauth.oauthCookieOptions,
+			oauthCookieOptions,
 		);
 		expect(oauth.performAuthorizationCodeFlow).toHaveBeenCalledWith(
 			req,
 			res,
 			{
 				redirectUri: `https://manage.${conf.DOMAIN}/oauth/callback`,
-				scopes: oauth.scopes,
+				scopes,
 				returnPath: '/profile',
 			},
 		);
@@ -84,7 +86,7 @@ describe('authenticateWithOAuth middleware - route requires signin', () => {
 		jest.spyOn(oauth, 'verifyAccessToken').mockResolvedValue({
 			isExpired: () => true,
 			claims: {
-				scp: oauth.scopes as readonly oauth.Scopes[],
+				scp: scopes as readonly Scopes[],
 			},
 		} as Jwt);
 		jest.spyOn(oauth, 'verifyIdToken').mockResolvedValue({
@@ -98,7 +100,7 @@ describe('authenticateWithOAuth middleware - route requires signin', () => {
 			res,
 			{
 				redirectUri: `https://manage.${conf.DOMAIN}/oauth/callback`,
-				scopes: oauth.scopes,
+				scopes,
 				returnPath: '/profile',
 			},
 		);
@@ -127,7 +129,7 @@ describe('authenticateWithOAuth middleware - route requires signin', () => {
 		jest.spyOn(oauth, 'verifyAccessToken').mockResolvedValue({
 			isExpired: () => false,
 			claims: {
-				scp: oauth.scopes as readonly oauth.Scopes[],
+				scp: scopes as readonly Scopes[],
 			},
 		} as Jwt);
 		jest.spyOn(oauth, 'verifyIdToken').mockResolvedValue(idToken);
@@ -139,7 +141,7 @@ describe('authenticateWithOAuth middleware - route requires signin', () => {
 			res,
 			{
 				redirectUri: `https://manage.${conf.DOMAIN}/oauth/callback`,
-				scopes: oauth.scopes,
+				scopes,
 				returnPath: '/profile',
 			},
 		);
@@ -172,7 +174,7 @@ describe('authenticateWithOAuth middleware - route requires signin', () => {
 		jest.spyOn(oauth, 'verifyAccessToken').mockResolvedValue({
 			isExpired: () => false,
 			claims: {
-				scp: oauth.scopes as readonly oauth.Scopes[],
+				scp: scopes as readonly Scopes[],
 			},
 		} as Jwt);
 		jest.spyOn(oauth, 'verifyIdToken').mockResolvedValue(idToken);
@@ -215,11 +217,11 @@ describe('authenticateWithOAuth middleware - route does not require signin', () 
 
 		expect(res.clearCookie).toHaveBeenCalledWith(
 			'GU_ACCESS_TOKEN',
-			oauth.oauthCookieOptions,
+			oauthCookieOptions,
 		);
 		expect(res.clearCookie).toHaveBeenCalledWith(
 			'GU_ID_TOKEN',
-			oauth.oauthCookieOptions,
+			oauthCookieOptions,
 		);
 		expect(next).toHaveBeenCalled();
 	});
@@ -288,7 +290,7 @@ describe('authenticateWithOAuth middleware - route does not require signin', () 
 		jest.spyOn(oauth, 'verifyAccessToken').mockResolvedValue({
 			isExpired: () => false,
 			claims: {
-				scp: oauth.scopes as readonly oauth.Scopes[],
+				scp: scopes as readonly Scopes[],
 			},
 		} as Jwt);
 		jest.spyOn(oauth, 'verifyIdToken').mockResolvedValue(idToken);

--- a/server/__tests__/middleware/okta.test.ts
+++ b/server/__tests__/middleware/okta.test.ts
@@ -1,0 +1,149 @@
+import { enableFetchMocks } from 'jest-fetch-mock';
+import { validateWithOkta } from '@/server/okta';
+import type { OktaConfig } from '@/server/oktaConfig';
+
+jest.mock('@/server/log');
+jest.mock('@/server/oauth');
+
+const oktaConfig: OktaConfig = {
+	useOkta: true,
+	orgUrl: 'https://example.com',
+	authServerId: 'foo',
+	clientId: 'bar',
+	clientSecret: 'baz',
+	cookieSecret: 'qux',
+};
+const accessToken = 'accessToken';
+
+describe('validateWithOkta', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		enableFetchMocks();
+	});
+
+	it('returns a valid response if the token is valid', async () => {
+		fetchMock.mockResponseOnce(
+			JSON.stringify({
+				sub: '00uid4BxXw6I6TV4m0g3',
+				name: 'John Doe',
+				nickname: 'Jimmy',
+				given_name: 'John',
+				middle_name: 'James',
+				family_name: 'Doe',
+				profile: 'https://example.com/john.doe',
+				zoneinfo: 'America/Los_Angeles',
+				locale: 'en-US',
+				updated_at: 1311280970,
+				email: 'john.doe@example.com',
+				email_verified: true,
+				address: {
+					street_address: '123 Hollywood Blvd.',
+					locality: 'Los Angeles',
+					region: 'CA',
+					postal_code: '90210',
+					country: 'US',
+				},
+				phone_number: '+1 (425) 555-1212',
+				// Guardian-specific fields
+				legacy_identity_id: '1234567890',
+			}),
+			{
+				status: 200,
+			},
+		);
+
+		const response = await validateWithOkta({
+			oktaConfig,
+			accessToken,
+		});
+
+		expect(response).toEqual({
+			ok: true,
+			valid: true,
+			userId: '1234567890',
+			displayName: 'John Doe',
+			email: 'john.doe@example.com',
+		});
+	});
+
+	it('returns an invalid response if the token is invalid', async () => {
+		fetchMock.mockResponseOnce(
+			JSON.stringify({
+				error: 'invalid_token',
+				error_description: 'The access token is invalid.',
+			}),
+			{
+				status: 401,
+			},
+		);
+
+		const response = await validateWithOkta({
+			oktaConfig,
+			accessToken,
+		});
+
+		expect(response).toEqual({
+			ok: true,
+			valid: false,
+		});
+	});
+
+	it('returns an invalid response if the request is forbidden', async () => {
+		fetchMock.mockResponseOnce(
+			JSON.stringify({
+				error: 'insufficient_scope',
+				error_description:
+					'The access token must provide access to at least one of these scopes - profile, email, address or phone',
+			}),
+			{
+				status: 403,
+			},
+		);
+
+		const response = await validateWithOkta({
+			oktaConfig,
+			accessToken,
+		});
+
+		expect(response).toEqual({
+			ok: true,
+			valid: false,
+		});
+	});
+
+	it('returns an invalid response if the request returns an unexpected status code', async () => {
+		fetchMock.mockResponseOnce(
+			JSON.stringify({
+				error: 'invalid_token',
+				error_description: 'The access token is invalid.',
+			}),
+			{
+				status: 500,
+			},
+		);
+
+		const response = await validateWithOkta({
+			oktaConfig,
+			accessToken,
+		});
+
+		expect(response).toEqual({
+			ok: false,
+			valid: false,
+		});
+	});
+
+	it('returns an invalid response if the request fails', async () => {
+		fetchMock.mockRejectOnce(new Error('Network error'));
+
+		const response = await validateWithOkta({
+			oktaConfig,
+			accessToken,
+		});
+
+		expect(response).toEqual({
+			ok: false,
+			valid: false,
+		});
+	});
+});

--- a/server/__tests__/middleware/oktaServerSideAuthMiddleware.test.ts
+++ b/server/__tests__/middleware/oktaServerSideAuthMiddleware.test.ts
@@ -1,0 +1,216 @@
+import type { Request, Response } from 'express';
+import {
+	clearIdentityLocalState,
+	getIdentityLocalState,
+	setIdentityLocalState,
+} from '@/server/identityLocalState';
+import type { OktaValidationResponse } from '@/server/middleware/oktaServerSideAuthMiddleware';
+import { withOktaServerSideValidation } from '@/server/middleware/oktaServerSideAuthMiddleware';
+import { validateWithOkta } from '@/server/okta';
+import type { OktaConfig } from '@/server/oktaConfig';
+import { getConfig } from '@/server/oktaConfig';
+import type { IdentityDetails } from '@/shared/globals';
+import { requiresSignin } from '@/shared/requiresSignin';
+
+jest.mock('@/server/log');
+jest.mock('@/server/oauth', () => ({
+	OAuthAccessTokenCookieName: 'GU_ACCESS_TOKEN',
+}));
+jest.mock('@/shared/requiresSignin', () => ({
+	requiresSignin: jest.fn(),
+}));
+const mockedRequiresSignin =
+	jest.mocked<(path: string) => boolean>(requiresSignin);
+jest.mock('@/server/oktaConfig', () => ({
+	getConfig: jest.fn(),
+}));
+const mockedGetOktaConfig = jest.mocked<() => Promise<OktaConfig>>(getConfig);
+jest.mock('@/server/okta', () => ({
+	validateWithOkta: jest.fn(),
+}));
+const mockedValidateWithOkta =
+	jest.mocked<
+		(params: {
+			oktaConfig: OktaConfig;
+			accessToken: string;
+		}) => Promise<OktaValidationResponse>
+	>(validateWithOkta);
+jest.mock('@/server/identityLocalState', () => ({
+	getIdentityLocalState: jest.fn(),
+	setIdentityLocalState: jest.fn(),
+	clearIdentityLocalState: jest.fn(),
+}));
+const mockedGetIdentityLocalState = jest.mocked<
+	(res: Response) => IdentityDetails | undefined
+>(getIdentityLocalState);
+const mockedClearIdentityLocalState = jest.mocked<(res: Response) => void>(
+	clearIdentityLocalState,
+);
+
+const accessToken = 'accessToken';
+
+const setupOktaConfig = (useOkta: boolean) => {
+	mockedGetOktaConfig.mockReturnValue(
+		Promise.resolve({
+			// This is so cursed but it works because at the moment
+			// that mockReturnValue is being invoked, mockedGetOktaConfig
+			// has not yet been mocked so just returns the original
+			// implementation.
+			...mockedGetOktaConfig(),
+			useOkta,
+		}),
+	);
+};
+
+describe('withOktaServerSideValidation', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		jest.resetAllMocks();
+	});
+
+	it('should call next() when Okta is not enabled', async () => {
+		setupOktaConfig(false);
+		const req = {} as unknown as Request;
+		const res = {} as unknown as Response;
+		const next = jest.fn();
+
+		await withOktaServerSideValidation(req, res, next);
+
+		expect(next).toHaveBeenCalled();
+	});
+
+	it('should handle the case where there is no token/user, but signin is required', async () => {
+		setupOktaConfig(true);
+		mockedRequiresSignin.mockReturnValue(true);
+		const mockedSendStatus = jest.fn();
+		const req = {
+			signedCookies: {},
+		} as unknown as Request;
+		const res = {
+			locals: {},
+			sendStatus: mockedSendStatus,
+		} as unknown as Response;
+		const next = jest.fn();
+
+		await withOktaServerSideValidation(req, res, next);
+
+		expect(mockedSendStatus).toHaveBeenCalledWith(500);
+	});
+
+	it('should handle the case where there is no token/user, and signin is not required', async () => {
+		setupOktaConfig(true);
+		mockedRequiresSignin.mockReturnValue(false);
+		mockedGetIdentityLocalState.mockReturnValue(undefined);
+		const req = {
+			signedCookies: {},
+		} as unknown as Request;
+		const res = {
+			locals: {},
+		} as unknown as Response;
+		const next = jest.fn();
+
+		await withOktaServerSideValidation(req, res, next);
+
+		expect(next).toHaveBeenCalled();
+	});
+
+	it('should handle the case where Okta validation fails', async () => {
+		setupOktaConfig(true);
+		mockedRequiresSignin.mockReturnValue(true);
+		mockedGetIdentityLocalState.mockReturnValue({
+			userId: 'userId',
+			email: 'email',
+			displayName: 'displayName',
+			signInStatus: 'signedInRecently',
+		});
+		mockedValidateWithOkta.mockReturnValue(
+			Promise.resolve({ ok: false, valid: false }),
+		);
+		const mockedSendStatus = jest.fn();
+		const req = {
+			signedCookies: {
+				GU_ACCESS_TOKEN: accessToken,
+			},
+		} as unknown as Request;
+		const res = {
+			locals: {},
+			sendStatus: mockedSendStatus,
+		} as unknown as Response;
+		const next = jest.fn();
+
+		await withOktaServerSideValidation(req, res, next);
+
+		expect(mockedSendStatus).toHaveBeenCalledWith(500);
+	});
+
+	it('should handle the case where Okta validation succeeds, but token is invalid', async () => {
+		setupOktaConfig(true);
+		mockedRequiresSignin.mockReturnValue(true);
+		mockedGetIdentityLocalState.mockReturnValue({
+			userId: 'userId',
+			email: 'email',
+			displayName: 'displayName',
+			signInStatus: 'signedInRecently',
+		});
+		const mockedSendStatus = jest.fn();
+		mockedValidateWithOkta.mockReturnValue(
+			Promise.resolve({ ok: true, valid: false }),
+		);
+		const req = {
+			signedCookies: {
+				GU_ACCESS_TOKEN: accessToken,
+			},
+		} as unknown as Request;
+		const res = {
+			locals: {},
+			sendStatus: mockedSendStatus,
+		} as unknown as Response;
+		const next = jest.fn();
+
+		await withOktaServerSideValidation(req, res, next);
+
+		expect(mockedClearIdentityLocalState).toHaveBeenCalled();
+		expect(mockedSendStatus).toHaveBeenCalledWith(401);
+	});
+
+	it('should handle the case where Okta validation succeeds and token is valid', async () => {
+		setupOktaConfig(true);
+		mockedRequiresSignin.mockReturnValue(true);
+		mockedGetIdentityLocalState.mockReturnValue({
+			userId: 'userId',
+			email: 'email',
+			displayName: 'displayName',
+			signInStatus: 'signedInRecently',
+		});
+		const mockedSendStatus = jest.fn();
+		mockedValidateWithOkta.mockReturnValue(
+			Promise.resolve({
+				ok: true,
+				valid: true,
+				userId: 'newUserId',
+				email: 'newEmail',
+				displayName: 'newDisplayName',
+			}),
+		);
+		const req = {
+			signedCookies: {
+				GU_ACCESS_TOKEN: accessToken,
+			},
+		} as unknown as Request;
+		const res = {
+			locals: {},
+			sendStatus: mockedSendStatus,
+		} as unknown as Response;
+		const next = jest.fn();
+
+		await withOktaServerSideValidation(req, res, next);
+
+		expect(setIdentityLocalState).toHaveBeenCalledWith(res, {
+			signInStatus: 'signedInRecently',
+			userId: 'newUserId',
+			email: 'newEmail',
+			displayName: 'newDisplayName',
+		});
+		expect(next).toHaveBeenCalled();
+	});
+});

--- a/server/__tests__/oauth.test.ts
+++ b/server/__tests__/oauth.test.ts
@@ -3,11 +3,13 @@
  */
 
 import type { Jwt } from '@okta/jwt-verifier';
-import type { Request } from 'express';
-import type { Scopes } from '../oauth';
+import type { Request, Response } from 'express';
+import * as identityLocalState from '../identityLocalState';
 import * as oauth from '../oauth';
-import { scopes } from '../oauth';
+import type { Scopes } from '../oauthConfig';
+import { scopes } from '../oauthConfig';
 
+jest.mock('@/server/log');
 jest.mock('@/server/idapiConfig', () => ({
 	getConfig: () => ({
 		idapiBaseUrl: 'https://idapi.example.com',
@@ -143,5 +145,87 @@ describe('verifyOAuthCookiesLocally', () => {
 		expect(spyOnVerifyAccessToken).toHaveBeenCalledWith('access-token');
 		expect(spyOnVerifyIdToken).toHaveBeenCalledWith('invalid-id-token');
 		expect(verify).toEqual({});
+	});
+});
+
+describe('setLocalStateFromIdTokenOrUserCookie', () => {
+	it('sets the local state from the ID token if it exists', () => {
+		const req = {
+			cookies: {
+				GU_U: 'gu_u',
+				SC_GU_U: 'sc_gu_u',
+				SC_GU_LA: 'sc_gu_la',
+			},
+		} as Request;
+		const res = {} as Response;
+		const spyOnSetIdentityLocalState = jest
+			.spyOn(identityLocalState, 'setIdentityLocalState')
+			.mockImplementation();
+
+		const idToken = {
+			claims: {
+				legacy_identity_id: 'legacy_identity_id',
+				name: 'name',
+				email: 'email',
+				iss: 'https://example.com',
+				aud: 'foo',
+				iat: 1234567890,
+				exp: 1234567890,
+				sub: 'sub',
+			},
+			header: {
+				alg: 'RS256',
+				typ: 'typ',
+				kid: 'kid',
+			},
+			isExpired: () => false,
+			isNotBefore: () => false,
+		} as Jwt;
+
+		oauth.setLocalStateFromIdTokenOrUserCookie(req, res, idToken);
+
+		expect(spyOnSetIdentityLocalState).toHaveBeenCalledWith(res, {
+			signInStatus: 'signedInRecently',
+			userId: 'legacy_identity_id',
+			displayName: 'name',
+			email: 'email',
+		});
+	});
+
+	it('sets the local state from the GU_U cookie if it exists', () => {
+		const req = {
+			cookies: {
+				GU_U: 'gu_u',
+				SC_GU_U: 'sc_gu_u',
+				SC_GU_LA: 'sc_gu_la',
+			},
+		} as Request;
+		const res = {} as Response;
+		const spyOnSetIdentityLocalState = jest
+			.spyOn(identityLocalState, 'setIdentityLocalState')
+			.mockImplementation();
+
+		oauth.setLocalStateFromIdTokenOrUserCookie(req, res);
+
+		expect(spyOnSetIdentityLocalState).toHaveBeenCalledWith(res, {
+			signInStatus: 'signedInRecently',
+		});
+	});
+
+	it("does not set 'signedInRecently' if neither the ID token nor the GU_U cookie exist", () => {
+		const req = {
+			cookies: {
+				SC_GU_U: 'sc_gu_u',
+				SC_GU_LA: 'sc_gu_la',
+			},
+		} as Request;
+		const res = {} as Response;
+		const spyOnSetIdentityLocalState = jest
+			.spyOn(identityLocalState, 'setIdentityLocalState')
+			.mockImplementation();
+
+		oauth.setLocalStateFromIdTokenOrUserCookie(req, res);
+
+		expect(spyOnSetIdentityLocalState).toHaveBeenCalledWith(res, {});
 	});
 });

--- a/server/identityLocalState.ts
+++ b/server/identityLocalState.ts
@@ -1,0 +1,17 @@
+import type { Response } from 'express';
+import type { IdentityDetails } from '@/shared/globals';
+
+export const setIdentityLocalState = (
+	res: Response,
+	identityLocalState: IdentityDetails,
+) => {
+	res.locals.identity = identityLocalState;
+};
+export const getIdentityLocalState = (
+	res: Response,
+): IdentityDetails | undefined => {
+	return res.locals?.identity;
+};
+export const clearIdentityLocalState = (res: Response) => {
+	delete res.locals.identity;
+};

--- a/server/middleware/identityMiddleware.ts
+++ b/server/middleware/identityMiddleware.ts
@@ -17,15 +17,17 @@ import {
 } from '@/server/middleware/requestMiddleware';
 import {
 	allIdapiCookiesSet,
-	OAuthAccessTokenCookieName,
-	oauthCookieOptions,
-	OAuthIdTokenCookieName,
 	performAuthorizationCodeFlow,
 	sanitizeReturnPath,
-	scopes,
 	setLocalStateFromIdTokenOrUserCookie,
 	verifyOAuthCookiesLocally,
 } from '@/server/oauth';
+import {
+	OAuthAccessTokenCookieName,
+	oauthCookieOptions,
+	OAuthIdTokenCookieName,
+	scopes,
+} from '@/server/oauthConfig';
 import { getConfig as getOktaConfig } from '@/server/oktaConfig';
 import {
 	getScopeFromRequestPathOrEmptyString,
@@ -36,7 +38,7 @@ import { requiresSignin } from '@/shared/requiresSignin';
 declare const CYPRESS: string;
 
 const handleIdentityMiddlewareError = (err: Error, res: Response) => {
-	console.log('OAuth / Middleware / Error', err);
+	log.error('OAuth / Middleware / Error', err);
 	res.redirect('/maintenance');
 };
 
@@ -143,7 +145,6 @@ export const authenticateWithOAuth = async (
 			return next();
 		}
 	} catch (err) {
-		console.error(err);
 		return handleIdentityMiddlewareError(err, res);
 	}
 };

--- a/server/middleware/oktaServerSideAuthMiddleware.ts
+++ b/server/middleware/oktaServerSideAuthMiddleware.ts
@@ -1,0 +1,112 @@
+import type { NextFunction, Request, Response } from 'express';
+import {
+	clearIdentityLocalState,
+	getIdentityLocalState,
+	setIdentityLocalState,
+} from '@/server/identityLocalState';
+import { OAuthAccessTokenCookieName } from '@/server/oauthConfig';
+import { validateWithOkta } from '@/server/okta';
+import { getConfig as getOktaConfig } from '@/server/oktaConfig';
+import { requiresSignin } from '@/shared/requiresSignin';
+import { log } from '../log';
+
+declare const CYPRESS: string;
+
+export interface OktaValidationResponse {
+	ok: boolean;
+	valid: boolean;
+	userId?: string;
+	displayName?: string;
+	email?: string;
+}
+
+export const withOktaServerSideValidation = async (
+	req: Request,
+	res: Response,
+	next: NextFunction,
+) => {
+	if (CYPRESS === 'SKIP_IDAPI') {
+		return next();
+	}
+	const oktaConfig = await getOktaConfig();
+	if (!oktaConfig.useOkta) {
+		/**
+		 * OKTA NOT ENABLED
+		 *
+		 * If Okta is disabled, we will still run this middleware, but
+		 * it won't be able to do anything so we just pass through.
+		 */
+		return next();
+	}
+
+	const signinRequired = requiresSignin(req.originalUrl);
+
+	const locallyValidatedIdentityData = getIdentityLocalState(res);
+	const accessToken = req.signedCookies[OAuthAccessTokenCookieName];
+	if (!accessToken || !locallyValidatedIdentityData?.userId) {
+		if (signinRequired) {
+			/**
+			 * NO TOKEN OR USER - SIGN IN REQUIRED
+			 *
+			 * This is unexpected and should be impossible because the withIdentity
+			 * middleware should have run first and not allowed the request to get
+			 * here. Return a 500.
+			 */
+			log.error(
+				`OAuth / Serverside Validation Middleware / Error: no access token or user in request for a sign-in required endpoint! This should have failed local validation.`,
+			);
+			return res.sendStatus(500);
+		} else {
+			/**
+			 * NO TOKEN OR USER - SIGN IN NOT REQUIRED
+			 *
+			 * This is expected - continue.
+			 */
+			return next();
+		}
+	}
+
+	const oktaValidationResponse = await validateWithOkta({
+		oktaConfig,
+		accessToken,
+	});
+
+	if (!oktaValidationResponse.ok) {
+		/**
+		 * UNEXPECTED ERROR
+		 */
+		return res.sendStatus(500);
+	}
+
+	if (!oktaValidationResponse.valid) {
+		/**
+		 * INVALID TOKEN
+		 *
+		 * Clear the local state. If the endpoint requires sign-in,
+		 * return a 401 which can be handled down the line. Otherwise
+		 * continue (the user will see the page as if they are not
+		 * signed in).
+		 */
+		clearIdentityLocalState(res);
+		if (signinRequired) {
+			return res.sendStatus(401);
+		}
+		return next();
+	}
+
+	/**
+	 * VALID TOKEN
+	 *
+	 * Update the local state with the latest user info from Okta.
+	 */
+	setIdentityLocalState(res, {
+		// This is always 'signedInRecently' because we've just checked
+		// the token is valid with Okta, and it's only valid for 30 minutes.
+		signInStatus: 'signedInRecently',
+		userId: oktaValidationResponse.userId,
+		displayName: oktaValidationResponse.displayName,
+		email: oktaValidationResponse.email,
+	});
+
+	return next();
+};

--- a/server/oauth.ts
+++ b/server/oauth.ts
@@ -1,28 +1,24 @@
 import crypto from 'crypto';
 import { joinUrl } from '@guardian/libs';
 import OktaJwtVerifier from '@okta/jwt-verifier';
-import type { CookieOptions, Request, Response } from 'express';
+import type { Request, Response } from 'express';
 import ms from 'ms';
 import type { Client, IssuerMetadata } from 'openid-client';
 import { generators, Issuer } from 'openid-client';
 import { conf } from '@/server/config';
+import { setIdentityLocalState } from '@/server/identityLocalState';
+import { log } from '@/server/log';
+import type { Scopes, VerifiedOAuthCookies } from '@/server/oauthConfig';
+import {
+	IdTokenClaims,
+	OAuthAccessTokenCookieName,
+	oauthCookieOptions,
+	OAuthIdTokenCookieName,
+	OAuthStateCookieName,
+	scopes,
+} from '@/server/oauthConfig';
 import type { OktaConfig } from '@/server/oktaConfig';
 import { getConfig as getOktaConfig } from '@/server/oktaConfig';
-
-export const OAuthAccessTokenCookieName = 'GU_ACCESS_TOKEN';
-export const OAuthIdTokenCookieName = 'GU_ID_TOKEN';
-export const OAuthStateCookieName = 'GU_oidc_auth_state';
-
-export interface VerifiedOAuthCookies {
-	accessToken?: OktaJwtVerifier.Jwt;
-	idToken?: OktaJwtVerifier.Jwt;
-}
-
-export const oauthCookieOptions: CookieOptions = {
-	signed: true,
-	secure: true,
-	httpOnly: true,
-};
 
 /**
  * @function getOktaOrgUrl
@@ -97,7 +93,7 @@ export const verifyAccessToken = async (token: string) => {
 		).verifyAccessToken(token, joinUrl(getOktaOrgUrl(oktaConfig), '/'));
 		return jwt;
 	} catch (error) {
-		console.error('OAuth / Access Token / Verification Error', error);
+		log.error('OAuth / Access Token / Verification Error', error);
 	}
 };
 
@@ -110,26 +106,9 @@ export const verifyIdToken = async (token: string) => {
 		);
 		return jwt;
 	} catch (error) {
-		console.error('OAuth / ID Token / Verification Error', error);
+		log.error('OAuth / ID Token / Verification Error', error);
 	}
 };
-
-export const scopes = [
-	'openid',
-	'profile',
-	'email',
-	'guardian.avatar-api.read.self',
-	'guardian.avatar-api.update.self',
-	'guardian.identity-api.newsletters.read.self',
-	'guardian.identity-api.newsletters.update.self',
-	'guardian.identity-api.user.read.self.secure',
-	'guardian.identity-api.user.update.self.secure',
-	'guardian.identity-api.user.username.create.self.secure',
-	'guardian.identity-api.consents.read.self',
-	'guardian.identity-api.consents.update.self',
-] as const;
-export type Scopes = typeof scopes[number];
-
 export const ManageMyAccountOpenIdClient = async (oktaConfig: OktaConfig) => {
 	const issuer = joinUrl(
 		oktaConfig.orgUrl,
@@ -301,8 +280,8 @@ export const performAuthorizationCodeFlow = async (
 export const verifyOAuthCookiesLocally = async (
 	req: Request,
 ): Promise<VerifiedOAuthCookies> => {
-	const accessTokenCookie = req.signedCookies['GU_ACCESS_TOKEN'];
-	const idTokenCookie = req.signedCookies['GU_ID_TOKEN'];
+	const accessTokenCookie = req.signedCookies[OAuthAccessTokenCookieName];
+	const idTokenCookie = req.signedCookies[OAuthIdTokenCookieName];
 
 	if (accessTokenCookie && idTokenCookie) {
 		const accessToken = await verifyAccessToken(accessTokenCookie);
@@ -346,12 +325,14 @@ export const setLocalStateFromIdTokenOrUserCookie = (
 	// but not the other fields. This will allow the frontend to show the
 	// signed in menu, but not show the user's name or email.
 	const hasIdTokenOrUserCookie = idToken || req.cookies['GU_U'];
-	res.locals.identity = {
+
+	const result = IdTokenClaims.safeParse(idToken?.claims);
+	setIdentityLocalState(res, {
 		signInStatus: hasIdTokenOrUserCookie ? 'signedInRecently' : undefined,
-		userId: idToken?.claims.legacy_identity_id,
-		name: idToken?.claims.name,
-		email: idToken?.claims.email,
-	};
+		userId: result.success ? result.data.legacy_identity_id : undefined,
+		displayName: result.success ? result.data.name : undefined,
+		email: result.success ? result.data.email : undefined,
+	});
 };
 
 // Sanitize the return path to prevent open redirects.

--- a/server/oauthConfig.ts
+++ b/server/oauthConfig.ts
@@ -1,0 +1,42 @@
+import type OktaJwtVerifier from '@okta/jwt-verifier';
+import type { CookieOptions } from 'express';
+import { z } from 'zod';
+
+export const OAuthAccessTokenCookieName = 'GU_ACCESS_TOKEN';
+export const OAuthIdTokenCookieName = 'GU_ID_TOKEN';
+export const OAuthStateCookieName = 'GU_oidc_auth_state';
+
+export interface VerifiedOAuthCookies {
+	accessToken?: OktaJwtVerifier.Jwt;
+	idToken?: OktaJwtVerifier.Jwt;
+}
+
+export const oauthCookieOptions: CookieOptions = {
+	signed: true,
+	secure: true,
+	httpOnly: true,
+};
+
+// Zod schema for the claims we expect to find in the ID token
+// and in responses from the Okta /userinfo endpoint
+export const IdTokenClaims = z.object({
+	legacy_identity_id: z.string(),
+	email: z.string(),
+	name: z.optional(z.string()),
+});
+
+export const scopes = [
+	'openid',
+	'profile',
+	'email',
+	'guardian.avatar-api.read.self',
+	'guardian.avatar-api.update.self',
+	'guardian.identity-api.newsletters.read.self',
+	'guardian.identity-api.newsletters.update.self',
+	'guardian.identity-api.user.read.self.secure',
+	'guardian.identity-api.user.update.self.secure',
+	'guardian.identity-api.user.username.create.self.secure',
+	'guardian.identity-api.consents.read.self',
+	'guardian.identity-api.consents.update.self',
+] as const;
+export type Scopes = typeof scopes[number];

--- a/server/okta.ts
+++ b/server/okta.ts
@@ -1,0 +1,50 @@
+import { joinUrl } from '@guardian/libs';
+import { log } from './log';
+import type { OktaValidationResponse } from './middleware/oktaServerSideAuthMiddleware';
+import { IdTokenClaims } from './oauthConfig';
+import type { OktaConfig } from './oktaConfig';
+
+export const validateWithOkta = async ({
+	oktaConfig,
+	accessToken,
+}: {
+	oktaConfig: OktaConfig;
+	accessToken: string;
+}): Promise<OktaValidationResponse> => {
+	const issuerUrl = joinUrl(
+		oktaConfig.orgUrl,
+		'/oauth2/',
+		oktaConfig.authServerId,
+	);
+
+	try {
+		const oktaResponse = await fetch(`${issuerUrl}/v1/userinfo/`, {
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${accessToken}`,
+			},
+		});
+		if (oktaResponse.status === 200) {
+			// Valid token
+			const oktaUserInfo = IdTokenClaims.parse(await oktaResponse.json());
+			return {
+				ok: true,
+				valid: true,
+				userId: oktaUserInfo.legacy_identity_id,
+				displayName: oktaUserInfo.name,
+				email: oktaUserInfo.email,
+			};
+		} else if ([401, 403].includes(oktaResponse.status)) {
+			log.error(`OAuth / Validate with Okta / Error: invalid token.`);
+			return { ok: true, valid: false };
+		} else {
+			log.error(
+				`OAuth / Validate with Okta / Error: unexpected status code from Okta: ${oktaResponse.status}`,
+			);
+			return { ok: false, valid: false };
+		}
+	} catch (error) {
+		log.error(`OAuth / Validate with Okta / Error: ${error.message}`);
+		return { ok: false, valid: false };
+	}
+};

--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -23,6 +23,7 @@ import { augmentProductDetailWithDeliveryAddressChangeEffectiveDateForToday } fr
 import { getArticleHandler, getTopicHandler } from '../helpCentreApi';
 import { log } from '../log';
 import { withIdentity } from '../middleware/identityMiddleware';
+import { withOktaServerSideValidation } from '../middleware/oktaServerSideAuthMiddleware';
 import {
 	cancelReminderHandler,
 	createOneOffReminderHandler,
@@ -126,6 +127,7 @@ router.post(
 
 router.post(
 	'/supporter-plus-cancel/:subscriptionName',
+	withOktaServerSideValidation,
 	productMoveAPI(
 		'supporter-plus-cancel/:subscriptionName',
 		'CANCEL_SUPPORTER_PLUS',
@@ -133,7 +135,11 @@ router.post(
 	),
 );
 
-router.post('/payment/card', stripeSetupIntentHandler);
+router.post(
+	'/payment/card',
+	withOktaServerSideValidation,
+	stripeSetupIntentHandler,
+);
 router.post(
 	'/payment/card/:subscriptionName',
 	membersDataApiHandler(
@@ -163,10 +169,12 @@ router.post(
 
 router.post(
 	'/case/:caseId?',
+	withOktaServerSideValidation,
 	cancellationSfCasesAPI('case', 'CREATE_CANCELLATION_CASE'),
 );
 router.patch(
 	'/case/:caseId?',
+	withOktaServerSideValidation,
 	cancellationSfCasesAPI('case/:caseId', 'UPDATE_CANCELLATION_CASE', [
 		'caseId',
 	]),
@@ -184,6 +192,7 @@ router.post(
 
 router.post(
 	'/product-move/:switchType/:subscriptionName',
+	withOktaServerSideValidation,
 	productMoveAPI(
 		'product-move/:switchType/:subscriptionName',
 		'MOVE_PRODUCT',
@@ -193,6 +202,7 @@ router.post(
 
 router.post(
 	'/update-supporter-plus-amount/:subscriptionName',
+	withOktaServerSideValidation,
 	productMoveAPI(
 		'update-supporter-plus-amount/:subscriptionName',
 		'MOVE_PRODUCT_UPDATE_AMOUNT',
@@ -220,9 +230,14 @@ router.get(
 		'subscriptionName',
 	]),
 );
-router.post('/holidays', holidayStopAPI('/hsr', 'HOLIDAY_STOP_CREATE'));
+router.post(
+	'/holidays',
+	withOktaServerSideValidation,
+	holidayStopAPI('/hsr', 'HOLIDAY_STOP_CREATE'),
+);
 router.patch(
 	'/holidays/:subscriptionName/:sfId',
+	withOktaServerSideValidation,
 	holidayStopAPI('hsr/:subscriptionName/:sfId', 'HOLIDAY_STOP_AMEND', [
 		'subscriptionName',
 		'sfId',
@@ -230,6 +245,7 @@ router.patch(
 );
 router.delete(
 	'/holidays/:subscriptionName/:sfId',
+	withOktaServerSideValidation,
 	holidayStopAPI('hsr/:subscriptionName/:sfId', 'HOLIDAY_STOP_WITHDRAW', [
 		'subscriptionName',
 		'sfId',
@@ -254,6 +270,7 @@ router.get(
 );
 router.post(
 	'/delivery-records/:subscriptionName',
+	withOktaServerSideValidation,
 	deliveryRecordsAPI(
 		'delivery-records/:subscriptionName',
 		'DELIVERY_PROBLEM_CREATE',

--- a/server/routes/oauth.ts
+++ b/server/routes/oauth.ts
@@ -1,17 +1,15 @@
 import type { Request, Response } from 'express';
 import { Router } from 'express';
 import ms from 'ms';
-import {
-	getOpenIdClient,
-	oauthCookieOptions,
-	OAuthStateCookieName,
-} from '@/server/oauth';
+import { getOpenIdClient } from '@/server/oauth';
+import { oauthCookieOptions, OAuthStateCookieName } from '@/server/oauthConfig';
 import { conf } from '../config';
+import { log } from '../log';
 
 const router = Router();
 
 const handleCallbackRouteError = (err: Error, res: Response) => {
-	console.error('OAuth / Callback endpoint error: ', err);
+	log.error('OAuth / Callback endpoint error: ', err);
 	res.redirect('/maintenance');
 };
 

--- a/shared/globals.ts
+++ b/shared/globals.ts
@@ -6,11 +6,11 @@ interface CommonGlobals {
 	dsn: string | null;
 }
 
-interface IdentityDetails {
+export interface IdentityDetails {
 	userId?: string;
 	email?: string;
 	displayName?: string;
-	signInStatus?: string;
+	signInStatus?: 'signedInRecently' | 'signedInNotRecently' | 'notSignedIn';
 }
 
 export interface Globals extends CommonGlobals {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "paths": {
       "@/*": ["./*"]
     },
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "strict": true
   },
   "exclude": ["cypress/**", "cdk/**", "cypress.config.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7834,6 +7834,13 @@ criteo-direct-rsa-validate@^1.1.0:
   resolved "https://registry.yarnpkg.com/criteo-direct-rsa-validate/-/criteo-direct-rsa-validate-1.1.0.tgz#eb2fead0ff0bcbe4f6369213dd5eef455f0e53c4"
   integrity sha512-7gQ3zX+d+hS/vOxzLrZ4aRAceB7qNJ0VzaGNpcWjDCmtOpASB50USJDupTik/H2nHgiSAA3VNZ3SFuONs8LR9Q==
 
+cross-fetch@^3.0.4:
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.8.tgz#0327eba65fd68a7d119f8fb2bf9334a1a7956f82"
+  integrity sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==
+  dependencies:
+    node-fetch "^2.6.12"
+
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -11201,6 +11208,14 @@ jest-environment-node@^29.7.0:
     jest-mock "^29.7.0"
     jest-util "^29.7.0"
 
+jest-fetch-mock@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
+  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
+  dependencies:
+    cross-fetch "^3.0.4"
+    promise-polyfill "^8.1.3"
+
 jest-get-type@^29.4.3:
   version "29.4.3"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.4.3.tgz#1ab7a5207c995161100b5187159ca82dd48b3dd5"
@@ -12547,7 +12562,7 @@ node-fetch@2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-fetch@^2.0.0:
+node-fetch@^2.0.0, node-fetch@^2.6.12:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
@@ -13455,6 +13470,11 @@ progress@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
+promise-polyfill@^8.1.3:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.3.0.tgz#9284810268138d103807b11f4e23d5e945a4db63"
+  integrity sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==
 
 prompts@^2.0.1, prompts@^2.4.0:
   version "2.4.2"
@@ -16519,3 +16539,8 @@ zip-stream@^2.1.2:
     archiver-utils "^2.1.0"
     compress-commons "^2.1.1"
     readable-stream "^3.4.0"
+
+zod@3.22.4:
+  version "3.22.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.4.tgz#f31c3a9386f61b1f228af56faa9255e845cf3fff"
+  integrity sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==


### PR DESCRIPTION
## What does this change?

Co-authored by @pvighi and @raphaelkabo.

### Server-side token validation middleware

As part of the MMA OAuth migration, this PR introduces a new middleware, `withOktaServerSideValidation`, which verifies an Okta OAuth access token against the [Okta API's `/userinfo` endpoint](https://developer.okta.com/docs/reference/api/oidc/#userinfo). This endpoint returns user data if a user with a valid, active session exists for the supplied access token. More importantly, if the access token is not associated with a valid, active session (i.e. if the user has been signed out), the endpoint returns an error code.

The middleware is always invoked after the standard `withIdentity` middleware function. `withIdentity` performs a **local** check on the access token, validating that it hasn't been tampered with, that it isn't expired, and that its scopes are what we expect. The local check cannot verify that the user to whom the token is connected still has an active Okta session, although MMA tokens last only 30 minutes to compensate for this. `withOktaServerSideValidation` performs an additional **server-side** check, ensuring that the final part of the authorization demand - that the token is connected to a valid session - is fulfilled.

We don't need to make this additional check everywhere. We add the new middleware selectively to API routes which fulfil the following criteria:

- They call a downstream API with an admin-level client access token which may allow the API to perform operations on various users, not just the currently signed in user
- They fetch or modify sensitive user data, such as payment or subscription information

In these cases, we want to be absolutely sure that the user is authorized to perform the operation.

### Unit tests

We add Jest unit tests to cover the new middleware functions.

### Helper functions and tweaks

- We add some functions to abstract setting and fetching local request state (objects which live in Express in `res.locals`).
- The middleware functions now send messages via the logger library, rather than direct to console.
- We add and use the `zod` package to validate responses in the ID and access tokens

## Tests

- [x] Tested on CODE (with Okta disabled)
- [x] Tested on CODE (with Okta enabled)
- [ ] Smoke tested on PROD