### PR TITLE
National Delivery - add test case for multiple delivery addresses, where one is national

### DIFF
--- a/cypress/e2e/parallel-4/deliveryAddress.cy.ts
+++ b/cypress/e2e/parallel-4/deliveryAddress.cy.ts
@@ -101,6 +101,30 @@ describe('Delivery address', () => {
 		cy.findByText(/Changed address?/).should('exist');
 	});
 
+	it('Cannot update Guardian Weekly address, if also have National delivery', () => {
+		cy.intercept('GET', '/api/me/mma**', {
+			statusCode: 200,
+			body: toMembersDataApiResponse(
+				nationalDelivery(),
+				guardianWeeklyPaidByCard(),
+				supporterPlus(),
+			),
+		}).as('mma');
+
+		cy.visit('/guardianweekly');
+
+		cy.wait('@mma');
+
+		cy.findByText('Manage delivery address').click();
+
+		cy.intercept('GET', '/api/me/mma?productType=ContentSubscription', {
+			statusCode: 200,
+			body: toMembersDataApiResponse(nationalDelivery(), supporterPlus()),
+		});
+
+		cy.findByText(/Changed address?/).should('exist');
+	});
+
 	it('Shows updated address when returning to manage subscription page', () => {
 		cy.intercept('GET', '/api/me/mma', {
 			statusCode: 200,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Follow up to #1234, as suggested by @charleycampbell. This PR adds a Cypress test where a user has multiple delivery products, one is national delivery and therefore they cannot update any of the addresses. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
