### PR TITLE
Fix: Add support for quarterly billing period

### DIFF
--- a/client/components/mma/paymentUpdate/PaymentDetailUpdateConfirmation.tsx
+++ b/client/components/mma/paymentUpdate/PaymentDetailUpdateConfirmation.tsx
@@ -85,6 +85,8 @@ function getPaymentInterval(interval: string) {
 		return 'annual';
 	} else if (interval === 'month') {
 		return 'monthly';
+	} else if (interval === 'quarter') {
+		return 'quarterly';
 	}
 }
 

--- a/client/fixtures/productBuilder/productBuilder.ts
+++ b/client/fixtures/productBuilder/productBuilder.ts
@@ -150,7 +150,7 @@ export class ProductBuilder {
 		return this;
 	}
 
-	withBillingPeriod(billingPeriod: 'month' | 'year') {
+	withBillingPeriod(billingPeriod: 'month' | 'year' | 'quarter') {
 		const { plan, currentPlans, futurePlans } =
 			this.productToBuild.subscription;
 		if (plan) {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a small fix to support quarterly billing periods in update payment component. And to the test product builder. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Take out quarterly Guardian Weekly. 
Update payment method. 
Witness "quarterly" on screen.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

There are a lot of places in the code that assume certain products are either monthly or annual. Digisubs and Guardian Weekly can have quarterly billing periods. How do we ensure we don't make incorrect assumptions?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Before
![image](https://github.com/guardian/manage-frontend/assets/114918544/518cc409-9e4c-4db4-889e-444799d77bb2)
After
![image](https://github.com/guardian/manage-frontend/assets/114918544/87d89c03-807b-43c0-9e16-a7335a395fc3)


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
