### PR TITLE
OAuth migration | Stop sending Cookies header

### DIFF
--- a/server/apiProxy.ts
+++ b/server/apiProxy.ts
@@ -108,12 +108,7 @@ export const proxyApiHandler =
 						Authorization: `Bearer ${req.signedCookies[OAuthAccessTokenCookieName]}`,
 					};
 				default:
-					// TODO: This is legacy code!
-					// We don't want to send literally all cookies to APIs so when
-					// we migrate to Okta tokens entirely we should remove this
-					return {
-						Cookie: getCookiesOrEmptyString(req),
-					};
+					return {};
 			}
 		};
 


### PR DESCRIPTION
## Changes

We stop sending the `Cookies` header to upstream APIs called by MMA. At last, we are free of the terror of IDAPI cookies.