### PR TITLE
Add `similar_guardian_products` to `marketingEmailConsents` list

### DIFF
--- a/client/components/mma/identity/emailAndMarketing/ConsentSection.tsx
+++ b/client/components/mma/identity/emailAndMarketing/ConsentSection.tsx
@@ -18,7 +18,13 @@ const supportReminderConsent = (consents: ConsentOption[]): ConsentOption[] =>
 	ConsentOptions.findByIds(consents, ['support_reminder']);
 
 const marketingEmailConsents = (consents: ConsentOption[]): ConsentOption[] => {
-	const ids = ['supporter', 'jobs', 'events', 'offers'];
+	const ids = [
+		'similar_guardian_products',
+		'supporter',
+		'jobs',
+		'events',
+		'offers',
+	];
 	return ConsentOptions.findByIds(consents, ids);
 };
 

--- a/client/fixtures/consents.ts
+++ b/client/fixtures/consents.ts
@@ -62,10 +62,10 @@ export const consents = [
 		id: 'similar_guardian_products',
 		isOptOut: false,
 		isChannel: false,
-		isProduct: true,
-		name: 'Similar Guardian products',
+		isProduct: false,
+		name: 'Guardian products and support',
 		description:
-			'Information on similar products and further ways to support our independent journalism.',
+			'Information on our products and ways to support and enjoy our independent journalism.',
 	},
 	{
 		id: 'market_research_optout',

--- a/cypress/e2e/parallel-6/emailAndMarketing.cy.ts
+++ b/cypress/e2e/parallel-6/emailAndMarketing.cy.ts
@@ -5,12 +5,11 @@ import { newsletters } from '../../../client/fixtures/newsletters';
 import { consents } from '../../../client/fixtures/consents';
 import { newsletterSubscriptions } from '../../../client/fixtures/newsletterSubscriptions';
 import { InAppPurchase } from '../../../client/fixtures/inAppPurchase';
+import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
 
 describe('Email and Marketing page', () => {
 	beforeEach(() => {
-		cy.session('auth', () => {
-			cy.setCookie('gu-cmp-disabled', 'true');
-		});
+		signInAndAcceptCookies();
 
 		cy.intercept('GET', '/idapi/user', {
 			body: userResponse,
@@ -64,7 +63,7 @@ describe('Email and Marketing page', () => {
 		cy.wait('@consents');
 		cy.wait('@reminders');
 
-		cy.findByText('Similar Guardian products');
+		cy.findByText('Guardian products and support');
 		cy.findByText('Your subscription/support');
 		cy.findByText('Supporter newsletter');
 	});
@@ -91,7 +90,7 @@ describe('Email and Marketing page', () => {
 		cy.wait('@consents');
 		cy.wait('@reminders');
 
-		cy.findByText('Similar Guardian products');
+		cy.findByText('Guardian products and support');
 		cy.findByText('Your subscription/support');
 		cy.findByText('Supporter newsletter');
 	});

--- a/shared/mpapiResponse.ts
+++ b/shared/mpapiResponse.ts
@@ -18,13 +18,11 @@ export function isValidAppSubscription(subscription: AppSubscription) {
 
 export const AppSubscriptionSoftOptInIds: string[] = [
 	SoftOptInIDs.SupportOnboarding,
-	SoftOptInIDs.SimilarProducts,
 	SoftOptInIDs.SupporterNewsletter,
 ];
 
 export const SingleContributionSoftOptInIds: string[] = [
 	SoftOptInIDs.SupportOnboarding,
-	SoftOptInIDs.SimilarProducts,
 	SoftOptInIDs.SupporterNewsletter,
 ];
 

--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -313,7 +313,6 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 		shouldShowJoinDateNotStartDate: true,
 		softOptInIDs: [
 			SoftOptInIDs.SupportOnboarding,
-			SoftOptInIDs.SimilarProducts,
 			SoftOptInIDs.SupporterNewsletter,
 		],
 	},
@@ -338,7 +337,6 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 		updateAmountMdaEndpoint: 'contribution-update-amount',
 		softOptInIDs: [
 			SoftOptInIDs.SupportOnboarding,
-			SoftOptInIDs.SimilarProducts,
 			SoftOptInIDs.SupporterNewsletter,
 		],
 		cancellation: {
@@ -404,7 +402,6 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 		softOptInIDs: [
 			SoftOptInIDs.SupportOnboarding,
 			SoftOptInIDs.SubscriberPreview,
-			SoftOptInIDs.SimilarProducts,
 			SoftOptInIDs.SupporterNewsletter,
 		],
 	},
@@ -421,7 +418,6 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 		softOptInIDs: [
 			SoftOptInIDs.SupportOnboarding,
 			SoftOptInIDs.SubscriberPreview,
-			SoftOptInIDs.SimilarProducts,
 			SoftOptInIDs.SupporterNewsletter,
 		],
 		holidayStops: {
@@ -461,7 +457,6 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 		softOptInIDs: [
 			SoftOptInIDs.SupportOnboarding,
 			SoftOptInIDs.SubscriberPreview,
-			SoftOptInIDs.SimilarProducts,
 			SoftOptInIDs.SupporterNewsletter,
 		],
 		holidayStops: {
@@ -501,7 +496,6 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 		softOptInIDs: [
 			SoftOptInIDs.SupportOnboarding,
 			SoftOptInIDs.SubscriberPreview,
-			SoftOptInIDs.SimilarProducts,
 			SoftOptInIDs.SupporterNewsletter,
 		],
 		holidayStops: {
@@ -551,7 +545,6 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 		softOptInIDs: [
 			SoftOptInIDs.SupportOnboarding,
 			SoftOptInIDs.SubscriberPreview,
-			SoftOptInIDs.SimilarProducts,
 			SoftOptInIDs.SupporterNewsletter,
 		],
 		holidayStops: {
@@ -576,7 +569,6 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 		softOptInIDs: [
 			SoftOptInIDs.SupportOnboarding,
 			SoftOptInIDs.GuardianWeeklyNewsletter,
-			SoftOptInIDs.SimilarProducts,
 		],
 		getOphanProductType: () => 'PRINT_SUBSCRIPTION', // TODO create a GUARDIAN_WEEKLY Product in Ophan data model
 		renewalMetadata: {
@@ -630,7 +622,6 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 		softOptInIDs: [
 			SoftOptInIDs.SupportOnboarding,
 			SoftOptInIDs.DigitalSubscriberPreview,
-			SoftOptInIDs.SimilarProducts,
 			SoftOptInIDs.SupporterNewsletter,
 		],
 		cancellation: {
@@ -675,7 +666,6 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 		showTrialRemainingIfApplicable: true,
 		softOptInIDs: [
 			SoftOptInIDs.SupportOnboarding,
-			SoftOptInIDs.SimilarProducts,
 			SoftOptInIDs.SupporterNewsletter,
 			SoftOptInIDs.DigitalSubscriberPreview,
 		],
@@ -716,7 +706,6 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 		softOptInIDs: [
 			SoftOptInIDs.SupportOnboarding,
 			SoftOptInIDs.DigitalSubscriberPreview,
-			SoftOptInIDs.SimilarProducts,
 			SoftOptInIDs.SupporterNewsletter,
 		],
 	},

--- a/shared/softOptInIDs.ts
+++ b/shared/softOptInIDs.ts
@@ -1,6 +1,5 @@
 export enum SoftOptInIDs {
 	SupportOnboarding = 'your_support_onboarding',
-	SimilarProducts = 'similar_guardian_products',
 	SupporterNewsletter = 'supporter_newsletter',
 	SubscriberPreview = 'subscriber_preview',
 	DigitalSubscriberPreview = 'digital_subscriber_preview',


### PR DESCRIPTION
## What does this change?

Adds the `similar_guardian_products` consent into the `marketingEmailConsents` list so it always shows up in on the emails and marketing page.

It's also no longer classified as a "product" consent, so we've removed from anywhere which said it was a product consent.

This consent used to be a "product" consent, so would previously only be given if a user has purchased a product. However this consent is being renamed, and repurposed into a new soft opt in for newly registered users also. So it's being moved out from being a "product" consent, and into the "main" marketing consents area. It will continue to use the same ID.

New copy:

**Guardian products and support**
Information on our products and ways to support and enjoy our independent journalism.

Other related work elsewhere:

Firstly Gateway to add it to the registration journey: https://github.com/guardian/gateway/pull/2455
And Identity API to rename the consent and description: https://github.com/guardian/identity/pull/2462
