### PR TITLE
Add owners info to readme/pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+### Current situation/background
+
+### What does this PR change?
+
+### Next steps/further info
+
+<!--
+This Repo is owned by SR Value team - guardian/value
+feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
+-->

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-# manage.theguardian.com
+# Welcome to [manage.theguardian.com](https://manage.theguardian.com) repo!
+🤝 This code is owned by the SR Value team, please feel free to [join our chat room](https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg) for advice 🤝
 
-This README contains mainly set-up information.
+💡 This README contains mainly set-up information. 💡
 
-[SEE THE WIKI FOR MAIN DOCUMENTATION!](https://github.com/guardian/manage-frontend/wiki)
+[Please see the wiki for the main documentation](https://github.com/guardian/manage-frontend/wiki)
 
 ## Technologies
 


### PR DESCRIPTION
As discussed in support mob it would be useful to make it easier to see which team owns the repo, this PR adds the info to the PR teplate and the readme.

Readme:
![image](https://github.com/guardian/manage-frontend/assets/7304387/e4fbee94-d1ae-4ae8-a4b8-f7f51cf7f888)