### PR TITLE
Rename 'Single Contribution' to 'One-time'

### DIFF
--- a/client/components/mma/accountoverview/SingleContributionCard.tsx
+++ b/client/components/mma/accountoverview/SingleContributionCard.tsx
@@ -25,7 +25,7 @@ export const SingleContributionCard = ({
 		<Stack space={4}>
 			<Card>
 				<Card.Header backgroundColor={productColour.singleContribution}>
-					<h3 css={productCardTitleCss(true)}>Single Support</h3>
+					<h3 css={productCardTitleCss(true)}>One-time Support</h3>
 				</Card.Header>
 				<Card.Section>
 					<div
@@ -50,7 +50,7 @@ export const SingleContributionCard = ({
 											}
 										`}
 									>
-										<dt>Single contribution of</dt>
+										<dt>One-time contribution of</dt>
 										<dd>
 											{convertCurrencyToSymbol(
 												contribution.currency,

--- a/cypress/e2e/parallel-1/accountOverview.cy.ts
+++ b/cypress/e2e/parallel-1/accountOverview.cy.ts
@@ -41,7 +41,7 @@ if (featureSwitches.singleContributions) {
 			cy.wait('@mobile_subscriptions');
 			cy.wait('@single_contributions');
 
-			cy.findByText('Single Support');
+			cy.findByText('One-time Support');
 			cy.findByText('$50');
 			cy.findByText('15 May 2023');
 			cy.findByText('Subscriptions');

--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -354,7 +354,7 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 					case 'mma_financial_circumstances':
 					case 'mma_value_for_money':
 					case 'mma_one_off':
-						return 'You can support The Guardian’s independent journalism with a single contribution, from as little as £1 – and it only takes a minute.';
+						return 'You can support The Guardian’s independent journalism with a One-time contribution, from as little as £1 – and it only takes a minute.';
 					case 'mma_wants_annual_contribution':
 						return 'You can support The Guardian’s independent journalism for the long term with an annual contribution.';
 					case 'mma_wants_monthly_contribution':
@@ -371,7 +371,7 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 					case 'mma_financial_circumstances':
 					case 'mma_value_for_money':
 					case 'mma_one_off':
-						return 'Make a single contribution';
+						return 'Make a One-time contribution';
 					case 'mma_wants_annual_contribution':
 						return 'Make an annual contribution';
 					case 'mma_wants_monthly_contribution':


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR changes the public facing bits of MMA to use the term "One-time support" instead of "Single Contribution"

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Take out a One-time contribution in the support checkout, visit account overview and see the product card. Should say "One-time support".

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Before
![image](https://github.com/guardian/manage-frontend/assets/114918544/75f7f25c-693f-46bb-a1fd-d04e71f7dfbe)

After
![image](https://github.com/guardian/manage-frontend/assets/114918544/3df66116-ce76-49f7-bb77-a993e3596fc0)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
