### PR TITLE
Newspaper archive endpoint: add parsing

### DIFF
--- a/server/routes/newspaperArchive.ts
+++ b/server/routes/newspaperArchive.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import type { Request, Response } from 'express';
 import fetch from 'node-fetch';
+import { z } from 'zod';
 import { X_GU_ID_FORWARDED_SCOPE } from '@/shared/identity';
 import { authorizationOrCookieHeader } from '../apiProxy';
 import { s3ConfigPromise } from '../awsIntegration';
@@ -14,9 +15,13 @@ type NewspapersRequestBody = {
 };
 
 // { url: "https://<subdomain>.newspapers.com/…?tpa=<token>" }
-type NewspapersResponseBody = {
-	url: string;
-};
+const NewspapersResponseSchema = z.object({
+	url: z.string(),
+});
+
+const UserAttributesSchema = z.object({
+	contentAccess: z.record(z.string(), z.boolean()),
+});
 
 type NewspaperArchiveConfig = {
 	authString: string;
@@ -64,8 +69,7 @@ router.get('/auth', async (req: Request, res: Response) => {
 		},
 	);
 
-	// ToDo: we have zod on the server, we could parse the responses with that
-	const responseJson = (await response.json()) as NewspapersResponseBody;
+	const responseJson = NewspapersResponseSchema.parse(await response.json());
 
 	const archiveReturnUrlString = req.query['ncom-return-url'];
 	if (archiveReturnUrlString && typeof archiveReturnUrlString === 'string') {
@@ -83,7 +87,9 @@ export { router };
 
 async function checkSupporterEntitlement(req: Request): Promise<boolean> {
 	const supporterAttributesResponse = await getSupporterStatus(req);
-	const supporterAttributes = await supporterAttributesResponse.json();
+	const supporterAttributes = UserAttributesSchema.parse(
+		await supporterAttributesResponse.json(),
+	);
 
 	// ToDo: this should return a flag that represents either Tier 3 or a newspaperArchive specific entitlement
 	return (

--- a/server/routes/newspaperArchive.ts
+++ b/server/routes/newspaperArchive.ts
@@ -69,7 +69,9 @@ router.get('/auth', async (req: Request, res: Response) => {
 			},
 		);
 
-	  const responseJson = NewspapersResponseSchema.parse(await response.json());
+		const responseJson = NewspapersResponseSchema.parse(
+			await response.json(),
+		);
 
 		const archiveReturnUrlString = req.query['ncom-return-url'];
 		if (


### PR DESCRIPTION
### Current situation/background

In #1404 we added a check to supporter entitlements to the newspaper archive auth endpoint

### What does this PR change?

This PR adds some zod parsing to make it more typesafe. I'm using `parse` rather than `safeParse`. Any parsing errors should get picked up by the try catch at the top level of the route

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->
