### PR TITLE
Digisub confirm cancel V1

### DIFF
--- a/client/components/mma/cancel/cancellationSaves/digipack/ConfirmCancellation.tsx
+++ b/client/components/mma/cancel/cancellationSaves/digipack/ConfirmCancellation.tsx
@@ -19,6 +19,9 @@ function GreyBulletpoints() {
 			height="17"
 			viewBox="0 0 16 17"
 			fill="none"
+			css={css`
+				padding-top: 5px;
+			`}
 		>
 			<circle cx="8" cy="8.13672" r="8" fill="#DCDCDC" />
 		</svg>
@@ -92,7 +95,7 @@ export const ConfirmCancellation = () => {
 			<section
 				css={css`
 					margin-top: 32px;
-					margin-bottom: 36px;
+					margin-bottom: 32px;
 				`}
 			>
 				<BenefitsNotAvailable />
@@ -126,6 +129,7 @@ export const ConfirmCancellation = () => {
 						justify-content: center;
 						margin-left: ${space[5]}px;
 						margin-top: ${space[4]}px;
+						display: flex;
 					`}
 					to={'/'} //todo update link
 				>

--- a/client/components/mma/cancel/cancellationSaves/digipack/ConfirmCancellation.tsx
+++ b/client/components/mma/cancel/cancellationSaves/digipack/ConfirmCancellation.tsx
@@ -48,22 +48,22 @@ const BenefitsNotAvailable = () => (
 			</div>
 			<ul css={benefitsCss}>
 				<li>
-					<GreyBulletpoints />
+					<GreyBulletpoint />
 					Funding independent journalism
 				</li>
 				<li>
-					<GreyBulletpoints />A regular supporter newsletter
+					<GreyBulletpoint />A regular supporter newsletter
 				</li>
 				<li>
-					<GreyBulletpoints />
+					<GreyBulletpoint />
 					Unlimited access in our app
 				</li>
 				<li>
-					<GreyBulletpoints />
+					<GreyBulletpoint />
 					Ad-free reading
 				</li>
 				<li>
-					<GreyBulletpoints />
+					<GreyBulletpoint />
 					Offline reading
 				</li>
 			</ul>

--- a/client/components/mma/cancel/cancellationSaves/digipack/ConfirmCancellation.tsx
+++ b/client/components/mma/cancel/cancellationSaves/digipack/ConfirmCancellation.tsx
@@ -11,7 +11,7 @@ import { Link } from 'react-router-dom';
 import { benefitsCss } from '@/client/components/mma/shared/benefits/BenefitsStyles';
 import { stackedButtonLayoutCss } from '@/client/styles/ButtonStyles';
 
-function GreyBulletpoints() {
+function GreyBulletpoint() {
 	return (
 		<svg
 			xmlns="http://www.w3.org/2000/svg"

--- a/client/components/mma/cancel/cancellationSaves/digipack/ConfirmCancellation.tsx
+++ b/client/components/mma/cancel/cancellationSaves/digipack/ConfirmCancellation.tsx
@@ -123,6 +123,7 @@ export const ConfirmCancellation = () => {
 					cssOverrides={css`
 						display: flex;
 						margin-left: ${space[5]}px;
+						justify-content: center;
 					`}
 					priority="subdued"
 				>

--- a/client/components/mma/cancel/cancellationSaves/digipack/ConfirmCancellation.tsx
+++ b/client/components/mma/cancel/cancellationSaves/digipack/ConfirmCancellation.tsx
@@ -1,0 +1,137 @@
+import { css } from '@emotion/react';
+import {
+	from,
+	headline,
+	palette,
+	space,
+	textSans,
+} from '@guardian/source-foundations';
+import { Button, Stack } from '@guardian/source-react-components';
+import { Link } from 'react-router-dom';
+import { benefitsCss } from '@/client/components/mma/shared/benefits/BenefitsStyles';
+import { stackedButtonLayoutCss } from '@/client/styles/ButtonStyles';
+
+function GreyBulletpoints() {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			width="16"
+			height="17"
+			viewBox="0 0 16 17"
+			fill="none"
+		>
+			<circle cx="8" cy="8.13672" r="8" fill="#DCDCDC" />
+		</svg>
+	);
+}
+
+const BenefitsNotAvailable = () => (
+	<Stack
+		space={4}
+		css={css`
+			background-color: #f3f7fe;
+			border-radius: 4px;
+			padding: ${space[4]}px;
+		`}
+	>
+		<div>
+			<div
+				css={css`
+					${textSans.large({ fontWeight: 'bold' })}
+					margin-bottom: ${space[2]}px;
+				`}
+			>
+				Extras you'll lose:
+			</div>
+			<ul css={benefitsCss}>
+				<li>
+					<GreyBulletpoints />
+					Funding independent journalism
+				</li>
+				<li>
+					<GreyBulletpoints />A regular supporter newsletter
+				</li>
+				<li>
+					<GreyBulletpoints />
+					Unlimited access in our app
+				</li>
+				<li>
+					<GreyBulletpoints />
+					Ad-free reading
+				</li>
+				<li>
+					<GreyBulletpoints />
+					Offline reading
+				</li>
+			</ul>
+		</div>
+	</Stack>
+);
+
+export const ConfirmCancellation = () => {
+	return (
+		<section
+			css={css`
+				margin-top: ${space[4]}px;
+			`}
+		>
+			<h1
+				css={css`
+					${headline.xsmall({ fontWeight: 'bold' })};
+					margin-top: 0;
+					margin-bottom: 0;
+					${from.tablet} {
+						${headline.medium({ fontWeight: 'bold' })};
+					}
+				`}
+			>
+				Losing you supporter extras
+			</h1>
+			Please keep in mind that you will be losing access to your supporter
+			extras if you cancel today.
+			<section
+				css={css`
+					margin-top: 32px;
+					margin-bottom: 36px;
+				`}
+			>
+				<BenefitsNotAvailable />
+			</section>
+			<div
+				css={css`
+					${textSans.large({ fontWeight: 'bold' })}
+					margin-bottom: ${space[4]}px;
+				`}
+			>
+				Please confirm to cancel your digital subscription
+			</div>
+			<div css={stackedButtonLayoutCss}>
+				<Button
+					cssOverrides={css`
+						background-color: ${palette.news['400']};
+						justify-content: center;
+						:hover {
+							background-color: ${palette.news['200']};
+						}
+					`}
+				>
+					Cancel subscription
+				</Button>
+				<Link
+					css={css`
+						${textSans.medium()};
+						color: ${palette.brand[400]};
+						font-weight: 700;
+						text-decoration-line: underline;
+						justify-content: center;
+						margin-left: ${space[5]}px;
+						margin-top: ${space[4]}px;
+					`}
+					to={'/'} //todo update link
+				>
+					Go back to discount
+				</Link>
+			</div>
+		</section>
+	);
+};

--- a/client/components/mma/cancel/cancellationSaves/digipack/ConfirmCancellation.tsx
+++ b/client/components/mma/cancel/cancellationSaves/digipack/ConfirmCancellation.tsx
@@ -88,7 +88,7 @@ export const ConfirmCancellation = () => {
 					}
 				`}
 			>
-				Losing you supporter extras
+				Losing your supporter extras
 			</h1>
 			Please keep in mind that you will be losing access to your supporter
 			extras if you cancel today.

--- a/client/components/mma/cancel/cancellationSaves/digipack/ConfirmCancellation.tsx
+++ b/client/components/mma/cancel/cancellationSaves/digipack/ConfirmCancellation.tsx
@@ -7,7 +7,6 @@ import {
 	textSans,
 } from '@guardian/source-foundations';
 import { Button, Stack } from '@guardian/source-react-components';
-import { Link } from 'react-router-dom';
 import { benefitsCss } from '@/client/components/mma/shared/benefits/BenefitsStyles';
 import { stackedButtonLayoutCss } from '@/client/styles/ButtonStyles';
 
@@ -120,21 +119,15 @@ export const ConfirmCancellation = () => {
 				>
 					Cancel subscription
 				</Button>
-				<Link
-					css={css`
-						${textSans.medium()};
-						color: ${palette.brand[400]};
-						font-weight: 700;
-						text-decoration-line: underline;
-						justify-content: center;
-						margin-left: ${space[5]}px;
-						margin-top: ${space[4]}px;
+				<Button
+					cssOverrides={css`
 						display: flex;
+						margin-left: ${space[5]}px;
 					`}
-					to={'/'} //todo update link
+					priority="subdued"
 				>
 					Go back to discount
-				</Link>
+				</Button>
 			</div>
 		</section>
 	);

--- a/client/components/mma/cancel/cancellationSaves/digipack/DigiSubSaves.stories.tsx
+++ b/client/components/mma/cancel/cancellationSaves/digipack/DigiSubSaves.stories.tsx
@@ -1,6 +1,7 @@
-import type { Meta, StoryFn , StoryObj } from '@storybook/react';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react';
 import { ReactRouterDecorator } from '@/.storybook/ReactRouterDecorator';
 import { CancellationContainer } from '@/client/components/mma/cancel/CancellationContainer';
+import { ConfirmCancellation } from '@/client/components/mma/cancel/cancellationSaves/digipack/ConfirmCancellation';
 import { DigiSubDiscountConfirm } from '@/client/components/mma/cancel/cancellationSaves/digipack/DigiSubDiscountConfirm';
 import { ThankYouOffer } from '@/client/components/mma/cancel/cancellationSaves/digipack/ThankYouOffer';
 import {
@@ -51,4 +52,10 @@ export const IneligibleForDiscount: StoryObj<typeof ThankYouOffer> = {
 			},
 		},
 	},
+};
+
+export const ConfirmDigiSubCancellation: StoryFn<
+	typeof ConfirmCancellation
+> = () => {
+	return <ConfirmCancellation />;
 };


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
New screen to confirm that users want to cancel their subscription

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
Test via storybook as URLs don't yet exist
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<img width="869" alt="image" src="https://github.com/guardian/manage-frontend/assets/115992455/28426fcf-15c1-4fd0-a257-582a4fdd0963">

<img width="341" alt="image" src="https://github.com/guardian/manage-frontend/assets/115992455/296cc53f-784b-471b-b044-d91158c49bd7">


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
