### PR TITLE
Fix flaky cypress tests to use `data-cy`

### DIFF
--- a/client/__tests__/components/identity/__snapshots__/NewsletterPreference.test.tsx.snap
+++ b/client/__tests__/components/identity/__snapshots__/NewsletterPreference.test.tsx.snap
@@ -114,6 +114,7 @@ exports[`NewsletterPreference component renders correctly and displays marketing
 
 <div
   className="emotion-0"
+  data-cy="13"
   onClick={[Function]}
 >
   <div
@@ -292,6 +293,7 @@ exports[`NewsletterPreference component will select the checkbox when the select
 
 <div
   className="emotion-0"
+  data-cy="13"
   onClick={[Function]}
 >
   <div

--- a/client/components/mma/identity/MarketingCheckbox.tsx
+++ b/client/components/mma/identity/MarketingCheckbox.tsx
@@ -40,6 +40,7 @@ export const MarketingCheckbox: FC<MarketingCheckboxProps> = (props) => {
 	const { id, description, selected, title, onClick } = props;
 	return (
 		<div
+			data-cy={id}
 			onClick={(e) => {
 				// Checkboxes inside labels will trigger click events twice.
 				// Ignore the input click event

--- a/client/components/mma/identity/MarketingToggle.tsx
+++ b/client/components/mma/identity/MarketingToggle.tsx
@@ -21,6 +21,7 @@ export const MarketingToggle: FC<MarketingToggleProps> = (props) => {
 	const { id, description, selected, title, onClick } = props;
 	return (
 		<div
+			data-cy={id}
 			css={[
 				standardSansText,
 				props.divCss ??

--- a/client/components/mma/identity/NewsletterPreference.tsx
+++ b/client/components/mma/identity/NewsletterPreference.tsx
@@ -93,6 +93,7 @@ export const NewsletterPreference: FC<NewsletterPreferenceProps> = (props) => {
 	} = props;
 	return (
 		<div
+			data-cy={id}
 			onClick={(e) => {
 				// Checkboxes inside labels will trigger click events twice.
 				// Ignore the input click event

--- a/client/fixtures/consents.ts
+++ b/client/fixtures/consents.ts
@@ -63,7 +63,7 @@ export const consents = [
 		isOptOut: false,
 		isChannel: false,
 		isProduct: false,
-		name: 'Guardian products and support',
+		name: 'Similar Guardian products',
 		description:
 			'Information on our products and ways to support and enjoy our independent journalism.',
 	},

--- a/cypress/tests/e2e/e2e.cy.ts
+++ b/cypress/tests/e2e/e2e.cy.ts
@@ -34,9 +34,9 @@ describe('E2E with Okta', () => {
 	context('emails tab', () => {
 		it('should allow the user to update their email preferences', () => {
 			cy.visit('/email-prefs');
-			cy.findByText('Guardian products and support').click();
+			cy.get('[data-cy="similar_guardian_products"]').click();
 			cy.visit('/email-prefs');
-			cy.findByText('Guardian products and support')
+			cy.get('[data-cy="similar_guardian_products"]')
 				.parents('div')
 				.get('input[type="checkbox"]')
 				.should('be.checked');

--- a/cypress/tests/mocked/parallel-6/emailAndMarketing.cy.ts
+++ b/cypress/tests/mocked/parallel-6/emailAndMarketing.cy.ts
@@ -63,7 +63,7 @@ describe('Email and Marketing page', () => {
 		cy.wait('@consents');
 		cy.wait('@reminders');
 
-		cy.findByText('Guardian products and support');
+		cy.get('[data-cy="similar_guardian_products"]');
 		cy.findByText('Your subscription/support');
 		cy.findByText('Supporter newsletter');
 	});
@@ -90,7 +90,7 @@ describe('Email and Marketing page', () => {
 		cy.wait('@consents');
 		cy.wait('@reminders');
 
-		cy.findByText('Guardian products and support');
+		cy.get('[data-cy="similar_guardian_products"]');
 		cy.findByText('Your subscription/support');
 		cy.findByText('Supporter newsletter');
 	});


### PR DESCRIPTION
### Current situation/background

We used a string label to target a checkbox in our Cypress tests - this has broken because the label changed in the backend.

### What does this PR change?

We now set the `data-cy` HTML attribute to the id of the newsletter/consent for that checkbox. The ID never changes even if the label does, so this will make our tests much more reliable.

### Testing

Tested by the tests passing!
