### PR TITLE
add default-style 'unsafe-inline' entry to the csp header

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -51,7 +51,7 @@ if (featureSwitches.cspSecurityAudit) {
 	const csp = [
 		'report-uri /api/csp-audit-report-endpoint',
 		'report-to csp-endpoint',
-		`default-src ${cspDefaultSrcAllowList}`,
+		`default-src ${cspDefaultSrcAllowList}; default-style 'unsafe-inline'`,
 	];
 	server.use(function (_: Request, res: Response, next: NextFunction) {
 		res.set({

--- a/server/server.ts
+++ b/server/server.ts
@@ -51,7 +51,8 @@ if (featureSwitches.cspSecurityAudit) {
 	const csp = [
 		'report-uri /api/csp-audit-report-endpoint',
 		'report-to csp-endpoint',
-		`default-src ${cspDefaultSrcAllowList}; default-style 'unsafe-inline'`,
+		`default-src ${cspDefaultSrcAllowList}`,
+		`default-style 'unsafe-inline'`, // this is unsafe but needed for now for emotion
 	];
 	server.use(function (_: Request, res: Response, next: NextFunction) {
 		res.set({


### PR DESCRIPTION
## What does this change?
Although we would prefer not to do this, the way that emotion (and probably more generally css in js) works is by changing inline style tags via js. However this will hopefully be a intermediate step towards a better approach perhaps using a hash or a nonce to validate specific inline styles within the csp header.

## Reference documents
- https://docs.google.com/document/d/1Vi7m35w46F72z6n4fucsxm6i28xbmn2iMfPGM7zWGz8/edit
- https://docs.google.com/document/d/1qV01OMUMrVPorLLAYj9aT4zTIITw99bAfirRgfc_R3I/edit
