### PR TITLE
Add a "Return to app" button for payment failure

### DIFF
--- a/client/components/mma/MMAPage.tsx
+++ b/client/components/mma/MMAPage.tsx
@@ -423,6 +423,10 @@ const MMARouter = () => {
 				>
 					<Routes>
 						<Route path="/" element={<AccountOverview />} />
+						<Route
+							path="/app"
+							element={<AccountOverview isFromApp />}
+						/>
 						<Route path="/billing" element={<Billing />} />
 						<Route path="/data-privacy" element={<DataPrivacy />} />
 						<Route

--- a/client/components/mma/accountoverview/AccountOverview.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.tsx
@@ -43,6 +43,7 @@ import { isCancelled } from '../cancel/CancellationSummary';
 import { PageContainer } from '../Page';
 import { JsonResponseHandler } from '../shared/asyncComponents/DefaultApiResponseHandler';
 import { DefaultLoadingView } from '../shared/asyncComponents/DefaultLoadingView';
+import type { IsFromAppProps } from '../shared/IsFromAppProps';
 import { nonServiceableCountries } from '../shared/NonServiceableCountries';
 import { PaymentFailureAlertIfApplicable } from '../shared/PaymentFailureAlertIfApplicable';
 import { CancelledProductCard } from './CancelledProductCard';
@@ -69,7 +70,7 @@ const subHeadingCss = css`
 	}
 `;
 
-const AccountOverviewPage = () => {
+const AccountOverviewPage = ({ isFromApp }: IsFromAppProps) => {
 	const {
 		data: accountOverviewResponse,
 		loadingState,
@@ -173,6 +174,7 @@ const AccountOverviewPage = () => {
 
 			<PaymentFailureAlertIfApplicable
 				productDetails={allActiveProductDetails}
+				isFromApp={isFromApp}
 			/>
 			{productCategories.map((category) => {
 				const groupedProductType = GROUPED_PRODUCT_TYPES[category];
@@ -272,13 +274,13 @@ const accountOverviewFetcher = () =>
 		allSingleProductsDetailFetcher(),
 	]);
 
-export const AccountOverview = () => {
+export const AccountOverview = ({ isFromApp }: IsFromAppProps) => {
 	return (
 		<PageContainer
 			selectedNavItem={NAV_LINKS.accountOverview}
 			pageTitle="Account overview"
 		>
-			<AccountOverviewPage />
+			<AccountOverviewPage isFromApp={isFromApp} />
 		</PageContainer>
 	);
 };

--- a/client/components/mma/paymentUpdate/PaymentDetailUpdate.tsx
+++ b/client/components/mma/paymentUpdate/PaymentDetailUpdate.tsx
@@ -53,7 +53,8 @@ import { ContactUs } from './ContactUs';
 import { CurrentPaymentDetails } from './CurrentPaymentDetail';
 import { DirectDebitInputForm } from './dd/DirectDebitInputForm';
 import type { NewPaymentMethodDetail } from './NewPaymentMethodDetail';
-import { PaymentUpdateProductDetailContext } from './PaymentDetailUpdateContainer';
+import type { PaymentUpdateContextInterface } from './PaymentDetailUpdateContainer';
+import { PaymentUpdateContext } from './PaymentDetailUpdateContainer';
 
 export enum PaymentMethod {
 	Card = 'Credit card / debit card',
@@ -219,9 +220,9 @@ export interface PaymentUpdaterStepState {
 }
 
 export const PaymentDetailUpdate = (props: WithProductType<ProductType>) => {
-	const productDetail = useContext(
-		PaymentUpdateProductDetailContext,
-	) as ProductDetail;
+	const { productDetail, isFromApp } = useContext(
+		PaymentUpdateContext,
+	) as PaymentUpdateContextInterface;
 
 	const currentPaymentMethod = subscriptionToPaymentMethod(productDetail);
 
@@ -316,6 +317,7 @@ export const PaymentDetailUpdate = (props: WithProductType<ProductType>) => {
 								newSubscriptionData[0].subscription,
 							),
 						newSubscriptionData,
+						isFromApp: isFromApp,
 					},
 				});
 			}

--- a/client/components/mma/paymentUpdate/PaymentDetailUpdateConfirmation.tsx
+++ b/client/components/mma/paymentUpdate/PaymentDetailUpdateConfirmation.tsx
@@ -1,17 +1,21 @@
-import { css } from '@emotion/react';
+import { css, ThemeProvider } from '@emotion/react';
 import {
-	brand,
 	from,
 	headline,
-	neutral,
+	palette,
 	space,
 	textSans,
 	until,
 } from '@guardian/source-foundations';
-import { Button } from '@guardian/source-react-components';
+import {
+	Button,
+	buttonThemeReaderRevenueBrand,
+	LinkButton,
+} from '@guardian/source-react-components';
 import { InfoSummary } from '@guardian/source-react-components-development-kitchen';
 import { useContext } from 'react';
 import { Navigate, useLocation, useNavigate } from 'react-router-dom';
+import { buttonCentredCss } from '@/client/styles/ButtonStyles';
 import type {
 	ProductDetail,
 	Subscription,
@@ -25,12 +29,14 @@ import {
 import { GROUPED_PRODUCT_TYPES } from '../../../../shared/productTypes';
 import { GenericErrorScreen } from '../../shared/GenericErrorScreen';
 import { ArrowIcon } from '../shared/assets/ArrowIcon';
-import { LinkButton } from '../shared/Buttons';
+import { LinkButton as MMALinkButton } from '../shared/Buttons';
 import { CardDisplay } from '../shared/CardDisplay';
 import { DirectDebitDisplay } from '../shared/DirectDebitDisplay';
+import type { IsFromAppProps } from '../shared/IsFromAppProps';
 import { PaypalDisplay } from '../shared/PaypalDisplay';
 import { SepaDisplay } from '../shared/SepaDisplay';
-import { PaymentUpdateProductDetailContext } from './PaymentDetailUpdateContainer';
+import type { PaymentUpdateContextInterface } from './PaymentDetailUpdateContainer';
+import { PaymentUpdateContext } from './PaymentDetailUpdateContainer';
 
 interface ConfirmedNewPaymentDetailsRendererProps {
 	subscription: Subscription;
@@ -69,7 +75,7 @@ const valueCss = css`
 `;
 
 const subHeadingCss = `
-      border-top: 1px solid ${neutral['86']};
+      border-top: 1px solid ${palette.neutral['86']};
       ${headline.small()};
       font-weight: bold;
       margin-top: ${space[9]}px;
@@ -105,7 +111,7 @@ export const ConfirmedNewPaymentDetailsRenderer = ({
 		return (
 			<div
 				css={css`
-					border: 1px solid ${neutral[86]};
+					border: 1px solid ${palette.neutral[86]};
 					margin-bottom: ${space[6]}px;
 				`}
 			>
@@ -114,7 +120,7 @@ export const ConfirmedNewPaymentDetailsRenderer = ({
 						display: flex;
 						justify-content: space-between;
 						align-items: start;
-						background-color: ${brand[400]};
+						background-color: ${palette.brand[400]};
 						${from.mobileLandscape} {
 							align-items: center;
 						}
@@ -126,7 +132,7 @@ export const ConfirmedNewPaymentDetailsRenderer = ({
 							font-weight: bold;
 							margin: 0;
 							padding: ${space[3]}px;
-							color: ${neutral[100]};
+							color: ${palette.neutral[100]};
 							${until.mobileLandscape} {
 								padding: ${space[3]}px;
 							}
@@ -235,7 +241,7 @@ export const ConfirmedNewPaymentDetailsRenderer = ({
 									<span
 										css={css`
 											${valueCss};
-											color: ${neutral[7]};
+											color: ${palette.neutral[7]};
 										`}
 									>
 										{subscription.card.expiry.month} /{' '}
@@ -251,7 +257,7 @@ export const ConfirmedNewPaymentDetailsRenderer = ({
 					<div
 						css={css`
 							padding: ${space[3]}px;
-							border-top: 1px solid ${neutral[86]};
+							border-top: 1px solid ${palette.neutral[86]};
 							${from.tablet} {
 								padding: ${space[5]}px;
 								display: flex;
@@ -327,7 +333,7 @@ export const ConfirmedNewPaymentDetailsRenderer = ({
 	); // unsupported operation currently
 };
 
-interface PaymentMethodUpdatedProps {
+interface PaymentMethodUpdatedProps extends IsFromAppProps {
 	subs: WithSubscription[] | {};
 	paymentFailureRecoveryMessage: string;
 	subHasExpectedPaymentType: boolean;
@@ -335,6 +341,7 @@ interface PaymentMethodUpdatedProps {
 }
 
 export const PaymentMethodUpdated = ({
+	isFromApp,
 	subs,
 	paymentFailureRecoveryMessage,
 	subHasExpectedPaymentType,
@@ -380,14 +387,25 @@ export const PaymentMethodUpdated = ({
 			</h2>
 			<span> You are helping to support independent journalism.</span>
 			<div css={{ marginTop: `${space[9]}px` }}>
-				<LinkButton
-					to="/"
-					text="Back to Account overview"
-					colour={brand[400]}
-					textColour={neutral[100]}
-					fontWeight="bold"
-					right
-				/>
+				{isFromApp ? (
+					<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
+						<LinkButton
+							href="x-gu://mma/payment-update?success"
+							cssOverrides={buttonCentredCss}
+						>
+							Return to the app
+						</LinkButton>
+					</ThemeProvider>
+				) : (
+					<MMALinkButton
+						to="/"
+						text="Back to Account overview"
+						colour={palette.brand[400]}
+						textColour={palette.neutral[100]}
+						fontWeight="bold"
+						right
+					/>
+				)}
 			</div>
 		</>
 	) : (
@@ -412,9 +430,9 @@ export const PaymentMethodUpdated = ({
 };
 
 export const PaymentDetailUpdateConfirmation = () => {
-	const previousProductDetail = useContext(
-		PaymentUpdateProductDetailContext,
-	) as ProductDetail;
+	const { productDetail: previousProductDetail, isFromApp } = useContext(
+		PaymentUpdateContext,
+	) as PaymentUpdateContextInterface;
 
 	const location = useLocation();
 	const state = location.state as {
@@ -431,6 +449,7 @@ export const PaymentDetailUpdateConfirmation = () => {
 			paymentFailureRecoveryMessage={state.paymentFailureRecoveryMessage}
 			subHasExpectedPaymentType={state.subHasExpectedPaymentType}
 			previousProductDetail={previousProductDetail}
+			isFromApp={isFromApp}
 		/>
 	) : (
 		<Navigate to="/" />

--- a/client/components/mma/shared/IsFromAppProps.ts
+++ b/client/components/mma/shared/IsFromAppProps.ts
@@ -1,0 +1,1 @@
+export type IsFromAppProps = { isFromApp?: boolean };

--- a/client/components/mma/shared/PaymentFailureAlertIfApplicable.tsx
+++ b/client/components/mma/shared/PaymentFailureAlertIfApplicable.tsx
@@ -1,9 +1,10 @@
 import { css } from '@emotion/react';
 import type { ProductDetail } from '../../../../shared/productResponse';
 import { GROUPED_PRODUCT_TYPES } from '../../../../shared/productTypes';
+import type { IsFromAppProps } from './IsFromAppProps';
 import { ProblemAlert } from './ProblemAlert';
 
-interface PaymentFailureAlertIfApplicableProps {
+interface PaymentFailureAlertIfApplicableProps extends IsFromAppProps {
 	productDetails: ProductDetail[];
 }
 
@@ -13,6 +14,7 @@ function findPaymentFailureProduct(allProductDetails: ProductDetail[]) {
 }
 
 export const PaymentFailureAlertIfApplicable = ({
+	isFromApp,
 	productDetails,
 }: PaymentFailureAlertIfApplicableProps) => {
 	const productDetail = findPaymentFailureProduct(productDetails);
@@ -32,7 +34,7 @@ export const PaymentFailureAlertIfApplicable = ({
 						productDetail.mmaCategory
 					].mapGroupedToSpecific(productDetail).urlPart
 				}`,
-				state: productDetail,
+				state: { productDetail, isFromApp },
 			}}
 			additionalcss={css`
 				margin-top: 30px;

--- a/client/components/mma/shared/ProblemAlert.tsx
+++ b/client/components/mma/shared/ProblemAlert.tsx
@@ -11,10 +11,15 @@ import type { ProductDetail } from '../../../../shared/productResponse';
 import { ErrorIcon } from './assets/ErrorIcon';
 import { LinkButton } from './Buttons';
 
+type ProblemAlertState = {
+	productDetail: ProductDetail;
+	isFromApp?: boolean;
+};
+
 interface AlertButtonProps {
 	title: string;
 	link: string;
-	state?: ProductDetail;
+	state?: ProblemAlertState;
 }
 
 interface ProblemAlertProps {

--- a/client/fixtures/productBuilder/testProducts.ts
+++ b/client/fixtures/productBuilder/testProducts.ts
@@ -59,6 +59,13 @@ export function digitalPackWithPaymentFailure() {
 		.getProductDetailObject();
 }
 
+export function digitalPackPaidByCardWithPaymentFailure() {
+	return new ProductBuilder(baseDigitalPack())
+		.payByCard()
+		.withAlertText('Payment failed')
+		.getProductDetailObject();
+}
+
 export function annualContributionPaidByCardWithCurrency(
 	currency: CurrencyIso,
 ) {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a new route to MMA, `/app`, which sets a prop `isFromApp` to true that is passed to the payment update journey using state. It is only passed through the component that highlights payment failure and its "Update payment method" button.

![image](https://github.com/guardian/manage-frontend/assets/114918544/42149243-94a2-4f86-b993-edbced102ac1)


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

With a product in payment failure, go to `/app` and click "Update payment failure" in the top "A payment needs your attention" box. See the next screen, update payment details, see confirmation and "return to app" button.

Repeat the journey going to `/` and do not see "return to app" after confirmation.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://github.com/guardian/manage-frontend/assets/114918544/f3003931-969c-42dc-bb8d-9dcd708cab64)


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
