### PR TITLE
Fix help centre sitemap

### DIFF
--- a/server/awsIntegration.ts
+++ b/server/awsIntegration.ts
@@ -113,7 +113,7 @@ export const s3TextFilePromise = (
 		const s3PromiseResult = await S3.getObject(filePath).promise();
 		if (
 			s3PromiseResult.Body &&
-			s3PromiseResult.ContentType === 'text/plain'
+			s3PromiseResult.ContentType === 'application/json'
 		) {
 			return s3PromiseResult.Body.toString();
 		}

--- a/server/routes/core.ts
+++ b/server/routes/core.ts
@@ -73,7 +73,7 @@ router.get('/sitemap.txt', async (_, res: Response) => {
 			const statusCode = data ? 200 : 404;
 			res.status(statusCode)
 				.contentType('text/plain')
-				.send(data || []);
+				.send(data ?? []);
 		})
 		.catch((error) => {
 			const errorMessage = `File ${filePath} not found`;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Fix the help centre sitemap by asserting the content type that it actually is in S3. Spotted because I was testing turning on  eslint rule `'@typescript-eslint/prefer-nullish-coalescing'`

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Go to https://manage.theguardian.com/sitemap.txt, see content instead of `[]` as before this change. 

![image](https://github.com/guardian/manage-frontend/assets/114918544/3b4bc26d-3f2e-438b-9917-7221ca1e7510)


<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

Should we rather just change the content type of the file in S3 to `text/plain` (which seems to be more accurate?) - or fix whatever is creating that file

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Before
![image](https://github.com/guardian/manage-frontend/assets/114918544/c5c8f850-ed06-45ad-babd-344cb623d625)

After
![image](https://github.com/guardian/manage-frontend/assets/114918544/8c377a24-5bdd-412b-98bd-a73747f3b21b)


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
