### PR TITLE
remove doNotSetUsername param as we no longer set username for test users

### DIFF
--- a/cypress/lib/signInOkta.ts
+++ b/cypress/lib/signInOkta.ts
@@ -16,7 +16,6 @@ export const signInOkta = () => {
 	cy.visit('/');
 	cy.createTestUser({
 		isUserEmailValidated: true,
-		doNotSetUsername: true,
 	})?.then(({ emailAddress, finalPassword }) => {
 		cy.get('input[name=email]').type(emailAddress);
 		cy.get('input[name=password]').type(finalPassword);

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -97,7 +97,6 @@ type IDAPITestUserOptions = {
 	password?: string;
 	deleteAfterMinute?: boolean;
 	isGuestUser?: boolean;
-	doNotSetUsername?: boolean;
 };
 type IDAPITestUserResponse = [
 	{
@@ -129,7 +128,6 @@ export const createTestUser = ({
 	isUserEmailValidated = false,
 	deleteAfterMinute = true,
 	isGuestUser = false,
-	doNotSetUsername = false,
 }: IDAPITestUserOptions) => {
 	// Generate a random email address if none is provided.
 	const finalEmail = primaryEmailAddress || randomMailosaurEmail();
@@ -152,7 +150,6 @@ export const createTestUser = ({
 					password: finalPassword,
 					deleteAfterMinute,
 					isGuestUser,
-					doNotSetUsername,
 				} as IDAPITestUserOptions,
 			})
 			.then((res) => {


### PR DESCRIPTION
This PR follows on when this one https://github.com/guardian/identity/pull/2528 is merged

It undoes some of the changes in https://github.com/guardian/manage-frontend/pull/1311
This is possible as we no longer set usernames for test users, so we don't need a flag to prevent that.

That flag is removed in the identity PR https://github.com/guardian/identity/pull/2528 as part of the changes to move the test user token from the username/firstname to the email address 