### PR TITLE
Bump cmp to 13.8.0 to pick up MSPS changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "@guardian/ab-core": "2.0.0",
     "@guardian/ab-react": "2.0.1",
     "@guardian/commercial": "11.19.1",
-    "@guardian/consent-management-platform": "13.7.1",
+    "@guardian/consent-management-platform": "13.8.0",
     "@guardian/libs": "15.9.1",
     "@guardian/source-foundations": "13.2.0",
     "@guardian/source-react-components": "16.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2931,10 +2931,10 @@
     web-vitals "^3.3.2"
     wolfy87-eventemitter "^5.2.9"
 
-"@guardian/consent-management-platform@13.7.1":
-  version "13.7.1"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.7.1.tgz#ba38f32de023775e615e79cfa97a3425f144eb89"
-  integrity sha512-BtUNkuCqd++A0Wkk9CA4kI95yVZJk1YMjPdppEnmq3cG/ros4ElXN4cNG7pWifeTR5cUtJflAiRRO4L5ewASpQ==
+"@guardian/consent-management-platform@13.8.0":
+  version "13.8.0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.8.0.tgz#60d1d319a2b438cdc8c6587ac20adf7b553815d3"
+  integrity sha512-J8YBXxpl/oGLmDGtjvkSwGmkaTJtnr/rxmYJAynaX0dkqopdDvG9REdbxMZBz3kugBpqHzhREzAk5Ut/uiyl8w==
 
 "@guardian/eslint-config-typescript@9.0.2":
   version "9.0.2"
@@ -13225,7 +13225,7 @@ prebid.js@guardian/prebid.js#0b4cccd55ab4e170b36bb944e9bdd2807a9da1c5:
   version "7.54.5"
   resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/0b4cccd55ab4e170b36bb944e9bdd2807a9da1c5"
   dependencies:
-    "@babel/core" "^7.16.7"
+    "@babel/core" "^7.23.2"
     "@babel/plugin-transform-runtime" "^7.18.9"
     "@babel/preset-env" "^7.16.8"
     "@babel/runtime" "^7.18.9"


### PR DESCRIPTION
## What does this change?

This includes a change to the regulatory framework used by US cookie banners to include the multi-state privacy agreement.  Details can be found  on this [Trello Card](https://trello.com/c/6qAHXGHq).

## How to test

Using a guest or incognito window, make a selection in the cookie banner and enter MMA. In devtools console window, `window.guCmpHotFix.cmp.version` should match that in the package.json file.  In MMA under the data privacy tab, you should be able to re-open and interact with the the Privacy Manager through the Privacy Settings option in the page and in the footer.

## How can we measure success?

Cookie banner shows and can be interacted with.

## Have we considered potential risks?

Can be rolled back if necessary though, in this case, there may be some ad revenue impact.

## Images

No UI changes.

## Accessibility

No UI changes.
