### PR TITLE
OAuth migration | Add `guardian.members-data-api.update.self.secure` scope

### DIFF
--- a/server/oauthConfig.ts
+++ b/server/oauthConfig.ts
@@ -40,5 +40,6 @@ export const scopes = [
 	'guardian.identity-api.consents.update.self',
 	'guardian.members-data-api.complete.read.self.secure',
 	'guardian.members-data-api.read.self',
+	'guardian.members-data-api.update.self.secure',
 ] as const;
 export type Scopes = typeof scopes[number];


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

MMA needs to be granted the `guardian.members-data-api.update.self.secure` scope to allow users to edit their details in MDAPI.

Okta Terraform PR: https://github.com/guardian/identity-platform/pull/700