### PR TITLE
Redesign Cancellation Landing page

### DIFF
--- a/client/components/mma/cancel/cancellationSaves/CancellationLanding.tsx
+++ b/client/components/mma/cancel/cancellationSaves/CancellationLanding.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { textSans } from '@guardian/source-foundations';
+import { space, textSans } from '@guardian/source-foundations';
 import { Button, Stack } from '@guardian/source-react-components';
 import { useContext } from 'react';
 import { Navigate, useNavigate } from 'react-router';
@@ -8,9 +8,11 @@ import type {
 	PaidSubscriptionPlan,
 	ProductDetail,
 } from '../../../../../shared/productResponse';
-import { getMainPlan } from '../../../../../shared/productResponse';
-import { buttonLayoutCss } from '../../../../styles/ButtonStyles';
-import { headingCss, sectionSpacing } from '../../../../styles/GenericStyles';
+import {
+	getMainPlan,
+	getSpecificProductTypeFromProduct,
+} from '../../../../../shared/productResponse';
+import { headingCss } from '../../../../styles/GenericStyles';
 import type { CurrencyIso } from '../../../../utilities/currencyIso';
 import {
 	LoadingState,
@@ -26,6 +28,20 @@ import { Heading } from '../../shared/Heading';
 import type { CancellationContextInterface } from '../CancellationContainer';
 import { CancellationContext } from '../CancellationContainer';
 import { ineligibleForSave } from './eligibilityCheck';
+
+function getNextRoute(productToCancel: ProductDetail): string {
+	const specificProductTypeKey =
+		getSpecificProductTypeFromProduct(productToCancel).productType;
+
+	switch (specificProductTypeKey) {
+		case 'membership': {
+			return '../details';
+		}
+		default: {
+			return '/';
+		}
+	}
+}
 
 function getPhoneRegion(currencyIso: CurrencyIso): PhoneRegionKey {
 	switch (currencyIso) {
@@ -86,14 +102,18 @@ export const CancellationLanding = () => {
 
 	return (
 		<>
-			<section css={sectionSpacing}>
-				<Stack space={3}>
+			<section
+				css={css`
+					margin-top: ${space[4]}px;
+				`}
+			>
+				<Stack space={1}>
 					<h2 css={headingCss}>
 						We're sorry to hear you're thinking of leaving
 					</h2>
 					<p
 						css={css`
-							${textSans.medium()}
+							${textSans.medium()};
 						`}
 					>
 						To cancel today, please choose from the following
@@ -101,15 +121,22 @@ export const CancellationLanding = () => {
 					</p>
 				</Stack>
 			</section>
-			<section css={sectionSpacing}>
+			<section
+				css={css`
+					margin-top: ${space[6] + space[2]}px;
+				`}
+			>
 				<Stack space={3}>
-					<Heading sansSerif>Call us to cancel</Heading>
+					<Heading borderless sansSerif level="3">
+						Contact us
+					</Heading>
 					<p
 						css={css`
-							${textSans.medium()}
+							${textSans.medium()};
+							margin: 0;
 						`}
 					>
-						Phone one of our customer service agents.
+						Speak to our customer service team.
 					</p>
 					<CallCentreEmailAndNumbers
 						hideEmailAddress={true}
@@ -121,26 +148,35 @@ export const CancellationLanding = () => {
 					/>
 				</Stack>
 			</section>
-			<section css={sectionSpacing}>
-				<Stack space={3}>
-					<Heading sansSerif>Cancel online</Heading>
-					<p
-						css={css`
-							${textSans.medium()}
-						`}
-					>
-						Continue without speaking to our customer service team.
-					</p>
-					<div css={buttonLayoutCss}>
+			<section
+				css={css`
+					margin-top: ${space[6] + space[2]}px;
+				`}
+			>
+				<Stack space={2}>
+					<span>
+						<Heading borderless sansSerif level="3">
+							Cancel online
+						</Heading>
+						<p
+							css={css`
+								${textSans.medium()};
+								margin: 0;
+							`}
+						>
+							End your subscription with just a few clicks.
+						</p>
+					</span>
+					<div>
 						<Button
-							// ToDo: navigate to different routes depending on the product journey
+							priority="subdued"
 							onClick={() =>
-								navigate('../details', {
+								navigate(getNextRoute(productToCancel), {
 									state: { user: data.user },
 								})
 							}
 						>
-							Cancel online
+							Continue to cancel online
 						</Button>
 					</div>
 				</Stack>

--- a/cypress/e2e/parallel-2/membershipSave.cy.ts
+++ b/cypress/e2e/parallel-2/membershipSave.cy.ts
@@ -92,7 +92,7 @@ if (featureSwitches.membershipSave) {
 				/We're sorry to hear you're thinking of leaving/,
 			).should('exist');
 			cy.findByRole('button', {
-				name: 'Cancel online',
+				name: 'Continue to cancel online',
 			}).click();
 
 			cy.findByText(/Thank you for supporting the Guardian/).should(
@@ -131,7 +131,7 @@ if (featureSwitches.membershipSave) {
 				/We're sorry to hear you're thinking of leaving/,
 			).should('exist');
 			cy.findByRole('button', {
-				name: 'Cancel online',
+				name: 'Continue to cancel online',
 			}).click();
 
 			cy.findByText(/Thank you for supporting the Guardian/).should(
@@ -172,7 +172,7 @@ if (featureSwitches.membershipSave) {
 				/We're sorry to hear you're thinking of leaving/,
 			).should('exist');
 			cy.findByRole('button', {
-				name: 'Cancel online',
+				name: 'Continue to cancel online',
 			}).click();
 
 			cy.findByText(/Thank you for supporting the Guardian/).should(

--- a/shared/productResponse.ts
+++ b/shared/productResponse.ts
@@ -241,12 +241,20 @@ export const getMainPlan: (subscription: Subscription) => SubscriptionPlan = (
 	};
 };
 
-export const isSpecificProductType = (
+export function getSpecificProductTypeFromProduct(
 	productDetail: ProductDetail,
-	targetProductType: ProductType,
-) => {
+): ProductType {
 	const groupedProductType = GROUPED_PRODUCT_TYPES[productDetail.mmaCategory];
 	const specificProductType =
 		groupedProductType.mapGroupedToSpecific(productDetail);
+	return specificProductType;
+}
+
+export function isSpecificProductType(
+	productDetail: ProductDetail,
+	targetProductType: ProductType,
+): boolean {
+	const specificProductType =
+		getSpecificProductTypeFromProduct(productDetail);
 	return specificProductType === targetProductType;
-};
+}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Redesign the cancellation landing page as per [design](https://www.figma.com/file/sx9jlOcpcK9V0gNgj4GWtW/Cancellation-saves-Q3-2023?type=design&node-id=155-53050&mode=design&t=CGHvl5rUB4H2LkRB-0) (except the accordion which will be done separately)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Membership cancellation flow should still work - Cypress tests pass.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://github.com/guardian/manage-frontend/assets/114918544/91774ec6-6406-4eda-97ae-0056ed47b23f)
![image](https://github.com/guardian/manage-frontend/assets/114918544/70784104-db44-4ec8-ae87-5f80773b4ad2)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
