### PR TITLE
Use new product-switch-api for recurring contribution to supporter plus

### DIFF
--- a/server/apiGatewayDiscovery.ts
+++ b/server/apiGatewayDiscovery.ts
@@ -28,6 +28,7 @@ const apiNames = [
 	'contact-us-api',
 	'product-move-api',
 	'discount-api',
+	'product-switch-api',
 ] as const;
 type ApiName = typeof apiNames[number];
 
@@ -219,6 +220,14 @@ const productMoveAPIGateway = getApiGateway(
 	generateAwsSignatureHeaders,
 );
 export const productMoveAPI = productMoveAPIGateway.authorisedExpressCallback;
+
+const productSwitchAPIGateway = getApiGateway(
+	'support',
+	'product-switch-api',
+	generateAwsSignatureHeaders,
+);
+export const productSwitchAPI =
+	productSwitchAPIGateway.authorisedExpressCallback;
 
 const invoicingAPIGateway = getApiGateway(
 	'support',

--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -10,6 +10,7 @@ import {
 	holidayStopAPI,
 	invoicingAPI,
 	productMoveAPI,
+	productSwitchAPI,
 } from '../apiGatewayDiscovery';
 import {
 	customMembersDataApiHandler,
@@ -194,7 +195,7 @@ router.post(
 router.post(
 	'/product-move/:switchType/:subscriptionName',
 	withOktaServerSideValidation,
-	productMoveAPI(
+	productSwitchAPI(
 		'product-move/:switchType/:subscriptionName',
 		'MOVE_PRODUCT',
 		['switchType', 'subscriptionName'],

--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -198,7 +198,7 @@ router.post(
 	'/product-move/to-recurring-contribution/:subscriptionName',
 	withOktaServerSideValidation,
 	productMoveAPI(
-		'product-move/:switchType/:subscriptionName',
+		'product-move/to-recurring-contribution/:subscriptionName',
 		'MOVE_PRODUCT',
 		['switchType', 'subscriptionName'],
 	),
@@ -208,7 +208,7 @@ router.post(
 	'/product-move/recurring-contribution-to-supporter-plus/:subscriptionName',
 	withOktaServerSideValidation,
 	productSwitchAPI(
-		'product-move/:switchType/:subscriptionName',
+		'product-move/recurring-contribution-to-supporter-plus/:subscriptionName',
 		'MOVE_PRODUCT',
 		['switchType', 'subscriptionName'],
 	),

--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -200,7 +200,7 @@ router.post(
 	productMoveAPI(
 		'product-move/to-recurring-contribution/:subscriptionName',
 		'MOVE_PRODUCT',
-		['switchType', 'subscriptionName'],
+		['subscriptionName'],
 	),
 );
 // recurring contribution to supporter plus is using the new api
@@ -210,7 +210,7 @@ router.post(
 	productSwitchAPI(
 		'product-move/recurring-contribution-to-supporter-plus/:subscriptionName',
 		'MOVE_PRODUCT',
-		['switchType', 'subscriptionName'],
+		['subscriptionName'],
 	),
 );
 

--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -1,8 +1,8 @@
 import * as Sentry from '@sentry/node';
 import { Router } from 'express';
-import { featureSwitches } from '../../shared/featureSwitches';
-import type { MembersDataApiResponse } from '../../shared/productResponse';
-import { isProduct, MDA_TEST_USER_HEADER } from '../../shared/productResponse';
+import { featureSwitches } from '@/shared/featureSwitches';
+import type { MembersDataApiResponse } from '@/shared/productResponse';
+import { isProduct, MDA_TEST_USER_HEADER } from '@/shared/productResponse';
 import {
 	cancellationSfCasesAPI,
 	deliveryRecordsAPI,
@@ -192,8 +192,20 @@ router.post(
 	discountAPI('apply-discount', 'APPLY_DISCOUNT'),
 );
 
+// The two switch types are using different apis for now, membership to recurring contribution
+// is using the old api
 router.post(
-	'/product-move/:switchType/:subscriptionName',
+	'/product-move/to-recurring-contribution/:subscriptionName',
+	withOktaServerSideValidation,
+	productMoveAPI(
+		'product-move/:switchType/:subscriptionName',
+		'MOVE_PRODUCT',
+		['switchType', 'subscriptionName'],
+	),
+);
+// recurring contribution to supporter plus is using the new api
+router.post(
+	'/product-move/recurring-contribution-to-supporter-plus/:subscriptionName',
 	withOktaServerSideValidation,
 	productSwitchAPI(
 		'product-move/:switchType/:subscriptionName',


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR changes manage-frontend so that it uses the [new product-switch api](https://github.com/guardian/support-service-lambdas/pull/2201) for recurring contribution to supporter plus product switches.

There is another type of product switch from membership to recurring contribution, but this is not currently handled by the new api and so will still call the old one.