### PR TITLE
fix conditional check

### DIFF
--- a/server/routes/mpapi.ts
+++ b/server/routes/mpapi.ts
@@ -36,7 +36,7 @@ router.get(
 			return;
 		}
 
-		if (!res.locals.identity && !res.locals.identity.userId) {
+		if (!res.locals.identity?.userId) {
 			log.error(
 				`Missing identity ID on the request object when fetching mobile subscriptions`,
 			);


### PR DESCRIPTION
## What does this change?

Fix conditional check that would fail if the left hand side of the condition returned a falsey value (the right hand side of the condition would try to access a property of undefined)