### PR TITLE
Newspaper Archive auth endpoint - check supporter entitlement

### DIFF
--- a/server/apiProxy.ts
+++ b/server/apiProxy.ts
@@ -88,30 +88,6 @@ export const proxyApiHandler =
 			outgoingURL,
 		};
 
-		const authorizationOrCookieHeader = async ({
-			req,
-			host,
-		}: {
-			req: Request;
-			host: string;
-		}): Promise<Headers> => {
-			// If Okta is disabled, always return the cookie header
-			const { useOkta } = await getOktaConfig();
-			if (!useOkta) {
-				return {
-					Cookie: getCookiesOrEmptyString(req),
-				};
-			}
-			switch (host) {
-				case 'members-data-api.' + conf.DOMAIN:
-					return {
-						Authorization: `Bearer ${req.signedCookies[OAuthAccessTokenCookieName]}`,
-					};
-				default:
-					return {};
-			}
-		};
-
 		fetch(outgoingURL, {
 			method: httpMethod,
 			body: requestBody,
@@ -192,6 +168,32 @@ export const proxyApiHandler =
 				res.status(500).send('Something broke!');
 			});
 	};
+
+export const authorizationOrCookieHeader = async ({
+	req,
+	host,
+}: {
+	req: Request;
+	host: string;
+}): Promise<Headers> => {
+	// If Okta is disabled, always return the cookie header
+	const { useOkta } = await getOktaConfig();
+	console.log('useOkta', useOkta);
+	console.log(req.signedCookies[OAuthAccessTokenCookieName]);
+	if (!useOkta) {
+		return {
+			Cookie: getCookiesOrEmptyString(req),
+		};
+	}
+	switch (host) {
+		case 'members-data-api.' + conf.DOMAIN:
+			return {
+				Authorization: `Bearer ${req.signedCookies[OAuthAccessTokenCookieName]}`,
+			};
+		default:
+			return {};
+	}
+};
 
 export const customMembersDataApiHandler = proxyApiHandler(
 	'members-data-api.' + conf.DOMAIN,


### PR DESCRIPTION
### Current situation/background

We have an endpoint that authenticates a user, and sends them off to newspapers dot com. It doesn't check if they're actually entitled to go there.

### What does this PR change?

This PR adds a check of the user's supporter entitlements - by sending a request to members data api's `user-attributes/me` endpoint.

### Next steps/further info

I've left 3 todos: 

1.  Refactor to parse the responses
2. Send the user somewhere if they aren't entitled (this is a nice to have)
3. Update the list of entitlements MDAPI returns, currently none accurately reflect this benefit of Tier3 

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->
