### PR TITLE
OAuth migration | Remove SC_GU_LA cookie check | Migrate MDAPI calls to use OAuth tokens

### DIFF
--- a/server/__tests__/middleware/identityMiddleware.test.ts
+++ b/server/__tests__/middleware/identityMiddleware.test.ts
@@ -221,7 +221,6 @@ describe('authenticateWithOAuth middleware - route requires signin', () => {
 			cookies: {
 				GU_U: 'gu_u',
 				SC_GU_U: 'sc_gu_u',
-				SC_GU_LA: 'sc_gu_la',
 			},
 			originalUrl: '/profile',
 		} as Request;
@@ -375,7 +374,6 @@ describe('authenticateWithOAuth middleware - route does not require signin', () 
 			cookies: {
 				GU_U: 'gu_u',
 				SC_GU_U: 'sc_gu_u',
-				SC_GU_LA: 'sc_gu_la',
 			},
 			originalUrl: '/help-centre',
 		} as Request;

--- a/server/__tests__/oauth.test.ts
+++ b/server/__tests__/oauth.test.ts
@@ -154,7 +154,6 @@ describe('setLocalStateFromIdTokenOrUserCookie', () => {
 			cookies: {
 				GU_U: 'gu_u',
 				SC_GU_U: 'sc_gu_u',
-				SC_GU_LA: 'sc_gu_la',
 			},
 		} as Request;
 		const res = {} as Response;
@@ -197,7 +196,6 @@ describe('setLocalStateFromIdTokenOrUserCookie', () => {
 			cookies: {
 				GU_U: 'gu_u',
 				SC_GU_U: 'sc_gu_u',
-				SC_GU_LA: 'sc_gu_la',
 			},
 		} as Request;
 		const res = {} as Response;
@@ -216,7 +214,6 @@ describe('setLocalStateFromIdTokenOrUserCookie', () => {
 		const req = {
 			cookies: {
 				SC_GU_U: 'sc_gu_u',
-				SC_GU_LA: 'sc_gu_la',
 			},
 		} as Request;
 		const res = {} as Response;

--- a/server/apiProxy.ts
+++ b/server/apiProxy.ts
@@ -9,6 +9,7 @@ import { conf } from './config';
 import { getCookiesOrEmptyString } from './idapiAuth';
 import { log, putMetric } from './log';
 import { augmentRedirectURL } from './middleware/requestMiddleware';
+import { OAuthAccessTokenCookieName } from './oauthConfig';
 
 type BodyHandler = (res: Response, body: Buffer) => void;
 type JsonString = Buffer | string | undefined;
@@ -86,12 +87,34 @@ export const proxyApiHandler =
 			outgoingURL,
 		};
 
+		const authorizationOrCookieHeader = ({
+			req,
+			host,
+		}: {
+			req: Request;
+			host: string;
+		}): Headers => {
+			switch (host) {
+				case 'members-data-api.' + conf.DOMAIN:
+					return {
+						Authorization: `Bearer ${req.signedCookies[OAuthAccessTokenCookieName]}`,
+					};
+				default:
+					// TODO: This is legacy code!
+					// We don't want to send literally all cookies to APIs so when
+					// we migrate to Okta tokens entirely we should remove this
+					return {
+						Cookie: getCookiesOrEmptyString(req),
+					};
+			}
+		};
+
 		fetch(outgoingURL, {
 			method: httpMethod,
 			body: requestBody,
 			headers: {
+				...authorizationOrCookieHeader({ req, host }),
 				'Content-Type': 'application/json', // TODO: set this from the client req headers (would need to check all client calls actually specify content-type)
-				Cookie: getCookiesOrEmptyString(req),
 				[X_GU_ID_FORWARDED_SCOPE]:
 					req.header(X_GU_ID_FORWARDED_SCOPE) || '',
 				...headers,

--- a/server/oauth.ts
+++ b/server/oauth.ts
@@ -348,6 +348,6 @@ export const sanitizeReturnPath = (returnPath: string) => {
 };
 
 export const allIdapiCookiesSet = (req: Request) => {
-	const idapiCookies = ['GU_U', 'SC_GU_U', 'SC_GU_LA'];
+	const idapiCookies = ['GU_U', 'SC_GU_U'];
 	return idapiCookies.every((cookie) => req.cookies[cookie]);
 };

--- a/server/oauthConfig.ts
+++ b/server/oauthConfig.ts
@@ -38,5 +38,7 @@ export const scopes = [
 	'guardian.identity-api.user.username.create.self.secure',
 	'guardian.identity-api.consents.read.self',
 	'guardian.identity-api.consents.update.self',
+	'guardian.members-data-api.complete.read.self.secure',
+	'guardian.members-data-api.read.self',
 ] as const;
 export type Scopes = typeof scopes[number];


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This changes two things, one resulting from the other.

### Remove the `SC_GU_LA` cookie check

After we enabled Okta on PROD MMA, we noticed a few browsers were experiencing redirect loops. We worked out that this was happening in the following situation:

- The current Okta session was newer than the `max_age` parameter being sent by MMA.
- Because of this, Okta considered the current session valid, and when a browser landed on MMA, immediately redirected the browser back to MMA, without refreshing or setting any cookies.
- However, for some reason (unknown), the `SC_GU_LA` cookie was missing from the browser context in the affected browsers. I suspect this was a race condition: the `SC_GU_LA` cookie had expired and been deleted before the OAuth session became invalid, despite the fact that both are set to 30 minutes.
- Seeing no `SC_GU_LA` cookie, MMA sent the browser back to Okta.
- Repeat _ad infinitum_.

The error may have been limited to developer machines with funky cookie setups, but we reverted the config change on PROD just in case.

Luckily, the solution is simple - we do not actually need to check for the `SC_GU_LA` cookie, as our downstream APIs don't use it and we're going to deprecate it as part of our migration to Okta anyway. Thank you to @coldlink for solving this!

The first commit removes the check for `SC_GU_LA` during login.

### Migrating MDAPI calls to use OAuth tokens

MDAPI supports authentication via IDAPI cookies and OAuth tokens. When making calls to MDAPI without the `SC_GU_LA` cookie set, these naturally fail. The second two commits in this PR update MMA to make calls to MDAPI only with the new OAuth access token, sent in an `Authorization` header, rather than the IDAPI cookies. This allows MMA to work without the `SC_GU_LA` cookie.

Currently, all other APIs still send the legacy IDAPI cookies. MDAPI needs to be updated because it is the only Guardian API which [calls the IDAPI `auth/redirect` endpoint to validate IDAPI cookies](https://github.com/guardian/members-data-api/blob/2aeee81450ccdde87c762286b86f9c31222f84b8/membership-attribute-service/app/actions/AuthAndBackendViaIdapiAction.scala#L72) - and that endpoint expects a valid `SC_GU_LA` value.

## Tests

- [ ] Tested on CODE
- [ ] Tested on PROD