### PR TITLE
Correct typo in email provided for product switch errors

### DIFF
--- a/client/components/shared/productSwitch/SwitchErrorSummary.tsx
+++ b/client/components/shared/productSwitch/SwitchErrorSummary.tsx
@@ -27,9 +27,9 @@ const SwitchErrorContext = ({
 			persists get in touch at{' '}
 			<a
 				css={errorSummaryLinkCss}
-				href="mailto:customer.help@guardian.com"
+				href="mailto:customer.help@theguardian.com"
 			>
-				customer.help@guardian.com
+				customer.help@theguardian.com
 			</a>
 			.
 		</>


### PR DESCRIPTION
## What does this change?
The contact centre have pointed out that the email address provided in the error shown in the product switching journey is not correct, which will cause some confusion/frustration for customers:

![Screenshot 2024-02-22 092928 - Chris Frost](https://github.com/guardian/manage-frontend/assets/23298731/b6c5565d-c2ad-49e8-a184-9acfcc33034b)

It was also noted that this error indicates there may be an issue with the customer's payment method, but it is in fact returned for a variety of product switch errors (for instance, if the customer subscription is not in a state that allows a switch). This again might confuse customers, but this would be a lot more work to fix.

