### PR TITLE
OAuth migration | Add E2E tests for OAuth authentication

### DIFF
--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -1,0 +1,64 @@
+name: manage-frontend cypress (E2E)
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  cypress:
+    name: Manage-frontend Cypress (E2E)
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.MANAGE_FRONTEND_IAM_ROLE }}
+          aws-region: eu-west-1
+
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          cache: yarn
+
+      - name: Setup OS, Nginx, and Certs
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libnss3-tools
+          sudo service nginx restart
+          wget -q https://github.com/FiloSottile/mkcert/releases/download/v1.4.3/mkcert-v1.4.3-linux-amd64
+          wget -q https://github.com/guardian/dev-nginx/releases/latest/download/dev-nginx.tar.gz
+          sudo cp mkcert-v1.4.3-linux-amd64 /usr/local/bin/mkcert
+          sudo chmod +x /usr/local/bin/mkcert
+          sudo mkdir -p /usr/local/bin/dev-nginx
+          sudo tar -xzf dev-nginx.tar.gz -C /usr/local
+          sudo chmod +x /usr/local/bin/dev-nginx
+          sudo dev-nginx setup-cert "profile.thegulocal.com"
+          sudo dev-nginx setup-cert "manage.thegulocal.com"
+          sudo dev-nginx setup-cert "members-data-api.thegulocal.com"
+          sudo cp ./cypress/cypress-nginx.conf /etc/nginx/nginx.conf
+          sudo dev-nginx restart-nginx
+
+      - name: Cypress run
+        uses: cypress-io/github-action@v6
+        env:
+          CYPRESS_IDAPI_CLIENT_ACCESS_TOKEN: ${{ secrets.IDAPI_CLIENT_ACCESS_TOKEN }}
+          # Required for the Cypress tests to run as we're unable to verify the created certs
+          NODE_TLS_REJECT_UNAUTHORIZED: 0
+        with:
+          start: yarn cypress:e2e:server
+          wait-on: 'https://manage.thegulocal.com'
+          wait-on-timeout: 30
+          quiet: true
+          browser: chrome
+          spec: cypress/tests/e2e/*.cy.ts
+
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: cypress/screenshots

--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -47,7 +47,9 @@ jobs:
         uses: cypress-io/github-action@v6
         env:
           CYPRESS_IDAPI_CLIENT_ACCESS_TOKEN: ${{ secrets.IDAPI_CLIENT_ACCESS_TOKEN }}
-          # Required for the Cypress tests to run as we're unable to verify the created certs
+          # This env variable prevents Node from rejecting self-signed TLS certificates. It's
+          # required for the Cypress tests to run as we're unable to verify the created certs.
+          # See: https://nodejs.org/api/cli.html#node_tls_reject_unauthorizedvalue
           NODE_TLS_REJECT_UNAUTHORIZED: 0
         with:
           start: yarn cypress:e2e:server

--- a/.github/workflows/cypress-mocked.yml
+++ b/.github/workflows/cypress-mocked.yml
@@ -31,8 +31,6 @@ jobs:
 
       - name: Cypress run
         uses: cypress-io/github-action@v6
-        env:
-          IDAPI_CLIENT_ACCESS_TOKEN: ${{ secrets.IDAPI_CLIENT_ACCESS_TOKEN }}
         with:
           start: yarn cypress:mocked:server
           wait-on: 'http://localhost:9234, http://localhost:9233'

--- a/.github/workflows/cypress-mocked.yml
+++ b/.github/workflows/cypress-mocked.yml
@@ -1,4 +1,4 @@
-name: manage-frontend cypress
+name: manage-frontend cypress (mocked)
 on:
   push:
     branches-ignore:
@@ -6,7 +6,7 @@ on:
 
 jobs:
   cypress:
-    name: Manage-frontend Cypress
+    name: Manage-frontend Cypress (mocked)
     runs-on: ubuntu-latest
 
     permissions:
@@ -34,9 +34,10 @@ jobs:
         env:
           IDAPI_CLIENT_ACCESS_TOKEN: ${{ secrets.IDAPI_CLIENT_ACCESS_TOKEN }}
         with:
-          start: yarn cypress:server
+          start: yarn cypress:mocked:server
           wait-on: 'http://localhost:9234, http://localhost:9233'
           wait-on-timeout: 30
           quiet: true
           browser: chrome
-          spec: cypress/e2e/parallel-${{ matrix.group }}/*.ts
+          spec: cypress/tests/mocked/parallel-${{ matrix.group }}/*.cy.ts
+          config: baseUrl=http://localhost:9234

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ manage-frontend.zip
 test-report.xml
 
 cypress/screenshots
+cypress.env.json

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -4,9 +4,7 @@ export default defineConfig({
 	viewportWidth: 1500,
 	viewportHeight: 860,
 	video: false,
-	failOnStatusCode: false,
 	chromeWebSecurity: false,
-	experimentalSessionSupport: true,
 	blockHosts: [
 		'*ophan.theguardian.com',
 		'pixel.adsafeprotected.com',
@@ -26,11 +24,10 @@ export default defineConfig({
 		openMode: 0,
 	},
 	e2e: {
-		// We've imported your old cypress plugins here.
-		// You may want to clean this up later by importing these.
+		specPattern: 'cypress/tests/**/*.cy.{js,jsx,ts,tsx}',
 		setupNodeEvents(on, config) {
 			return require('./cypress/plugins/index.ts')(on, config);
 		},
-		baseUrl: 'http://localhost:9234/',
+		baseUrl: 'https://manage.thegulocal.com',
 	},
 });

--- a/cypress/cypress-nginx.conf
+++ b/cypress/cypress-nginx.conf
@@ -1,0 +1,131 @@
+# NGINX Conf file used by Cypress-Nginx Github actions
+# so we can run cypress tests against the local nginx server
+# with a ssl cert set on the domain
+
+#user  nobody;
+worker_processes  1;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    sendfile        on;
+
+    keepalive_timeout  65;
+
+    # fixes issues for large response headers
+    proxy_buffer_size   128k;
+    proxy_buffers   4 256k;
+    proxy_busy_buffers_size   256k;
+
+
+	# manage.thegulocal.com
+	# ======================
+	server {
+		listen 443 ssl;
+		server_name manage.thegulocal.com;
+		proxy_http_version 1.1; # this is essential for chunked responses to work
+
+		ssl_certificate manage.thegulocal.com.crt;
+		ssl_certificate_key manage.thegulocal.com.key;
+		ssl_session_timeout 5m;
+		ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+		ssl_ciphers HIGH:!aNULL:!MD5;
+		ssl_prefer_server_ciphers on;
+
+		location / {
+			proxy_pass http://localhost:9234/;
+			proxy_set_header Host $http_host;
+			proxy_http_version 1.1;
+			proxy_set_header Upgrade $http_upgrade;
+			proxy_set_header Connection "Upgrade";
+		}
+	}
+
+	# members-data-api.thegulocal.com
+	# ======================
+	server {
+		listen 443 ssl;
+		server_name members-data-api.thegulocal.com;
+		proxy_http_version 1.1; # this is essential for chunked responses to work
+
+		ssl_certificate members-data-api.thegulocal.com.crt;
+		ssl_certificate_key members-data-api.thegulocal.com.key;
+		ssl_session_timeout 5m;
+		ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+		ssl_ciphers HIGH:!aNULL:!MD5;
+		ssl_prefer_server_ciphers on;
+
+		location / {
+			proxy_pass https://members-data-api.code.dev-theguardian.com;
+			proxy_next_upstream error timeout http_404 non_idempotent;
+			proxy_set_header "X-Forwarded-Proto" "https";
+			proxy_set_header 		Host members-data-api.code.dev-theguardian.com;
+			proxy_set_header        Accept-Encoding "";
+			proxy_hide_header 		Content-Security-Policy;
+
+			proxy_cookie_domain 	members-data-api.code.dev-theguardian.com members-data-api.thegulocal.com;
+			proxy_cookie_domain 	.code.dev-theguardian.com .thegulocal.com;
+
+			sub_filter_types        application/json;
+			sub_filter_once         off;
+			sub_filter              'members-data-api.code.dev-theguardian.com'  'members-data-api.thegulocal.com';
+		}
+	}
+
+
+    # profile.thegulocal.com
+	# ======================
+    server {
+      listen 443 ssl;
+      server_name profile.thegulocal.com;
+      proxy_http_version 1.1; # this is essential for chunked responses to work
+
+      ssl_certificate profile.thegulocal.com.crt;
+      ssl_certificate_key profile.thegulocal.com.key;
+      ssl_session_timeout 5m;
+      ssl_protocols TLSv1.2 TLSv1.3;
+      ssl_ciphers HIGH:!aNULL:!MD5;
+      ssl_prefer_server_ciphers on;
+
+      # dummy location header for the API
+      proxy_set_header X-GU-ID-Geolocation ip:$remote_addr,country:GB,city:Leeds;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+      location / {
+        proxy_pass https://profile.code.dev-theguardian.com;
+        proxy_next_upstream error timeout http_404 non_idempotent;
+        proxy_set_header "X-Forwarded-Proto" "https";
+        proxy_set_header "X-GU-Okta-Env" "profile.code.dev-theguardian.com";
+        proxy_set_header 		Host profile.code.dev-theguardian.com;
+        proxy_set_header        Accept-Encoding "";
+        proxy_hide_header 		Content-Security-Policy;
+
+        proxy_cookie_domain 	profile.code.dev-theguardian.com profile.thegulocal.com;
+        proxy_cookie_domain 	.code.dev-theguardian.com .thegulocal.com;
+
+        sub_filter_types        application/json;
+        sub_filter_once         off;
+        sub_filter              'profile.code.dev-theguardian.com'  'profile.thegulocal.com';
+
+        ######
+        # remove `sid` cookie in requests to Gateway
+        # save original "Cookie" header value
+        set $altered_cookie $http_cookie;
+        # check if the "sid" cookie is present
+        if ($http_cookie ~ '(.*)(^|;\s)sid=("[^"]*"|[^\s]*[^;]?)(\2|$|;$)(?:;\s)?(.*)') {
+          # cut "sid" cookie from the string
+          set $altered_cookie $1$4$5;
+        }
+        # hide original "Cookie" header
+        proxy_hide_header Cookie;
+        # set "Cookie" header to the new value
+        proxy_set_header  Cookie $altered_cookie;
+        ######
+      }
+    }
+}

--- a/cypress/cypress-nginx.conf
+++ b/cypress/cypress-nginx.conf
@@ -3,67 +3,69 @@
 # with a ssl cert set on the domain
 
 #user  nobody;
-worker_processes  1;
+worker_processes 			1;
 
 events {
-    worker_connections  1024;
+    worker_connections  	1024;
 }
 
 http {
-    include       mime.types;
-    default_type  application/octet-stream;
+    include       			mime.types;
+    default_type  			application/octet-stream;
 
-    sendfile        on;
+    sendfile        		on;
 
-    keepalive_timeout  65;
+    # Set to 5 seconds longer than 60 seconds (pretty sure this is a magic numnber).
+	# This should help prevent timeouts in Cypress requests inside Github Actions.
+    keepalive_timeout  		65;
 
     # fixes issues for large response headers
-    proxy_buffer_size   128k;
-    proxy_buffers   4 256k;
-    proxy_busy_buffers_size   256k;
+	proxy_buffer_size		128k;
+    proxy_buffers  			4 256k;
+    proxy_busy_buffers_size 256k;
 
 
 	# manage.thegulocal.com
 	# ======================
 	server {
-		listen 443 ssl;
-		server_name manage.thegulocal.com;
-		proxy_http_version 1.1; # this is essential for chunked responses to work
+		listen 						443 ssl;
+		server_name 				manage.thegulocal.com;
+		proxy_http_version 			1.1; # this is essential for chunked responses to work
 
-		ssl_certificate manage.thegulocal.com.crt;
-		ssl_certificate_key manage.thegulocal.com.key;
-		ssl_session_timeout 5m;
-		ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-		ssl_ciphers HIGH:!aNULL:!MD5;
-		ssl_prefer_server_ciphers on;
+		ssl_certificate				manage.thegulocal.com.crt;
+		ssl_certificate_key 		manage.thegulocal.com.key;
+		ssl_session_timeout 		5m;
+		ssl_protocols 				TLSv1 TLSv1.1 TLSv1.2;
+		ssl_ciphers 				HIGH:!aNULL:!MD5;
+		ssl_prefer_server_ciphers 	on;
 
 		location / {
-			proxy_pass http://localhost:9234/;
-			proxy_set_header Host $http_host;
-			proxy_http_version 1.1;
-			proxy_set_header Upgrade $http_upgrade;
-			proxy_set_header Connection "Upgrade";
+			proxy_pass 				http://localhost:9234/;
+			proxy_set_header 		Host $http_host;
+			proxy_http_version		1.1;
+			proxy_set_header 		Upgrade $http_upgrade;
+			proxy_set_header 		Connection "Upgrade";
 		}
 	}
 
 	# members-data-api.thegulocal.com
 	# ======================
 	server {
-		listen 443 ssl;
-		server_name members-data-api.thegulocal.com;
-		proxy_http_version 1.1; # this is essential for chunked responses to work
+		listen 						443 ssl;
+		server_name 				members-data-api.thegulocal.com;
+		proxy_http_version 			1.1; # this is essential for chunked responses to work
 
-		ssl_certificate members-data-api.thegulocal.com.crt;
-		ssl_certificate_key members-data-api.thegulocal.com.key;
-		ssl_session_timeout 5m;
-		ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-		ssl_ciphers HIGH:!aNULL:!MD5;
-		ssl_prefer_server_ciphers on;
+		ssl_certificate 			members-data-api.thegulocal.com.crt;
+		ssl_certificate_key 		members-data-api.thegulocal.com.key;
+		ssl_session_timeout 		5m;
+		ssl_protocols 				TLSv1.2 TLSv1.3;
+		ssl_ciphers 				HIGH:!aNULL:!MD5;
+		ssl_prefer_server_ciphers 	on;
 
 		location / {
-			proxy_pass https://members-data-api.code.dev-theguardian.com;
-			proxy_next_upstream error timeout http_404 non_idempotent;
-			proxy_set_header "X-Forwarded-Proto" "https";
+			proxy_pass 				https://members-data-api.code.dev-theguardian.com;
+			proxy_next_upstream 	error timeout http_404 non_idempotent;
+			proxy_set_header 		"X-Forwarded-Proto" "https";
 			proxy_set_header 		Host members-data-api.code.dev-theguardian.com;
 			proxy_set_header        Accept-Encoding "";
 			proxy_hide_header 		Content-Security-Policy;
@@ -81,50 +83,51 @@ http {
     # profile.thegulocal.com
 	# ======================
     server {
-      listen 443 ssl;
-      server_name profile.thegulocal.com;
-      proxy_http_version 1.1; # this is essential for chunked responses to work
+      listen 						443 ssl;
+      server_name 					profile.thegulocal.com;
+      proxy_http_version			1.1; # this is essential for chunked responses to work
 
-      ssl_certificate profile.thegulocal.com.crt;
-      ssl_certificate_key profile.thegulocal.com.key;
-      ssl_session_timeout 5m;
-      ssl_protocols TLSv1.2 TLSv1.3;
-      ssl_ciphers HIGH:!aNULL:!MD5;
-      ssl_prefer_server_ciphers on;
+      ssl_certificate 				profile.thegulocal.com.crt;
+      ssl_certificate_key 			profile.thegulocal.com.key;
+      ssl_session_timeout 			5m;
+      ssl_protocols 				TLSv1.2 TLSv1.3;
+      ssl_ciphers 					HIGH:!aNULL:!MD5;
+      ssl_prefer_server_ciphers 	on;
 
       # dummy location header for the API
-      proxy_set_header X-GU-ID-Geolocation ip:$remote_addr,country:GB,city:Leeds;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header 				X-GU-ID-Geolocation ip:$remote_addr,country:GB,city:Leeds;
+      proxy_set_header 				X-Forwarded-For $proxy_add_x_forwarded_for;
 
       location / {
-        proxy_pass https://profile.code.dev-theguardian.com;
-        proxy_next_upstream error timeout http_404 non_idempotent;
-        proxy_set_header "X-Forwarded-Proto" "https";
-        proxy_set_header "X-GU-Okta-Env" "profile.code.dev-theguardian.com";
-        proxy_set_header 		Host profile.code.dev-theguardian.com;
-        proxy_set_header        Accept-Encoding "";
-        proxy_hide_header 		Content-Security-Policy;
+        proxy_pass 					https://profile.code.dev-theguardian.com;
+        proxy_next_upstream error 	timeout http_404 non_idempotent;
+        proxy_set_header			"X-Forwarded-Proto" "https";
+        proxy_set_header 			"X-GU-Okta-Env" "profile.code.dev-theguardian.com";
+        proxy_set_header 			Host profile.code.dev-theguardian.com;
+        proxy_set_header        	Accept-Encoding "";
+        proxy_hide_header 			Content-Security-Policy;
 
-        proxy_cookie_domain 	profile.code.dev-theguardian.com profile.thegulocal.com;
-        proxy_cookie_domain 	.code.dev-theguardian.com .thegulocal.com;
+        proxy_cookie_domain 		profile.code.dev-theguardian.com profile.thegulocal.com;
+        proxy_cookie_domain 		.code.dev-theguardian.com .thegulocal.com;
 
-        sub_filter_types        application/json;
-        sub_filter_once         off;
-        sub_filter              'profile.code.dev-theguardian.com'  'profile.thegulocal.com';
+        sub_filter_types        	application/json;
+        sub_filter_once         	off;
+        sub_filter              	'profile.code.dev-theguardian.com'  'profile.thegulocal.com';
 
         ######
         # remove `sid` cookie in requests to Gateway
         # save original "Cookie" header value
-        set $altered_cookie $http_cookie;
+        set 						$altered_cookie $http_cookie;
         # check if the "sid" cookie is present
+		# From: https://stackoverflow.com/a/67627604
         if ($http_cookie ~ '(.*)(^|;\s)sid=("[^"]*"|[^\s]*[^;]?)(\2|$|;$)(?:;\s)?(.*)') {
           # cut "sid" cookie from the string
-          set $altered_cookie $1$4$5;
+          set						$altered_cookie $1$4$5;
         }
         # hide original "Cookie" header
-        proxy_hide_header Cookie;
+        proxy_hide_header 			Cookie;
         # set "Cookie" header to the new value
-        proxy_set_header  Cookie $altered_cookie;
+        proxy_set_header  			Cookie $altered_cookie;
         ######
       }
     }

--- a/cypress/lib/signInOkta.ts
+++ b/cypress/lib/signInOkta.ts
@@ -1,0 +1,24 @@
+/**
+ * Non-mocked sign-in with Gateway using Okta
+ */
+
+export const signInOkta = () => {
+	// When this function runs, the browser will already be showing the Gateway sign-in page
+	// because MMA will have redirected to it when it loads the first page of the test.
+	cy.setCookie('gu-cmp-disabled', 'true', {
+		domain: '.thegulocal.com',
+	});
+
+	// Necessary otherwise we get a 502 error back from MMA for some reason, perhaps a race condition?
+	// TODO: Make this not suck
+	cy.wait(1000);
+
+	cy.visit('/');
+	cy.createTestUser({
+		isUserEmailValidated: true,
+	})?.then(({ emailAddress, finalPassword }) => {
+		cy.get('input[name=email]').type(emailAddress);
+		cy.get('input[name=password]').type(finalPassword);
+		cy.get('[data-cy="main-form-submit-button"]').click();
+	});
+};

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -55,6 +55,16 @@ Cypress.Commands.add('iframeLoaded', { prevSubject: 'element' }, ($iframe) => {
 	});
 });
 
+Cypress.Commands.add('solveGoogleReCAPTCHA', () => {
+	cy.get('#recaptcha *> iframe').then(($iframe) => {
+		const $body = $iframe.contents().find('body');
+		cy.wrap($body)
+			.find('.recaptcha-checkbox-border')
+			.should('be.visible')
+			.click();
+	});
+});
+
 Cypress.Commands.add('resolve', (name, options = {}) => {
 	const getValue = () => {
 		// @ts-ignore

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -33,6 +33,7 @@ declare global {
 			resolve(name: string): Chainable<Element>;
 			getIframeBody(selector: string): Chainable<Element>;
 			findByText(text: string): Chainable<Element>;
+			solveGoogleReCAPTCHA(): Chainable<Element>;
 		}
 	}
 }

--- a/cypress/tests/e2e/e2e.cy.ts
+++ b/cypress/tests/e2e/e2e.cy.ts
@@ -1,0 +1,97 @@
+import { signInOkta } from '../../lib/signInOkta';
+
+describe('E2E with Okta', () => {
+	beforeEach(() => {
+		cy.clearAllCookies();
+		signInOkta();
+		cy.get('h1', {
+			timeout: 30000,
+		}).should('contain', 'Account overview');
+	});
+
+	context('account overview tab', () => {
+		it('should contain an email address', () => {
+			cy.findByText('Email address', {
+				timeout: 30000,
+			});
+		});
+	});
+
+	context('profile tab', () => {
+		it('should contain a username', () => {
+			cy.visit('/public-settings');
+			cy.findByText('Username', {
+				timeout: 30000,
+			});
+		});
+	});
+
+	context('emails tab', () => {
+		it('should allow the user to update their email preferences', () => {
+			cy.visit('/email-prefs');
+			cy.findByText('Guardian products and support', {
+				timeout: 30000,
+			}).click();
+			cy.visit('/email-prefs');
+			cy.findByText('Guardian products and support', {
+				timeout: 30000,
+			})
+				.parents('div')
+				.get('input[type="checkbox"]')
+				.should('be.checked');
+		});
+
+		it('should allow the user to unsubscribe from all emails', () => {
+			cy.visit('/email-prefs');
+			cy.findByText('Unsubscribe from all emails', {
+				timeout: 30000,
+			}).click();
+			cy.visit('/email-prefs');
+			cy.get('input[type="checkbox"]', {
+				timeout: 30000,
+			}).should('not.be.checked');
+		});
+	});
+
+	context('settings tab', () => {
+		it('should allow the user to update their personal information', () => {
+			cy.visit('/account-settings');
+			cy.findByLabelText('First Name', {
+				timeout: 30000,
+			}).clear();
+			cy.findByLabelText('Last Name').clear();
+			cy.findByLabelText('First Name').type('Test');
+			cy.findByLabelText('Last Name').type('User');
+			cy.findByText('Save changes').click();
+			cy.visit('/account-settings');
+			cy.findByLabelText('First Name').should('have.value', 'Test');
+			cy.findByLabelText('Last Name').should('have.value', 'User');
+		});
+	});
+
+	context('help tab', () => {
+		it('should allow the user to submit the help centre contact form', () => {
+			cy.visit('/help');
+			cy.findByText(
+				'If you still can’t find what you need and want to contact us, check',
+				{
+					timeout: 30000,
+				},
+			)
+				.parent()
+				.findByText('here')
+				.click();
+			cy.findByText('Take me to the form').click();
+			cy.findByText('Begin form').click();
+			cy.findByText('Continue to step 2').click();
+			cy.findByLabelText('Full Name').type('Test');
+			cy.get('textarea[name="message"]').type('Problem details');
+			cy.solveGoogleReCAPTCHA();
+			cy.wait(1000);
+			cy.findByText('Submit').click();
+			cy.findByText('Thank you for contacting us', {
+				timeout: 30000,
+			});
+		});
+	});
+});

--- a/cypress/tests/e2e/e2e.cy.ts
+++ b/cypress/tests/e2e/e2e.cy.ts
@@ -2,40 +2,32 @@ import { signInOkta } from '../../lib/signInOkta';
 
 describe('E2E with Okta', () => {
 	beforeEach(() => {
+		Cypress.config('defaultCommandTimeout', 30_000);
+
 		cy.clearAllCookies();
 		signInOkta();
-		cy.get('h1', {
-			timeout: 30000,
-		}).should('contain', 'Account overview');
+		cy.get('h1').should('contain', 'Account overview');
 	});
 
 	context('account overview tab', () => {
 		it('should contain an email address', () => {
-			cy.findByText('Email address', {
-				timeout: 30000,
-			});
+			cy.findByText('Email address');
 		});
 	});
 
 	context('profile tab', () => {
 		it('should contain a username', () => {
 			cy.visit('/public-settings');
-			cy.findByText('Username', {
-				timeout: 30000,
-			});
+			cy.findByText('Username');
 		});
 	});
 
 	context('emails tab', () => {
 		it('should allow the user to update their email preferences', () => {
 			cy.visit('/email-prefs');
-			cy.findByText('Guardian products and support', {
-				timeout: 30000,
-			}).click();
+			cy.findByText('Guardian products and support').click();
 			cy.visit('/email-prefs');
-			cy.findByText('Guardian products and support', {
-				timeout: 30000,
-			})
+			cy.findByText('Guardian products and support')
 				.parents('div')
 				.get('input[type="checkbox"]')
 				.should('be.checked');
@@ -43,22 +35,16 @@ describe('E2E with Okta', () => {
 
 		it('should allow the user to unsubscribe from all emails', () => {
 			cy.visit('/email-prefs');
-			cy.findByText('Unsubscribe from all emails', {
-				timeout: 30000,
-			}).click();
+			cy.findByText('Unsubscribe from all emails').click();
 			cy.visit('/email-prefs');
-			cy.get('input[type="checkbox"]', {
-				timeout: 30000,
-			}).should('not.be.checked');
+			cy.get('input[type="checkbox"]').should('not.be.checked');
 		});
 	});
 
 	context('settings tab', () => {
 		it('should allow the user to update their personal information', () => {
 			cy.visit('/account-settings');
-			cy.findByLabelText('First Name', {
-				timeout: 30000,
-			}).clear();
+			cy.findByLabelText('First Name').clear();
 			cy.findByLabelText('Last Name').clear();
 			cy.findByLabelText('First Name').type('Test');
 			cy.findByLabelText('Last Name').type('User');
@@ -74,9 +60,6 @@ describe('E2E with Okta', () => {
 			cy.visit('/help');
 			cy.findByText(
 				'If you still can’t find what you need and want to contact us, check',
-				{
-					timeout: 30000,
-				},
 			)
 				.parent()
 				.findByText('here')
@@ -89,9 +72,7 @@ describe('E2E with Okta', () => {
 			cy.solveGoogleReCAPTCHA();
 			cy.wait(1000);
 			cy.findByText('Submit').click();
-			cy.findByText('Thank you for contacting us', {
-				timeout: 30000,
-			});
+			cy.findByText('Thank you for contacting us');
 		});
 	});
 });

--- a/cypress/tests/mocked/parallel-1/accountOverview.cy.ts
+++ b/cypress/tests/mocked/parallel-1/accountOverview.cy.ts
@@ -1,6 +1,6 @@
-import { toMembersDataApiResponse } from '../../../client/fixtures/mdapiResponse';
-import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
-import { singleContributionsAPIResponse } from '../../../client/fixtures/singleContribution';
+import { toMembersDataApiResponse } from '../../../../client/fixtures/mdapiResponse';
+import { signInAndAcceptCookies } from '../../../lib/signInAndAcceptCookies';
+import { singleContributionsAPIResponse } from '../../../../client/fixtures/singleContribution';
 
 describe('single contributions test', () => {
 	beforeEach(() => {

--- a/cypress/tests/mocked/parallel-1/updateContributionAmount.cy.ts
+++ b/cypress/tests/mocked/parallel-1/updateContributionAmount.cy.ts
@@ -1,9 +1,9 @@
 import {
 	contributionPaidByCard,
 	supporterPlus,
-} from '../../../client/fixtures/productBuilder/testProducts';
-import { toMembersDataApiResponse } from '../../../client/fixtures/mdapiResponse';
-import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
+} from '../../../../client/fixtures/productBuilder/testProducts';
+import { toMembersDataApiResponse } from '../../../../client/fixtures/mdapiResponse';
+import { signInAndAcceptCookies } from '../../../lib/signInAndAcceptCookies';
 
 describe('Update contribution amount', () => {
 	const setSignInStatus = () => {

--- a/cypress/tests/mocked/parallel-1/updatePaymentDetails.cy.ts
+++ b/cypress/tests/mocked/parallel-1/updatePaymentDetails.cy.ts
@@ -1,17 +1,17 @@
-import { toMembersDataApiResponse } from '../../../client/fixtures/mdapiResponse';
+import { toMembersDataApiResponse } from '../../../../client/fixtures/mdapiResponse';
 import {
 	stripeSetupIntent,
 	executePaymentUpdateResponse,
 	ddPaymentMethod,
-} from '../../../client/fixtures/payment';
-import { paymentMethods } from '../../../client/fixtures/stripe';
-import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
+} from '../../../../client/fixtures/payment';
+import { paymentMethods } from '../../../../client/fixtures/stripe';
+import { signInAndAcceptCookies } from '../../../lib/signInAndAcceptCookies';
 import {
 	digitalPackPaidByCardWithPaymentFailure,
 	digitalPackPaidByDirectDebit,
 	guardianWeeklyPaidByCard,
-} from '../../../client/fixtures/productBuilder/testProducts';
-import { singleContributionsAPIResponse } from '../../../client/fixtures/singleContribution';
+} from '../../../../client/fixtures/productBuilder/testProducts';
+import { singleContributionsAPIResponse } from '../../../../client/fixtures/singleContribution';
 
 describe('Update payment details', () => {
 	beforeEach(() => {

--- a/cypress/tests/mocked/parallel-2/cancelContribution.cy.ts
+++ b/cypress/tests/mocked/parallel-2/cancelContribution.cy.ts
@@ -1,6 +1,6 @@
-import { contributionPaidByCard } from '../../../client/fixtures/productBuilder/testProducts';
-import { toMembersDataApiResponse } from '../../../client/fixtures/mdapiResponse';
-import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
+import { contributionPaidByCard } from '../../../../client/fixtures/productBuilder/testProducts';
+import { toMembersDataApiResponse } from '../../../../client/fixtures/mdapiResponse';
+import { signInAndAcceptCookies } from '../../../lib/signInAndAcceptCookies';
 
 describe('Cancel contribution', () => {
 	const setSignInStatus = () => {

--- a/cypress/tests/mocked/parallel-2/cancelGW.cy.ts
+++ b/cypress/tests/mocked/parallel-2/cancelGW.cy.ts
@@ -1,6 +1,6 @@
-import { guardianWeeklyPaidByCard } from '../../../client/fixtures/productBuilder/testProducts';
-import { toMembersDataApiResponse } from '../../../client/fixtures/mdapiResponse';
-import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
+import { guardianWeeklyPaidByCard } from '../../../../client/fixtures/productBuilder/testProducts';
+import { toMembersDataApiResponse } from '../../../../client/fixtures/mdapiResponse';
+import { signInAndAcceptCookies } from '../../../lib/signInAndAcceptCookies';
 
 describe('Cancel guardian weekly', () => {
 	beforeEach(() => {

--- a/cypress/tests/mocked/parallel-2/cancelSupporterPlus.cy.ts
+++ b/cypress/tests/mocked/parallel-2/cancelSupporterPlus.cy.ts
@@ -1,6 +1,6 @@
-import { supporterPlus } from '../../../client/fixtures/productBuilder/testProducts';
-import { toMembersDataApiResponse } from '../../../client/fixtures/mdapiResponse';
-import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
+import { supporterPlus } from '../../../../client/fixtures/productBuilder/testProducts';
+import { toMembersDataApiResponse } from '../../../../client/fixtures/mdapiResponse';
+import { signInAndAcceptCookies } from '../../../lib/signInAndAcceptCookies';
 
 describe('Cancel Supporter Plus', () => {
 	const setupCancellation = () => {

--- a/cypress/tests/mocked/parallel-2/digisubSave.cy.ts
+++ b/cypress/tests/mocked/parallel-2/digisubSave.cy.ts
@@ -1,6 +1,6 @@
-import { digitalPackPaidByDirectDebit } from '../../../client/fixtures/productBuilder/testProducts';
-import { toMembersDataApiResponse } from '../../../client/fixtures/mdapiResponse';
-import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
+import { digitalPackPaidByDirectDebit } from '../../../../client/fixtures/productBuilder/testProducts';
+import { toMembersDataApiResponse } from '../../../../client/fixtures/mdapiResponse';
+import { signInAndAcceptCookies } from '../../../lib/signInAndAcceptCookies';
 
 describe('Cancel digi sub', () => {
 	beforeEach(() => {

--- a/cypress/tests/mocked/parallel-2/membershipSave.cy.ts
+++ b/cypress/tests/mocked/parallel-2/membershipSave.cy.ts
@@ -2,10 +2,10 @@ import {
 	contributionPaidByCard,
 	guardianWeeklyExpiredCard,
 	membershipSupporterWithOldPrice,
-} from '../../../client/fixtures/productBuilder/testProducts';
-import { toMembersDataApiResponse } from '../../../client/fixtures/mdapiResponse';
-import { productMovePreviewResponse } from '../../../client/fixtures/productMove';
-import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
+} from '../../../../client/fixtures/productBuilder/testProducts';
+import { toMembersDataApiResponse } from '../../../../client/fixtures/mdapiResponse';
+import { productMovePreviewResponse } from '../../../../client/fixtures/productMove';
+import { signInAndAcceptCookies } from '../../../lib/signInAndAcceptCookies';
 
 describe('Cancel Membership saves', () => {
 	const setSignInStatus = () => {

--- a/cypress/tests/mocked/parallel-2/productSwitch.cy.ts
+++ b/cypress/tests/mocked/parallel-2/productSwitch.cy.ts
@@ -1,15 +1,15 @@
-import { toMembersDataApiResponse } from '../../../client/fixtures/mdapiResponse';
-import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
+import { toMembersDataApiResponse } from '../../../../client/fixtures/mdapiResponse';
+import { signInAndAcceptCookies } from '../../../lib/signInAndAcceptCookies';
 import {
 	productMovePreviewResponse,
 	productMoveSuccessfulResponse,
-} from '../../../client/fixtures/productMove';
+} from '../../../../client/fixtures/productMove';
 import {
 	contributionAboveSupporterPlusThreshold,
 	contributionPaidByPayPalAboveSupporterPlusThreshold,
 	contributionWithPaymentFailure,
 	nonServicedCountryContributor,
-} from '../../../client/fixtures/productBuilder/testProducts';
+} from '../../../../client/fixtures/productBuilder/testProducts';
 
 const setSignInStatus = () => {
 	cy.window().then((window) => {

--- a/cypress/tests/mocked/parallel-2/upgradeSupport.cy.ts
+++ b/cypress/tests/mocked/parallel-2/upgradeSupport.cy.ts
@@ -1,10 +1,10 @@
-import { toMembersDataApiResponse } from '../../../client/fixtures/mdapiResponse';
+import { toMembersDataApiResponse } from '../../../../client/fixtures/mdapiResponse';
 import {
 	contributionPaidByCard,
 	contributionPaidByPayPal,
-} from '../../../client/fixtures/productBuilder/testProducts';
-import { productMovePreviewResponse } from '../../../client/fixtures/productMove';
-import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
+} from '../../../../client/fixtures/productBuilder/testProducts';
+import { productMovePreviewResponse } from '../../../../client/fixtures/productMove';
+import { signInAndAcceptCookies } from '../../../lib/signInAndAcceptCookies';
 
 describe('upgrade support', () => {
 	beforeEach(() => {

--- a/cypress/tests/mocked/parallel-3/holidayStops.cy.ts
+++ b/cypress/tests/mocked/parallel-3/holidayStops.cy.ts
@@ -1,4 +1,4 @@
-import { toMembersDataApiResponse } from '../../../client/fixtures/mdapiResponse';
+import { toMembersDataApiResponse } from '../../../../client/fixtures/mdapiResponse';
 import {
 	potentialDeliveries,
 	noPotentialDeliveries,
@@ -7,9 +7,9 @@ import {
 	multiplePotentialDeliveries,
 	existingHolidaysFirstIssueDecember,
 	yearSpanningPotentialDeliveries,
-} from '../../../client/fixtures/holidays';
-import { guardianWeeklyPaidByCard } from '../../../client/fixtures/productBuilder/testProducts';
-import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
+} from '../../../../client/fixtures/holidays';
+import { guardianWeeklyPaidByCard } from '../../../../client/fixtures/productBuilder/testProducts';
+import { signInAndAcceptCookies } from '../../../lib/signInAndAcceptCookies';
 
 describe('Holiday stops', () => {
 	beforeEach(() => {

--- a/cypress/tests/mocked/parallel-4/deliveryAddress.cy.ts
+++ b/cypress/tests/mocked/parallel-4/deliveryAddress.cy.ts
@@ -2,9 +2,9 @@ import {
 	guardianWeeklyPaidByCard,
 	nationalDelivery,
 	supporterPlus,
-} from '../../../client/fixtures/productBuilder/testProducts';
-import { toMembersDataApiResponse } from '../../../client/fixtures/mdapiResponse';
-import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
+} from '../../../../client/fixtures/productBuilder/testProducts';
+import { toMembersDataApiResponse } from '../../../../client/fixtures/mdapiResponse';
+import { signInAndAcceptCookies } from '../../../lib/signInAndAcceptCookies';
 
 describe('Delivery address', () => {
 	beforeEach(() => {

--- a/cypress/tests/mocked/parallel-4/deliveryRecords.cy.ts
+++ b/cypress/tests/mocked/parallel-4/deliveryRecords.cy.ts
@@ -1,22 +1,22 @@
-import { toMembersDataApiResponse } from '../../../client/fixtures/mdapiResponse';
+import { toMembersDataApiResponse } from '../../../../client/fixtures/mdapiResponse';
 import {
 	deliveryRecordsWithNoDeliveries,
 	deliveryRecordsWithDelivery,
 	deliveryRecordsWithReportedProblem,
-} from '../../../client/fixtures/deliveryRecords';
-import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
-import { potentialDeliveries } from '../../../client/fixtures/holidays';
+} from '../../../../client/fixtures/deliveryRecords';
+import { signInAndAcceptCookies } from '../../../lib/signInAndAcceptCookies';
+import { potentialDeliveries } from '../../../../client/fixtures/holidays';
 import {
 	dateAddDays,
 	dateString,
 	DATE_FNS_INPUT_FORMAT,
-} from '../../../shared/dates';
-import { singleContributionsAPIResponse } from '../../../client/fixtures/singleContribution';
+} from '../../../../shared/dates';
+import { singleContributionsAPIResponse } from '../../../../client/fixtures/singleContribution';
 import {
 	guardianWeeklyPaidByCard,
 	homeDelivery,
 	nationalDelivery,
-} from '../../../client/fixtures/productBuilder/testProducts';
+} from '../../../../client/fixtures/productBuilder/testProducts';
 
 describe('Delivery records', () => {
 	beforeEach(() => {

--- a/cypress/tests/mocked/parallel-5/membership.cy.ts
+++ b/cypress/tests/mocked/parallel-5/membership.cy.ts
@@ -1,6 +1,6 @@
-import { membershipSupporter } from '../../../client/fixtures/productBuilder/testProducts';
-import { toMembersDataApiResponse } from '../../../client/fixtures/mdapiResponse';
-import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
+import { membershipSupporter } from '../../../../client/fixtures/productBuilder/testProducts';
+import { toMembersDataApiResponse } from '../../../../client/fixtures/mdapiResponse';
+import { signInAndAcceptCookies } from '../../../lib/signInAndAcceptCookies';
 
 describe('membership test', () => {
 	beforeEach(() => {

--- a/cypress/tests/mocked/parallel-5/patron.cy.ts
+++ b/cypress/tests/mocked/parallel-5/patron.cy.ts
@@ -1,9 +1,9 @@
 import {
 	guardianWeeklyPaidByCard,
 	patronDigitalPack,
-} from '../../../client/fixtures/productBuilder/testProducts';
-import { toMembersDataApiResponse } from '../../../client/fixtures/mdapiResponse';
-import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
+} from '../../../../client/fixtures/productBuilder/testProducts';
+import { toMembersDataApiResponse } from '../../../../client/fixtures/mdapiResponse';
+import { signInAndAcceptCookies } from '../../../lib/signInAndAcceptCookies';
 
 describe('patron test', () => {
 	beforeEach(() => {

--- a/cypress/tests/mocked/parallel-6/emailAndMarketing.cy.ts
+++ b/cypress/tests/mocked/parallel-6/emailAndMarketing.cy.ts
@@ -1,11 +1,11 @@
-import { user as userResponse } from '../../../client/fixtures/user';
-import { toMembersDataApiResponse } from '../../../client/fixtures/mdapiResponse';
-import { singleContributionsAPIResponse } from '../../../client/fixtures/singleContribution';
-import { newsletters } from '../../../client/fixtures/newsletters';
-import { consents } from '../../../client/fixtures/consents';
-import { newsletterSubscriptions } from '../../../client/fixtures/newsletterSubscriptions';
-import { InAppPurchase } from '../../../client/fixtures/inAppPurchase';
-import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
+import { user as userResponse } from '../../../../client/fixtures/user';
+import { toMembersDataApiResponse } from '../../../../client/fixtures/mdapiResponse';
+import { singleContributionsAPIResponse } from '../../../../client/fixtures/singleContribution';
+import { newsletters } from '../../../../client/fixtures/newsletters';
+import { consents } from '../../../../client/fixtures/consents';
+import { newsletterSubscriptions } from '../../../../client/fixtures/newsletterSubscriptions';
+import { InAppPurchase } from '../../../../client/fixtures/inAppPurchase';
+import { signInAndAcceptCookies } from '../../../lib/signInAndAcceptCookies';
 
 describe('Email and Marketing page', () => {
 	beforeEach(() => {

--- a/cypress/tests/mocked/parallel-6/identitySettingsForm.cy.ts
+++ b/cypress/tests/mocked/parallel-6/identitySettingsForm.cy.ts
@@ -1,5 +1,5 @@
-import { user as userResponse } from '../../../client/fixtures/user';
-import { signInAndAcceptCookies } from '../../lib/signInAndAcceptCookies';
+import { user as userResponse } from '../../../../client/fixtures/user';
+import { signInAndAcceptCookies } from '../../../lib/signInAndAcceptCookies';
 
 describe('Settings Form', () => {
 	beforeEach(() => {

--- a/docs/07-testing.md
+++ b/docs/07-testing.md
@@ -1,0 +1,62 @@
+# Cypress testing
+
+Cypress tests come in two types: mocked and end-to-end (E2E).
+
+## Mocked tests
+
+Most of the tests are mocked tests. They mock responses from various APIs and
+short-circuit the identity middleware, which prevents the tests from needing to
+log a user in. The middleware is short-circuited by setting the value of the
+global variable `CYPRESS` to `'SKIP_IDAPI'` in the `bundle-dev-server-cypress`
+script in `package.json`.
+
+The mocked tests live in `cypress/tests/mocked`.
+
+The mocked tests use the following commands in `package.json`:
+
+-   `yarn cypress:mocked:server`: starts a dev server (essentially the same as the standard `yarn watch` command but with the `CYPRESS` variable set to `'SKIP_IDAPI'`, and doesn't open a new browser tab).
+-   `yarn cypress:mocked:open`: opens the Cypress test runner in mocked mode.
+-   `yarn cypress:mocked:run`: runs the Cypress tests headless in mocked mode.
+
+In CI, the mocked tests are run by the `cypress-mocked.yml` GitHub Actions job.
+
+## End-to-end tests
+
+The end-to-end tests live in `cypress/tests/e2e`. They currently comprise a
+small suite of basic tests which use CODE IDAPI to generate a test user and CODE
+Gateway to sign that user in before performing a few basic functions on the
+frontend.
+
+To run E2E tests locally, it is necessary to download a Cypress env file from S3
+with the following command (after getting fresh tokens from Janus):
+
+```bash
+aws s3 cp --profile membership s3://gu-reader-revenue-private/manage-frontend/CODE/cypress.env.json cypress.env.json
+```
+
+Also ensure that you have run the setup script in the `nginx` directory, which
+sets up the local Nginx proxy to CODE Gateway and IDAPI. If you are also developing
+Identity projects such as Gateway, you may have already run the setup script in the
+`identity-platform` repo. If this is the case, you will have conflicting server blocks
+for the `profile.thegulocal.com` domain. You will need to either:
+
+-   Always run Gateway locally while running MMA E2E tests, and delete the
+    `identity-frontend-CODE-fallback.conf` file in the Nginx config directory; or
+-   Comment out the `profile.thegulocal.com` server block in the `identity.conf`
+    file in the Nginx config directory.
+
+Remember to restart Nginx after making any changes to the Nginx config files.
+
+```bash
+cd $(dev-nginx locate)/servers
+sudo rm identity-frontend-CODE-fallback.conf
+# OR
+sudo vim identity.conf
+sudo nginx -s reload
+```
+
+The E2E tests use the following commands in `package.json`:
+
+-   `yarn cypress:e2e:server`: starts a dev server without setting the `CYPRESS` variable.
+-   `yarn cypress:e2e:open`: opens the Cypress test runner in E2E mode.
+-   `yarn cypress:e2e:run`: runs the Cypress tests headless in E2E mode.

--- a/nginx/identity-frontend-CODE-fallback.conf
+++ b/nginx/identity-frontend-CODE-fallback.conf
@@ -1,7 +1,5 @@
 upstream identity_services { # avoids naming clash with Identity's own nginx config if already installed
-  server localhost:9009; # Dotcom Identity Frontend
-  server localhost:8860; # Identity Frontend
-  server localhost:8800; # IDAPI ??
+  server localhost:8861; # Gateway
 }
 
 server {
@@ -16,23 +14,83 @@ server {
     ssl_ciphers HIGH:!aNULL:!MD5;
     ssl_prefer_server_ciphers on;
 
-    location / {
-        proxy_pass http://identity_services;
-        proxy_set_header Host $http_host;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
+	# fixes issues for large response headers
+	proxy_buffer_size   		128k;
+	proxy_buffers   			4 256k;
+	proxy_busy_buffers_size   	256k;
+	large_client_header_buffers 4 32k;
 
-        proxy_intercept_errors on;
+    location / {
+        proxy_pass 				http://identity_services;
+        proxy_set_header 		Host $http_host;
+        proxy_http_version 		1.1;
+        proxy_set_header 		Upgrade $http_upgrade;
+        proxy_set_header 		Connection "Upgrade";
+		proxy_set_header 		"X-GU-Okta-Env" "profile.code.dev-theguardian.com";
+
+        ######
+        # remove `sid` cookie in requests to Gateway
+        # save original "Cookie" header value
+        set $altered_cookie $http_cookie;
+        # check if the "sid" cookie is present
+        if ($http_cookie ~ '(.*)(^|;\s)sid=("[^"]*"|[^\s]*[^;]?)(\2|$|;$)(?:;\s)?(.*)') {
+          # cut "sid" cookie from the string
+          set $altered_cookie $1$4$5;
+        }
+        # hide original "Cookie" header
+        proxy_hide_header Cookie;
+        # set "Cookie" header to the new value
+        proxy_set_header  Cookie $altered_cookie;
+        ######
+
+        proxy_intercept_errors 	on;
         error_page 404 502 503 504 = @fallback;
     }
 
+	# paths to proxy to okta
+	location ~ ^/(oauth2|api\/v1|login|idp|sso|.well-known\/openid-configuration) {
+		resolver                8.8.8.8;
+		proxy_pass              https://profile.code.dev-theguardian.com;
+		proxy_set_header        Host                    profile.code.dev-theguardian.com;
+		proxy_set_header        X-Real-IP               $remote_addr;
+		proxy_set_header        X-Forwarded-For         $proxy_add_x_forwarded_for;
+		proxy_set_header        X-Forwarded-Protocol    $scheme;
+		proxy_set_header        Referer                 https://profile.code.dev-theguardian.com;
+		# rewrite any domain in the response to our proxy
+		proxy_set_header        Accept-Encoding "";
+		sub_filter_types        application/json;
+		sub_filter_once         off;
+		sub_filter              'profile.code.dev-theguardian.com'  'profile.thegulocal.com';
+
+        ######
+        # remove `sid` cookie in requests to Gateway
+        # save original "Cookie" header value
+        set $altered_cookie $http_cookie;
+        # check if the "sid" cookie is present
+        if ($http_cookie ~ '(.*)(^|;\s)sid=("[^"]*"|[^\s]*[^;]?)(\2|$|;$)(?:;\s)?(.*)') {
+          # cut "sid" cookie from the string
+          set $altered_cookie $1$4$5;
+        }
+        # hide original "Cookie" header
+        proxy_hide_header Cookie;
+        # set "Cookie" header to the new value
+        proxy_set_header  Cookie $altered_cookie;
+        ######
+
+		error_page 404 502 503 504 = @fallback;
+	}
+
     location @fallback {
-        proxy_pass https://profile.code.dev-theguardian.com;
-        proxy_set_header Host profile.code.dev-theguardian.com;
-        proxy_set_header Origin https://profile.code.dev-theguardian.com;
-        proxy_hide_header Content-Security-Policy;
-        proxy_cookie_domain profile.code.dev-theguardian.com profile.thegulocal.com;
-        proxy_cookie_domain .code.dev-theguardian.com .thegulocal.com;
+        proxy_pass       		https://profile.code.dev-theguardian.com;
+        proxy_set_header 		Host profile.code.dev-theguardian.com;
+        proxy_set_header 		Origin https://profile.code.dev-theguardian.com;
+        proxy_set_header        Accept-Encoding "";
+        proxy_hide_header 		Content-Security-Policy;
+        proxy_cookie_domain 	profile.code.dev-theguardian.com profile.thegulocal.com;
+        proxy_cookie_domain 	.code.dev-theguardian.com .thegulocal.com;
+
+        sub_filter_types        application/json;
+        sub_filter_once         off;
+        sub_filter              'profile.code.dev-theguardian.com'  'profile.thegulocal.com';
     }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "start": "nodemon --inspect ./dist/server",
+    "cypress:start": "RUNNING_IN_CYPRESS=true nodemon --inspect ./dist/server",
     "type-check": "tsc --skipLibCheck",
     "lint": "eslint 'client/**' 'server/**' 'shared/**'",
     "bundle": "copy-node-modules . ./dist && yarn webpack --config webpack.production.js",
@@ -20,9 +21,12 @@
     "updateSnapshot": "jest -u",
     "storybook": "storybook dev -p 6006 -s 'static'",
     "build-storybook": "storybook build -s '.storybook/static'",
-    "cypress:open": "DEBUG=cypress:* cypress open",
-    "cypress:run": "cypress run",
-    "cypress:server": "yarn bundle-dev-server && (yarn bundle-dev-server-cypress -w & yarn start & yarn serve-dev-cypress)",
+    "cypress:mocked:open": "DEBUG=cypress:* cypress open --config '{\"e2e\":{\"specPattern\":\"cypress/tests/mocked/**/*.cy.{js,jsx,ts,tsx}\"}}' --e2e --browser chrome",
+    "cypress:mocked:run": "cypress run --config '{\"e2e\":{\"specPattern\":\"cypress/tests/mocked/**/*.cy.{js,jsx,ts,tsx}\"}}' --e2e --browser chrome",
+    "cypress:mocked:server": "yarn bundle-dev-server && (yarn bundle-dev-server-cypress -w & yarn start & yarn serve-dev-cypress)",
+    "cypress:e2e:open": "cypress open --config '{\"e2e\":{\"specPattern\":\"cypress/tests/e2e/**/*.cy.{js,jsx,ts,tsx}\"}}' --e2e --browser chrome",
+    "cypress:e2e:run": "cypress run --config '{\"e2e\":{\"specPattern\":\"cypress/tests/e2e/**/*.cy.{js,jsx,ts,tsx}\"}}' --e2e --browser chrome",
+    "cypress:e2e:server": "yarn bundle-dev-server && (yarn bundle-dev-server -w & yarn cypress:start & yarn serve-dev-cypress)",
     "chromatic": "chromatic"
   },
   "lint-staged": {

--- a/server/log.ts
+++ b/server/log.ts
@@ -21,6 +21,9 @@ interface MetricLoggingFields {
 }
 
 export const putMetric = (fields: MetricLoggingFields) => {
+	if (process.env.RUNNING_IN_CYPRESS === 'true') {
+		return;
+	}
 	const dimensions = {
 		Stage: conf.STAGE,
 		outcome: fields.isOK ? 'SUCCESS' : 'ERROR',

--- a/server/oktaConfig.ts
+++ b/server/oktaConfig.ts
@@ -34,5 +34,8 @@ export const getConfig = async (): Promise<OktaConfig> => {
 	if (!isValidConfig(config)) {
 		throw new Error('Error loading a valid config');
 	}
+	if (process.env.RUNNING_IN_CYPRESS === 'true') {
+		config.useOkta = true;
+	}
 	return config;
 };


### PR DESCRIPTION
## What does this change?

This adds a small suite of end-to-end (E2E) Cypress tests to manage-frontend. The existing Cypress tests all mock various API endpoints to allow testing specific user and supporter conditions. However to do this, they entirely skip the authentication middleware, and for our OAuth migration we really want to have that middleware tested end-to-end. Hence these new tests!

A lot of the changes here are refactoring file locations; most of the rest is support to allow end-to-end testing to work on local machines and the GHA runners. Specifically, we borrow from the general strategy in [Gateway](https://github.com/guardian/gateway), using Nginx configs to proxy the CODE locations of Gateway, IDAPI and MDAPI to `.thegulocal.com` domains. This allows a locally running MMA on `manage.thegulocal.com` to interact with, and read cookies set on, CODE services.

- We move the original mocked Cypress tests to `cypress/tests/mocked`, and rename the GitHub Actions workflow file to `cypress-mocked.yml`.
- The new tests live in `cypress/tests/e2e`, and use the `cypress-e2e.yml` workflow file.
- We add an Nginx config file, `cypress/cypress-nginx.conf`, which is used in GitHub Actions.
- We add a basic suite of E2E Cypress tests which we will expand on down the line, and some docs explaining how to set them up and run them locally.
- When running in Cypress (defined by the presence of the `RUNNING_IN_CYPRESS` environment variable), we skip metrics as these aren't authorised to be added in GHA, and always run the authentication middleware via OAuth/Okta.
- We change some Yarn commands and add some new ones:
    - `yarn cypress:mocked:server`: starts a dev server (essentially the same as the standard `yarn watch` command but with the `CYPRESS` variable set to `'SKIP_IDAPI'`, and doesn't open a new browser tab).
    -   `yarn cypress:mocked:open`: opens the Cypress test runner in mocked mode.
    -   `yarn cypress:mocked:run`: runs the Cypress tests headless in mocked mode.
    -   `yarn cypress:e2e:server`: starts a dev server without setting the `CYPRESS` variable.
    -   `yarn cypress:e2e:open`: opens the Cypress test runner in E2E mode.
    -   `yarn cypress:e2e:run`: runs the Cypress tests headless in E2E mode.

## Notes

- The E2E tests only run against the new, Okta-enabled authentication middleware, by overwriting the Okta config when Cypress is running.