### PR TITLE
CSS fix

### DIFF
--- a/client/components/helpCentre/BackToHelpCentreLink.tsx
+++ b/client/components/helpCentre/BackToHelpCentreLink.tsx
@@ -12,7 +12,8 @@ const dividerCss = css`
 const linkCss = css`
 	display: flex;
 	align-items: center;
-	${textSans17}: color: ${palette.brand[500]};
+	${textSans17};
+	color: ${palette.brand[500]};
 	&:hover,
 	&:focus {
 		text-decoration: underline;


### PR DESCRIPTION
## What does this change?

Small fix to some css styles where a colon was used instead of a semi-colon :s

It affected the link colour in the help centre.