### PR TITLE
Make sure that the production build uses the current lockfile

### DIFF
--- a/script/ci.sh
+++ b/script/ci.sh
@@ -14,9 +14,10 @@ yarn test
 yarn bundle
 
 cp package.json dist
+cp yarn.lock dist
 
 cd dist
 
-yarn install --production
+yarn install --production --frozen-lockfile
 
 zip -FSr "${ROOT_DIR}/manage-frontend.zip" ./*


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Up until now the final production build was being run with no lockfile. This meant that the versions of dependencies which end up being used in production can be different from those used during development. 

This PR fixes that issue.

We actually found this because of an issue in the okta library, where a newer version of a dependency broke the library, this PR has more information: https://github.com/guardian/gateway/pull/2775