### PR TITLE
restrict switch journey for supporter plus subs

### DIFF
--- a/client/components/mma/switch/options/SwitchOptions.tsx
+++ b/client/components/mma/switch/options/SwitchOptions.tsx
@@ -130,6 +130,32 @@ export const SwitchOptions = () => {
 
 	const navigate = useNavigate();
 
+	if (contributionToSwitch.tier === 'Supporter Plus') {
+		return (
+			<section css={sectionSpacing}>
+				<ErrorSummary
+					cssOverrides={errorSummaryOverrideCss}
+					message="There is a problem with your subscription type"
+					context={
+						<>
+							Your subscription does not allow you to perform this
+							switch.
+							<Link
+								css={[
+									errorSummaryLinkCss,
+									errorSummaryBlockLinkCss,
+								]}
+								to="/"
+							>
+								Return to account overview
+							</Link>
+						</>
+					}
+				/>
+			</section>
+		);
+	}
+
 	return (
 		<>
 			{contributionToSwitch.alertText && (

--- a/cypress/tests/mocked/parallel-2/productSwitch.cy.ts
+++ b/cypress/tests/mocked/parallel-2/productSwitch.cy.ts
@@ -9,6 +9,7 @@ import {
 	contributionPaidByPayPalAboveSupporterPlusThreshold,
 	contributionWithPaymentFailure,
 	nonServicedCountryContributor,
+	supporterPlusMonthlyAllAccessDigital,
 } from '../../../../client/fixtures/productBuilder/testProducts';
 
 const setSignInStatus = () => {
@@ -121,6 +122,22 @@ describe('product switching', () => {
 		).should('exist');
 
 		cy.get('@mdapi_get_contribution.all').should('have.length', 1);
+	});
+
+	it('Does not allow switching from supporter plus to supporter plus', () => {
+		cy.intercept('GET', '/api/me/mma*', {
+			statusCode: 200,
+			body: toMembersDataApiResponse(
+				supporterPlusMonthlyAllAccessDigital(),
+			),
+		});
+
+		cy.visit('/switch');
+		setSignInStatus();
+
+		cy.findByText('There is a problem with your subscription type').should(
+			'exist',
+		);
 	});
 
 	it('Does not allow user to navigate back to switch review and confirmation pages after switch completion', () => {


### PR DESCRIPTION
### What does this PR change?
Stop people with supporter plus subscriptions from using the contribution to supporter plus switch journey

### Images
![Screenshot 2024-07-17 at 17 53 35](https://github.com/user-attachments/assets/6ad8fce3-2c85-4b7a-b6ac-2ad4bd781ff9)

This is just a little clientside nicety. It seems as though we were getting some traffic to the /switch route from users with a supporter plus subscription, which shouldn't be possible unless they have manually gone to this url, instead of letting them attempt a failed switch we can show the user an error message and send them off to the account overview.
