### PR TITLE
Remove commented out data from cancellation reasons

### DIFF
--- a/client/components/mma/cancel/membership/MembershipCancellationReasons.tsx
+++ b/client/components/mma/cancel/membership/MembershipCancellationReasons.tsx
@@ -10,19 +10,13 @@ export const membershipCancellationReasons: CancellationReason[] = [
 		saveBody: [
 			'Making a smaller contribution to the Guardian can be an inexpensive way of keeping journalism open for everyone to read and enjoy. There are a number of flexible ways to support us and one of our customer service specialist would be happy to hear from you.',
 		],
-		// alternateFeedbackThankYouBody: "One of our customer service specialists will be in touch shortly."
 	},
 	{
 		reasonId: 'mma_payment_issue',
 		linkLabel: "I didn't expect The Guardian to take another payment",
 		saveTitle: 'We are sorry that you have been charged again',
 		saveBody: PaymentIssue,
-		// TODO restore commented after Coronavirus
-		// saveBody: "We’d like to know more details to help resolve the issue. One of our customer service specialists will be more than happy to assist.",
-		// alternateFeedbackIntro: "Alternatively please provide some more details in the form below and we’ll get back to you as soon as possible",
 		alternateFeedbackIntro: '',
-		// alternateFeedbackThankYouTitle: "Thank you.",
-		// alternateFeedbackThankYouBody: "One of our customer service specialists will be in touch shortly."
 	},
 	{
 		reasonId: 'mma_editorial',
@@ -71,7 +65,6 @@ export const membershipCancellationReasons: CancellationReason[] = [
 		saveTitle:
 			'We understand that sometimes the news cycle can feel a little overwhelming.',
 		saveBody: BreakFromNewsWithGW,
-		// alternateFeedbackIntro: "Alternatively please provide some more details in the form below and we’ll get back to you as soon as possible"
 	},
 	{
 		reasonId: 'mma_values',


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Remove commented out cancellation reason data, and a comment saying it should be restored "after Coronavirus". 

It's been gone for a while, and no one has raised it. We won't increase expectations on CSRs.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
