### PR TITLE
Add basic CSP to manage-frontend

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -41,12 +41,16 @@ if (conf.DOMAIN === 'thegulocal.com') {
 server.use(helmet());
 
 if (featureSwitches.cspSecurityAudit) {
+	const csp = [
+		'report-uri /api/csp-audit-report-endpoint',
+		'report-to csp-endpoint',
+		"default-src 'self' https://sourcepoint.theguardian.com",
+	];
 	server.use(function (_: Request, res: Response, next: NextFunction) {
 		res.set({
 			'Report-To':
 				'{ "group": "csp-endpoint", "endpoints": [ { "url": "/api/csp-audit-report-endpoint" } ] }',
-			'Content-Security-Policy-Report-Only':
-				'report-uri /api/csp-audit-report-endpoint; report-to csp-endpoint; default-src https:',
+			'Content-Security-Policy-Report-Only': csp.join('; '),
 		});
 		next();
 	});

--- a/server/server.ts
+++ b/server/server.ts
@@ -50,7 +50,7 @@ if (featureSwitches.cspSecurityAudit) {
 		res.set({
 			'Report-To':
 				'{ "group": "csp-endpoint", "endpoints": [ { "url": "/api/csp-audit-report-endpoint" } ] }',
-			'Content-Security-Policy-Report-Only': csp.join('; '),
+			'Content-Security-Policy-Report-Only': `${csp.join('; ')};`,
 		});
 		next();
 	});


### PR DESCRIPTION
At the moment we are trying to report on CSP violations, however there are huge numbers of vialoations being logged for manage.theguardian.com, which should definitely be allowed.  In the first 1000 results we mostly could only find manage.theguardian.com.

this PR adds 'self' as an allowed source which should hopefully reduce the noise.  Also sourcepoint.

After this we can do more PRs to add other domains based on the results from cloudwatch logs.