### PR TITLE
CSP script hashes report only

### DIFF
--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -1,6 +1,5 @@
 import * as Sentry from '@sentry/node';
 import { Router } from 'express';
-import { featureSwitches } from '@/shared/featureSwitches';
 import type { MembersDataApiResponse } from '@/shared/productResponse';
 import { isProduct, MDA_TEST_USER_HEADER } from '@/shared/productResponse';
 import {
@@ -354,12 +353,10 @@ router.get(
 router.post('/reminders/cancel', cancelReminderHandler);
 router.post('/reminders/reactivate', reactivateReminderHandler);
 
-if (featureSwitches.cspSecurityAudit) {
-	router.post('/csp-audit-report-endpoint', (req, res) => {
-		const parsedBody = JSON.parse(req.body.toString());
-		log.warn(JSON.stringify(parsedBody));
-		res.status(204).end();
-	});
-}
+router.post('/csp-audit-report-endpoint', (req, res) => {
+	const parsedBody = JSON.parse(req.body.toString());
+	log.warn(JSON.stringify(parsedBody));
+	res.status(204).end();
+});
 
 export { router };

--- a/server/routes/helpCentreFrontend.ts
+++ b/server/routes/helpCentreFrontend.ts
@@ -39,7 +39,7 @@ router.use(async (_: Request, res: Response) => {
 		),
 	});
 
-	res.send(htmlStrAndScriptHashes);
+	res.send(htmlStrAndScriptHashes.body);
 });
 
 export { router };

--- a/server/routes/helpCentreFrontend.ts
+++ b/server/routes/helpCentreFrontend.ts
@@ -2,8 +2,9 @@ import { Router } from 'express';
 import type { Request, Response } from 'express';
 import { DEFAULT_PAGE_TITLE } from '../../shared/helpCentreConfig';
 import { conf } from '../config';
-import { html } from '../html';
+import { htmlAndScriptHashes } from '../html';
 import { withIdentity } from '../middleware/identityMiddleware';
+import { createCsp } from '../server';
 import {
 	clientDSN,
 	getRecaptchaPublicKey,
@@ -18,19 +19,27 @@ router.use(async (_: Request, res: Response) => {
 	const title = DEFAULT_PAGE_TITLE;
 	const src = '/static/help-centre.js';
 
-	res.send(
-		html({
-			title,
-			src,
-			globals: {
-				domain: conf.DOMAIN,
-				dsn: clientDSN,
-				identityDetails: res.locals.identity,
-				recaptchaPublicKey: await getRecaptchaPublicKey(),
-				...(await getStripePublicKeys()),
-			},
-		}),
-	);
+	const htmlStrAndScriptHashes = htmlAndScriptHashes({
+		title,
+		src,
+		globals: {
+			domain: conf.DOMAIN,
+			dsn: clientDSN,
+			identityDetails: res.locals.identity,
+			recaptchaPublicKey: await getRecaptchaPublicKey(),
+			...(await getStripePublicKeys()),
+		},
+	});
+
+	res.set({
+		'Report-To':
+			'{ "group": "csp-endpoint", "endpoints": [ { "url": "/api/csp-audit-report-endpoint" } ] }',
+		'Content-Security-Policy-Report-Only': createCsp(
+			htmlStrAndScriptHashes.hashes,
+		),
+	});
+
+	res.send(htmlStrAndScriptHashes);
 });
 
 export { router };

--- a/server/server.ts
+++ b/server/server.ts
@@ -41,11 +41,13 @@ if (conf.DOMAIN === 'thegulocal.com') {
 server.use(helmet());
 
 export const createCsp = (hashes: string[]) => {
-	return `script-src ${hashes
-		.map((hash) => `'sha256-${hash}'`)
-		.join(
-			' ',
-		)} 'strict-dynamic'; style-src 'unsafe-inline'; object-src 'none'; base-uri 'none';`;
+	const prefixedHashes = hashes.map((hash) => `'sha256-${hash}'`);
+	const csp = [
+		`script-src ${prefixedHashes.join(' ')} 'strict-dynamic'`,
+		`style-src 'unsafe-inline'`,
+		`object-src 'none'`,
+	];
+	return csp.join('; ');
 };
 
 server.use(function (_: Request, res: Response, next: NextFunction) {

--- a/server/server.ts
+++ b/server/server.ts
@@ -41,14 +41,11 @@ if (conf.DOMAIN === 'thegulocal.com') {
 server.use(helmet());
 
 export const createCsp = (hashes: string[]) => {
-	return `
-		script-src ${hashes
-			.map((hash) => `'sha256-${hash}'`)
-			.join(' ')} 'strict-dynamic';
-		style-src 'unsafe-inline';
-		object-src 'none';
-		base-uri 'none';
-	`;
+	return `script-src ${hashes
+		.map((hash) => `'sha256-${hash}'`)
+		.join(
+			' ',
+		)} 'strict-dynamic'; style-src 'unsafe-inline'; object-src 'none'; base-uri 'none';`;
 };
 
 server.use(function (_: Request, res: Response, next: NextFunction) {

--- a/server/server.ts
+++ b/server/server.ts
@@ -4,7 +4,6 @@ import cookieParser from 'cookie-parser';
 import type { NextFunction, Request, RequestHandler, Response } from 'express';
 import { default as express } from 'express';
 import helmet from 'helmet';
-import { featureSwitches } from '../shared/featureSwitches';
 import { MAX_FILE_ATTACHMENT_SIZE_KB } from '../shared/fileUploadUtils';
 import { conf } from './config';
 import { log } from './log';
@@ -18,6 +17,7 @@ const server = express();
 const oktaConfig = await getConfig();
 
 declare let WEBPACK_BUILD: string;
+
 if (conf.SERVER_DSN) {
 	Sentry.init({
 		dsn: conf.SERVER_DSN,
@@ -40,29 +40,31 @@ if (conf.DOMAIN === 'thegulocal.com') {
 
 server.use(helmet());
 
-if (featureSwitches.cspSecurityAudit) {
-	const cspDefaultSrcAllowList = [
-		"'self'",
-		'https://sourcepoint.theguardian.com',
-		'https://gnm-app.quantummetric.com',
-		'https://assets.guim.co.uk',
-		'https://ophan.theguardian.com',
-	].join(' ');
-	const csp = [
-		'report-uri /api/csp-audit-report-endpoint',
-		'report-to csp-endpoint',
-		`default-src ${cspDefaultSrcAllowList}`,
-		`style-src 'unsafe-inline'`, // this is unsafe but needed for now for emotion
-	];
-	server.use(function (_: Request, res: Response, next: NextFunction) {
-		res.set({
-			'Report-To':
-				'{ "group": "csp-endpoint", "endpoints": [ { "url": "/api/csp-audit-report-endpoint" } ] }',
-			'Content-Security-Policy-Report-Only': `${csp.join('; ')};`,
-		});
-		next();
+export const createCsp = (hashes: string[]) => {
+	return `
+		script-src ${hashes
+			.map((hash) => `'sha256-${hash}'`)
+			.join(' ')} 'strict-dynamic';
+		style-src 'unsafe-inline';
+		object-src 'none';
+		base-uri 'none';
+	`;
+};
+
+server.use(function (_: Request, res: Response, next: NextFunction) {
+	/*
+	 * This sets a default csp header, this is overriden in:
+	 * - mmaFrontend.ts
+	 * - helpcentreFrontend.ts
+	 * Where a more specific policy with script hashes can be added
+	 */
+	res.set({
+		'Report-To':
+			'{ "group": "csp-endpoint", "endpoints": [ { "url": "/api/csp-audit-report-endpoint" } ] }',
+		'Content-Security-Policy-Report-Only': createCsp([]),
 	});
-}
+	next();
+});
 
 const serveStaticAssets: RequestHandler = express.static(__dirname + '/static');
 

--- a/shared/featureSwitches.ts
+++ b/shared/featureSwitches.ts
@@ -28,7 +28,6 @@ type FeatureSwitchName =
 	| 'appSubscriptions'
 	| 'supporterPlusUpdateAmount'
 	| 'digisubSave'
-	| 'cspSecurityAudit'
 	| 'supporterplusCancellationOffer';
 
 export const featureSwitches: Record<FeatureSwitchName, boolean> = {
@@ -36,6 +35,5 @@ export const featureSwitches: Record<FeatureSwitchName, boolean> = {
 	appSubscriptions: true,
 	supporterPlusUpdateAmount: true,
 	digisubSave: true,
-	cspSecurityAudit: true,
 	supporterplusCancellationOffer: true,
 };


### PR DESCRIPTION
## What does this change?
Rework csp report header to work with inline script hashes and `strict-dynamic` to allow those inline scripts to load further scripts

#### More rational around constructing a csp header for an SPA can be found here:

https://auth0.com/blog/deploying-csp-in-spa/

https://web.dev/articles/strict-csp#adopting-a-strict-csp

