### PR TITLE
Add new help centre banner

### DIFF
--- a/client/components/helpCentre/HelpCentrePage.tsx
+++ b/client/components/helpCentre/HelpCentrePage.tsx
@@ -77,7 +77,13 @@ const HelpCentreRouter = () => {
 	]
 	*/
 
-	const knownIssues: KnownIssueObj[] = [];
+	const knownIssues: KnownIssueObj[] = [
+		{
+			date: '7th Aug 2024 5:00 pm',
+			message:
+				'We are experiencing an unexpected interruption across Customer Service phone lines and live chat. We recommend contacting us via email until full service is restored.',
+		},
+	];
 
 	return (
 		<Main signInStatus={signInStatus} isHelpCentrePage>


### PR DESCRIPTION
### Current situation/background

New help centre banner copy requested by customer operations.

### What does this PR change?

Adds the new help centre banner copy.

In CODE:

<img width="1051" alt="Screenshot 2024-08-07 at 13 57 45" src="https://github.com/user-attachments/assets/75fe792b-d384-4b0a-8903-569e555dcc0f">


### Next steps/further info

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->
