### PR TITLE
Revert "OAuth migration | Remove SC_GU_LA cookie check | Migrate MDAPI calls to use OAuth tokens"

### DIFF
--- a/server/__tests__/middleware/identityMiddleware.test.ts
+++ b/server/__tests__/middleware/identityMiddleware.test.ts
@@ -221,6 +221,7 @@ describe('authenticateWithOAuth middleware - route requires signin', () => {
 			cookies: {
 				GU_U: 'gu_u',
 				SC_GU_U: 'sc_gu_u',
+				SC_GU_LA: 'sc_gu_la',
 			},
 			originalUrl: '/profile',
 		} as Request;
@@ -374,6 +375,7 @@ describe('authenticateWithOAuth middleware - route does not require signin', () 
 			cookies: {
 				GU_U: 'gu_u',
 				SC_GU_U: 'sc_gu_u',
+				SC_GU_LA: 'sc_gu_la',
 			},
 			originalUrl: '/help-centre',
 		} as Request;

--- a/server/__tests__/oauth.test.ts
+++ b/server/__tests__/oauth.test.ts
@@ -154,6 +154,7 @@ describe('setLocalStateFromIdTokenOrUserCookie', () => {
 			cookies: {
 				GU_U: 'gu_u',
 				SC_GU_U: 'sc_gu_u',
+				SC_GU_LA: 'sc_gu_la',
 			},
 		} as Request;
 		const res = {} as Response;
@@ -196,6 +197,7 @@ describe('setLocalStateFromIdTokenOrUserCookie', () => {
 			cookies: {
 				GU_U: 'gu_u',
 				SC_GU_U: 'sc_gu_u',
+				SC_GU_LA: 'sc_gu_la',
 			},
 		} as Request;
 		const res = {} as Response;
@@ -214,6 +216,7 @@ describe('setLocalStateFromIdTokenOrUserCookie', () => {
 		const req = {
 			cookies: {
 				SC_GU_U: 'sc_gu_u',
+				SC_GU_LA: 'sc_gu_la',
 			},
 		} as Request;
 		const res = {} as Response;

--- a/server/oauth.ts
+++ b/server/oauth.ts
@@ -348,6 +348,6 @@ export const sanitizeReturnPath = (returnPath: string) => {
 };
 
 export const allIdapiCookiesSet = (req: Request) => {
-	const idapiCookies = ['GU_U', 'SC_GU_U'];
+	const idapiCookies = ['GU_U', 'SC_GU_U', 'SC_GU_LA'];
 	return idapiCookies.every((cookie) => req.cookies[cookie]);
 };

--- a/server/oauthConfig.ts
+++ b/server/oauthConfig.ts
@@ -38,7 +38,5 @@ export const scopes = [
 	'guardian.identity-api.user.username.create.self.secure',
 	'guardian.identity-api.consents.read.self',
 	'guardian.identity-api.consents.update.self',
-	'guardian.members-data-api.complete.read.self.secure',
-	'guardian.members-data-api.read.self',
 ] as const;
 export type Scopes = typeof scopes[number];


### PR DESCRIPTION
Reverts guardian/manage-frontend#1294

This broke MMA when using IDAPI cookies, so reverting this change.

The `authorizationOrCookieHeader` function only works in Okta, and does not take into account cases where Okta is disabled! So when Okta was turned off, it broke as it was trying to use non-existant okta tokens.