### PR TITLE
Show Partner and Patron Event benefits on relevant Product Card Section

### DIFF
--- a/client/__tests__/components/updateAmount/contributionUpdateAmount.test.tsx
+++ b/client/__tests__/components/updateAmount/contributionUpdateAmount.test.tsx
@@ -11,6 +11,7 @@ const mainPlan = (billingPeriod: string) => ({
 	currency: '£',
 	currencyISO: 'GBP',
 	billingPeriod,
+	features: '',
 });
 
 const productType = PRODUCT_TYPES['contributions'];

--- a/client/__tests__/components/updateAmount/supporterPlusUpdateAmount.test.tsx
+++ b/client/__tests__/components/updateAmount/supporterPlusUpdateAmount.test.tsx
@@ -11,6 +11,7 @@ const mainPlan = (billingPeriod: string) => ({
 	currencyISO: 'GBP',
 	billingPeriod,
 	price: 500,
+	features: '',
 });
 
 const productType = PRODUCT_TYPES['supporterplus'];

--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -123,6 +123,11 @@ export const ProductCard = ({
 		groupedProductType.mapGroupedToSpecific(productDetail);
 
 	const isPatron = productDetail.subscription.readerType === 'Patron';
+
+	const entitledToEvents =
+		['Partner', 'Patron'].includes(productDetail.tier) &&
+		(mainPlan as PaidSubscriptionPlan).features.includes('Events');
+
 	const productTitle = `${specificProductType.productTitle(mainPlan)}${
 		isPatron ? ' — Patron' : ''
 	}`;
@@ -379,6 +384,33 @@ export const ProductCard = ({
 						</div>
 					</div>
 				</Card.Section>
+				{entitledToEvents && (
+					<Card.Section>
+						<div>
+							<h4 css={sectionHeadingCss}>
+								Guardian Live - Eventbrite discount codes
+							</h4>
+							<div>
+								<dl css={keyValueCss}>
+									<dt>{atob('TFBQRlJFRTZHTFRY')}</dt>
+									<dd>
+										gives you 6 free tickets each year (1
+										per event)
+									</dd>
+								</dl>
+							</div>
+							<div>
+								<dl css={keyValueCss}>
+									<dt>{atob('TFBQMjAyR0xUWA==')}</dt>
+									<dd>
+										gives you 20% off an extra 2 tickets per
+										event
+									</dd>
+								</dl>
+							</div>
+						</div>
+					</Card.Section>
+				)}
 				{productDetail.isPaidTier && (
 					<Card.Section>
 						<div css={productDetailLayoutCss}>

--- a/client/fixtures/productBuilder/baseProducts.ts
+++ b/client/fixtures/productBuilder/baseProducts.ts
@@ -50,6 +50,7 @@ export function baseMembership(): ProductDetail {
 				start: '',
 				end: '',
 				shouldBeVisible: false,
+				features: '',
 			},
 			currentPlans: [
 				{
@@ -172,6 +173,7 @@ export function baseDigitalPack(): ProductDetail {
 				start: '2022-12-23',
 				end: '2024-12-11',
 				shouldBeVisible: true,
+				features: '',
 			},
 			currentPlans: [],
 			futurePlans: [

--- a/shared/productResponse.ts
+++ b/shared/productResponse.ts
@@ -137,6 +137,7 @@ export interface PaidSubscriptionPlan
 	end: string;
 	chargedThrough?: string | null;
 	price: number;
+	features: string;
 }
 
 export function isPaidSubscriptionPlan(


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Building atop https://github.com/guardian/members-data-api/pull/1038, this change responds to Partner and Patron Members with details of their Events benefit, if they are eligible.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
1) Manually assign yourself to a Partner or Patron Member in Zuora, selecting Events features
2) Log into MMA and see your Account Details page
3) New Guardian Live - Eventbrite ... section should be there
4) Create an amendment to Update your Product, switching the features to Books
5) Screen should not show the new section - be exactly as it was before.

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
Before:
<img width="864" alt="Screenshot 2023-11-20 at 20 47 13" src="https://github.com/guardian/manage-frontend/assets/1515970/f7424379-f9e1-4b94-8c85-f3a71c1d5d6d">

After:
<img width="836" alt="Screenshot 2023-11-20 at 20 35 27" src="https://github.com/guardian/manage-frontend/assets/1515970/982fae9d-0733-47a7-aed6-57da3e5c117d">

And after entering either code on Eventbrite:

<img width="463" alt="Screenshot 2023-11-20 at 20 51 59" src="https://github.com/guardian/manage-frontend/assets/1515970/8a67570a-227a-4710-8280-a3b19abd8a27">

<img width="463" alt="Screenshot 2023-11-20 at 20 51 45" src="https://github.com/guardian/manage-frontend/assets/1515970/aa83aeba-ed03-4a81-afba-1d84d79fe964">


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
