### PR TITLE
Digisub Save: thank you + offer

### DIFF
--- a/client/components/mma/cancel/cancellationSaves/digipack/ThankYouOffer.stories.tsx
+++ b/client/components/mma/cancel/cancellationSaves/digipack/ThankYouOffer.stories.tsx
@@ -1,6 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { ReactRouterDecorator } from '@/.storybook/ReactRouterDecorator';
-import { digitalPackPaidByDirectDebit } from '@/client/fixtures/productBuilder/testProducts';
+import {
+	digitalPackPaidByDirectDebit,
+	digitalPackWithPaymentFailure,
+} from '@/client/fixtures/productBuilder/testProducts';
 import { PRODUCT_TYPES } from '@/shared/productTypes';
 import { CancellationContainer } from '../../CancellationContainer';
 import { ThankYouOffer } from './ThankYouOffer';
@@ -23,6 +26,24 @@ export const Default: StoryObj<typeof ThankYouOffer> = {
 		reactRouter: {
 			state: {
 				productDetail: digitalPackPaidByDirectDebit(),
+				user: { email: 'test@test.com' },
+			},
+			container: (
+				<CancellationContainer productType={PRODUCT_TYPES.digipack} />
+			),
+		},
+	},
+};
+
+export const IneligibleForDiscount: StoryObj<typeof ThankYouOffer> = {
+	render: () => {
+		return <ThankYouOffer />;
+	},
+
+	parameters: {
+		reactRouter: {
+			state: {
+				productDetail: digitalPackWithPaymentFailure(),
 				user: { email: 'test@test.com' },
 			},
 			container: (

--- a/client/components/mma/cancel/cancellationSaves/digipack/ThankYouOffer.stories.tsx
+++ b/client/components/mma/cancel/cancellationSaves/digipack/ThankYouOffer.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ReactRouterDecorator } from '@/.storybook/ReactRouterDecorator';
+import { digitalPackPaidByDirectDebit } from '@/client/fixtures/productBuilder/testProducts';
+import { PRODUCT_TYPES } from '@/shared/productTypes';
+import { CancellationContainer } from '../../CancellationContainer';
+import { ThankYouOffer } from './ThankYouOffer';
+
+export default {
+	title: 'Pages/CancellationSave/DigiPack/Thank You + Offer',
+	component: CancellationContainer,
+	decorators: [ReactRouterDecorator],
+	parameters: {
+		layout: 'fullscreen',
+	},
+} as Meta<typeof CancellationContainer>;
+
+export const Default: StoryObj<typeof ThankYouOffer> = {
+	render: () => {
+		return <ThankYouOffer />;
+	},
+
+	parameters: {
+		reactRouter: {
+			state: {
+				productDetail: digitalPackPaidByDirectDebit(),
+				user: { email: 'test@test.com' },
+			},
+			container: (
+				<CancellationContainer productType={PRODUCT_TYPES.digipack} />
+			),
+		},
+	},
+};

--- a/client/components/mma/cancel/cancellationSaves/digipack/ThankYouOffer.tsx
+++ b/client/components/mma/cancel/cancellationSaves/digipack/ThankYouOffer.tsx
@@ -21,7 +21,11 @@ import type {
 } from '../../CancellationContainer';
 import { CancellationContext } from '../../CancellationContainer';
 
-const Offer = () => (
+const DiscountOffer = ({
+	handleDiscountOfferClick,
+}: {
+	handleDiscountOfferClick: () => void;
+}) => (
 	<Stack
 		space={4}
 		css={css`
@@ -75,7 +79,10 @@ const Offer = () => (
 		</div>
 		<div css={buttonContainerCss}>
 			<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
-				<Button cssOverrides={buttonCentredCss}>
+				<Button
+					cssOverrides={buttonCentredCss}
+					onClick={handleDiscountOfferClick}
+				>
 					Keep support with discount
 				</Button>
 			</ThemeProvider>
@@ -101,6 +108,10 @@ export const ThankYouOffer = () => {
 		new Date(productDetail.joinDate),
 		'yyyy',
 	);
+
+	const hasDiscountLive = false; // ToDo
+	const hasPaymentFailure = !!productDetail.alertText;
+	const eligibleForDiscount = !hasDiscountLive && !hasPaymentFailure;
 
 	return (
 		<section
@@ -138,7 +149,13 @@ export const ThankYouOffer = () => {
 						world. We're so grateful.
 					</p>
 				</Stack>
-				<Offer />
+				{eligibleForDiscount && (
+					<DiscountOffer
+						handleDiscountOfferClick={() =>
+							navigate('todo', { state: { ...routerState } })
+						}
+					/>
+				)}
 				<div>
 					<h3
 						css={css`

--- a/client/components/mma/cancel/cancellationSaves/digipack/ThankYouOffer.tsx
+++ b/client/components/mma/cancel/cancellationSaves/digipack/ThankYouOffer.tsx
@@ -72,7 +72,8 @@ const DiscountOffer = ({
 							padding-top: ${space[1]}px;
 						`}
 					>
-						Retain exclusive access to our daily Editions app
+						Exclusive access to the Editions app (our daily digital
+						newspaper)
 					</span>
 				</li>
 			</ul>

--- a/client/components/mma/cancel/cancellationSaves/digipack/ThankYouOffer.tsx
+++ b/client/components/mma/cancel/cancellationSaves/digipack/ThankYouOffer.tsx
@@ -1,0 +1,163 @@
+import { css, ThemeProvider } from '@emotion/react';
+import { from, headline, space, textSans } from '@guardian/source-foundations';
+import {
+	Button,
+	buttonThemeReaderRevenueBrand,
+	Stack,
+	SvgTickRound,
+} from '@guardian/source-react-components';
+import { useContext } from 'react';
+import { Navigate, useLocation, useNavigate } from 'react-router';
+import {
+	buttonCentredCss,
+	buttonContainerCss,
+} from '@/client/styles/ButtonStyles';
+import { dateString } from '../../../../../../shared/dates';
+import { benefitsCss } from '../../../shared/benefits/BenefitsStyles';
+import { Heading } from '../../../shared/Heading';
+import type {
+	CancellationContextInterface,
+	CancellationRouterState,
+} from '../../CancellationContainer';
+import { CancellationContext } from '../../CancellationContainer';
+
+const Offer = () => (
+	<Stack
+		space={4}
+		css={css`
+			background-color: #f3f7fe;
+			border-radius: 4px;
+			padding: ${space[4]}px;
+		`}
+	>
+		<div>
+			<div
+				css={css`
+					${textSans.large({ fontWeight: 'bold' })}
+					margin-bottom: ${space[2]}px;
+				`}
+			>
+				A subscription offer just for you
+			</div>
+			<ul css={benefitsCss}>
+				<li>
+					<SvgTickRound isAnnouncedByScreenReader size="medium" />
+					<span
+						css={css`
+							padding-top: ${space[1]}px;
+						`}
+					>
+						Get a 25% discount for 3 months (x, then y)
+					</span>
+				</li>
+				<li>
+					<SvgTickRound isAnnouncedByScreenReader size="medium" />{' '}
+					<span
+						css={css`
+							padding-top: ${space[1]}px;
+						`}
+					>
+						Keep all your supporter extras, including unlimited,
+						ad-free reading
+					</span>
+				</li>
+				<li>
+					<SvgTickRound isAnnouncedByScreenReader size="medium" />{' '}
+					<span
+						css={css`
+							padding-top: ${space[1]}px;
+						`}
+					>
+						Retain exclusive access to our daily Editions app
+					</span>
+				</li>
+			</ul>
+		</div>
+		<div css={buttonContainerCss}>
+			<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
+				<Button cssOverrides={buttonCentredCss}>
+					Keep support with discount
+				</Button>
+			</ThemeProvider>
+		</div>
+	</Stack>
+);
+
+export const ThankYouOffer = () => {
+	const navigate = useNavigate();
+	const cancellationContext = useContext(
+		CancellationContext,
+	) as CancellationContextInterface;
+	const productDetail = cancellationContext.productDetail;
+
+	const location = useLocation();
+	const routerState = location.state as CancellationRouterState;
+
+	if (!productDetail) {
+		return <Navigate to="/" />;
+	}
+
+	const supportStartYear = dateString(
+		new Date(productDetail.joinDate),
+		'yyyy',
+	);
+
+	return (
+		<section
+			css={css`
+				margin-top: ${space[4]}px;
+			`}
+		>
+			<Stack space={6}>
+				<h2
+					css={css`
+						${headline.xsmall({ fontWeight: 'bold' })};
+						margin-top: 0;
+						margin-bottom: 0;
+						${from.tablet} {
+							${headline.medium({ fontWeight: 'bold' })};
+						}
+					`}
+				>
+					Thank you for supporting the Guardian since{' '}
+					{supportStartYear}
+				</h2>
+				<Stack space={1}>
+					<Heading sansSerif borderless level="3">
+						Your funding has played a vital role in our progress
+					</Heading>
+					<p
+						css={css`
+							${textSans.medium()};
+						`}
+					>
+						Since you first joined as a Guardian supporter, we've
+						lived through some of the most important news events of
+						our times. Without you, our fearless, independent
+						journalism wouldn't have reached millions around the
+						world. We're so grateful.
+					</p>
+				</Stack>
+				<Offer />
+				<div>
+					<h3
+						css={css`
+							${textSans.large({ fontWeight: 'bold' })};
+							margin: 0;
+						`}
+					>
+						Still want to cancel?
+					</h3>
+					<Button
+						priority="subdued"
+						onClick={() =>
+							navigate('todo', { state: { ...routerState } })
+						}
+					>
+						Continue to cancel
+					</Button>
+				</div>
+			</Stack>
+		</section>
+	);
+};

--- a/client/fixtures/productBuilder/testProducts.ts
+++ b/client/fixtures/productBuilder/testProducts.ts
@@ -52,6 +52,13 @@ export function digitalPackPaidByDirectDebit() {
 		.getProductDetailObject();
 }
 
+export function digitalPackWithPaymentFailure() {
+	return new ProductBuilder(baseDigitalPack())
+		.payByDirectDebit()
+		.withAlertText('Payment failed')
+		.getProductDetailObject();
+}
+
 export function annualContributionPaidByCardWithCurrency(
 	currency: CurrencyIso,
 ) {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR creates the Thank you + Offer page component ([figma](https://www.figma.com/file/sx9jlOcpcK9V0gNgj4GWtW/DigiSub-Price-Rise-%E2%80%94-cancellation-saves?type=design&node-id=162-1897&mode=design&t=S8EomeJqNPk59B5b-4)) for the new DigiSub cancellation journey.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

See the new storybook story.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://github.com/guardian/manage-frontend/assets/114918544/42a48a01-adbf-492f-897a-c1c93f9f1f02)
![image](https://github.com/guardian/manage-frontend/assets/114918544/638064b5-2581-442a-b919-92ee5cd31c55)


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
