### PR TITLE
stop cancelled supporter plus users from being able to change their c…

### DIFF
--- a/client/components/mma/accountoverview/ManageProduct.tsx
+++ b/client/components/mma/accountoverview/ManageProduct.tsx
@@ -109,7 +109,8 @@ const InnerContent = ({
 
 	const showSupporterPlusUpdateAmount =
 		specificProductType.productType === 'supporterplus' &&
-		featureSwitches.supporterPlusUpdateAmount;
+		featureSwitches.supporterPlusUpdateAmount &&
+		!hasCancellationPending;
 
 	return (
 		<>

--- a/cypress/tests/mocked/parallel-1/updateContributionAmount.cy.ts
+++ b/cypress/tests/mocked/parallel-1/updateContributionAmount.cy.ts
@@ -1,5 +1,6 @@
 import {
 	contributionPaidByCard,
+	supporterPlusCancelled,
 	supporterPlusMonthlyAllAccessDigital,
 	supporterPlusMonthlyAllAccessDigitalBeforePriceRise,
 } from '../../../../client/fixtures/productBuilder/testProducts';
@@ -116,6 +117,19 @@ describe('Update contribution amount', () => {
 		cy.contains(
 			'We have successfully updated the amount of your support.',
 		).should('exist');
+	});
+
+	it('Should not be able to change amount of cancelled supporterplus', () => {
+		cy.intercept('GET', '/api/me/mma', {
+			statusCode: 200,
+			body: toMembersDataApiResponse(supporterPlusCancelled()),
+		});
+		cy.visit('/?withFeature=supporterPlusUpdateAmount');
+
+		setSignInStatus();
+
+		cy.findByText('Manage subscription').click();
+		cy.wait('@cancelled');
 	});
 
 	it('Updates supporter plus amount (for user on old lower min amount)', () => {

--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -693,6 +693,8 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 			SoftOptInIDs.SupporterNewsletter,
 			SoftOptInIDs.DigitalSubscriberPreview,
 		],
+		cancelledCopy:
+			'Your subscription has been cancelled. You are able to access your subscription until',
 		cancellation: {
 			alternateSummaryMainPara:
 				"This is immediate and you will not be charged again. If you've cancelled within the first 14 days, we'll send you a full refund.",


### PR DESCRIPTION
### What does this PR change?
Stop cancelled supporter plus users from being able to change their contrubution amount.

Copy fix to show cancellation date prefix copy on manage product page before the cancellation date.

### Images
Before            |  After
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/4460f35a-5386-46fc-86a1-0e036be7a5ae)  |  ![](https://github.com/user-attachments/assets/4a7f9947-9f33-4fbe-bb57-e773754d0a94)


