### PR TITLE
Revert "Add Value as CODEOWNERS"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @guardian/value


### PR DESCRIPTION
Remove CODEOWNERS because it requests reviews from everyone in the team automatically as soon as anyone raises a PR.  This is a problem because it's spammy and also it's no longer clear whether PRs are ready for review.