### PR TITLE
Identity | Replace "Similar Guardian products" with "Guardian products and services"

### DIFF
--- a/client/components/mma/identity/emailAndMarketing/ConsentSection.tsx
+++ b/client/components/mma/identity/emailAndMarketing/ConsentSection.tsx
@@ -19,7 +19,7 @@ const supportReminderConsent = (consents: ConsentOption[]): ConsentOption[] =>
 
 const marketingEmailConsents = (consents: ConsentOption[]): ConsentOption[] => {
 	const ids = [
-		'similar_guardian_products',
+		'guardian_products_services',
 		'supporter',
 		'jobs',
 		'events',

--- a/client/fixtures/consents.ts
+++ b/client/fixtures/consents.ts
@@ -59,13 +59,13 @@ export const consents = [
 			'Receive weekly newsletters about our upcoming Live events and Masterclasses. Interact with leading minds and nourish your curiosity in our immersive online events, available worldwide.',
 	},
 	{
-		id: 'similar_guardian_products',
+		id: 'guardian_products_services',
 		isOptOut: false,
 		isChannel: false,
 		isProduct: false,
-		name: 'Similar Guardian products',
+		name: 'Guardian products and services',
 		description:
-			'Information on our products and ways to support and enjoy our independent journalism.',
+			'Receive information on our products and ways to support and enjoy our journalism.',
 	},
 	{
 		id: 'market_research_optout',

--- a/client/fixtures/user.ts
+++ b/client/fixtures/user.ts
@@ -90,7 +90,7 @@ export const user = {
 			},
 			{
 				actor: 'user',
-				id: 'similar_guardian_products',
+				id: 'guardian_products_services',
 				version: 0,
 				consented: false,
 				timestamp: '2021-11-23T22:43:25Z',

--- a/cypress/tests/e2e/e2e.cy.ts
+++ b/cypress/tests/e2e/e2e.cy.ts
@@ -34,9 +34,9 @@ describe('E2E with Okta', () => {
 	context('emails tab', () => {
 		it('should allow the user to update their email preferences', () => {
 			cy.visit('/email-prefs');
-			cy.get('[data-cy="similar_guardian_products"]').click();
+			cy.get('[data-cy="guardian_products_services"]').click();
 			cy.visit('/email-prefs');
-			cy.get('[data-cy="similar_guardian_products"]')
+			cy.get('[data-cy="guardian_products_services"]')
 				.parents('div')
 				.get('input[type="checkbox"]')
 				.should('be.checked');

--- a/cypress/tests/mocked/parallel-6/emailAndMarketing.cy.ts
+++ b/cypress/tests/mocked/parallel-6/emailAndMarketing.cy.ts
@@ -63,7 +63,7 @@ describe('Email and Marketing page', () => {
 		cy.wait('@consents');
 		cy.wait('@reminders');
 
-		cy.get('[data-cy="similar_guardian_products"]');
+		cy.get('[data-cy="guardian_products_services"]');
 		cy.findByText('Your subscription/support');
 		cy.findByText('Supporter newsletter');
 	});
@@ -90,7 +90,7 @@ describe('Email and Marketing page', () => {
 		cy.wait('@consents');
 		cy.wait('@reminders');
 
-		cy.get('[data-cy="similar_guardian_products"]');
+		cy.get('[data-cy="guardian_products_services"]');
 		cy.findByText('Your subscription/support');
 		cy.findByText('Supporter newsletter');
 	});


### PR DESCRIPTION
### What does this PR change?

There is some work to replace the "Similar Guardian products" (`similar_guardian_products`) consent with the "Guardian products and services" (`guardian_products_services`) consent. This PR does just that.

After a backfill is performed to add the `guardian_products_services` consent to users, the `similar_guardian_products` consent will no longer be used, and readers will need a way to opt out from the "Guardian products and services" consent, and no longer be able to opt out of the "Similar Guardian products" consent

### Next steps/further info

- Do not merge until the backfill is finished
- A sibling PR in Gateway updates the create account flow to use  "Guardian products and services": https://github.com/guardian/gateway/pull/2913

### Tested

- [x] CODE - Deploy this build and the Gateway build
