### PR TITLE
Fix Cancellations: add `gaData` back into body

### DIFF
--- a/client/components/mma/cancel/CancellationReasonReview.tsx
+++ b/client/components/mma/cancel/CancellationReasonReview.tsx
@@ -359,6 +359,7 @@ export const CancellationReasonReview = () => {
 			reason: routerState.selectedReasonId,
 			product: productType.cancellation.sfCaseProduct,
 			subscriptionName: productDetail.subscription.subscriptionId,
+			gaData: '',
 		}),
 		headers: {
 			'Content-Type': 'application/json',

--- a/client/components/mma/cancel/cancellationSaves/membership/ConfirmMembershipCancellation.tsx
+++ b/client/components/mma/cancel/cancellationSaves/membership/ConfirmMembershipCancellation.tsx
@@ -50,6 +50,7 @@ export const ConfirmMembershipCancellation = () => {
 				reason: selectedReasonId,
 				product: productType.cancellation.sfCaseProduct,
 				subscriptionName: productDetail.subscription.subscriptionId,
+				gaData: '',
 			}),
 			headers: {
 				'Content-Type': 'application/json',

--- a/client/components/mma/cancel/cancellationSaves/membership/SelectReason.tsx
+++ b/client/components/mma/cancel/cancellationSaves/membership/SelectReason.tsx
@@ -144,6 +144,7 @@ function cancellationCaseFetch(
 			reason: selectedReasonId,
 			product: productType.cancellation.sfCaseProduct,
 			subscriptionName: productDetail.subscription.subscriptionId,
+			gaData: '',
 		}),
 		headers: {
 			'Content-Type': 'application/json',


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add back `gaData` that cancellation-sf-cases api is expecting. 

Error message:
"Bad request: request body couldn't be parsed: List((/gaData,List(JsonValidationError(List(error.path.missing),List()))))"
without this property

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Tested locally, without this included the cancellation Review shows "Oops" and network call fails. With it it passes.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
