### PR TITLE
Remove message about covid-19 and inaccurate holidays

### DIFF
--- a/client/components/mma/cancel/voucher/VoucherCancellationFlowStart.tsx
+++ b/client/components/mma/cancel/voucher/VoucherCancellationFlowStart.tsx
@@ -33,24 +33,6 @@ export const voucherCancellationFlowStart = ({
 				We’re sorry to hear you’re thinking of cancelling your voucher
 				subscription
 			</Heading>
-
-			<p>
-				We understand that some of you may have concerns about claiming
-				your paper during the COVID-19 outbreak. We are now offering all
-				our voucher customers a holiday suspension of up to 10 weeks,
-				which you can arrange{' '}
-				<a
-					css={hrefStyle}
-					href="/suspend/voucher"
-					onClick={trackCancellationClickEvent(
-						'voucher_holiday_suspension',
-					)}
-				>
-					online
-				</a>
-				.
-			</p>
-
 			<p>
 				You can also opt for home delivery. Sign up to a free trial with{' '}
 				<a


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Removes a message in newspaper voucher cancellation flow about covid-19, and an inaccurate number of holiday stops.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Vouchers are only available in the UK, and self serve cancellation is not available in the UK...so hard to test.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Before
<img width="896" alt="image" src="https://github.com/guardian/manage-frontend/assets/114918544/adc4c5fc-67d3-4793-8836-2381cd9a6e55">

After
<img width="873" alt="image" src="https://github.com/guardian/manage-frontend/assets/114918544/1da2f2c7-0ff0-41cc-8391-c43f4752d456">


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
