### PR TITLE
OAuth migration | Refactor GU_SO handling based on new flow

### DIFF
--- a/server/__tests__/oauth.test.ts
+++ b/server/__tests__/oauth.test.ts
@@ -114,7 +114,7 @@ describe('verifyOAuthCookiesLocally', () => {
 			'invalid-access-token',
 		);
 		expect(spyOnVerifyIdToken).toHaveBeenCalledWith('id-token');
-		expect(verify).toEqual({});
+		expect(verify).toEqual(undefined);
 	});
 
 	it('returns an empty object if the ID token is invalid', async () => {
@@ -144,7 +144,7 @@ describe('verifyOAuthCookiesLocally', () => {
 
 		expect(spyOnVerifyAccessToken).toHaveBeenCalledWith('access-token');
 		expect(spyOnVerifyIdToken).toHaveBeenCalledWith('invalid-id-token');
-		expect(verify).toEqual({});
+		expect(verify).toEqual(undefined);
 	});
 });
 

--- a/server/oauth.ts
+++ b/server/oauth.ts
@@ -279,7 +279,7 @@ export const performAuthorizationCodeFlow = async (
  */
 export const verifyOAuthCookiesLocally = async (
 	req: Request,
-): Promise<VerifiedOAuthCookies> => {
+): Promise<VerifiedOAuthCookies | undefined> => {
 	const accessTokenCookie = req.signedCookies[OAuthAccessTokenCookieName];
 	const idTokenCookie = req.signedCookies[OAuthIdTokenCookieName];
 
@@ -300,13 +300,7 @@ export const verifyOAuthCookiesLocally = async (
 				accessToken,
 				idToken,
 			};
-		} else {
-			// Access or ID token invalid, return empty object
-			return {};
 		}
-	} else {
-		// No access token or ID token cookie found, return empty object
-		return {};
 	}
 };
 

--- a/server/oauthConfig.ts
+++ b/server/oauthConfig.ts
@@ -7,8 +7,8 @@ export const OAuthIdTokenCookieName = 'GU_ID_TOKEN';
 export const OAuthStateCookieName = 'GU_oidc_auth_state';
 
 export interface VerifiedOAuthCookies {
-	accessToken?: OktaJwtVerifier.Jwt;
-	idToken?: OktaJwtVerifier.Jwt;
+	accessToken: OktaJwtVerifier.Jwt;
+	idToken: OktaJwtVerifier.Jwt;
 }
 
 export const oauthCookieOptions: CookieOptions = {


### PR DESCRIPTION
## What does this change?

In the new flow, we first check if the access and ID tokens are set. If so, we check if the GU_SO cookie was set after the access token's iat claim, which means that the user signed out after they generated these tokens. In this case, we follow the signout behaviour. Otherwise, we handle the subsequent cases (IDAPI cookies are/aren't set). If the GU_SO cookie was set before the iat claim, we can safely ignore it, and continue the flow as above.

For documentation on this, see this PR: https://github.com/guardian/gateway/pull/2530