### PR TITLE
Fix set username component by not throwing on incomplete user object

### DIFF
--- a/client/components/mma/identity/idapi/user.ts
+++ b/client/components/mma/identity/idapi/user.ts
@@ -137,7 +137,9 @@ export const toUser = (response: UserAPIResponse): User => {
 		localNumber: getFromUser('privateFields.telephoneNumber.localNumber'),
 		registrationLocation: getFromUser('privateFields.registrationLocation'),
 		consents,
-		validated: user.statusFields.userEmailValidated,
+		// We don't always receive a full user response from IDAPI, so we shouldn't
+		// assume that the statusFields object is always present.
+		validated: user?.statusFields?.userEmailValidated,
 	};
 };
 


### PR DESCRIPTION
### Current situation/background

When the user sets their username, on success, the API returns a partial user response object containing only the new username. In the MMA handler, we assume that the user response is always at least complete enough to include the  `user.statusFields` property, which it doesn't in this case - the handler throws as a result. The UX is that the user sees an error message when setting their username even though the call succeeds, and the form field doesn't disappear, meaning they can keep trying to change their username, getting more and more confused each time until they leave the Guardian and never come back.

### What does this PR change?

We make the fetch for the `user.statusFields` property optional.
