### PR TITLE
digisub tidy ups v1

### DIFF
--- a/client/components/mma/cancel/cancellationReason.ts
+++ b/client/components/mma/cancel/cancellationReason.ts
@@ -50,6 +50,7 @@ export type CancellationReasonId =
 	| 'mma_no_need'
 	| 'mma_dont_know_what_for'
 	| 'mma_other'
-	| 'mma_membership_cancellation_default';
+	| 'mma_membership_cancellation_default'
+	| 'mma_cancellation_default';
 
 export type OptionalCancellationReasonId = CancellationReasonId | undefined;

--- a/client/components/mma/cancel/cancellationSaves/digipack/ConfirmDigiSubCancellation.tsx
+++ b/client/components/mma/cancel/cancellationSaves/digipack/ConfirmDigiSubCancellation.tsx
@@ -100,8 +100,7 @@ export const ConfirmDigiSubCancellation = () => {
 	const routerState = location.state as DigisubCancellationRouterState;
 	const eligibleForDiscount = routerState?.eligibleForDiscount;
 
-	const reason: OptionalCancellationReasonId =
-		'mma_membership_cancellation_default'; //reason needs to be provided as undefined doesn't work. Reason updated if user provides one on next screen.
+	const reason: OptionalCancellationReasonId = 'mma_cancellation_default'; //reason needs to be provided as undefined doesn't work. Reason updated if user provides one on next screen.
 
 	const createCase = (
 		selectedReasonId: string,

--- a/client/components/mma/cancel/cancellationSaves/digipack/DigiSubDiscountConfirmed.tsx
+++ b/client/components/mma/cancel/cancellationSaves/digipack/DigiSubDiscountConfirmed.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { palette, space } from '@guardian/source-foundations';
+import { palette, space, textSans } from '@guardian/source-foundations';
 import {
 	LinkButton,
 	Stack,
@@ -79,6 +79,7 @@ export const DigiSubDiscountConfirmed = () => {
 				css={css`
 					padding-top: ${space[4]}px;
 					margin-bottom: 32px;
+					${textSans.medium()};
 				`}
 			>
 				<h2 css={headingCss}>Discount confirmed</h2>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Two minor changes after testing of the digisub journey: 
- default cancellation reason has been changed to ```mma_cancellation_default``` 
- updated the font on the subheading fro discount confirmation page
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
