### PR TITLE
Newspaper Archive endpoint - add ncom-return-url support

### DIFF
--- a/server/routes/newspaperArchive.ts
+++ b/server/routes/newspaperArchive.ts
@@ -55,10 +55,11 @@ router.get('/auth', async (req: Request, res: Response) => {
 	);
 
 	const responseJson = (await response.json()) as NewspapersResponseBody;
-	const tpaToken = new URL(responseJson.url).searchParams.get('tpa');
 
 	const archiveReturnUrlString = req.query['ncom-return-url'];
 	if (archiveReturnUrlString && typeof archiveReturnUrlString === 'string') {
+		const tpaToken = new URL(responseJson.url).searchParams.get('tpa');
+
 		const archiveReturnUrl = new URL(archiveReturnUrlString);
 		archiveReturnUrl.searchParams.set('tpa', tpaToken ?? '');
 		return res.redirect(archiveReturnUrl.toString());

--- a/server/routes/newspaperArchive.ts
+++ b/server/routes/newspaperArchive.ts
@@ -57,10 +57,11 @@ router.get('/auth', async (req: Request, res: Response) => {
 	const responseJson = (await response.json()) as NewspapersResponseBody;
 	const tpaToken = new URL(responseJson.url).searchParams.get('tpa');
 
-	const archiveReturnUrl = req.query['ncom-return-url'];
-
-	if (archiveReturnUrl && typeof archiveReturnUrl === 'string') {
-		return res.redirect(archiveReturnUrl + '?tpa=' + tpaToken);
+	const archiveReturnUrlString = req.query['ncom-return-url'];
+	if (archiveReturnUrlString && typeof archiveReturnUrlString === 'string') {
+		const archiveReturnUrl = new URL(archiveReturnUrlString);
+		archiveReturnUrl.searchParams.set('tpa', tpaToken ?? '');
+		return res.redirect(archiveReturnUrl.toString());
 	}
 
 	return res.redirect(responseJson.url);

--- a/server/routes/newspaperArchive.ts
+++ b/server/routes/newspaperArchive.ts
@@ -31,7 +31,7 @@ const router = Router();
 
 router.use(withIdentity(401));
 
-router.get('/auth', async (_req: Request, res: Response) => {
+router.get('/auth', async (req: Request, res: Response) => {
 	const config = await newspaperArchiveConfigPromise;
 	const authString = config?.authString;
 	if (authString === undefined) {
@@ -55,7 +55,15 @@ router.get('/auth', async (_req: Request, res: Response) => {
 	);
 
 	const responseJson = (await response.json()) as NewspapersResponseBody;
-	res.redirect(responseJson.url);
+	const tpaToken = new URL(responseJson.url).searchParams.get('tpa');
+
+	const archiveReturnUrl = req.query['ncom-return-url'];
+
+	if (archiveReturnUrl && typeof archiveReturnUrl === 'string') {
+		return res.redirect(archiveReturnUrl + '?tpa=' + tpaToken);
+	}
+
+	return res.redirect(responseJson.url);
 });
 
 export { router };


### PR DESCRIPTION
### Current situation/background

Currently we have an endpoint that redirects a user to newspapers dot com with a token.

### What does this PR change?

This adds a mechanism to return the user to the image they were viewing. Newspapers.com will construct a url to send them to our endpoint. Eg going to -> https://manage.thegulocal.com/newspaperArchive/auth/?ncom-return-url=https%3A%2F%2Ftheguardian.newspapers.com%2Fimage%2F258351828%2F

redirects the user to this screen

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/892ea9f8-8195-445f-bb69-8ce5735844a8">

The popup modal shouldn't be there but we do have "Free access" in the top right hand corner and you can view the page once you dismiss the modal.

### Next steps/further info

1. Find out why the popup is showing or if we're not constructing this URL correctly 
2. Add a check for supporter status to this endpoint

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->
