### PR TITLE
Use update-supporter-plus-amount api

### DIFF
--- a/server/apiGatewayDiscovery.ts
+++ b/server/apiGatewayDiscovery.ts
@@ -29,6 +29,7 @@ const apiNames = [
 	'product-move-api',
 	'discount-api',
 	'product-switch-api',
+	'update-supporter-plus-amount',
 ] as const;
 type ApiName = typeof apiNames[number];
 
@@ -228,6 +229,14 @@ const productSwitchAPIGateway = getApiGateway(
 );
 export const productSwitchAPI =
 	productSwitchAPIGateway.authorisedExpressCallback;
+
+const updateSupporterPlusAmountAPIGateway = getApiGateway(
+	'support',
+	'update-supporter-plus-amount',
+	generateAwsSignatureHeaders,
+);
+export const updateSupporterPlusAmountAPI =
+	updateSupporterPlusAmountAPIGateway.authorisedExpressCallback;
 
 const invoicingAPIGateway = getApiGateway(
 	'support',

--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -11,6 +11,7 @@ import {
 	invoicingAPI,
 	productMoveAPI,
 	productSwitchAPI,
+	updateSupporterPlusAmountAPI,
 } from '../apiGatewayDiscovery';
 import {
 	customMembersDataApiHandler,
@@ -217,9 +218,9 @@ router.post(
 router.post(
 	'/update-supporter-plus-amount/:subscriptionName',
 	withOktaServerSideValidation,
-	productMoveAPI(
+	updateSupporterPlusAmountAPI(
 		'update-supporter-plus-amount/:subscriptionName',
-		'MOVE_PRODUCT_UPDATE_AMOUNT',
+		'UPDATE_SUPPORTER_PLUS_AMOUNT',
 		['subscriptionName'],
 	),
 );


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Updates manage-frontend to use the new [update-supporter-plus-amount api](https://github.com/guardian/support-service-lambdas/pull/2289) rather than the old product-move-api for supporter plus amount changes.