### PR TITLE
Add App Incident banner to Help Centre

### DIFF
--- a/client/components/helpCentre/HelpCentrePage.tsx
+++ b/client/components/helpCentre/HelpCentrePage.tsx
@@ -81,7 +81,7 @@ const HelpCentreRouter = () => {
 		{
 			date: '18th Jan 2024 12:15',
 			message:
-				'We are currently investigating reports of a technical issue for customers signing into our The Guardian live app. We are working to resolve this and apologise for any inconvenience.',
+				'We are currently investigating reports of a technical issue for customers signing into The Guardian live app on Android. We are working to resolve this and apologise for any inconvenience caused.',
 		},
 		{
 			date: '4th Dec 2023 12:45',

--- a/client/components/helpCentre/HelpCentrePage.tsx
+++ b/client/components/helpCentre/HelpCentrePage.tsx
@@ -79,6 +79,11 @@ const HelpCentreRouter = () => {
 
 	const knownIssues: KnownIssueObj[] = [
 		{
+			date: '18th Jan 2024 12:15',
+			message:
+				'We are currently investigating reports of a technical issue for customers signing into our The Guardian live app. We are working to resolve this and apologise for any inconvenience.',
+		},
+		{
 			date: '4th Dec 2023 12:45',
 			message:
 				'Due to a technical issue, Customer Service phonelines in the USA & Canada are currently not available. Live chat and email are unaffected.',


### PR DESCRIPTION
## What does this change?
Adds a banner to the Help Centre about an ongoing incident with the premium app:

`We are currently investigating reports of a technical issue for customers signing into The Guardian live app on Android. We are working to resolve this and apologise for any inconvenience caused.`
