### PR TITLE
Newspaper archive auth - show disclaimer message to user missing entitlements

### DIFF
--- a/client/components/mma/accountoverview/AccountOverview.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.tsx
@@ -51,6 +51,7 @@ import { PaymentFailureAlertIfApplicable } from '../shared/PaymentFailureAlertIf
 import { CancelledProductCard } from './CancelledProductCard';
 import { EmptyAccountOverview } from './EmptyAccountOverview';
 import { InAppPurchaseCard } from './InAppPurchaseCard';
+import { MaybeNewspaperArchiveInfo } from './MaybeNewspaperArchiveInfo';
 import { PersonalisedHeader } from './PersonalisedHeader';
 import { ProductCard } from './ProductCard';
 import { SingleContributionCard } from './SingleContributionCard';
@@ -196,6 +197,7 @@ const AccountOverviewPage = ({ isFromApp }: IsFromAppProps) => {
 				mdapiResponse={mdapiResponse}
 				mpapiResponse={mpapiResponse}
 			/>
+			<MaybeNewspaperArchiveInfo />
 
 			<PaymentFailureAlertIfApplicable
 				productDetails={allActiveProductDetails}

--- a/client/components/mma/accountoverview/MaybeNewspaperArchiveInfo.tsx
+++ b/client/components/mma/accountoverview/MaybeNewspaperArchiveInfo.tsx
@@ -1,0 +1,15 @@
+import { InfoSummary } from '@guardian/source-development-kitchen/react-components';
+
+export function MaybeNewspaperArchiveInfo() {
+	const urlSearchParams = new URLSearchParams(window.location.search);
+	const missingNewspaperArchiveEntitlement = urlSearchParams.get(
+		'missingNewspaperArchiveEntitlement',
+	);
+
+	return missingNewspaperArchiveEntitlement ? (
+		<InfoSummary
+			message="You do not have access to the Guardian's newspaper archive"
+			context="Subscribe to Digital + Print to get access"
+		/>
+	) : null;
+}

--- a/server/routes/newspaperArchive.ts
+++ b/server/routes/newspaperArchive.ts
@@ -45,8 +45,7 @@ router.get('/auth', async (req: Request, res: Response) => {
 		const hasCorrectEntitlement = await checkSupporterEntitlement(req);
 
 		if (!hasCorrectEntitlement) {
-			// ToDo: show the user an error/info page
-			return res.redirect('/');
+			return res.redirect('/?missingNewspaperArchiveEntitlement=true');
 		}
 
 		const authHeader = base64(`${authString}`);


### PR DESCRIPTION
### Current situation/background

If a user hits the newspaper archive authentication link without the requisite product, they are redirected to the account overview.

### What does this PR change?

This PR adds an info box to show users who have a product but not the correct one.

### Next steps/further info

Copy TBC. This is a nice to have rather than a MVP feature.

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->

### Screenshots

User has other products (ignore the payment failure that's not relevant for access)

![image](https://github.com/user-attachments/assets/019656fe-9893-4ab0-8077-e51bd6990051)

User has no products (the existing text seems to cover this scenario)

![image](https://github.com/user-attachments/assets/18058d59-d898-4d5e-b419-5532a8e99799)

