### PR TITLE
Add discount prices and number of months in save screens

### DIFF
--- a/client/components/mma/cancel/cancellationSaves/digipack/DigiSubDiscountConfirm.tsx
+++ b/client/components/mma/cancel/cancellationSaves/digipack/DigiSubDiscountConfirm.tsx
@@ -23,6 +23,12 @@ import {
 	buttonCentredCss,
 	stackedButtonLayoutCss,
 } from '@/client/styles/ButtonStyles';
+import {
+	getDiscountMonthsForDigisub,
+	getNewDigisubPrice,
+	getOldDigisubPrice,
+} from '@/client/utilities/pricingConfig/digisubDiscountPricing';
+import { formatAmount } from '@/client/utilities/utils';
 import { DATE_FNS_LONG_OUTPUT_FORMAT, parseDate } from '@/shared/dates';
 import type { PaidSubscriptionPlan } from '@/shared/productResponse';
 import { getMainPlan } from '@/shared/productResponse';
@@ -49,7 +55,10 @@ export const DigiSubDiscountConfirm = () => {
 
 	const mainPlan = getMainPlan(digiSub.subscription) as PaidSubscriptionPlan;
 
-	const priceDisplay = `${mainPlan.currency}${mainPlan.price / 100}`;
+	const currencySymbol = mainPlan.currency;
+	const discountMonths = getDiscountMonthsForDigisub(digiSub);
+	const discountedPrice = getOldDigisubPrice(mainPlan);
+	const newPrice = getNewDigisubPrice(mainPlan);
 
 	const nextBillingDate = parseDate(
 		mainPlan.chargedThrough ?? undefined,
@@ -116,11 +125,15 @@ export const DigiSubDiscountConfirm = () => {
 										padding-bottom: ${space[1]}px;
 									`}
 								>
-									25% discount for ABC
+									25% discount for {discountMonths} months
 								</strong>
 								<br />
-								You’ll pay X per {mainPlan.billingPeriod} for Y,
-								then Z per {mainPlan.billingPeriod}
+								You’ll pay {currencySymbol}
+								{formatAmount(discountedPrice)} per{' '}
+								{mainPlan.billingPeriod} for {discountMonths}{' '}
+								months, then {currencySymbol}
+								{formatAmount(newPrice)} per{' '}
+								{mainPlan.billingPeriod}
 							</span>
 						</li>
 						<li>
@@ -135,7 +148,8 @@ export const DigiSubDiscountConfirm = () => {
 								</strong>
 								<br />
 								From {nextBillingDate}, your ongoing{' '}
-								{billingPeriod} payment will be {priceDisplay}.
+								{billingPeriod} payment will be {currencySymbol}
+								{formatAmount(discountedPrice)}.
 							</span>
 						</li>
 					</ul>

--- a/client/components/mma/cancel/cancellationSaves/digipack/DigiSubDiscountConfirm.tsx
+++ b/client/components/mma/cancel/cancellationSaves/digipack/DigiSubDiscountConfirm.tsx
@@ -32,7 +32,6 @@ import { formatAmount } from '@/client/utilities/utils';
 import { DATE_FNS_LONG_OUTPUT_FORMAT, parseDate } from '@/shared/dates';
 import type { PaidSubscriptionPlan } from '@/shared/productResponse';
 import { getMainPlan } from '@/shared/productResponse';
-import { getBillingPeriodAdjective } from '@/shared/productTypes';
 import {
 	headingCss,
 	iconListCss,
@@ -61,14 +60,10 @@ export const DigiSubDiscountConfirm = () => {
 	const newPrice = getNewDigisubPrice(mainPlan);
 
 	const nextBillingDate = parseDate(
-		mainPlan.chargedThrough ?? undefined,
+		digiSub.subscription.nextPaymentDate ?? undefined,
 	).dateStr(DATE_FNS_LONG_OUTPUT_FORMAT);
 
 	const userEmailAddress = routerState?.user?.email;
-
-	const billingPeriod = getBillingPeriodAdjective(
-		mainPlan.billingPeriod,
-	).toLowerCase();
 
 	useEffect(() => {
 		pageTitleContext.setPageTitle('Your subscription');
@@ -147,9 +142,7 @@ export const DigiSubDiscountConfirm = () => {
 									Your billing date
 								</strong>
 								<br />
-								From {nextBillingDate}, your ongoing{' '}
-								{billingPeriod} payment will be {currencySymbol}
-								{formatAmount(discountedPrice)}.
+								{nextBillingDate}
 							</span>
 						</li>
 					</ul>

--- a/client/components/mma/cancel/cancellationSaves/digipack/ThankYouOffer.tsx
+++ b/client/components/mma/cancel/cancellationSaves/digipack/ThankYouOffer.tsx
@@ -12,6 +12,14 @@ import {
 	buttonCentredCss,
 	buttonContainerCss,
 } from '@/client/styles/ButtonStyles';
+import {
+	getDiscountMonthsForDigisub,
+	getNewDigisubPrice,
+	getOldDigisubPrice,
+} from '@/client/utilities/pricingConfig/digisubDiscountPricing';
+import { formatAmount } from '@/client/utilities/utils';
+import type { PaidSubscriptionPlan } from '@/shared/productResponse';
+import { getMainPlan } from '@/shared/productResponse';
 import { dateString } from '../../../../../../shared/dates';
 import { benefitsCss } from '../../../shared/benefits/BenefitsStyles';
 import { Heading } from '../../../shared/Heading';
@@ -23,9 +31,17 @@ import { CancellationContext } from '../../CancellationContainer';
 import { eligibleForDigisubDiscount } from '../saveEligibilityCheck';
 
 const DiscountOffer = ({
+	currencySymbol,
+	discountMonths,
+	discountedPrice,
 	handleDiscountOfferClick,
+	newPrice,
 }: {
+	currencySymbol: string;
+	discountMonths: number;
+	discountedPrice: number;
 	handleDiscountOfferClick: () => void;
+	newPrice: number;
 }) => (
 	<Stack
 		space={4}
@@ -52,7 +68,10 @@ const DiscountOffer = ({
 							padding-top: ${space[1]}px;
 						`}
 					>
-						Get a 25% discount for 3 months (x, then y)
+						Get a 25% discount for {discountMonths} months (
+						{currencySymbol}
+						{formatAmount(discountedPrice)}, then {currencySymbol}
+						{newPrice})
 					</span>
 				</li>
 				<li>
@@ -111,7 +130,14 @@ export const ThankYouOffer = () => {
 		'yyyy',
 	);
 
+	const mainPlan = getMainPlan(
+		productDetail.subscription,
+	) as PaidSubscriptionPlan;
+
 	const eligibleForDiscount = eligibleForDigisubDiscount(productDetail);
+	const discountMonths = getDiscountMonthsForDigisub(productDetail);
+	const discountedPrice = getOldDigisubPrice(mainPlan);
+	const newPrice = getNewDigisubPrice(mainPlan);
 
 	return (
 		<section
@@ -151,9 +177,13 @@ export const ThankYouOffer = () => {
 				</Stack>
 				{eligibleForDiscount && (
 					<DiscountOffer
+						currencySymbol={mainPlan.currency}
+						discountMonths={discountMonths}
+						discountedPrice={discountedPrice}
 						handleDiscountOfferClick={() =>
 							navigate('todo', { state: { ...routerState } })
 						}
+						newPrice={newPrice}
 					/>
 				)}
 				<div>

--- a/client/utilities/pricingConfig/digisubDiscountPricing.ts
+++ b/client/utilities/pricingConfig/digisubDiscountPricing.ts
@@ -1,5 +1,10 @@
 import { isOneOf } from '@guardian/libs';
-import type { PaidSubscriptionPlan } from '@/shared/productResponse';
+import {
+	getMainPlan,
+	isPaidSubscriptionPlan,
+	type PaidSubscriptionPlan,
+	type ProductDetail,
+} from '@/shared/productResponse';
 import { type CurrencyIso, CurrencyIsos } from '../currencyIso';
 
 /* 
@@ -102,4 +107,27 @@ export function getNewDigisubPrice(plan: PaidSubscriptionPlan): number {
 
 export function getOldDigisubPrice(plan: PaidSubscriptionPlan): number {
 	return getDigisubPrice(plan, oldDigisubPricePerCurrency);
+}
+
+export function getDiscountMonthsForDigisub(
+	productDetail: ProductDetail,
+): number {
+	const mainPlan = getMainPlan(productDetail.subscription);
+
+	if (!isPaidSubscriptionPlan(mainPlan)) {
+		throw new Error('Unexpected digisub plan type');
+	}
+
+	if (!isOneOf(billingPeriods)(mainPlan.billingPeriod)) {
+		throw new Error('Unsupported digisub billing period');
+	}
+
+	switch (mainPlan.billingPeriod) {
+		case 'month':
+			return 3;
+		case 'quarter':
+			return 3;
+		case 'year':
+			return 12;
+	}
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds the discounted and non-discounted prices to the digisub saves journeys, and how many months the discount applies for. Using data stored in a config object.

If the api endpoint can return this information we will use that instead, but it's yet to be built as of this PR.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Digisub saves storybook screens

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<img width="637" alt="image" src="https://github.com/guardian/manage-frontend/assets/114918544/1a52da0b-637c-479c-803e-1ca5e7ad647d">

![image](https://github.com/guardian/manage-frontend/assets/114918544/3cd76ef0-650a-452a-a1f0-b0ffc41ae4e3)


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
