### PR TITLE
'+ extras' product name change

### DIFF
--- a/client/components/mma/accountoverview/AccountOverview.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.tsx
@@ -108,18 +108,16 @@ const AccountOverviewPage = ({ isFromApp }: IsFromAppProps) => {
 			b.subscription.start.localeCompare(a.subscription.start),
 	);
 
-	const productCategories = [
-		...new Set(
-			[...allActiveProductDetails, ...allCancelledProductDetails].map(
-				(product: ProductDetail | CancelledProductDetail) => {
-					if (product.mmaCategory === 'recurringSupport') {
-						return 'subscriptions';
-					}
-					return product.mmaCategory;
-				},
-			),
-		),
-	];
+	const allProductCategories = [
+		...allActiveProductDetails,
+		...allCancelledProductDetails,
+	].map((product: ProductDetail | CancelledProductDetail) => {
+		if (product.mmaCategory === 'recurringSupport') {
+			return 'subscriptions';
+		}
+		return product.mmaCategory;
+	});
+	const uniqueProductCategories = [...new Set(allProductCategories)];
 	const appSubscriptions = mpapiResponse.subscriptions.filter(
 		isValidAppSubscription,
 	);
@@ -127,16 +125,16 @@ const AccountOverviewPage = ({ isFromApp }: IsFromAppProps) => {
 	if (
 		featureSwitches.appSubscriptions &&
 		appSubscriptions.length > 0 &&
-		!productCategories.includes('subscriptions')
+		!uniqueProductCategories.includes('subscriptions')
 	) {
-		productCategories.push('subscriptions');
+		uniqueProductCategories.push('subscriptions');
 	}
 
 	if (
 		singleContributions.length > 0 &&
-		!productCategories.includes('subscriptions')
+		!uniqueProductCategories.includes('subscriptions')
 	) {
-		productCategories.push('subscriptions');
+		uniqueProductCategories.push('subscriptions');
 	}
 
 	if (
@@ -188,7 +186,7 @@ const AccountOverviewPage = ({ isFromApp }: IsFromAppProps) => {
 				productDetails={allActiveProductDetails}
 				isFromApp={isFromApp}
 			/>
-			{productCategories.map((category) => {
+			{uniqueProductCategories.map((category) => {
 				const groupedProductType = GROUPED_PRODUCT_TYPES[category];
 				const activeProductsInCategory = allActiveProductDetails.filter(
 					(activeProduct) =>

--- a/client/components/mma/accountoverview/AccountOverview.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.tsx
@@ -113,11 +113,13 @@ const AccountOverviewPage = ({ isFromApp }: IsFromAppProps) => {
 		...allCancelledProductDetails,
 	].map((product: ProductDetail | CancelledProductDetail) => {
 		if (product.mmaCategory === 'recurringSupport') {
-			return 'subscriptions';
+			return 'subscriptions'; // we want to override the display text in MMA for RC/S+ but not affect functionality
 		}
 		return product.mmaCategory;
 	});
+
 	const uniqueProductCategories = [...new Set(allProductCategories)];
+
 	const appSubscriptions = mpapiResponse.subscriptions.filter(
 		isValidAppSubscription,
 	);

--- a/client/components/mma/accountoverview/ManageProduct.stories.tsx
+++ b/client/components/mma/accountoverview/ManageProduct.stories.tsx
@@ -5,6 +5,7 @@ import { PRODUCT_TYPES } from '../../../../shared/productTypes';
 import {
 	digitalPackPaidByDirectDebit,
 	guardianWeeklyPaidByCard,
+	monthlyContributionPaidByCard,
 	newspaperVoucherPaidByPaypal,
 	supporterPlusAnnual,
 } from '../../../fixtures/productBuilder/testProducts';
@@ -51,6 +52,18 @@ export const NewspaperSubscriptionCard: StoryObj<typeof ManageProduct> = {
 	parameters: {
 		reactRouter: {
 			state: { productDetail: newspaperVoucherPaidByPaypal() },
+		},
+	},
+};
+
+export const Contribution: StoryObj<typeof ManageProduct> = {
+	render: () => {
+		return <ManageProduct productType={PRODUCT_TYPES.contributions} />;
+	},
+
+	parameters: {
+		reactRouter: {
+			state: { productDetail: monthlyContributionPaidByCard() },
 		},
 	},
 };

--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -20,10 +20,7 @@ import type {
 	Subscription,
 } from '@/shared/productResponse';
 import { getMainPlan, isGift } from '@/shared/productResponse';
-import {
-	calculateSupporterPlusTitle,
-	GROUPED_PRODUCT_TYPES,
-} from '@/shared/productTypes';
+import { GROUPED_PRODUCT_TYPES } from '@/shared/productTypes';
 import { wideButtonLayoutCss } from '../../../styles/ButtonStyles';
 import { trackEvent } from '../../../utilities/analytics';
 import { ErrorIcon } from '../shared/assets/ErrorIcon';
@@ -373,11 +370,7 @@ export const ProductCard = ({
 											})
 										}
 									>
-										Change to{' '}
-										{calculateSupporterPlusTitle(
-											(mainPlan as PaidSubscriptionPlan)
-												.billingPeriod,
-										)}
+										Change to all-access digital
 									</Button>
 								</ThemeProvider>
 							)}

--- a/client/components/mma/cancel/CancellationSummary.tsx
+++ b/client/components/mma/cancel/CancellationSummary.tsx
@@ -36,9 +36,7 @@ const actuallyCancelled = (
 						`,
 					]}
 				>
-					{productType.cancellation?.alternateSummaryHeading(
-						cancelledProductDetail,
-					) ||
+					{productType.cancellation?.alternateSummaryHeading ||
 						`Your ${productType.friendlyName(
 							cancelledProductDetail,
 						)} is cancelled`}

--- a/client/components/mma/cancel/CancellationSummary.tsx
+++ b/client/components/mma/cancel/CancellationSummary.tsx
@@ -36,10 +36,9 @@ const actuallyCancelled = (
 						`,
 					]}
 				>
-					{productType.cancellation?.alternateSummaryHeading ||
-						`Your ${productType.friendlyName(
-							cancelledProductDetail,
-						)} is cancelled`}
+					{`Your ${productType.friendlyName(
+						cancelledProductDetail,
+					)} is cancelled`}
 				</Heading>
 				{productType.cancellation &&
 					!productType.cancellation.shouldHideSummaryMainPara && (

--- a/client/components/mma/cancel/contributions/ContributionsCancellationFlowStart.tsx
+++ b/client/components/mma/cancel/contributions/ContributionsCancellationFlowStart.tsx
@@ -5,13 +5,13 @@ import { Heading } from '../../shared/Heading';
 export const contributionsCancellationFlowStart = () => (
 	<Stack space={4}>
 		<Heading cssOverrides={measure.heading}>
-			We’re sorry to see you go…
+			We’re sorry to see you go …
 		</Heading>
 
 		<p>
 			<strong>
-				…please could you take a moment to tell us why you would like to
-				cancel today?
+				… please could you take a moment to tell us why you would like
+				to cancel today?
 			</strong>
 			<br />
 			As a reader-funded organisation, we rely on the generous support

--- a/client/components/mma/cancel/supporterplus/SupporterplusCancellationFlowStart.tsx
+++ b/client/components/mma/cancel/supporterplus/SupporterplusCancellationFlowStart.tsx
@@ -5,13 +5,13 @@ import { Heading } from '../../shared/Heading';
 export const supporterplusCancellationFlowStart = () => (
 	<Stack space={4}>
 		<Heading cssOverrides={measure.heading}>
-			We’re sorry to see you go…
+			We’re sorry to see you go …
 		</Heading>
 
 		<p>
 			<strong>
-				…please could you take a moment to tell us why you would like to
-				cancel today?
+				… please could you take a moment to tell us why you would like
+				to cancel today?
 			</strong>
 			<br />
 			As a reader-funded organisation, we rely on the generous support

--- a/client/components/mma/shared/benefits/BenefitsToggle.tsx
+++ b/client/components/mma/shared/benefits/BenefitsToggle.tsx
@@ -28,7 +28,7 @@ export const BenefitsToggle = (props: { productType: ProductTypeKeys }) => {
 				aria-controls="benefits"
 				onClick={() => setShowBenefits(!showBenefits)}
 			>
-				{showBenefits ? 'hide' : 'view'} extras
+				{showBenefits ? 'hide' : 'view'} benefits
 			</button>
 		</>
 	);

--- a/client/components/mma/switch/SwitchContainer.tsx
+++ b/client/components/mma/switch/SwitchContainer.tsx
@@ -160,7 +160,8 @@ const RenderedPage = (props: {
 					user: props.user,
 					mainPlan,
 					monthlyOrAnnual,
-					supporterPlusTitle: `${monthlyOrAnnual} + extras`,
+					supporterPlusTitle:
+						PRODUCT_TYPES.supporterplus.productTitle(),
 					thresholds: getThresholds(
 						mainPlan,
 						monthlyOrAnnual == 'Monthly',

--- a/client/fixtures/productBuilder/testProducts.ts
+++ b/client/fixtures/productBuilder/testProducts.ts
@@ -66,6 +66,13 @@ export function digitalPackPaidByCardWithPaymentFailure() {
 		.getProductDetailObject();
 }
 
+export function monthlyContributionPaidByCard() {
+	return new ProductBuilder(baseContribution())
+		.payByCard()
+		.withPrice(400)
+		.getProductDetailObject();
+}
+
 export function annualContributionPaidByCardWithCurrency(
 	currency: CurrencyIso,
 ) {

--- a/cypress/tests/mocked/parallel-1/updateContributionAmount.cy.ts
+++ b/cypress/tests/mocked/parallel-1/updateContributionAmount.cy.ts
@@ -66,7 +66,7 @@ describe('Update contribution amount', () => {
 
 		setSignInStatus();
 
-		cy.findByText('Manage recurring support').click();
+		cy.findByText('Manage subscription').click();
 		cy.wait('@cancelled');
 
 		cy.findByText('Change amount').click();
@@ -93,7 +93,7 @@ describe('Update contribution amount', () => {
 
 		setSignInStatus();
 
-		cy.findByText('Manage recurring support').click();
+		cy.findByText('Manage subscription').click();
 		cy.wait('@cancelled');
 
 		cy.findByText('Change amount').click();

--- a/cypress/tests/mocked/parallel-2/cancelContribution.cy.ts
+++ b/cypress/tests/mocked/parallel-2/cancelContribution.cy.ts
@@ -19,11 +19,11 @@ describe('Cancel contribution', () => {
 
 		setSignInStatus();
 
-		cy.findByText('Manage recurring support').click();
+		cy.findByText('Manage subscription').click();
 		cy.wait('@cancelled');
 
 		cy.findByRole('link', {
-			name: 'Cancel recurring support',
+			name: 'Cancel subscription',
 		}).click();
 	};
 

--- a/cypress/tests/mocked/parallel-2/cancelSupporterPlus.cy.ts
+++ b/cypress/tests/mocked/parallel-2/cancelSupporterPlus.cy.ts
@@ -11,10 +11,10 @@ describe('Cancel Supporter Plus', () => {
 		cy.wait('@mobile_subscriptions');
 		cy.wait('@single_contributions');
 
-		cy.findByText('Manage recurring support').click();
+		cy.findByText('Manage subscription').click();
 
 		cy.findByRole('link', {
-			name: 'Cancel recurring support',
+			name: 'Cancel subscription',
 		}).click();
 	};
 
@@ -123,7 +123,7 @@ describe('Cancel Supporter Plus', () => {
 		cy.wait('@get_cancelled_product');
 
 		cy.findByRole('heading', {
-			name: 'Monthly support + extras cancelled',
+			name: 'Your All-access digital subscription is cancelled',
 		});
 
 		cy.get('@get_cancellation_date.all').should('have.length', 0);

--- a/cypress/tests/mocked/parallel-2/cancelSupporterPlus.cy.ts
+++ b/cypress/tests/mocked/parallel-2/cancelSupporterPlus.cy.ts
@@ -123,7 +123,7 @@ describe('Cancel Supporter Plus', () => {
 		cy.wait('@get_cancelled_product');
 
 		cy.findByRole('heading', {
-			name: 'Your All-access digital subscription is cancelled',
+			name: 'Your all-access digital subscription is cancelled',
 		});
 
 		cy.get('@get_cancellation_date.all').should('have.length', 0);

--- a/cypress/tests/mocked/parallel-2/productSwitch.cy.ts
+++ b/cypress/tests/mocked/parallel-2/productSwitch.cy.ts
@@ -67,8 +67,11 @@ describe('product switching', () => {
 		cy.visit('/');
 		setSignInStatus();
 
-		cy.findAllByText('Change to monthly + extras').should('have.length', 2);
-		cy.findAllByText('Change to monthly + extras').last().click();
+		cy.findAllByText('Change to all-access digital').should(
+			'have.length',
+			2,
+		);
+		cy.findAllByText('Change to all-access digital').last().click();
 		cy.findByText('Your current support').should('exist');
 
 		cy.findByRole('button', {
@@ -205,11 +208,17 @@ describe('product switching', () => {
 		cy.visit('/');
 		setSignInStatus();
 
-		cy.findAllByText('Change to monthly + extras').should('have.length', 0);
+		cy.findAllByText('Change to all-access digital').should(
+			'have.length',
+			0,
+		);
 
 		cy.visit('/switch');
 
 		cy.findByRole('heading', { name: 'Account overview' }).should('exist');
-		cy.findAllByText('Change to monthly + extras').should('have.length', 0);
+		cy.findAllByText('Change to all-access digital').should(
+			'have.length',
+			0,
+		);
 	});
 });

--- a/cypress/tests/mocked/parallel-4/deliveryAddress.cy.ts
+++ b/cypress/tests/mocked/parallel-4/deliveryAddress.cy.ts
@@ -1,7 +1,6 @@
 import {
 	guardianWeeklyPaidByCard,
 	nationalDelivery,
-	supporterPlus,
 } from '../../../../client/fixtures/productBuilder/testProducts';
 import { toMembersDataApiResponse } from '../../../../client/fixtures/mdapiResponse';
 import { signInAndAcceptCookies } from '../../../lib/signInAndAcceptCookies';
@@ -12,10 +11,7 @@ describe('Delivery address', () => {
 
 		cy.intercept('GET', '/api/me/mma?productType=ContentSubscription', {
 			statusCode: 200,
-			body: toMembersDataApiResponse(
-				guardianWeeklyPaidByCard(),
-				supporterPlus(),
-			),
+			body: toMembersDataApiResponse(guardianWeeklyPaidByCard()),
 		}).as('product_detail');
 
 		cy.intercept('GET', '/mpapi/user/mobile-subscriptions', {
@@ -42,10 +38,7 @@ describe('Delivery address', () => {
 	it('Can update delivery address. Navigating from account overview', () => {
 		cy.intercept('GET', '/api/me/mma', {
 			statusCode: 200,
-			body: toMembersDataApiResponse(
-				guardianWeeklyPaidByCard(),
-				supporterPlus(),
-			),
+			body: toMembersDataApiResponse(guardianWeeklyPaidByCard()),
 		}).as('mma');
 
 		cy.visit('/');
@@ -80,7 +73,7 @@ describe('Delivery address', () => {
 	it('Cannot update National delivery address. Navigating from account overview', () => {
 		cy.intercept('GET', '/api/me/mma', {
 			statusCode: 200,
-			body: toMembersDataApiResponse(nationalDelivery(), supporterPlus()),
+			body: toMembersDataApiResponse(nationalDelivery()),
 		}).as('mma');
 
 		cy.visit('/');
@@ -93,7 +86,7 @@ describe('Delivery address', () => {
 
 		cy.intercept('GET', '/api/me/mma?productType=ContentSubscription', {
 			statusCode: 200,
-			body: toMembersDataApiResponse(nationalDelivery(), supporterPlus()),
+			body: toMembersDataApiResponse(nationalDelivery()),
 		});
 
 		cy.findByText('Manage delivery address').click();
@@ -107,7 +100,6 @@ describe('Delivery address', () => {
 			body: toMembersDataApiResponse(
 				nationalDelivery(),
 				guardianWeeklyPaidByCard(),
-				supporterPlus(),
 			),
 		}).as('mma');
 
@@ -119,7 +111,7 @@ describe('Delivery address', () => {
 
 		cy.intercept('GET', '/api/me/mma?productType=ContentSubscription', {
 			statusCode: 200,
-			body: toMembersDataApiResponse(nationalDelivery(), supporterPlus()),
+			body: toMembersDataApiResponse(nationalDelivery()),
 		});
 
 		cy.findByText(/Changed address?/).should('exist');
@@ -128,10 +120,7 @@ describe('Delivery address', () => {
 	it('Shows updated address when returning to manage subscription page', () => {
 		cy.intercept('GET', '/api/me/mma', {
 			statusCode: 200,
-			body: toMembersDataApiResponse(
-				guardianWeeklyPaidByCard(),
-				supporterPlus(),
-			),
+			body: toMembersDataApiResponse(guardianWeeklyPaidByCard()),
 		}).as('mma');
 
 		cy.visit('/');

--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -91,7 +91,6 @@ interface CancellationFlowProperties {
 	startPageOfferEffectiveDateOptions?: true;
 	hideReasonTitlePrefix?: true;
 	alternateSummaryMainPara?: string;
-	alternateSummaryHeading?: string;
 	shouldHideSummaryMainPara?: true;
 	summaryReasonSpecificPara: (
 		reasonId: OptionalCancellationReasonId,
@@ -636,8 +635,6 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 		cancellation: {
 			alternateSummaryMainPara:
 				"This is immediate and you will not be charged again. If you've cancelled within the first 14 days, we'll send you a full refund.",
-			alternateSummaryHeading:
-				'Your All-access digital subscription is cancelled',
 			linkOnProductPage: true,
 			reasons: shuffledSupporterPlusCancellationReasons,
 			sfCaseProduct: 'Supporter Plus',


### PR DESCRIPTION
## What does this change?
Copy changes to refelect a switch from `Monthly + extras` and `Annual + extras` to `All-access digital`. Adjacent copy changes `Recurring support` to become `subscription` and visually grouping contributions and all access digital products into the 'subscriptions' sub section on the account overview

## Images
<img width="736" alt="Screenshot 2024-05-17 at 10 37 20" src="https://github.com/guardian/manage-frontend/assets/2510683/4d6181a2-7549-4064-af65-8da101d29ab6">

<img width="755" alt="Screenshot 2024-05-17 at 10 37 58" src="https://github.com/guardian/manage-frontend/assets/2510683/8c732023-d9a8-4497-b51d-2ebd30117cd1">

<img width="755" alt="Screenshot 2024-05-17 at 10 38 29" src="https://github.com/guardian/manage-frontend/assets/2510683/5d371a5f-c855-4e6f-9c3a-1683e7631791">
