### PR TITLE
fix(accessibility): Improve accessibility of "Email & Marketing" page.

### DIFF
--- a/client/__tests__/components/identity/MarketingCheckbox.test.tsx
+++ b/client/__tests__/components/identity/MarketingCheckbox.test.tsx
@@ -26,7 +26,7 @@ describe('MarketingCheckbox component', () => {
 		render(marketingCheckbox(false));
 
 		const checkboxRoles = screen.getAllByRole('checkbox');
-		expect(checkboxRoles).toHaveLength(2);
+		expect(checkboxRoles).toHaveLength(1);
 		checkboxRoles.map((role) => expect(role).not.toBeChecked());
 
 		expect(screen.getByText('Test title')).toBeVisible();

--- a/client/__tests__/components/identity/__snapshots__/DropMenu.test.tsx.snap
+++ b/client/__tests__/components/identity/__snapshots__/DropMenu.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`DropMenu displays the text in the supplied color 1`] = `
   font-weight: bold;
   line-height: 24px;
   text-transform: capitalize;
+  display: block;
   color: green;
 }
 
@@ -47,13 +48,23 @@ exports[`DropMenu displays the text in the supplied color 1`] = `
 
 <div
   className="emotion-0"
+  role="heading"
 >
-  <div
+  <a
+    aria-controls=":r0:"
+    aria-expanded={false}
     className="emotion-1"
+    href="#"
+    id=":r0:"
     onClick={[Function]}
+    onKeyDown={[Function]}
+    role="button"
   >
     TEST DROPMENU
-  </div>
+  </a>
+  <div
+    id=":r0:"
+  />
 </div>
 `;
 
@@ -72,6 +83,7 @@ exports[`DropMenu if closed, opens and shows children on click 1`] = `
   font-weight: bold;
   line-height: 24px;
   text-transform: capitalize;
+  display: block;
   color: blue;
 }
 
@@ -105,15 +117,25 @@ exports[`DropMenu if closed, opens and shows children on click 1`] = `
 <div>
   <div
     class="emotion-0"
+    role="heading"
   >
-    <div
+    <a
+      aria-controls=":r1:"
+      aria-expanded="true"
       class="open emotion-1"
+      href="#"
+      id=":r1:"
+      role="button"
     >
       TEST DROPMENU
+    </a>
+    <div
+      id=":r1:"
+    >
+      <p>
+        TEST_CONTENT
+      </p>
     </div>
-    <p>
-      TEST_CONTENT
-    </p>
   </div>
 </div>
 `;
@@ -133,6 +155,7 @@ exports[`DropMenu if open, closes and hides children on click 1`] = `
   font-weight: bold;
   line-height: 24px;
   text-transform: capitalize;
+  display: block;
   color: blue;
 }
 
@@ -166,12 +189,21 @@ exports[`DropMenu if open, closes and hides children on click 1`] = `
 <div>
   <div
     class="emotion-0"
+    role="heading"
   >
-    <div
+    <a
+      aria-controls=":r2:"
+      aria-expanded="false"
       class="emotion-1"
+      href="#"
+      id=":r2:"
+      role="button"
     >
       TEST DROPMENU
-    </div>
+    </a>
+    <div
+      id=":r2:"
+    />
   </div>
 </div>
 `;
@@ -191,6 +223,7 @@ exports[`DropMenu initalises in the unopened state and displays the title 1`] = 
   font-weight: bold;
   line-height: 24px;
   text-transform: capitalize;
+  display: block;
   color: blue;
 }
 
@@ -224,12 +257,21 @@ exports[`DropMenu initalises in the unopened state and displays the title 1`] = 
 <div>
   <div
     class="emotion-0"
+    role="heading"
   >
-    <div
+    <a
+      aria-controls=":r0:"
+      aria-expanded="false"
       class="emotion-1"
+      href="#"
+      id=":r0:"
+      role="button"
     >
       TEST DROPMENU
-    </div>
+    </a>
+    <div
+      id=":r0:"
+    />
   </div>
 </div>
 `;

--- a/client/__tests__/components/identity/__snapshots__/NewsletterPreference.test.tsx.snap
+++ b/client/__tests__/components/identity/__snapshots__/NewsletterPreference.test.tsx.snap
@@ -51,13 +51,6 @@ exports[`NewsletterPreference component renders correctly and displays marketing
 
 .emotion-4 {
   position: absolute;
-  z-index: -999999;
-  overflow: hidden;
-  opacity: 0;
-}
-
-.emotion-5 {
-  position: absolute;
   left: 3px;
   top: 5px;
   width: 12px;
@@ -69,7 +62,7 @@ exports[`NewsletterPreference component renders correctly and displays marketing
   text-align: right;
 }
 
-.emotion-6 {
+.emotion-5 {
   width: 2px;
   height: 6px;
   border-color: #FFFFFF;
@@ -80,7 +73,7 @@ exports[`NewsletterPreference component renders correctly and displays marketing
   transition-delay: .1s;
 }
 
-.emotion-7 {
+.emotion-6 {
   font-size: 14px;
   font-family: "Guardian Text Sans Web","Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
   cursor: pointer;
@@ -91,24 +84,24 @@ exports[`NewsletterPreference component renders correctly and displays marketing
   margin: 0;
 }
 
-.emotion-8 {
+.emotion-7 {
   padding: 2.88px 0 0 0;
 }
 
-.emotion-9 {
+.emotion-8 {
   font-size: 12px;
   line-height: 16px;
   margin: 3px 0 0 0;
   opacity: 0.75;
 }
 
-.emotion-10 {
+.emotion-9 {
   display: inline-block;
   margin-right: 8px;
   vertical-align: middle;
 }
 
-.emotion-11 {
+.emotion-10 {
   fill: #DCDCDC;
 }
 
@@ -125,47 +118,40 @@ exports[`NewsletterPreference component renders correctly and displays marketing
     >
       <div
         aria-checked={false}
+        aria-label="Test title (Test frequency)"
         className="checkbox emotion-3"
-        onKeyPress={[Function]}
+        onKeyDown={[Function]}
         role="checkbox"
         tabIndex={0}
       >
-        <input
-          checked={false}
-          className="emotion-4"
-          onChange={[Function]}
-          tabIndex={-1}
-          type="checkbox"
-        />
         <div
-          className="emotion-5"
+          className="emotion-4"
         >
           <div
-            className="emotion-6"
+            className="emotion-5"
           />
         </div>
       </div>
-      <span />
     </label>
   </div>
   <p
-    className="emotion-7"
+    className="emotion-6"
   >
     Test title
   </p>
   <p
-    className="emotion-8"
+    className="emotion-7"
   >
     Test description
   </p>
   <p
-    className="emotion-9"
+    className="emotion-8"
   >
     <span
-      className="emotion-10"
+      className="emotion-9"
     >
       <svg
-        className="emotion-11"
+        className="emotion-10"
         height="11px"
         viewBox="0 0 11 11"
         width="11px"
@@ -230,13 +216,6 @@ exports[`NewsletterPreference component will select the checkbox when the select
 
 .emotion-4 {
   position: absolute;
-  z-index: -999999;
-  overflow: hidden;
-  opacity: 0;
-}
-
-.emotion-5 {
-  position: absolute;
   left: 3px;
   top: 5px;
   width: 12px;
@@ -248,7 +227,7 @@ exports[`NewsletterPreference component will select the checkbox when the select
   text-align: right;
 }
 
-.emotion-6 {
+.emotion-5 {
   width: 12px;
   height: 6px;
   border-color: #FFFFFF;
@@ -259,7 +238,7 @@ exports[`NewsletterPreference component will select the checkbox when the select
   transition-delay: .1s;
 }
 
-.emotion-7 {
+.emotion-6 {
   font-size: 14px;
   font-family: "Guardian Text Sans Web","Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
   cursor: pointer;
@@ -270,24 +249,24 @@ exports[`NewsletterPreference component will select the checkbox when the select
   margin: 0;
 }
 
-.emotion-8 {
+.emotion-7 {
   padding: 2.88px 0 0 0;
 }
 
-.emotion-9 {
+.emotion-8 {
   font-size: 12px;
   line-height: 16px;
   margin: 3px 0 0 0;
   opacity: 0.75;
 }
 
-.emotion-10 {
+.emotion-9 {
   display: inline-block;
   margin-right: 8px;
   vertical-align: middle;
 }
 
-.emotion-11 {
+.emotion-10 {
   fill: #DCDCDC;
 }
 
@@ -304,47 +283,40 @@ exports[`NewsletterPreference component will select the checkbox when the select
     >
       <div
         aria-checked={true}
+        aria-label="Test title (Test frequency)"
         className="checkbox emotion-3"
-        onKeyPress={[Function]}
+        onKeyDown={[Function]}
         role="checkbox"
         tabIndex={0}
       >
-        <input
-          checked={true}
-          className="emotion-4"
-          onChange={[Function]}
-          tabIndex={-1}
-          type="checkbox"
-        />
         <div
-          className="emotion-5"
+          className="emotion-4"
         >
           <div
-            className="emotion-6"
+            className="emotion-5"
           />
         </div>
       </div>
-      <span />
     </label>
   </div>
   <p
-    className="emotion-7"
+    className="emotion-6"
   >
     Test title
   </p>
   <p
-    className="emotion-8"
+    className="emotion-7"
   >
     Test description
   </p>
   <p
-    className="emotion-9"
+    className="emotion-8"
   >
     <span
-      className="emotion-10"
+      className="emotion-9"
     >
       <svg
-        className="emotion-11"
+        className="emotion-10"
         height="11px"
         viewBox="0 0 11 11"
         width="11px"

--- a/client/components/mma/identity/DropMenu.tsx
+++ b/client/components/mma/identity/DropMenu.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { palette } from '@guardian/source/foundations';
 import type { FC, ReactNode } from 'react';
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import { serif } from '../../../styles/fonts';
 
 interface DropMenuProps {
@@ -24,6 +24,7 @@ const headerStyles = css({
 	fontWeight: 'bold',
 	lineHeight: '24px',
 	textTransform: 'capitalize',
+	display: 'block',
 	':after': {
 		content: "''",
 		border: '2px solid currentColor',
@@ -47,16 +48,34 @@ const headerStyles = css({
 export const DropMenu: FC<DropMenuProps> = (props) => {
 	const { children, color, title } = props;
 	const [open, setOpen] = useState(false);
+
+	const dropDownId = useId();
+
 	return (
-		<div css={rootStyles}>
-			<div
+		<div role="heading" css={rootStyles}>
+			<a
+				id={dropDownId}
+				href="#"
+				role="button"
+				aria-expanded={open}
+				aria-controls={dropDownId}
 				className={open ? 'open' : undefined}
 				css={[headerStyles, { color }]}
+				onKeyDown={(e) => {
+					// https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role
+					// Space and Enter should toggle the dropdown. Enter is already handled implicitly by anchors.
+					// This is handled implicitly when using a native input[type="button"] or button.
+					if (e.key === ' ') {
+						// Prevent the page from jumping when the space key is pressed
+						e.preventDefault();
+						setOpen(!open);
+					}
+				}}
 				onClick={() => setOpen(!open)}
 			>
 				{title}
-			</div>
-			{open && children}
+			</a>
+			<div id={dropDownId}>{open && children}</div>
 		</div>
 	);
 };

--- a/client/components/mma/identity/MarketingCheckbox.tsx
+++ b/client/components/mma/identity/MarketingCheckbox.tsx
@@ -5,7 +5,7 @@ import { standardSansText } from './sharedStyles';
 interface MarketingCheckboxProps {
 	id: string;
 	description?: string;
-	title?: string;
+	title: string;
 	selected?: boolean;
 	onClick: (id: string) => {};
 }
@@ -38,18 +38,11 @@ const getDescription = (description: MarketingCheckboxProps['description']) => (
 
 export const MarketingCheckbox: FC<MarketingCheckboxProps> = (props) => {
 	const { id, description, selected, title, onClick } = props;
+
 	return (
 		<div
 			data-cy={id}
-			onClick={(e) => {
-				// Checkboxes inside labels will trigger click events twice.
-				// Ignore the input click event
-				if (
-					e.target instanceof Element &&
-					e.target.nodeName === 'INPUT'
-				) {
-					return;
-				}
+			onClick={() => {
 				onClick(id);
 			}}
 			css={[
@@ -64,9 +57,9 @@ export const MarketingCheckbox: FC<MarketingCheckboxProps> = (props) => {
 			<div css={{ position: 'absolute', left: 0 }}>
 				<Checkbox
 					checked={!!selected}
-					onChange={(_) => {
-						return;
-					}}
+					onChange={() => onClick(id)}
+					label={title}
+					hideLabel={true}
 				/>
 			</div>
 			{title && getTitle(title)}

--- a/client/components/mma/identity/NewsletterPreference.tsx
+++ b/client/components/mma/identity/NewsletterPreference.tsx
@@ -91,34 +91,30 @@ export const NewsletterPreference: FC<NewsletterPreferenceProps> = (props) => {
 		identityName,
 		onClick,
 	} = props;
+	const accessibleLabel = `${title} (${frequency})`;
+
+	const interact = () => {
+		onClick(id);
+		// If we have an identityName id then this is a newsletter subscription event
+		// and we want to log it in Ophan
+		if (identityName) {
+			window?.guardian?.ophan?.record({
+				componentEvent: {
+					component: {
+						componentType: 'NEWSLETTER_SUBSCRIPTION',
+						id: identityName,
+					},
+					action: 'CLICK',
+					value: selected ? 'untick' : 'tick',
+				},
+			});
+		}
+	};
+
 	return (
 		<div
 			data-cy={id}
-			onClick={(e) => {
-				// Checkboxes inside labels will trigger click events twice.
-				// Ignore the input click event
-				if (
-					e.target instanceof Element &&
-					e.target.nodeName === 'INPUT'
-				) {
-					return;
-				}
-				onClick(id);
-				// If we have an identityName id then this is a newsletter subscription event
-				// and we want to log it in Ophan
-				if (identityName) {
-					window?.guardian?.ophan?.record({
-						componentEvent: {
-							component: {
-								componentType: 'NEWSLETTER_SUBSCRIPTION',
-								id: identityName,
-							},
-							action: 'CLICK',
-							value: selected ? 'untick' : 'tick',
-						},
-					});
-				}
-			}}
+			onClick={interact}
 			css={[
 				standardText,
 				{
@@ -132,9 +128,9 @@ export const NewsletterPreference: FC<NewsletterPreferenceProps> = (props) => {
 			<div css={{ position: 'absolute', left: 0 }}>
 				<Checkbox
 					checked={!!selected}
-					onChange={(_) => {
-						return;
-					}}
+					onChange={interact}
+					label={accessibleLabel}
+					hideLabel={true}
 				/>
 			</div>
 			{title && getTitle(title)}

--- a/client/components/mma/shared/Checkbox.stories.tsx
+++ b/client/components/mma/shared/Checkbox.stories.tsx
@@ -8,6 +8,7 @@ export default {
 		checked: false,
 		required: undefined,
 		label: '',
+		hideLabel: false,
 		checkboxFill: undefined,
 		maxWidth: '',
 	},
@@ -33,6 +34,13 @@ export const Checked = {
 export const WithLabel = {
 	args: {
 		label: 'Guardian Weekly newsletter',
+	},
+};
+
+export const WithHiddenLabel = {
+	args: {
+		label: 'Guardian Weekly newsletter',
+		hideLabel: true,
 	},
 };
 

--- a/client/components/mma/shared/Checkbox.tsx
+++ b/client/components/mma/shared/Checkbox.tsx
@@ -1,11 +1,12 @@
 import { palette } from '@guardian/source/foundations';
-import type * as React from 'react';
 
 export interface CheckboxProps {
 	checked: boolean;
 	required?: true;
 	onChange: (newValue: boolean) => void;
-	label?: string;
+	// A label should always be provided for accessibility reasons, it can be hidden with the hideLabel prop.
+	label: string;
+	hideLabel?: boolean;
 	checkboxFill?: string;
 	maxWidth?: string;
 }
@@ -45,25 +46,20 @@ export const Checkbox = (props: CheckboxProps) => (
 			}}
 			// accessibility props below
 			role="checkbox"
+			aria-label={props.label}
 			aria-checked={props.checked}
 			tabIndex={0}
-			onKeyPress={() => props.onChange(!props.checked)}
-		>
-			<input
-				type="checkbox"
-				css={{
-					position: 'absolute',
-					zIndex: -999999,
-					overflow: 'hidden',
-					opacity: 0,
-				}}
-				onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-					props.onChange(event.target.checked)
+			onKeyDown={(e) => {
+				// https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/checkbox_role
+				// Space should toggle the checkbox
+				// This is handled implicitly when using a native input[type="checkbox"]
+				if (e.key === ' ') {
+					// Prevent the page from jumping when the space key is pressed
+					e.preventDefault();
+					props.onChange(!props.checked);
 				}
-				checked={props.checked}
-				required={props.required}
-				tabIndex={-1}
-			/>
+			}}
+		>
 			<div
 				css={{
 					position: 'absolute',
@@ -88,6 +84,6 @@ export const Checkbox = (props: CheckboxProps) => (
 				/>
 			</div>
 		</div>
-		<span>{props.label}</span>
+		{!props.hideLabel && <span>{props.label}</span>}
 	</label>
 );

--- a/cypress/tests/e2e/e2e.cy.ts
+++ b/cypress/tests/e2e/e2e.cy.ts
@@ -38,15 +38,18 @@ describe('E2E with Okta', () => {
 			cy.visit('/email-prefs');
 			cy.get('[data-cy="similar_guardian_products"]')
 				.parents('div')
-				.get('input[type="checkbox"]')
-				.should('be.checked');
+				.get('.checkbox')
+				.should('have.attr', 'aria-checked')
+				.and('eq', 'true');
 		});
 
 		it('should allow the user to unsubscribe from all emails', () => {
 			cy.visit('/email-prefs');
 			cy.findByText('Unsubscribe from all emails').click();
 			cy.visit('/email-prefs');
-			cy.get('input[type="checkbox"]').should('not.be.checked');
+			cy.get('.checkbox')
+				.should('have.attr', 'aria-checked')
+				.and('eq', 'false');
 		});
 	});
 


### PR DESCRIPTION
## Current situation/background

Current the "Email & Marketing" page is a bit of a headache to navigate using a screen reader, there are 2 major issues in particular:

 - Dropdowns are not marked as interactive, they appear as regular text to screen readers, and they also cannot be toggled using the expected keys "Space" or "Enter"
 - Checkboxes cannot be toggled when navigated to with a screen reader, more context on this below.


## What does this PR change?

 - Removes hidden `input` in consent checkboxes. I believe these were here to try and make the checkbox more accessible, but they seem to have the opposite effect at the moment as screen readers will focus them preferentially instead of the "real" checkbox, and these hidden checkboxes aren't hooked up properly to accept input.
 - Correctly handle onKeyDown events in the Dropdown and Checkboxes, as per https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role these elements should be interactable with Space and sometimes Enter.
 - Switch dropdown button to an `a` instead of `div` and attach more accessibility attributes. Previously this dropdown gave no hint to screen readers that it was interactable and was quite difficult to interact with.
 - Add labels to all consent checkboxes.

## Next steps/further info

| Before | After |
|--------|--------|
| <img width="368" alt="image" src="https://github.com/user-attachments/assets/e10a390f-13d4-483f-b6a8-0d3724252c81"> | <img width="364" alt="image" src="https://github.com/user-attachments/assets/4adb4292-36b3-4335-a806-0fb323cbeea2"> |
| **Voiceover Prompts** |
| Dropdown |
| ![image](https://github.com/user-attachments/assets/7f25d772-38fd-45bf-bd5c-ecba4e20180b) | <img width="621" alt="image" src="https://github.com/user-attachments/assets/30420abc-926e-478e-bd2f-214dc4285ecd"> |
| ![image](https://github.com/user-attachments/assets/6560590d-f76e-4425-8493-ee4667f8426f) |<img width="628" alt="image" src="https://github.com/user-attachments/assets/3c210320-5942-4201-8922-2e4b5429cadd">| 

### Further improvements that could be made

 - Newsletter dropdowns are a H2, but they should/could probably be a H3 as the "Your newsletters" heading is already a H2.
 - The clock SVG by the newsletter frequency should be hidden or given a label
 
 

