### PR TITLE
OAuth migration | Use new set username route

### DIFF
--- a/client/components/mma/identity/idapi/user.ts
+++ b/client/components/mma/identity/idapi/user.ts
@@ -2,6 +2,7 @@ import { get } from 'lodash';
 import {
 	addCSRFToken,
 	fetchWithDefaultParameters,
+	postRequest,
 	putRequest,
 } from '@/client/utilities/fetch';
 import type { User, UserError } from '../models';
@@ -193,4 +194,22 @@ export const read = async (): Promise<User> => {
 		url,
 	).then((response) => response.json());
 	return toUser(response);
+};
+
+export const setUsername = async (user: Partial<User>): Promise<User> => {
+	const url = '/idapi/user/username';
+	const body = toUserApiRequest(user);
+	console.log('sending', body);
+	try {
+		const response: UserAPIResponse = await fetchWithDefaultParameters(
+			url,
+			addCSRFToken(postRequest(body)),
+		).then((response) => response.json());
+		if (isErrorResponse(response)) {
+			throw toUserError(response);
+		}
+		return toUser(response);
+	} catch (e) {
+		throw isErrorResponse(e) ? toUserError(e) : e;
+	}
 };

--- a/client/components/mma/identity/idapi/user.ts
+++ b/client/components/mma/identity/idapi/user.ts
@@ -198,8 +198,11 @@ export const read = async (): Promise<User> => {
 
 export const setUsername = async (user: Partial<User>): Promise<User> => {
 	const url = '/idapi/user/username';
-	const body = toUserApiRequest(user);
-	console.log('sending', body);
+	const body = {
+		publicFields: {
+			username: user.username,
+		},
+	};
 	try {
 		const response: UserAPIResponse = await fetchWithDefaultParameters(
 			url,

--- a/client/components/mma/identity/identity.ts
+++ b/client/components/mma/identity/identity.ts
@@ -72,6 +72,9 @@ export const Users: UserCollection = {
 	getChangedFields(original: User, changed: User): Partial<User> {
 		return diffWithCompositeFields(original, changed);
 	},
+	async setUsername(user: User): Promise<User> {
+		return await UserAPI.setUsername(user);
+	},
 };
 
 export const ConsentOptions: ConsentOptionCollection = {

--- a/client/components/mma/identity/models.ts
+++ b/client/components/mma/identity/models.ts
@@ -57,6 +57,7 @@ export interface UserCollection {
 	save: (user: User) => Promise<User>;
 	saveChanges: (original: User, changed: User) => Promise<User>;
 	getChangedFields: (original: User, changed: User) => Partial<User>;
+	setUsername: (user: User) => Promise<User>;
 }
 
 export interface ConsentOption {

--- a/client/components/mma/identity/publicProfile/PublicProfile.tsx
+++ b/client/components/mma/identity/publicProfile/PublicProfile.tsx
@@ -60,7 +60,9 @@ export const PublicProfile = (_: { path?: string }) => {
 	const usernameDisplay = (u: User) => (
 		<>
 			<WithStandardTopMargin>
-				<PageSection title="Username">{u.username}</PageSection>
+				<PageSection title="Username">
+					<span data-cy="username-display">{u.username}</span>
+				</PageSection>
 			</WithStandardTopMargin>
 			<WithStandardTopMargin>
 				<Lines n={1} />

--- a/client/components/mma/identity/publicProfile/PublicProfile.tsx
+++ b/client/components/mma/identity/publicProfile/PublicProfile.tsx
@@ -43,10 +43,7 @@ export const PublicProfile = (_: { path?: string }) => {
 			.catch(handleGeneralError);
 	}, []);
 
-	const saveUser = async (originalUser: User, values: User) => {
-		const changedUser = { ...originalUser, ...values };
-		return await Users.saveChanges(originalUser, changedUser);
-	};
+	const setUsername = async (values: User) => await Users.setUsername(values);
 
 	useEffect(() => {
 		if (error && errorRef.current) {
@@ -75,7 +72,7 @@ export const PublicProfile = (_: { path?: string }) => {
 		<>
 			<ProfileFormSection
 				user={u}
-				saveUser={(values) => saveUser(u, values)}
+				saveUser={(values) => setUsername(values)}
 				onError={handleGeneralError}
 				onSuccess={setUser}
 			/>

--- a/cypress/lib/signInOkta.ts
+++ b/cypress/lib/signInOkta.ts
@@ -16,6 +16,7 @@ export const signInOkta = () => {
 	cy.visit('/');
 	cy.createTestUser({
 		isUserEmailValidated: true,
+		doNotSetUsername: true,
 	})?.then(({ emailAddress, finalPassword }) => {
 		cy.get('input[name=email]').type(emailAddress);
 		cy.get('input[name=password]').type(finalPassword);

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -97,6 +97,7 @@ type IDAPITestUserOptions = {
 	password?: string;
 	deleteAfterMinute?: boolean;
 	isGuestUser?: boolean;
+	doNotSetUsername?: boolean;
 };
 type IDAPITestUserResponse = [
 	{
@@ -128,6 +129,7 @@ export const createTestUser = ({
 	isUserEmailValidated = false,
 	deleteAfterMinute = true,
 	isGuestUser = false,
+	doNotSetUsername = false,
 }: IDAPITestUserOptions) => {
 	// Generate a random email address if none is provided.
 	const finalEmail = primaryEmailAddress || randomMailosaurEmail();
@@ -150,6 +152,7 @@ export const createTestUser = ({
 					password: finalPassword,
 					deleteAfterMinute,
 					isGuestUser,
+					doNotSetUsername,
 				} as IDAPITestUserOptions,
 			})
 			.then((res) => {

--- a/cypress/tests/e2e/e2e.cy.ts
+++ b/cypress/tests/e2e/e2e.cy.ts
@@ -16,9 +16,18 @@ describe('E2E with Okta', () => {
 	});
 
 	context('profile tab', () => {
-		it('should contain a username', () => {
+		it('should allow the user to set a username', () => {
+			const randomUsername = `testuser${Math.floor(
+				Math.random() * 100000,
+			)}`;
 			cy.visit('/public-settings');
-			cy.findByText('Username');
+			cy.get('input[name="username"]').type(randomUsername);
+			cy.findByText('Save changes').click();
+			cy.visit('/public-settings');
+			cy.get('span[data-cy="username-display"]').should(
+				'contain',
+				randomUsername,
+			);
 		});
 	});
 

--- a/server/routes/idapi.ts
+++ b/server/routes/idapi.ts
@@ -99,6 +99,15 @@ router.delete(
 	}),
 );
 
+router.post(
+	'/user/username',
+	csrfValidateMiddleware,
+	idapiProxyHandler({
+		url: '/user/me/username',
+		method: 'POST',
+	}),
+);
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- assume we don't know the range of possible types for the err argument?
 router.use((err: any, _: Request, res: Response, next: NextFunction) => {
 	if (err.code && err.code === 'EBADCSRFTOKEN') {


### PR DESCRIPTION
## What does this change?

As part of the OAuth migration, we've removed an old bug in IDAPI - being able to set your username more than once, if you happened to know the API endpoint to hit (because setting username just used `POST /user/me`). We've already introduced a new IDAPI endpoint, `POST /user/me/username`, which only allows setting username once and only if it's not been set before. Once OAuth authorization to IDAPI is enabled in MMA, we will also be preventing the username being changed via `POST /user/me`. This PR modifies the MMA frontend to use the new endpoint, and adds an E2E test for username updating.

## Dependencies

- https://github.com/guardian/identity/pull/2492, because we need to let IDAPI create test users without a preset username before the E2E tests here pass.

## Tests

- [x] Tested on CODE