### PR TITLE
Create newspaper archive endpoint

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -1,5 +1,6 @@
 export { router as core } from './core';
 export { router as api } from './api';
+export { router as newspaperArchive } from './newspaperArchive';
 export { router as profile } from './profile';
 export { router as frontend } from './mmaFrontend';
 export { router as helpcentre } from './helpCentreFrontend';

--- a/server/routes/newspaperArchive.ts
+++ b/server/routes/newspaperArchive.ts
@@ -3,6 +3,16 @@ import type { Request, Response } from 'express';
 import fetch from 'node-fetch';
 import { withIdentity } from '../middleware/identityMiddleware';
 
+type NewspapersRequestBody = {
+	expires?: number; // defaults to 24 hours
+	'query-string'?: string;
+};
+
+// { url: "https://<subdomain>.newspapers.com/…?tpa=<token>" }
+type NewspapersResponseBody = {
+	url: string;
+};
+
 function base64(input: string) {
 	return Buffer.from(input).toString('base64');
 }
@@ -12,13 +22,9 @@ router.use(withIdentity(401));
 
 router.get('/auth', async (_req: Request, res: Response) => {
 	const subdomain = 'theguardian';
-	const authKey = process.env.newspaperArchive;
+	const authKey = '';
 	const authHeader = base64(`${subdomain}:${authKey}`);
-	const requestBody = {
-		expires: 86400, // optional, defaults to 24 hours,
-		'query-string':
-			'xid=1234&utm_campaign=awesome-campaign&utm_medium=referral&utm_source=editorial&utm_content=&utm_term=',
-	};
+	const requestBody: NewspapersRequestBody = {};
 
 	const response = await fetch(
 		'https://www.newspapers.com/api/userauth/public/get-tpa-token',
@@ -30,9 +36,9 @@ router.get('/auth', async (_req: Request, res: Response) => {
 			method: 'POST',
 			body: JSON.stringify(requestBody),
 		},
-	); // { url: "https://<subdomain>.newspapers.com/…?tpa=<token>" }
+	);
 
-	const responseJson = await response.json();
+	const responseJson = (await response.json()) as NewspapersResponseBody;
 	res.redirect(responseJson.url);
 });
 

--- a/server/routes/newspaperArchive.ts
+++ b/server/routes/newspaperArchive.ts
@@ -1,0 +1,39 @@
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import fetch from 'node-fetch';
+import { withIdentity } from '../middleware/identityMiddleware';
+
+function base64(input: string) {
+	return Buffer.from(input).toString('base64');
+}
+
+const router = Router();
+router.use(withIdentity(401));
+
+router.get('/auth', async (_req: Request, res: Response) => {
+	const subdomain = 'theguardian';
+	const authKey = process.env.newspaperArchive;
+	const authHeader = base64(`${subdomain}:${authKey}`);
+	const requestBody = {
+		expires: 86400, // optional, defaults to 24 hours,
+		'query-string':
+			'xid=1234&utm_campaign=awesome-campaign&utm_medium=referral&utm_source=editorial&utm_content=&utm_term=',
+	};
+
+	const response = await fetch(
+		'https://www.newspapers.com/api/userauth/public/get-tpa-token',
+		{
+			headers: {
+				Authorization: `Basic ${authHeader}`,
+				'Content-Type': 'application/json',
+			},
+			method: 'POST',
+			body: JSON.stringify(requestBody),
+		},
+	); // { url: "https://<subdomain>.newspapers.com/…?tpa=<token>" }
+
+	const responseJson = await response.json();
+	res.redirect(responseJson.url);
+});
+
+export { router };

--- a/server/server.ts
+++ b/server/server.ts
@@ -120,6 +120,7 @@ server.use(routes.core);
 server.use('/oauth', routes.oauth);
 server.use('/profile/', routes.profile);
 server.use('/api/', routes.api);
+server.use('/newspaperArchive', routes.newspaperArchive);
 server.use('/idapi', routes.idapi);
 server.use('/mpapi', routes.mpapi);
 server.use('/aapi', routes.aapi);


### PR DESCRIPTION
An authentication endpoint to give users access to newspapers.com archive of the Guardian using their third party authentication endpoint.

Creates a new route at `/newspaperArchive/auth` that redirects to the URL returned by their API.

This relies on a new S3 secret for the auth key, which I've uploaded for DEV, CODE and PROD

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->

## Why are we doing this?

We want to test this as a benefit to the Tier 3 product, initially the user experience will be a link within MMA only for those with this product. For the test we won't be checking the product in the endpoint but at the client side logic rendering the link.
