### PR TITLE
Guardian Light

### DIFF
--- a/client/components/mma/accountoverview/AccountOverview.stories.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.stories.tsx
@@ -17,6 +17,7 @@ import {
 	contributionCancelled,
 	contributionPaidByPayPal,
 	digitalPackPaidByDirectDebit,
+	guardianLight,
 	guardianWeeklyCancelled,
 	guardianWeeklyGiftPurchase,
 	guardianWeeklyGiftRecipient,
@@ -327,6 +328,31 @@ export const WithSupporterPlusDuringOffer: StoryObj<typeof AccountOverview> = {
 			http.get('/api/me/mma', () => {
 				return HttpResponse.json(
 					toMembersDataApiResponse(supporterPlusInOfferPeriod()),
+				);
+			}),
+			http.get('/api/me/one-off-contributions', () => {
+				return HttpResponse.json([]);
+			}),
+		],
+	},
+};
+
+export const WithGuardianLight: StoryObj<typeof AccountOverview> = {
+	render: () => {
+		return <AccountOverview />;
+	},
+
+	parameters: {
+		msw: [
+			http.get('/api/cancelled/', () => {
+				return HttpResponse.json([]);
+			}),
+			http.get('/mpapi/user/mobile-subscriptions', () => {
+				return HttpResponse.json({ subscriptions: [] });
+			}),
+			http.get('/api/me/mma', () => {
+				return HttpResponse.json(
+					toMembersDataApiResponse(guardianLight()),
 				);
 			}),
 			http.get('/api/me/one-off-contributions', () => {

--- a/client/components/mma/accountoverview/ManageProduct.stories.tsx
+++ b/client/components/mma/accountoverview/ManageProduct.stories.tsx
@@ -4,6 +4,7 @@ import { featureSwitches } from '../../../../shared/featureSwitches';
 import { PRODUCT_TYPES } from '../../../../shared/productTypes';
 import {
 	digitalPackPaidByDirectDebit,
+	guardianLight,
 	guardianWeeklyPaidByCard,
 	monthlyContributionPaidByCard,
 	newspaperVoucherPaidByPaypal,
@@ -104,6 +105,18 @@ export const SupporterPlusAllAccessDigital: StoryObj<typeof ManageProduct> = {
 	parameters: {
 		reactRouter: {
 			state: { productDetail: supporterPlusMonthlyAllAccessDigital() },
+		},
+	},
+};
+
+export const GuardianLight: StoryObj<typeof ManageProduct> = {
+	render: () => {
+		return <ManageProduct productType={PRODUCT_TYPES.guardianlight} />;
+	},
+
+	parameters: {
+		reactRouter: {
+			state: { productDetail: guardianLight() },
 		},
 	},
 };

--- a/client/components/mma/accountoverview/ProductCardConfiguration.ts
+++ b/client/components/mma/accountoverview/ProductCardConfiguration.ts
@@ -44,6 +44,9 @@ export const productCardConfiguration: {
 	contributions: {
 		colour: productColour.recurringContribution,
 	},
+	guardianlight: {
+		colour: productColour.recurringContribution,
+	},
 	supporterplus: {
 		colour: productColour.supporterPlus,
 		showBenefitsSection: true,

--- a/client/components/mma/billing/Billing.stories.tsx
+++ b/client/components/mma/billing/Billing.stories.tsx
@@ -12,6 +12,7 @@ import { guardianWeeklyCardInvoice } from '../../../fixtures/invoices';
 import { toMembersDataApiResponse } from '../../../fixtures/mdapiResponse';
 import {
 	digitalPackPaidByDirectDebit,
+	guardianLight,
 	guardianWeeklyPaidByCard,
 	newspaperVoucherPaidByPaypal,
 	tierThree,
@@ -67,6 +68,7 @@ export const WithSubscriptions: StoryObj<typeof Billing> = {
 						digitalPackPaidByDirectDebit(),
 						newspaperVoucherPaidByPaypal(),
 						tierThree(),
+						guardianLight(),
 					),
 				);
 			}),

--- a/client/components/mma/shared/benefits/BenefitsConfiguration.ts
+++ b/client/components/mma/shared/benefits/BenefitsConfiguration.ts
@@ -100,6 +100,7 @@ export const benefitsConfiguration: {
 	nationaldelivery: [],
 	voucher: [],
 	guardianweekly: [],
+	guardianlight: [],
 	guardianpatron: [],
 };
 

--- a/client/fixtures/productBuilder/baseProducts.ts
+++ b/client/fixtures/productBuilder/baseProducts.ts
@@ -11,6 +11,7 @@ import type { ProductDetail } from '../../../shared/productResponse';
 // 	| 'digipack'
 // 	| 'supporterplus'
 // 	| 'guardianpatron';
+// 	| 'guardianlight';
 
 export function baseMembership(): ProductDetail {
 	return {
@@ -504,6 +505,61 @@ export function baseNationalDelivery(): ProductDetail {
 			readerType: 'Direct',
 			accountId: '8ad0965d7dbcc507017dbe20afd33ac4',
 			deliveryAddressChangeEffectiveDate: '2022-02-11',
+		},
+		isTestUser: false,
+	};
+}
+
+export function baseGuardianLight(): ProductDetail {
+	return {
+		tier: 'Guardian Light',
+		isPaidTier: true,
+		selfServiceCancellation: {
+			isAllowed: true,
+			shouldDisplayEmail: true,
+			phoneRegionsToDisplay: ['UK & ROW', 'US', 'AUS'],
+		},
+		joinDate: '2022-07-20',
+		optIn: true,
+		subscription: {
+			contactId: '0039E00001KA26BQAT',
+			deliveryAddress: {
+				addressLine1: 'Kings Place',
+				addressLine2: '90 York Place',
+				town: 'London',
+				postcode: 'N1 9GU',
+				country: 'United Kingdom',
+			},
+			safeToUpdatePaymentMethod: true,
+			start: '2022-07-20',
+			end: '2022-08-20',
+			nextPaymentPrice: 700,
+			nextPaymentDate: '2022-08-20',
+			lastPaymentDate: '2022-07-20',
+			potentialCancellationDate: null,
+			chargedThroughDate: '2022-08-20',
+			renewalDate: '2023-07-20',
+			anniversaryDate: '2023-07-20',
+			cancelledAt: false,
+			subscriptionId: 'A-S00303371',
+			trialLength: -2,
+			autoRenew: true,
+			currentPlans: [
+				{
+					name: null,
+					start: '2022-07-20',
+					end: '2023-07-20',
+					shouldBeVisible: true,
+					chargedThrough: '2022-08-20',
+					price: 700,
+					currency: '£',
+					currencyISO: 'GBP',
+					billingPeriod: 'month',
+				},
+			],
+			futurePlans: [],
+			readerType: 'Direct',
+			accountId: '8ad09f8a7e25bda3017e296317464818',
 		},
 		isTestUser: false,
 	};

--- a/client/fixtures/productBuilder/testProducts.ts
+++ b/client/fixtures/productBuilder/testProducts.ts
@@ -3,6 +3,7 @@ import {
 	baseContribution,
 	baseDigitalPack,
 	baseDigitalVoucher,
+	baseGuardianLight,
 	baseGuardianWeekly,
 	baseHomeDelivery,
 	baseMembership,
@@ -256,6 +257,12 @@ export function supporterPlusInOfferPeriod() {
 	return new ProductBuilder(baseSupporterPlus())
 		.payByCard()
 		.inOfferPeriod()
+		.getProductDetailObject();
+}
+
+export function guardianLight() {
+	return new ProductBuilder(baseGuardianLight())
+		.payByCard()
 		.getProductDetailObject();
 }
 

--- a/cypress/tests/mocked/parallel-1/updatePaymentDetails.cy.ts
+++ b/cypress/tests/mocked/parallel-1/updatePaymentDetails.cy.ts
@@ -9,6 +9,7 @@ import { signInAndAcceptCookies } from '../../../lib/signInAndAcceptCookies';
 import {
 	digitalPackPaidByCardWithPaymentFailure,
 	digitalPackPaidByDirectDebit,
+	guardianLight,
 	guardianWeeklyPaidByCard,
 } from '../../../../client/fixtures/productBuilder/testProducts';
 import { singleContributionsAPIResponse } from '../../../../client/fixtures/singleContribution';
@@ -343,5 +344,88 @@ describe('Update payment details', () => {
 		cy.findByText('Update payment method').click();
 
 		cy.findByText('Recaptcha has not been completed.');
+	});
+
+	it.only('allows payment update for Guardian light product', () => {
+		cy.intercept('GET', '/api/me/mma*', {
+			statusCode: 200,
+			body: toMembersDataApiResponse(guardianLight()),
+		}).as('product_detail');
+
+		cy.intercept('GET', '/api/me/mma/**', {
+			statusCode: 200,
+			body: toMembersDataApiResponse(guardianLight()),
+		}).as('refetch_subscription');
+
+		cy.intercept('GET', '/mpapi/user/mobile-subscriptions', {
+			statusCode: 200,
+			body: { subscriptions: [] },
+		}).as('mobile_subscriptions');
+
+		cy.intercept('GET', '/api/me/one-off-contributions', {
+			statusCode: 200,
+			body: singleContributionsAPIResponse,
+		}).as('single_contributions');
+
+		cy.intercept('GET', '/api/cancelled/', {
+			statusCode: 200,
+			body: [],
+		}).as('cancelled');
+
+		cy.intercept('POST', '/api/payment/card', {
+			statusCode: 200,
+			body: stripeSetupIntent,
+		}).as('createSetupIntent');
+
+		cy.intercept('POST', '/api/payment/card/**', {
+			statusCode: 200,
+			body: executePaymentUpdateResponse,
+		}).as('update_payment');
+
+		cy.intercept('POST', 'https://api.stripe.com/v1/setup_intents/**', {
+			statusCode: 200,
+			body: { status: 'succeeded' },
+		}).as('confirmCardSetup');
+
+		cy.intercept('POST', 'https://api.stripe.com/v1/payment_methods', {
+			statusCode: 200,
+			body: paymentMethods,
+		});
+
+		cy.visit('/');
+		cy.wait('@product_detail');
+		cy.wait('@mobile_subscriptions');
+		cy.wait('@single_contributions');
+		cy.findByText('Manage support').click();
+		cy.wait('@cancelled');
+
+		cy.findByText('Update payment method').click();
+
+		cy.resolve('Stripe').should((value) => {
+			expect(value).to.be.ok;
+		});
+
+		cy.fillElementsInput('cardNumber', '4242424242424242');
+		cy.fillElementsInput('cardExpiry', '1025');
+		cy.fillElementsInput('cardCvc', '123');
+
+		cy.get('#recaptcha *> iframe').then(($iframe) => {
+			const $body = $iframe.contents().find('body');
+			cy.wrap($body)
+				.find('.recaptcha-checkbox-border')
+				.should('be.visible')
+				.click()
+				.then(() => {
+					// wait for recaptcha to resolve
+					cy.wait(1000);
+
+					cy.findByText('Update payment method').click();
+				});
+		});
+
+		cy.wait('@update_payment');
+		cy.wait('@refetch_subscription');
+
+		cy.findByText('Your payment details were updated successfully');
 	});
 });

--- a/shared/ophanTypes.ts
+++ b/shared/ophanTypes.ts
@@ -12,6 +12,7 @@ export type OphanProduct =
 	| 'PAPER_SUBSCRIPTION_SUNDAY'
 	| 'PRINT_SUBSCRIPTION'
 	| 'APP_PREMIUM_TIER'
+	| 'GUARDIAN_LIGHT'
 	| 'GUARDIAN_PATRON';
 
 type OphanAction =

--- a/shared/productResponse.ts
+++ b/shared/productResponse.ts
@@ -86,6 +86,7 @@ export const productTiers = [
 	'Newspaper Delivery',
 	'Patron',
 	'Partner',
+	'Guardian Light',
 ];
 
 export type ProductTier = typeof productTiers[number];
@@ -294,6 +295,9 @@ export function getSpecificProductTypeFromTier(
 			break;
 		case 'Newspaper Digital Voucher':
 			productType = PRODUCT_TYPES.digitalvoucher;
+			break;
+		case 'Guardian Light':
+			productType = PRODUCT_TYPES.guardianlight;
 			break;
 		case 'guardianpatron':
 			productType = PRODUCT_TYPES.guardianpatron;

--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -46,6 +46,7 @@ type ProductFriendlyName =
 	| 'subscription'
 	| 'support'
 	| 'recurring support'
+	| 'guardian light'
 	| 'guardian patron';
 type ProductUrlPart =
 	| 'membership'
@@ -61,6 +62,7 @@ type ProductUrlPart =
 	| 'digital+print'
 	| 'subscriptions'
 	| 'recurringsupport'
+	| 'guardianlight'
 	| 'guardianpatron';
 type SfCaseProduct =
 	| 'Membership'
@@ -70,6 +72,7 @@ type SfCaseProduct =
 	| 'Digital Pack Subscriptions'
 	| 'Supporter Plus'
 	| 'Tier Three'
+	| 'Guardian Light'
 	| 'Guardian Patron';
 export type AllProductsProductTypeFilterString =
 	| 'Weekly'
@@ -83,12 +86,12 @@ export type AllProductsProductTypeFilterString =
 	| 'SupporterPlus'
 	| 'ContentSubscription'
 	| 'GuardianPatron'
+	| 'GuardianLight'
 	| 'TierThree';
 
 interface CancellationFlowProperties {
 	reasons: CancellationReason[];
 	sfCaseProduct: SfCaseProduct;
-	linkOnProductPage?: true;
 	checkForOutstandingCredits?: true;
 	flowWrapper?: (
 		productDetail: ProductDetail,
@@ -175,7 +178,6 @@ export interface ProductType {
 	showSupporterId?: boolean;
 	tierLabel?: string;
 	renewalMetadata?: SupportTheGuardianButtonProps;
-	noProductSupportUrlSuffix?: string;
 	cancellation?: CancellationFlowProperties; // undefined 'cancellation' means no cancellation flow
 	cancelledCopy?: string;
 	showTrialRemainingIfApplicable?: true;
@@ -263,6 +265,7 @@ export type ProductTypeKeys =
 	| 'digipack'
 	| 'supporterplus'
 	| 'tierthree'
+	| 'guardianlight'
 	| 'guardianpatron';
 
 export type GroupedProductTypeKeys =
@@ -325,7 +328,6 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 		allProductsProductTypeFilterString: 'Contribution',
 		urlPart: 'contributions',
 		getOphanProductType: () => 'RECURRING_CONTRIBUTION',
-		noProductSupportUrlSuffix: '/contribute',
 		updateAmountMdaEndpoint: 'contribution-update-amount',
 		softOptInIDs: [
 			SoftOptInIDs.SupportOnboarding,
@@ -334,7 +336,6 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 		cancellation: {
 			alternateSummaryMainPara:
 				'This is immediate and you will not be charged again.',
-			linkOnProductPage: true,
 			reasons: shuffledContributionsCancellationReasons,
 			sfCaseProduct: 'Recurring - Contributions',
 			startPageBody: contributionsCancellationFlowStart,
@@ -510,7 +511,6 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 			enableDeliveryInstructionsUpdate: true,
 		},
 		cancellation: {
-			linkOnProductPage: true,
 			reasons: voucherCancellationReasons,
 			sfCaseProduct: 'Voucher Subscriptions',
 			checkForOutstandingCredits: true,
@@ -582,7 +582,6 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 			},
 		},
 		cancellation: {
-			linkOnProductPage: true,
 			reasons: gwCancellationReasons,
 			sfCaseProduct: 'Guardian Weekly',
 			checkForOutstandingCredits: true,
@@ -628,7 +627,6 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 			},
 		},
 		cancellation: {
-			linkOnProductPage: true,
 			reasons: gwCancellationReasons,
 			sfCaseProduct: 'Tier Three',
 			checkForOutstandingCredits: true,
@@ -667,7 +665,6 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 			SoftOptInIDs.SupporterNewsletter,
 		],
 		cancellation: {
-			linkOnProductPage: true,
 			reasons: digipackCancellationReasons,
 			sfCaseProduct: 'Digital Pack Subscriptions',
 			startPageBody: digipackCancellationFlowStart,
@@ -698,7 +695,6 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 		cancellation: {
 			alternateSummaryMainPara:
 				"This is immediate and you will not be charged again. If you've cancelled within the first 14 days, we'll send you a full refund.",
-			linkOnProductPage: true,
 			reasons: shuffledSupporterPlusCancellationReasons,
 			sfCaseProduct: 'Supporter Plus',
 			startPageBody: supporterplusCancellationFlowStart,
@@ -724,6 +720,64 @@ export const PRODUCT_TYPES: { [productKey in ProductTypeKeys]: ProductType } = {
 			SoftOptInIDs.DigitalSubscriberPreview,
 			SoftOptInIDs.SupporterNewsletter,
 		],
+	},
+	guardianlight: {
+		productTitle: () => 'Guardian Light',
+		friendlyName: 'guardian light',
+		productType: 'guardianlight',
+		groupedProductType: 'recurringSupport',
+		allProductsProductTypeFilterString: 'GuardianLight',
+		urlPart: 'guardianlight',
+		getOphanProductType: () => 'GUARDIAN_LIGHT',
+		softOptInIDs: [
+			SoftOptInIDs.SupportOnboarding,
+			SoftOptInIDs.SupporterNewsletter,
+		],
+		cancellation: {
+			alternateSummaryMainPara:
+				'This is immediate and you will not be charged again.',
+			reasons: shuffledContributionsCancellationReasons,
+			sfCaseProduct: 'Guardian Light',
+			startPageBody: contributionsCancellationFlowStart,
+			shouldHideSummaryMainPara: true,
+			summaryReasonSpecificPara: (
+				reasonId: OptionalCancellationReasonId,
+			) => {
+				switch (reasonId) {
+					case 'mma_financial_circumstances':
+					case 'mma_value_for_money':
+					case 'mma_one_off':
+						return 'You can support The Guardian’s independent journalism with a One-time contribution, from as little as £1 – and it only takes a minute.';
+					case 'mma_wants_annual_contribution':
+						return 'You can support The Guardian’s independent journalism for the long term with an annual contribution.';
+					case 'mma_wants_monthly_contribution':
+						return 'You can support The Guardian’s independent journalism for the long term with a monthly contribution.';
+					default:
+						return undefined;
+				}
+			},
+			onlyShowSupportSectionIfAlternateText: true,
+			alternateSupportButtonText: (
+				reasonId: OptionalCancellationReasonId,
+			) => {
+				switch (reasonId) {
+					case 'mma_financial_circumstances':
+					case 'mma_value_for_money':
+					case 'mma_one_off':
+						return 'Make a One-time contribution';
+					case 'mma_wants_annual_contribution':
+						return 'Make an annual contribution';
+					case 'mma_wants_monthly_contribution':
+						return 'Make a monthly contribution';
+					default:
+						return undefined;
+				}
+			},
+			alternateSupportButtonUrlSuffix: () => undefined,
+			swapFeedbackAndContactUs: true,
+			shouldHideThrasher: true,
+			shouldShowReminder: true,
+		},
 	},
 };
 


### PR DESCRIPTION
### What does this PR change?

Add a new product 'Guardian Light' to manage frontend.

The product has minimal functionality, users should be able to see the product in the account overview, manage product and billing pages. They should be able to update their payment details and cancel the product.

This pr adds the product to the relevant pages and allows the user to update their payment details. The cancellation journey for Guardian Light will follow in a subsequent pr.

### Images
![Screenshot 2024-10-24 at 10 32 39](https://github.com/user-attachments/assets/6eeb1792-4d48-4080-aca1-892376781bdb)
