### PR TITLE
content security policy audit

### DIFF
--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/node';
 import { Router } from 'express';
+import { featureSwitches } from '../../shared/featureSwitches';
 import type { MembersDataApiResponse } from '../../shared/productResponse';
 import { isProduct, MDA_TEST_USER_HEADER } from '../../shared/productResponse';
 import {
@@ -339,10 +340,12 @@ router.get(
 router.post('/reminders/cancel', cancelReminderHandler);
 router.post('/reminders/reactivate', reactivateReminderHandler);
 
-router.post('/csp-audit-report-endpoint', (req, res) => {
-	const parsedBody = JSON.parse(req.body.toString());
-	log.warn(JSON.stringify(parsedBody));
-	res.status(204).end();
-});
+if (featureSwitches.cspSecurityAudit) {
+	router.post('/csp-audit-report-endpoint', (req, res) => {
+		const parsedBody = JSON.parse(req.body.toString());
+		log.warn(JSON.stringify(parsedBody));
+		res.status(204).end();
+	});
+}
 
 export { router };

--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -339,4 +339,10 @@ router.get(
 router.post('/reminders/cancel', cancelReminderHandler);
 router.post('/reminders/reactivate', reactivateReminderHandler);
 
+router.post('/csp-audit-report-endpoint', (req, res) => {
+	const parsedBody = JSON.parse(req.body.toString());
+	log.warn(JSON.stringify(parsedBody));
+	res.status(204).end();
+});
+
 export { router };

--- a/server/routes/core.ts
+++ b/server/routes/core.ts
@@ -8,11 +8,6 @@ import { log } from '../log';
 
 const router = Router();
 
-router.get('/csp-audit-report-endpoint', (req: Request, res: Response) => {
-	log.info(`CSP_AUDIT: ${req.body}`);
-	res.status(204).send();
-});
-
 router.get(
 	'/_healthcheck',
 	/**

--- a/server/routes/core.ts
+++ b/server/routes/core.ts
@@ -8,6 +8,11 @@ import { log } from '../log';
 
 const router = Router();
 
+router.get('/csp-audit-report-endpoint', (req: Request, res: Response) => {
+	log.info(`CSP_AUDIT: ${req.body}`);
+	res.status(202).send();
+});
+
 router.get(
 	'/_healthcheck',
 	/**

--- a/server/routes/core.ts
+++ b/server/routes/core.ts
@@ -10,7 +10,7 @@ const router = Router();
 
 router.get('/csp-audit-report-endpoint', (req: Request, res: Response) => {
 	log.info(`CSP_AUDIT: ${req.body}`);
-	res.status(202).send();
+	res.status(204).send();
 });
 
 router.get(

--- a/server/server.ts
+++ b/server/server.ts
@@ -4,6 +4,7 @@ import cookieParser from 'cookie-parser';
 import type { NextFunction, Request, RequestHandler, Response } from 'express';
 import { default as express } from 'express';
 import helmet from 'helmet';
+import { featureSwitches } from '../shared/featureSwitches';
 import { MAX_FILE_ATTACHMENT_SIZE_KB } from '../shared/fileUploadUtils';
 import { conf } from './config';
 import { log } from './log';
@@ -39,15 +40,17 @@ if (conf.DOMAIN === 'thegulocal.com') {
 
 server.use(helmet());
 
-server.use(function (_: Request, res: Response, next: NextFunction) {
-	res.set({
-		'Report-To':
-			'{ "group": "csp-endpoint", "endpoints": [ { "url": "/api/csp-audit-report-endpoint" } ] }',
-		'Content-Security-Policy-Report-Only':
-			'report-uri /api/csp-audit-report-endpoint; report-to csp-endpoint; default-src https:',
+if (featureSwitches.cspSecurityAudit) {
+	server.use(function (_: Request, res: Response, next: NextFunction) {
+		res.set({
+			'Report-To':
+				'{ "group": "csp-endpoint", "endpoints": [ { "url": "/api/csp-audit-report-endpoint" } ] }',
+			'Content-Security-Policy-Report-Only':
+				'report-uri /api/csp-audit-report-endpoint; report-to csp-endpoint; default-src https:',
+		});
+		next();
 	});
-	next();
-});
+}
 
 const serveStaticAssets: RequestHandler = express.static(__dirname + '/static');
 

--- a/server/server.ts
+++ b/server/server.ts
@@ -41,10 +41,8 @@ server.use(helmet());
 
 server.use(function (_: Request, res: Response, next: NextFunction) {
 	res.set({
-		'Report-To':
-			'{ "group": "csp-endpoint", "endpoints": [ { "url": "/csp-audit-report-endpoint" } ] }',
-		'Content-Security-Policy-Report-Only':
-			'report-uri /csp-audit-report-endpoint; report-to csp-endpoint; default-src https:',
+		'Report-To': `{ "group": "csp-endpoint", "endpoints": [ { "url": "${conf.DOMAIN}/csp-audit-report-endpoint" } ] }`,
+		'Content-Security-Policy-Report-Only': `report-uri ${conf.DOMAIN}/csp-audit-report-endpoint; report-to csp-endpoint; default-src https:`,
 	});
 	next();
 });

--- a/server/server.ts
+++ b/server/server.ts
@@ -39,6 +39,14 @@ if (conf.DOMAIN === 'thegulocal.com') {
 
 server.use(helmet());
 
+server.use(function (_: Request, res: Response, next: NextFunction) {
+	res.setHeader(
+		'Content-Security-Policy-Report-Only',
+		'report-to /csp-audit-report-endpoint',
+	);
+	next();
+});
+
 const serveStaticAssets: RequestHandler = express.static(__dirname + '/static');
 
 /** static asses are cached by fastly */

--- a/server/server.ts
+++ b/server/server.ts
@@ -40,10 +40,12 @@ if (conf.DOMAIN === 'thegulocal.com') {
 server.use(helmet());
 
 server.use(function (_: Request, res: Response, next: NextFunction) {
-	res.setHeader(
-		'Content-Security-Policy-Report-Only',
-		'report-to /csp-audit-report-endpoint',
-	);
+	res.set({
+		'Report-To':
+			'{ "group": "csp-endpoint", "endpoints": [ { "url": "/csp-audit-report-endpoint" } ] }',
+		'Content-Security-Policy-Report-Only':
+			'report-uri /csp-audit-report-endpoint; report-to csp-endpoint; default-src https:',
+	});
 	next();
 });
 

--- a/server/server.ts
+++ b/server/server.ts
@@ -41,8 +41,10 @@ server.use(helmet());
 
 server.use(function (_: Request, res: Response, next: NextFunction) {
 	res.set({
-		'Report-To': `{ "group": "csp-endpoint", "endpoints": [ { "url": "${conf.DOMAIN}/csp-audit-report-endpoint" } ] }`,
-		'Content-Security-Policy-Report-Only': `report-uri ${conf.DOMAIN}/csp-audit-report-endpoint; report-to csp-endpoint; default-src https:`,
+		'Report-To':
+			'{ "group": "csp-endpoint", "endpoints": [ { "url": "/api/csp-audit-report-endpoint" } ] }',
+		'Content-Security-Policy-Report-Only':
+			'report-uri /api/csp-audit-report-endpoint; report-to csp-endpoint; default-src https:',
 	});
 	next();
 });

--- a/shared/featureSwitches.ts
+++ b/shared/featureSwitches.ts
@@ -27,11 +27,13 @@ type FeatureSwitchName =
 	| 'exampleFeature'
 	| 'appSubscriptions'
 	| 'supporterPlusUpdateAmount'
-	| 'digisubSave';
+	| 'digisubSave'
+	| 'cspSecurityAudit';
 
 export const featureSwitches: Record<FeatureSwitchName, boolean> = {
 	exampleFeature: false,
 	appSubscriptions: true,
 	supporterPlusUpdateAmount: true,
 	digisubSave: true,
+	cspSecurityAudit: true,
 };

--- a/shared/requiresSignin.ts
+++ b/shared/requiresSignin.ts
@@ -7,6 +7,7 @@ const publicPaths = [
 	'/api/reminders/cancel/',
 	'/api/public/reminders/',
 	'/api/help-centre/',
+	'/api/csp-audit-report-endpoint/',
 	'/cancel-reminders/',
 	'/create-reminder/',
 	'/help-centre/',


### PR DESCRIPTION
## What does this change?
Adds a content security policy report header to all requests so that we can audit which endpoints need adding to a future content-security-policy header

as per docs at https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only

### Example of csp report in cloudwatch logs
<img width="1584" alt="Screenshot 2024-04-19 at 13 04 22" src="https://github.com/guardian/manage-frontend/assets/2510683/99f563e2-c85b-4eaa-8b21-4a2dfbf36230">
