### PR TITLE
Add referrer as a tag in Sentry browser errors in the help centre

### DIFF
--- a/client/HelpCentrePage.ts
+++ b/client/HelpCentrePage.ts
@@ -8,17 +8,12 @@ import { HelpCentrePage } from './components/helpCentre/HelpCentrePage';
 declare let WEBPACK_BUILD: string;
 
 if (typeof window !== 'undefined' && window.guardian && window.guardian.dsn) {
-	console.log('Initialising Sentry');
 	Sentry.init({
 		dsn: window.guardian.dsn,
 		release: WEBPACK_BUILD || 'local',
 		environment: window.guardian.domain,
 	});
 
-	console.log(
-		'Setting the referrer as tag gu:referrer',
-		document.referrer || 'none',
-	);
 	Sentry.setTag('gu:referrer', document.referrer || 'none');
 }
 

--- a/client/HelpCentrePage.ts
+++ b/client/HelpCentrePage.ts
@@ -8,11 +8,18 @@ import { HelpCentrePage } from './components/helpCentre/HelpCentrePage';
 declare let WEBPACK_BUILD: string;
 
 if (typeof window !== 'undefined' && window.guardian && window.guardian.dsn) {
+	console.log('Initialising Sentry');
 	Sentry.init({
 		dsn: window.guardian.dsn,
 		release: WEBPACK_BUILD || 'local',
 		environment: window.guardian.domain,
 	});
+
+	console.log(
+		'Setting the referrer as tag gu:referrer',
+		document.referrer || 'none',
+	);
+	Sentry.setTag('gu:referrer', document.referrer || 'none');
 }
 
 const element = document.getElementById('app');

--- a/client/MMAPage.ts
+++ b/client/MMAPage.ts
@@ -13,6 +13,8 @@ if (typeof window !== 'undefined' && window.guardian && window.guardian.dsn) {
 		release: WEBPACK_BUILD || 'local',
 		environment: window.guardian.domain,
 	});
+
+	Sentry.setTag('gu:referrer', document.referrer || 'none');
 }
 
 const element = document.getElementById('app');

--- a/client/MMAPage.ts
+++ b/client/MMAPage.ts
@@ -8,12 +8,17 @@ import { MMAPage } from './components/mma/MMAPage';
 declare let WEBPACK_BUILD: string;
 
 if (typeof window !== 'undefined' && window.guardian && window.guardian.dsn) {
+	console.log('Initialising Sentry');
 	Sentry.init({
 		dsn: window.guardian.dsn,
 		release: WEBPACK_BUILD || 'local',
 		environment: window.guardian.domain,
 	});
 
+	console.log(
+		'Setting the referrer as tag gu:referrer',
+		document.referrer || 'none',
+	);
 	Sentry.setTag('gu:referrer', document.referrer || 'none');
 }
 

--- a/client/MMAPage.ts
+++ b/client/MMAPage.ts
@@ -8,18 +8,11 @@ import { MMAPage } from './components/mma/MMAPage';
 declare let WEBPACK_BUILD: string;
 
 if (typeof window !== 'undefined' && window.guardian && window.guardian.dsn) {
-	console.log('Initialising Sentry');
 	Sentry.init({
 		dsn: window.guardian.dsn,
 		release: WEBPACK_BUILD || 'local',
 		environment: window.guardian.domain,
 	});
-
-	console.log(
-		'Setting the referrer as tag gu:referrer',
-		document.referrer || 'none',
-	);
-	Sentry.setTag('gu:referrer', document.referrer || 'none');
 }
 
 const element = document.getElementById('app');


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds the referrer as a custom tag (`gu:referrer`) to Sentry browser error reports from help centre pages. If not available it'll be set to "none". We're trying to track down the origin of some 404s we're seeing.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

I deployed to CODE and forced an error. The referrer showed up in Sentry:

![Screenshot 2024-01-26 at 11 52 57](https://github.com/guardian/manage-frontend/assets/379839/24a8b3bc-747c-42b5-98f7-61a8e0b6cf3a)

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
