### PR TITLE
OAuth migration | Force user to sign in if Access token `auth_time` older than 30 minutes

### DIFF
--- a/client/components/mma/MMAPage.tsx
+++ b/client/components/mma/MMAPage.tsx
@@ -35,6 +35,7 @@ import { Main } from '../shared/Main';
 import { DeliveryAddressUpdate } from './delivery/address/DeliveryAddressForm';
 import { Maintenance } from './maintenance/Maintenance';
 import { MMAPageSkeleton } from './MMAPageSkeleton';
+import { SignInError } from './signInError/SignInError';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Ophan events are diverse (and unguessable?)
 const record = (event: any) => {
@@ -782,7 +783,13 @@ const MMARouter = () => {
 								<CreateReminder reminderType={'RECURRING'} />
 							}
 						/>
+						{/*Does not require sign in*/}
 						<Route path="/maintenance" element={<Maintenance />} />
+						{/*Does not require sign in*/}
+						<Route
+							path="/sign-in-error"
+							element={<SignInError />}
+						/>
 						<Route path="*" element={<Navigate to="/" />} />
 					</Routes>
 				</ErrorBoundary>

--- a/client/components/mma/signInError/SignInError.stories.tsx
+++ b/client/components/mma/signInError/SignInError.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import { ReactRouterDecorator } from '@/.storybook/ReactRouterDecorator';
+import { SignInError } from './SignInError';
+
+export default {
+	title: 'Pages/SignInError',
+	component: SignInError,
+	decorators: [ReactRouterDecorator],
+	parameters: {
+		layout: 'fullscreen',
+	},
+} as Meta<typeof SignInError>;
+
+export const Default: StoryFn<typeof SignInError> = () => <SignInError />;

--- a/client/components/mma/signInError/SignInError.tsx
+++ b/client/components/mma/signInError/SignInError.tsx
@@ -1,0 +1,65 @@
+import { css } from '@emotion/react';
+import {
+	breakpoints,
+	from,
+	headline,
+	neutral,
+	space,
+	textSans,
+} from '@guardian/source-foundations';
+import { LinkButton } from '@guardian/source-react-components';
+import { conf } from '@/server/config';
+
+const containerStyle = css`
+	max-width: ${breakpoints.wide}px;
+	margin: 0 auto;
+	padding: ${space[12]}px 0;
+	border-left: 1px solid ${neutral[86]};
+	border-right: 1px solid ${neutral[86]};
+	height: 100%;
+`;
+
+const wrapperStyle = css`
+	margin: 0 10px;
+	max-width: ${breakpoints.mobileLandscape}px;
+	${from.tablet} {
+		margin: 0 20px;
+	}
+`;
+
+const headingStyle = css`
+	${headline.medium({ fontWeight: 'bold' })};
+	margin: 0;
+	padding-bottom: ${space[4]}px;
+	border-bottom: 1px solid ${neutral['86']};
+`;
+
+const grafStyle = css`
+	${textSans.medium()};
+	margin-top: ${space[4]}px;
+	margin-bottom: ${space[4]}px;
+`;
+
+export const SignInError = () => {
+	const domain =
+		typeof window !== 'undefined' && window.guardian
+			? window.guardian.domain
+			: conf.DOMAIN;
+	const signOutUrl = `https://profile.${domain}/signout?returnUrl=${encodeURIComponent(
+		`https://manage.${domain}/`,
+	)}`;
+
+	return (
+		<div css={containerStyle}>
+			<section css={wrapperStyle}>
+				<h1 css={headingStyle}>Sign in error</h1>
+				<p css={grafStyle}>
+					There's been a problem signing you in. Please sign in again
+					to continue managing your account.
+				</p>
+
+				<LinkButton href={signOutUrl}>Continue</LinkButton>
+			</section>
+		</div>
+	);
+};

--- a/cypress/tests/e2e/authExpiry.cy.ts
+++ b/cypress/tests/e2e/authExpiry.cy.ts
@@ -1,0 +1,25 @@
+import { signInOkta } from '../../lib/signInOkta';
+
+describe('Okta auth expiry', () => {
+	beforeEach(() => {
+		Cypress.config('defaultCommandTimeout', 30_000);
+
+		cy.clearAllCookies();
+		signInOkta();
+		cy.get('h1').should('contain', 'Account overview');
+	});
+
+	it('should redirect to /reauthenticate if the ID token auth_time is too old', () => {
+		cy.wait(6000); // 6 seconds (maxAge is 5 seconds)
+		cy.setCookie('okta-config-override', JSON.stringify({ maxAge: 5 }));
+		cy.visit('/profile');
+		cy.url().should('contain', '/reauthenticate');
+		// If the URL contains 'fromURI', we've been redirected to /reauthenticate
+		// by Gateway, not by the identity middleware.
+		cy.url().should('not.contain', 'fromURI');
+		cy.url().should(
+			'contain',
+			'returnUrl=https%3A%2F%2Fmanage.thegulocal.com%2Fprofile',
+		);
+	});
+});

--- a/server/__tests__/middleware/okta.test.ts
+++ b/server/__tests__/middleware/okta.test.ts
@@ -7,6 +7,7 @@ jest.mock('@/server/oauth');
 
 const oktaConfig: OktaConfig = {
 	useOkta: true,
+	maxAge: 1800,
 	orgUrl: 'https://example.com',
 	authServerId: 'foo',
 	clientId: 'bar',

--- a/server/middleware/identityMiddleware.ts
+++ b/server/middleware/identityMiddleware.ts
@@ -43,7 +43,7 @@ declare const CYPRESS: string;
 
 const handleIdentityMiddlewareError = (err: Error, res: Response) => {
 	log.error('OAuth / Middleware / Error', err);
-	res.redirect('/maintenance');
+	res.redirect('/sign-in-error');
 };
 
 export const clearOAuthCookies = (res: Response) => {
@@ -229,7 +229,7 @@ const authenticateWithIdapi: (statusCodeOverride?: number) => RequestHandler =
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- assume we don't know the range of possible types for the detail argument?
 		const errorHandler = (message: string, detail?: any) => {
 			handleAwsRelatedError(message, detail);
-			res.redirect('/maintenance');
+			res.redirect('/sign-in-error');
 		};
 
 		const useRefererHeaderForManageUrl = !!statusCodeOverride;

--- a/server/routes/oauth.ts
+++ b/server/routes/oauth.ts
@@ -10,7 +10,7 @@ const router = Router();
 
 const handleCallbackRouteError = (err: Error, res: Response) => {
 	log.error('OAuth / Callback endpoint error: ', err);
-	res.redirect('/maintenance');
+	res.redirect('/sign-in-error');
 };
 
 router.get('/callback', async (req: Request, res: Response) => {

--- a/server/routes/oauth.ts
+++ b/server/routes/oauth.ts
@@ -1,10 +1,10 @@
 import type { Request, Response } from 'express';
 import { Router } from 'express';
-import ms from 'ms';
 import { getOpenIdClient } from '@/server/oauth';
 import { oauthCookieOptions, OAuthStateCookieName } from '@/server/oauthConfig';
 import { conf } from '../config';
 import { log } from '../log';
+import { getConfig as getOktaConfig } from '../oktaConfig';
 
 const router = Router();
 
@@ -14,6 +14,8 @@ const handleCallbackRouteError = (err: Error, res: Response) => {
 };
 
 router.get('/callback', async (req: Request, res: Response) => {
+	const oktaConfig = await getOktaConfig();
+
 	// Read the state cookie
 	if (!req.signedCookies[OAuthStateCookieName]) {
 		return handleCallbackRouteError(
@@ -61,11 +63,11 @@ router.get('/callback', async (req: Request, res: Response) => {
 		// Set the access token and ID tokens as cookies
 		res.cookie('GU_ACCESS_TOKEN', tokenSet.access_token, {
 			...oauthCookieOptions,
-			maxAge: ms('30m'), // Same expiry as set in Okta
+			maxAge: oktaConfig.maxAge * 1000, // Same expiry as set in Okta, but in ms
 		});
 		res.cookie('GU_ID_TOKEN', tokenSet.id_token, {
 			...oauthCookieOptions,
-			maxAge: ms('30m'), // Same expiry as set in Okta
+			maxAge: oktaConfig.maxAge * 1000, // Same expiry as set in Okta, but in ms
 		});
 
 		// Delete state cookie, for it is no longer needed

--- a/shared/requiresSignin.ts
+++ b/shared/requiresSignin.ts
@@ -11,6 +11,7 @@ const publicPaths = [
 	'/create-reminder/',
 	'/help-centre/',
 	'/maintenance/',
+	'/sign-in-error/',
 ];
 
 export const requiresSignin = (path: string) => {


### PR DESCRIPTION
## Changes

### Context

After deploying https://github.com/guardian/manage-frontend/pull/1294 and enabling Okta on PROD manage-frontend, we discovered an Okta behaviour which was undocumented in the sense that it was _only_ documented in a modal in the UI, three layers down, after you clicked a specific radio button, and the actual documentation completely contradicted it:

![Screenshot 2024-01-29 at 12 09 57](https://github.com/guardian/manage-frontend/assets/101555242/740e86f7-2dcb-4f84-8539-90f6691e7cc7)

One is reminded of a quote from _The Hitchhiker's Guide To The Galaxy_:

> “But the plans were on display…”
“On display? I eventually had to go down to the cellar to find them.”
“That’s the display department.”
“With a flashlight.”
“Ah, well, the lights had probably gone.”
“So had the stairs.”
“But look, you found the notice, didn’t you?”
“Yes,” said Arthur, “yes I did. It was on display in the bottom of a locked filing cabinet stuck in a disused lavatory with a sign on the door saying ‘Beware of the Leopard.”

What this means in practice is that, when passing the `max_age` parameter when requesting OAuth tokens:

- Regular email/password users will be forced to sign in again after `max_age`
- Users of the `FEDERATION` or `SOCIAL` types (i.e. social login users who have never set a password) will _never_ be forced to sign in again as long as their global Okta session is not expired. This is probably most of our social users.

This behaviour means that we can't reliably enforce the MMA behaviour where a user _must_ reauthenticate if they last authenticated more than 30 minutes ago using Okta settings alone.

For this reason, this PR adds the following check into `identityMiddleware`:

- Does the user's ID token have an `auth_time` claim longer than 30 minutes in the past?
- If the claim is **older than 30 minutes**, we:
  - Call the Okta OAuth API to revoke the associated Access token
  - Delete the ID and Access token cookies
  - Redirect the browser to the Gateway `/reauthenticate` route. This route _always_ shows a signin form, irrespective of any session set in the browser. This essentially replicates the previous, IDAPI behaviour in MMA.
- If the claim is **newer than 30 minutes**, we proceed with the rest of the middleware.
- For routes which don't _require_ sign in, if the ID token is older than 30 minutes, the user is designated `signedInNotRecently` but allowed to proceed to the route. This again replicates the old IDAPI behaviour.

### The `auth_time` claim

According to the OpenID spec, and confirmed by Okta, the `auth_time` claim is "Time when the End-User authentication occurred" in UNIX seconds, which in Okta land means the last time the user actively authenticated, i.e. created their Okta session. The OpenID spec states that `auth_time` is returned whenever the `max_age` parameter is sent in the OAuth request, which in MMA is always. The Okta docs state that `auth_time` is a 'base claim', always returned. We've added logging in the check for `auth_time` which will give us data on missing `auth_time` claims, if any.

Further reading for nerds here:

- https://openid.net/specs/openid-connect-core-1_0.html
- https://openid.net/specs/openid-connect-basic-1_0.html
- https://developer.okta.com/docs/reference/api/oidc/#reserved-claims-in-the-payload-section

### Other changes

- We add end-to-end testing for the `auth_time` behaviour, which sets the Okta `max_age` to a very short value and attempts to refresh the page, expecting to be redirected.
- We add unit tests for the new utility functions.
- There's a fair amount of refactoring to improve the middleware - rather than various utility functions fetching their own Okta config object `async`, the top-level middleware does this once and passes it down the chain. This also required a lot of refactoring in tests.
- We now redirect `identityMiddleware` error states to a new frontend error page, `/sign-in-error`, which shows a more helpful message and a link to sign out, which is likely to resolve edge-case sign in issues:

<img width="695" alt="Screenshot 2024-01-29 at 15 39 12" src="https://github.com/guardian/manage-frontend/assets/101555242/7ef16714-9061-4e09-a72b-3ef2e8bc31b3">

## Testing

- [x] Tested on CODE (Okta disabled)
- [x] Tested on CODE (Okta enabled)
- [ ] Tested on PROD (Okta disabled)
- [ ] Tested on PROD (Okta enabled)