### PR TITLE
csp header css update

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -53,7 +53,6 @@ if (featureSwitches.cspSecurityAudit) {
 		'report-to csp-endpoint',
 		`default-src ${cspDefaultSrcAllowList}`,
 		`style-src 'unsafe-inline'`, // this is unsafe but needed for now for emotion
-		`style-src-elem 'unsafe-inline'`, // this is unsafe but needed for now for emotion
 	];
 	server.use(function (_: Request, res: Response, next: NextFunction) {
 		res.set({

--- a/server/server.ts
+++ b/server/server.ts
@@ -52,7 +52,8 @@ if (featureSwitches.cspSecurityAudit) {
 		'report-uri /api/csp-audit-report-endpoint',
 		'report-to csp-endpoint',
 		`default-src ${cspDefaultSrcAllowList}`,
-		`default-style 'unsafe-inline'`, // this is unsafe but needed for now for emotion
+		`style-src 'unsafe-inline'`, // this is unsafe but needed for now for emotion
+		`style-src-elem 'unsafe-inline'`, // this is unsafe but needed for now for emotion
 	];
 	server.use(function (_: Request, res: Response, next: NextFunction) {
 		res.set({


### PR DESCRIPTION
## What does this change?

Change invalid `default-style` to the correct `style-src` https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src

This will allow inline styles for `<style>` and `<link>` tags as well as inline `style` attribute.

This is not a welcome attribute but a necessary one in order to implement a csp header in manage. Hopefully at a later date we can look into using a hash or nonce to validate specific inline sources.