### PR TITLE
Bump types node

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@types/jest": "29.5.6",
     "@types/js-cookie": "2.2.3",
     "@types/lodash": "4.14.168",
-    "@types/node": "10.14.4",
+    "@types/node": "18.6",
     "@types/node-fetch": "1.6.9",
     "@types/number-to-words": "1.2.0",
     "@types/prettier": "2.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5183,10 +5183,10 @@
   dependencies:
     undici-types "~5.25.1"
 
-"@types/node@10.14.4":
-  version "10.14.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.4.tgz#1c586b991457cbb58fef51bc4e0cfcfa347714b5"
-  integrity sha512-DT25xX/YgyPKiHFOpNuANIQIVvYEwCWXgK2jYYwqgaMrYE6+tq+DtmMwlD3drl6DJbUwtlIDnn0d7tIn/EbXBg==
+"@types/node@18.6":
+  version "18.6.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.6.5.tgz#06caea822caf9e59d5034b695186ee74154d2802"
+  integrity sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==
 
 "@types/node@^12.7.1":
   version "12.20.55"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Bump `@types/node` to match the version of node specified in the `.nvmrc` file. We should try to keep these in sync as per [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/#how-do-definitely-typed-package-versions-relate-to-versions-of-the-corresponding-library)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
