### PR TITLE
Use discount api response for cancellation offer payment date

### DIFF
--- a/client/components/mma/cancel/Cancellation.stories.tsx
+++ b/client/components/mma/cancel/Cancellation.stories.tsx
@@ -98,6 +98,7 @@ export const Offer: StoryObj<typeof CancellationContainer> = {
 				upToPeriodsType: 'months',
 				firstDiscountedPaymentDate: '2024-05-30',
 				nextNonDiscountedPaymentDate: '2024-07-30',
+				nonDiscountedPayments: [{ date: '2024-07-30', amount: 14.99 }],
 			},
 		},
 	},
@@ -116,6 +117,7 @@ export const OfferReview: StoryObj<typeof CancellationContainer> = {
 				upToPeriodsType: 'months',
 				firstDiscountedPaymentDate: '2024-05-30',
 				nextNonDiscountedPaymentDate: '2024-07-30',
+				nonDiscountedPayments: [{ date: '2024-07-30', amount: 14.99 }],
 			},
 		},
 		msw: [
@@ -136,6 +138,7 @@ export const OfferConfirmed: StoryObj<typeof CancellationContainer> = {
 		reactRouter: {
 			state: {
 				nextNonDiscountedPaymentDate: '2024-07-30',
+				nonDiscountedPayments: [{ date: '2024-07-30', amount: 14.99 }],
 			},
 		},
 	},
@@ -156,6 +159,9 @@ export const SupportplusCancelConfirm: StoryObj<typeof CancellationContainer> =
 					upToPeriodsType: 'months',
 					firstDiscountedPaymentDate: '2024-05-30',
 					nextNonDiscountedPaymentDate: '2024-07-30',
+					nonDiscountedPayments: [
+						{ date: '2024-07-30', amount: 14.99 },
+					],
 				},
 			},
 		},

--- a/client/components/mma/cancel/cancellationSaves/supporterplus/SupporterPlusOffer.tsx
+++ b/client/components/mma/cancel/cancellationSaves/supporterplus/SupporterPlusOffer.tsx
@@ -19,6 +19,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { Ribbon } from '@/client/components/shared/Ribbon';
 import { measure } from '@/client/styles/typography';
 import type { DiscountPreviewResponse } from '@/client/utilities/discountPreview';
+import { getMaxNonDiscountedPrice } from '@/client/utilities/discountPreview';
 import { DATE_FNS_LONG_OUTPUT_FORMAT, parseDate } from '@/shared/dates';
 import { number2words } from '@/shared/numberUtils';
 import { getMainPlan, isPaidSubscriptionPlan } from '@/shared/productResponse';
@@ -175,13 +176,10 @@ export const SupporterPlusOffer = () => {
 		'yyyy-MM-dd',
 	).dateStr(DATE_FNS_LONG_OUTPUT_FORMAT);
 
-	const strikethroughPrice = routerState.nonDiscountedPayments.reduce(
-		(prev, current) =>
-			prev && prev.amount > current.amount ? prev : current,
-	).amount;
-	const humanReadableStrikethroughPrice = Number.isInteger(strikethroughPrice)
-		? strikethroughPrice
-		: strikethroughPrice.toFixed(2);
+	const humanReadableStrikethroughPrice = getMaxNonDiscountedPrice(
+		routerState.nonDiscountedPayments,
+		true,
+	);
 
 	return (
 		<>

--- a/client/components/mma/cancel/cancellationSaves/supporterplus/SupporterPlusOffer.tsx
+++ b/client/components/mma/cancel/cancellationSaves/supporterplus/SupporterPlusOffer.tsx
@@ -175,6 +175,14 @@ export const SupporterPlusOffer = () => {
 		'yyyy-MM-dd',
 	).dateStr(DATE_FNS_LONG_OUTPUT_FORMAT);
 
+	const strikethroughPrice = routerState.nonDiscountedPayments.reduce(
+		(prev, current) =>
+			prev && prev.amount > current.amount ? prev : current,
+	).amount;
+	const humanReadableStrikethroughPrice = Number.isInteger(strikethroughPrice)
+		? strikethroughPrice
+		: strikethroughPrice.toFixed(2);
+
 	return (
 		<>
 			<ProgressStepper
@@ -220,7 +228,8 @@ export const SupporterPlusOffer = () => {
 						<p css={strikethroughPriceCss}>
 							<s>
 								{mainPlan.currency}
-								{mainPlan.price / 100}/{mainPlan.billingPeriod}
+								{humanReadableStrikethroughPrice}/
+								{mainPlan.billingPeriod}
 							</s>
 						</p>
 					)}

--- a/client/components/mma/cancel/cancellationSaves/supporterplus/SupporterPlusOfferConfirmed.tsx
+++ b/client/components/mma/cancel/cancellationSaves/supporterplus/SupporterPlusOfferConfirmed.tsx
@@ -13,6 +13,7 @@ import { useContext, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { measure } from '@/client/styles/typography';
 import type { DiscountPreviewResponse } from '@/client/utilities/discountPreview';
+import { getMaxNonDiscountedPrice } from '@/client/utilities/discountPreview';
 import { DATE_FNS_LONG_OUTPUT_FORMAT, parseDate } from '@/shared/dates';
 import type { PaidSubscriptionPlan } from '@/shared/productResponse';
 import { getMainPlan } from '@/shared/productResponse';
@@ -186,15 +187,10 @@ export const SupporterPlusOfferConfirmed = () => {
 		'yyyy-MM-dd',
 	).dateStr(DATE_FNS_LONG_OUTPUT_FORMAT);
 
-	const nextNonDiscountedPrice = routerState.nonDiscountedPayments.reduce(
-		(prev, current) =>
-			prev && prev.amount > current.amount ? prev : current,
-	).amount;
-	const humanReadableNextNonDiscountedPrice = Number.isInteger(
-		nextNonDiscountedPrice,
-	)
-		? nextNonDiscountedPrice
-		: nextNonDiscountedPrice.toFixed(2);
+	const humanReadableNextNonDiscountedPrice = getMaxNonDiscountedPrice(
+		routerState.nonDiscountedPayments,
+		true,
+	);
 
 	return (
 		<>

--- a/client/components/mma/cancel/cancellationSaves/supporterplus/SupporterPlusOfferConfirmed.tsx
+++ b/client/components/mma/cancel/cancellationSaves/supporterplus/SupporterPlusOfferConfirmed.tsx
@@ -14,6 +14,8 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { measure } from '@/client/styles/typography';
 import type { DiscountPreviewResponse } from '@/client/utilities/discountPreview';
 import { DATE_FNS_LONG_OUTPUT_FORMAT, parseDate } from '@/shared/dates';
+import type { PaidSubscriptionPlan } from '@/shared/productResponse';
+import { getMainPlan } from '@/shared/productResponse';
 import { DownloadAppCta } from '../../../shared/DownloadAppCta';
 import { Heading } from '../../../shared/Heading';
 import type {
@@ -170,6 +172,9 @@ export const SupporterPlusOfferConfirmed = () => {
 	) as CancellationContextInterface;
 
 	const productDetail = cancellationContext.productDetail;
+	const mainPlan = getMainPlan(
+		productDetail.subscription,
+	) as PaidSubscriptionPlan;
 
 	useEffect(() => {
 		pageTitleContext.setPageTitle('Confirmation');
@@ -180,6 +185,16 @@ export const SupporterPlusOfferConfirmed = () => {
 		routerState.nextNonDiscountedPaymentDate,
 		'yyyy-MM-dd',
 	).dateStr(DATE_FNS_LONG_OUTPUT_FORMAT);
+
+	const nextNonDiscountedPrice = routerState.nonDiscountedPayments.reduce(
+		(prev, current) =>
+			prev && prev.amount > current.amount ? prev : current,
+	).amount;
+	const humanReadableNextNonDiscountedPrice = Number.isInteger(
+		nextNonDiscountedPrice,
+	)
+		? nextNonDiscountedPrice
+		: nextNonDiscountedPrice.toFixed(2);
 
 	return (
 		<>
@@ -210,7 +225,10 @@ export const SupporterPlusOfferConfirmed = () => {
 					</li>
 					<li>
 						You will not be billed until{' '}
-						{nextNonDiscountedPaymentDate}
+						{nextNonDiscountedPaymentDate} after which you will pay{' '}
+						{mainPlan.currency}
+						{humanReadableNextNonDiscountedPrice}/
+						{mainPlan.billingPeriod}
 					</li>
 				</ul>
 			</div>

--- a/client/components/mma/cancel/cancellationSaves/supporterplus/SupporterPlusOfferReview.tsx
+++ b/client/components/mma/cancel/cancellationSaves/supporterplus/SupporterPlusOfferReview.tsx
@@ -127,6 +127,14 @@ export const SupporterPlusOfferReview = () => {
 		'yyyy-MM-dd',
 	).dateStr(DATE_FNS_LONG_OUTPUT_FORMAT);
 
+	const strikethroughPrice = routerState.nonDiscountedPayments.reduce(
+		(prev, current) =>
+			prev && prev.amount > current.amount ? prev : current,
+	).amount;
+	const humanReadableStrikethroughPrice = Number.isInteger(strikethroughPrice)
+		? strikethroughPrice
+		: strikethroughPrice.toFixed(2);
+
 	const [performingDiscountStatus, setPerformingDiscountStatus] =
 		useState<OfferApiCallStatus>('NOT_READY');
 
@@ -194,7 +202,8 @@ export const SupporterPlusOfferReview = () => {
 					<p css={strikethroughPriceCss}>
 						<s>
 							{mainPlan.currency}
-							{mainPlan.price / 100}/{mainPlan.billingPeriod}
+							{humanReadableStrikethroughPrice}/
+							{mainPlan.billingPeriod}
 						</s>
 					</p>
 				)}

--- a/client/components/mma/cancel/cancellationSaves/supporterplus/SupporterPlusOfferReview.tsx
+++ b/client/components/mma/cancel/cancellationSaves/supporterplus/SupporterPlusOfferReview.tsx
@@ -18,6 +18,7 @@ import { useContext, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { measure } from '@/client/styles/typography';
 import type { DiscountPreviewResponse } from '@/client/utilities/discountPreview';
+import { getMaxNonDiscountedPrice } from '@/client/utilities/discountPreview';
 import { fetchWithDefaultParameters } from '@/client/utilities/fetch';
 import { DATE_FNS_LONG_OUTPUT_FORMAT, parseDate } from '@/shared/dates';
 import { number2words } from '@/shared/numberUtils';
@@ -127,13 +128,10 @@ export const SupporterPlusOfferReview = () => {
 		'yyyy-MM-dd',
 	).dateStr(DATE_FNS_LONG_OUTPUT_FORMAT);
 
-	const strikethroughPrice = routerState.nonDiscountedPayments.reduce(
-		(prev, current) =>
-			prev && prev.amount > current.amount ? prev : current,
-	).amount;
-	const humanReadableStrikethroughPrice = Number.isInteger(strikethroughPrice)
-		? strikethroughPrice
-		: strikethroughPrice.toFixed(2);
+	const humanReadableStrikethroughPrice = getMaxNonDiscountedPrice(
+		routerState.nonDiscountedPayments,
+		true,
+	);
 
 	const [performingDiscountStatus, setPerformingDiscountStatus] =
 		useState<OfferApiCallStatus>('NOT_READY');

--- a/client/utilities/discountPreview.ts
+++ b/client/utilities/discountPreview.ts
@@ -1,8 +1,27 @@
+interface NonDiscountedPayments {
+	date: string;
+	amount: number;
+}
+
 export type DiscountPreviewResponse = {
 	discountedPrice: number;
 	upToPeriods: number;
 	upToPeriodsType: string;
 	firstDiscountedPaymentDate: string;
 	nextNonDiscountedPaymentDate: string;
-	nonDiscountedPayments: Array<{ date: string; amount: number }>;
+	nonDiscountedPayments: NonDiscountedPayments[];
+};
+
+export const getMaxNonDiscountedPrice = (
+	nonDiscountedPayments: NonDiscountedPayments[],
+	asHumanReadable?: boolean,
+) => {
+	const allNonDiscountedAmounts = nonDiscountedPayments.map((p) => p.amount);
+	const maxNonDiscountedPrice = Math.max(...allNonDiscountedAmounts);
+	if (!asHumanReadable) {
+		return maxNonDiscountedPrice;
+	}
+	return Number.isInteger(maxNonDiscountedPrice)
+		? maxNonDiscountedPrice
+		: maxNonDiscountedPrice.toFixed(2);
 };

--- a/client/utilities/discountPreview.ts
+++ b/client/utilities/discountPreview.ts
@@ -4,4 +4,5 @@ export type DiscountPreviewResponse = {
 	upToPeriodsType: string;
 	firstDiscountedPaymentDate: string;
 	nextNonDiscountedPaymentDate: string;
+	nonDiscountedPayments: Array<{ date: string; amount: number }>;
 };

--- a/cypress/tests/mocked/parallel-2/cancelSupporterPlus.cy.ts
+++ b/cypress/tests/mocked/parallel-2/cancelSupporterPlus.cy.ts
@@ -149,6 +149,7 @@ describe('Cancel Supporter Plus', () => {
 			upToPeriodsType: 'Months',
 			firstDiscountedPaymentDate: '2024-05-30',
 			nextNonDiscountedPaymentDate: '2024-07-30',
+			nonDiscountedPayments: [{ date: '2024-07-30', amount: 14.5 }],
 		};
 		it('user accepts offer instead of cancelling', () => {
 			cy.intercept('GET', '/api/me/mma', {
@@ -183,6 +184,8 @@ describe('Cancel Supporter Plus', () => {
 			cy.findByRole('button', {
 				name: 'Continue to cancellation',
 			}).click();
+
+			cy.findByText('£14.50/month');
 
 			cy.findByRole('button', { name: 'Redeem your offer' }).click();
 


### PR DESCRIPTION
### What does this PR change?

Use the discount api response to return the next payment price (after the cancellation offer period ends). This should handle the case where the returning payment price will be different from the price paid before the offer was taken up, a price rise for example 👍 

![Screenshot 2024-09-06 at 14 19 43](https://github.com/user-attachments/assets/c166bc68-3b85-4e15-9c9e-b41c3387f9fc)
