### PR TITLE
ProgressIndicator and ProgressStepper seperate stories

### DIFF
--- a/client/components/mma/shared/ProgressIndicator.stories.tsx
+++ b/client/components/mma/shared/ProgressIndicator.stories.tsx
@@ -10,37 +10,6 @@ export default {
 	},
 } as Meta<typeof ProgressStepper>;
 
-export const Default: StoryFn<typeof ProgressStepper> = () => {
-	return (
-		<>
-			<ProgressStepper
-				steps={[{ title: 'Reason' }, { title: 'Review' }]}
-			/>
-			<ProgressStepper
-				steps={[
-					{ title: 'Reason' },
-					{ title: 'Review', isCurrentStep: true },
-					{ title: 'Confirmation' },
-				]}
-			/>
-			<ProgressStepper
-				steps={[
-					{ title: 'Reason', isCurrentStep: true },
-					{ title: 'Review' },
-					{ title: 'Confirmation' },
-				]}
-			/>
-			<ProgressStepper
-				steps={[
-					{ title: 'Reason' },
-					{ title: 'Review' },
-					{ title: 'Confirmation', isCurrentStep: true },
-				]}
-			/>
-		</>
-	);
-};
-
 export const OldVersion: StoryFn<typeof ProgressIndicator> = () => {
 	return (
 		<ProgressIndicator

--- a/client/components/mma/shared/ProgressIndicator.stories.tsx
+++ b/client/components/mma/shared/ProgressIndicator.stories.tsx
@@ -1,23 +1,24 @@
-import type { Meta, StoryFn } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { ProgressIndicator } from './ProgressIndicator';
-import { ProgressStepper } from './ProgressStepper';
 
 export default {
 	title: 'Components/ProgressIndicator',
-	component: ProgressStepper,
+	component: ProgressIndicator,
 	parameters: {
 		layout: 'fullscreen',
 	},
-} as Meta<typeof ProgressStepper>;
+} as Meta<typeof ProgressIndicator>;
 
-export const OldVersion: StoryFn<typeof ProgressIndicator> = () => {
-	return (
-		<ProgressIndicator
-			steps={[
-				{ title: 'Reason' },
-				{ title: 'Review', isCurrentStep: true },
-				{ title: 'Confirmation' },
-			]}
-		/>
-	);
+export const OldVersion: StoryObj<typeof ProgressIndicator> = {
+	render: () => {
+		return (
+			<ProgressIndicator
+				steps={[
+					{ title: 'Reason' },
+					{ title: 'Review', isCurrentStep: true },
+					{ title: 'Confirmation' },
+				]}
+			/>
+		);
+	},
 };

--- a/client/components/mma/shared/ProgressIndicator.tsx
+++ b/client/components/mma/shared/ProgressIndicator.tsx
@@ -8,7 +8,7 @@ interface Step {
 	isCurrentStep?: true;
 }
 
-interface ProgressIndicatorProps {
+export interface ProgressIndicatorProps {
 	steps: [Step, Step, ...Step[]];
 	additionalCSS?: SerializedStyles;
 }

--- a/client/components/mma/shared/ProgressStepper.stories.tsx
+++ b/client/components/mma/shared/ProgressStepper.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ProgressStepper } from './ProgressStepper';
+
+export default {
+	title: 'Components/ProgressStepper',
+	component: ProgressStepper,
+	parameters: {
+		layout: 'fullscreen',
+	},
+} as Meta<typeof ProgressStepper>;
+
+export const WithTitleWithCurrentStep: StoryObj<typeof ProgressStepper> = {
+	render: () => {
+		return (
+			<ProgressStepper
+				steps={[
+					{ title: 'Reason' },
+					{ title: 'Review', isCurrentStep: true },
+					{ title: 'Confirmation' },
+				]}
+			/>
+		);
+	},
+};
+
+export const WithoutTitleWithCurrentStep: StoryObj<typeof ProgressStepper> = {
+	render: () => {
+		return <ProgressStepper steps={[{}, { isCurrentStep: true }, {}]} />;
+	},
+};


### PR DESCRIPTION
## What does this change?
Seperates out the ProgressIndicator (older) and ProgressStepper (new) components into seperate stories. Quick tidy up in order to help with the eventual aim of replacing the ProgressIndicator component entirely.

## Images
<img width="601" alt="Screenshot 2024-07-08 at 17 19 23" src="https://github.com/guardian/manage-frontend/assets/2510683/a0576f19-a574-4327-b539-f4199439eec2">
