### PR TITLE
Run E2E tests on push to main

### DIFF
--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -1,5 +1,8 @@
 name: manage-frontend cypress (E2E)
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## What does this change?

We've previously had this trigger configuration for the E2E testing GitHub Action:

```
on:
  pull_request:
    branches:
      - main
 ```

This runs the action on activity in a PR pointing at `main`, but _not_ when the PR is merged in.

We're changing it to this:

```
on:
  push:
    branches:
      - main
  pull_request:
    branches:
      - main
```

Which will also run the E2E tests once a commit is merged into `main`, i.e. when a PR is accepted and merged in.