### PR TITLE
remove mention of masterclass in "your newsletters" description

### DIFF
--- a/client/components/mma/identity/emailAndMarketing/NewsletterSection.tsx
+++ b/client/components/mma/identity/emailAndMarketing/NewsletterSection.tsx
@@ -91,7 +91,7 @@ export const NewsletterSection: FC<NewsletterSectionProps> = (props) => {
         The Guardian’s newsletters include content from our website, which may
         be funded by outside parties. Newsletters may also display information
         about Guardian News and Media's other products, services or events
-        (such as Guardian Jobs or Masterclasses), chosen charities or online
+        (such as Guardian Jobs), chosen charities or online
         advertisements.
       `}
 		>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Remove masterclass from description in "your newsletters" section

## Images
before 
<img width="467" alt="image" src="https://github.com/guardian/manage-frontend/assets/15324270/c4a564a0-5d7e-44e0-9d4c-41ff8bb79dff">

after
<img width="467" alt="image" src="https://github.com/guardian/manage-frontend/assets/15324270/6e1e4c33-fafa-453d-9d3a-cc6c851afe07">

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
