### PR TITLE
Guardian ad-lite

### DIFF
--- a/client/components/mma/accountoverview/AccountOverview.stories.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.stories.tsx
@@ -17,7 +17,7 @@ import {
 	contributionCancelled,
 	contributionPaidByPayPal,
 	digitalPackPaidByDirectDebit,
-	guardianLight,
+	guardianAdLite,
 	guardianWeeklyCancelled,
 	guardianWeeklyGiftPurchase,
 	guardianWeeklyGiftRecipient,
@@ -363,7 +363,7 @@ export const WithSupporterPlusDuringOffer: StoryObj<typeof AccountOverview> = {
 	},
 };
 
-export const WithGuardianLight: StoryObj<typeof AccountOverview> = {
+export const WithGuardianAdLite: StoryObj<typeof AccountOverview> = {
 	render: () => {
 		return <AccountOverview />;
 	},
@@ -378,7 +378,7 @@ export const WithGuardianLight: StoryObj<typeof AccountOverview> = {
 			}),
 			http.get('/api/me/mma', () => {
 				return HttpResponse.json(
-					toMembersDataApiResponse(guardianLight()),
+					toMembersDataApiResponse(guardianAdLite()),
 				);
 			}),
 			http.get('/api/me/one-off-contributions', () => {

--- a/client/components/mma/accountoverview/AccountOverview.stories.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.stories.tsx
@@ -17,6 +17,7 @@ import {
 	contributionCancelled,
 	contributionPaidByPayPal,
 	digitalPackPaidByDirectDebit,
+	guardianLight,
 	guardianWeeklyCancelled,
 	guardianWeeklyGiftPurchase,
 	guardianWeeklyGiftRecipient,
@@ -353,6 +354,31 @@ export const WithSupporterPlusDuringOffer: StoryObj<typeof AccountOverview> = {
 			http.get('/api/me/mma', () => {
 				return HttpResponse.json(
 					toMembersDataApiResponse(supporterPlusInOfferPeriod()),
+				);
+			}),
+			http.get('/api/me/one-off-contributions', () => {
+				return HttpResponse.json([]);
+			}),
+		],
+	},
+};
+
+export const WithGuardianLight: StoryObj<typeof AccountOverview> = {
+	render: () => {
+		return <AccountOverview />;
+	},
+
+	parameters: {
+		msw: [
+			http.get('/api/cancelled/', () => {
+				return HttpResponse.json([]);
+			}),
+			http.get('/mpapi/user/mobile-subscriptions', () => {
+				return HttpResponse.json({ subscriptions: [] });
+			}),
+			http.get('/api/me/mma', () => {
+				return HttpResponse.json(
+					toMembersDataApiResponse(guardianLight()),
 				);
 			}),
 			http.get('/api/me/one-off-contributions', () => {

--- a/client/components/mma/accountoverview/AccountOverview.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import {
+	from,
 	headlineBold28,
 	palette,
 	space,
@@ -66,12 +67,15 @@ type AccountOverviewResponse = [
 ];
 
 const subHeadingCss = css`
-	margin: ${space[12]}px 0 ${space[6]}px;
+	margin: ${space[6]}px 0 ${space[6]}px;
 	border-top: 1px solid ${palette.neutral['86']};
 	${headlineBold28};
 	${until.tablet} {
 		font-size: 1.25rem;
 		line-height: 1.6;
+	}
+	${from.tablet} {
+		margin-top: ${space[8]}px;
 	}
 `;
 

--- a/client/components/mma/accountoverview/ManageProduct.stories.tsx
+++ b/client/components/mma/accountoverview/ManageProduct.stories.tsx
@@ -4,6 +4,7 @@ import { featureSwitches } from '../../../../shared/featureSwitches';
 import { PRODUCT_TYPES } from '../../../../shared/productTypes';
 import {
 	digitalPackPaidByDirectDebit,
+	guardianLight,
 	guardianWeeklyPaidByCard,
 	monthlyContributionPaidByCard,
 	newspaperVoucherPaidByPaypal,
@@ -104,6 +105,18 @@ export const SupporterPlusAllAccessDigital: StoryObj<typeof ManageProduct> = {
 	parameters: {
 		reactRouter: {
 			state: { productDetail: supporterPlusMonthlyAllAccessDigital() },
+		},
+	},
+};
+
+export const GuardianLight: StoryObj<typeof ManageProduct> = {
+	render: () => {
+		return <ManageProduct productType={PRODUCT_TYPES.guardianlight} />;
+	},
+
+	parameters: {
+		reactRouter: {
+			state: { productDetail: guardianLight() },
 		},
 	},
 };

--- a/client/components/mma/accountoverview/ManageProduct.stories.tsx
+++ b/client/components/mma/accountoverview/ManageProduct.stories.tsx
@@ -4,7 +4,7 @@ import { featureSwitches } from '../../../../shared/featureSwitches';
 import { PRODUCT_TYPES } from '../../../../shared/productTypes';
 import {
 	digitalPackPaidByDirectDebit,
-	guardianLight,
+	guardianAdLite,
 	guardianWeeklyPaidByCard,
 	monthlyContributionPaidByCard,
 	newspaperVoucherPaidByPaypal,
@@ -109,14 +109,14 @@ export const SupporterPlusAllAccessDigital: StoryObj<typeof ManageProduct> = {
 	},
 };
 
-export const GuardianLight: StoryObj<typeof ManageProduct> = {
+export const GuardianAdLite: StoryObj<typeof ManageProduct> = {
 	render: () => {
-		return <ManageProduct productType={PRODUCT_TYPES.guardianlight} />;
+		return <ManageProduct productType={PRODUCT_TYPES.guardianadlite} />;
 	},
 
 	parameters: {
 		reactRouter: {
-			state: { productDetail: guardianLight() },
+			state: { productDetail: guardianAdLite() },
 		},
 	},
 };

--- a/client/components/mma/accountoverview/ManageProduct.tsx
+++ b/client/components/mma/accountoverview/ManageProduct.tsx
@@ -64,7 +64,7 @@ const subHeadingTitleCss = `
   `;
 const subHeadingBorderTopCss = `
     border-top: 1px solid ${palette.neutral['86']};
-    margin: 50px 0 ${space[5]}px;
+    margin: ${space[10]}px 0 ${space[5]}px;
   `;
 export const subHeadingCss = `
     ${subHeadingBorderTopCss}

--- a/client/components/mma/accountoverview/PersonalisedHeader.tsx
+++ b/client/components/mma/accountoverview/PersonalisedHeader.tsx
@@ -1,6 +1,8 @@
 import { css } from '@emotion/react';
 import {
-	headlineBold42,
+	from,
+	headlineBold24,
+	headlineBold34,
 	headlineMedium17,
 	space,
 } from '@guardian/source/foundations';
@@ -53,12 +55,18 @@ export const PersonalisedHeader = ({
 	return (
 		<hgroup
 			css={css`
-				margin-top: ${space[12]}px;
+				margin-top: ${space[6]}px;
+				${from.tablet} {
+					margin-top: ${space[8]}px;
+				}
 			`}
 		>
 			<h2
 				css={css`
-					${headlineBold42};
+					${headlineBold24};
+					${from.tablet} {
+						${headlineBold34};
+					}
 					margin-bottom: 0;
 				`}
 				data-qm-masking="blocklist"

--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -277,7 +277,10 @@ export const ProductCard = ({
 				/>
 			)}
 			<Card>
-				<Card.Header backgroundColor={cardConfig.colour}>
+				<Card.Header
+					backgroundColor={cardConfig.colour}
+					minHeightOverride="auto"
+				>
 					<h3 css={productCardTitleCss(cardConfig.invertText)}>
 						{productTitle}
 					</h3>
@@ -312,6 +315,18 @@ export const ProductCard = ({
 						/>
 					</Card.Section>
 				)}
+				{specificProductType.productType === 'guardianadlite' &&
+					nextPaymentDetails && (
+						<Card.Section backgroundColor="#edf5fA">
+							<p css={benefitsTextCss}>
+								You’re subscribed to{' '}
+								{specificProductType.productTitle()} and pay{' '}
+								{nextPaymentDetails.paymentValueShort} a{' '}
+								{nextPaymentDetails.paymentInterval} for
+								non-personalised advertising.
+							</p>
+						</Card.Section>
+					)}
 				<Card.Section>
 					<div css={productDetailLayoutCss}>
 						<div>

--- a/client/components/mma/accountoverview/ProductCardConfiguration.ts
+++ b/client/components/mma/accountoverview/ProductCardConfiguration.ts
@@ -45,6 +45,9 @@ export const productCardConfiguration: Record<
 	contributions: {
 		colour: productColour.recurringContribution,
 	},
+	guardianlight: {
+		colour: productColour.recurringContribution,
+	},
 	supporterplus: {
 		colour: productColour.supporterPlus,
 		showBenefitsSection: true,

--- a/client/components/mma/accountoverview/ProductCardConfiguration.ts
+++ b/client/components/mma/accountoverview/ProductCardConfiguration.ts
@@ -45,7 +45,7 @@ export const productCardConfiguration: Record<
 	contributions: {
 		colour: productColour.recurringContribution,
 	},
-	guardianlight: {
+	guardianadlite: {
 		colour: productColour.recurringContribution,
 	},
 	supporterplus: {

--- a/client/components/mma/accountoverview/ProductCardConfiguration.ts
+++ b/client/components/mma/accountoverview/ProductCardConfiguration.ts
@@ -45,12 +45,12 @@ export const productCardConfiguration: Record<
 	contributions: {
 		colour: productColour.recurringContribution,
 	},
-	guardianadlite: {
-		colour: productColour.recurringContribution,
-	},
 	supporterplus: {
 		colour: productColour.supporterPlus,
 		showBenefitsSection: true,
+	},
+	guardianadlite: {
+		colour: productColour.supporterPlus,
 	},
 	tierthree: {
 		colour: productColour.supporterPlus,

--- a/client/components/mma/billing/Billing.stories.tsx
+++ b/client/components/mma/billing/Billing.stories.tsx
@@ -12,6 +12,7 @@ import { guardianWeeklyCardInvoice } from '../../../fixtures/invoices';
 import { toMembersDataApiResponse } from '../../../fixtures/mdapiResponse';
 import {
 	digitalPackPaidByDirectDebit,
+	guardianLight,
 	guardianWeeklyPaidByCard,
 	newspaperVoucherPaidByPaypal,
 	tierThree,
@@ -67,6 +68,7 @@ export const WithSubscriptions: StoryObj<typeof Billing> = {
 						digitalPackPaidByDirectDebit(),
 						newspaperVoucherPaidByPaypal(),
 						tierThree(),
+						guardianLight(),
 					),
 				);
 			}),

--- a/client/components/mma/billing/Billing.stories.tsx
+++ b/client/components/mma/billing/Billing.stories.tsx
@@ -12,7 +12,7 @@ import { guardianWeeklyCardInvoice } from '../../../fixtures/invoices';
 import { toMembersDataApiResponse } from '../../../fixtures/mdapiResponse';
 import {
 	digitalPackPaidByDirectDebit,
-	guardianLight,
+	guardianAdLite,
 	guardianWeeklyPaidByCard,
 	newspaperVoucherPaidByPaypal,
 	tierThree,
@@ -68,7 +68,7 @@ export const WithSubscriptions: StoryObj<typeof Billing> = {
 						digitalPackPaidByDirectDebit(),
 						newspaperVoucherPaidByPaypal(),
 						tierThree(),
-						guardianLight(),
+						guardianAdLite(),
 					),
 				);
 			}),

--- a/client/components/mma/cancel/Cancellation.stories.tsx
+++ b/client/components/mma/cancel/Cancellation.stories.tsx
@@ -7,8 +7,8 @@ import {
 	contributionCancelled,
 	contributionPaidByCard,
 	contributionPaidByPayPal,
-	guardianLight,
-	guardianLightCancelled,
+	guardianAdLite,
+	guardianAdLiteCancelled,
 	guardianWeeklyPaidByCard,
 	supporterPlus,
 	supporterPlusAnnual,
@@ -125,60 +125,61 @@ export const ReviewWithReduceAmount: StoryObj<typeof CancellationContainer> = {
 	},
 };
 
-export const ReviewGuardianLight: StoryObj<typeof CancellationContainer> = {
+export const ReviewGuardianAdLite: StoryObj<typeof CancellationContainer> = {
 	render: () => {
 		return <ConfirmCancellation />;
 	},
 	parameters: {
 		reactRouter: {
 			state: {
-				productDetail: guardianLight(),
+				productDetail: guardianAdLite(),
 			},
 			container: (
 				<CancellationContainer
-					productType={PRODUCT_TYPES.guardianlight}
+					productType={PRODUCT_TYPES.guardianadlite}
 				/>
 			),
 		},
 	},
 };
 
-export const ConfirmationGuardianLight: StoryObj<typeof ExecuteCancellation> = {
-	render: () => {
-		// @ts-expect-error set identity details email in the window
-		window.guardian = { identityDetails: { email: 'test' } };
-		return <ExecuteCancellation />;
-	},
-	parameters: {
-		msw: [
-			http.patch('/api/case/**', () => {
-				return HttpResponse.json({ id: 'caseId' });
-			}),
-			http.get('/api/me/mma/**', () => {
-				return HttpResponse.json(
-					toMembersDataApiResponse(guardianLightCancelled()),
-				);
-			}),
-			http.post('/api/cancel/**', () => {
-				return new HttpResponse(null, {
-					status: 201,
-				});
-			}),
-		],
-		reactRouter: {
-			state: {
-				productDetail: guardianLight(),
-				selectedReasonId: '1',
-				caseId: 'caseId',
-			},
-			container: (
-				<CancellationContainer
-					productType={PRODUCT_TYPES.guardianlight}
-				/>
-			),
+export const ConfirmationGuardianAdLite: StoryObj<typeof ExecuteCancellation> =
+	{
+		render: () => {
+			// @ts-expect-error set identity details email in the window
+			window.guardian = { identityDetails: { email: 'test' } };
+			return <ExecuteCancellation />;
 		},
-	},
-};
+		parameters: {
+			msw: [
+				http.patch('/api/case/**', () => {
+					return HttpResponse.json({ id: 'caseId' });
+				}),
+				http.get('/api/me/mma/**', () => {
+					return HttpResponse.json(
+						toMembersDataApiResponse(guardianAdLiteCancelled()),
+					);
+				}),
+				http.post('/api/cancel/**', () => {
+					return new HttpResponse(null, {
+						status: 201,
+					});
+				}),
+			],
+			reactRouter: {
+				state: {
+					productDetail: guardianAdLite(),
+					selectedReasonId: '1',
+					caseId: 'caseId',
+				},
+				container: (
+					<CancellationContainer
+						productType={PRODUCT_TYPES.guardianadlite}
+					/>
+				),
+			},
+		},
+	};
 
 export const OfferMonthly: StoryObj<typeof CancellationContainer> = {
 	render: () => {

--- a/client/components/mma/cancel/Cancellation.stories.tsx
+++ b/client/components/mma/cancel/Cancellation.stories.tsx
@@ -91,6 +91,11 @@ export const Review: StoryObj<typeof CancellationContainer> = {
 				selectedReasonId: 'mma_editorial',
 				cancellationPolicy: 'Today',
 			},
+			container: (
+				<CancellationContainer
+					productType={PRODUCT_TYPES.contributions}
+				/>
+			),
 		},
 	},
 };
@@ -111,6 +116,11 @@ export const ReviewWithReduceAmount: StoryObj<typeof CancellationContainer> = {
 				productDetail: contributionPaidByPayPal(),
 				selectedReasonId: 'mma_financial_circumstances',
 			},
+			container: (
+				<CancellationContainer
+					productType={PRODUCT_TYPES.contributions}
+				/>
+			),
 		},
 	},
 };

--- a/client/components/mma/cancel/Cancellation.stories.tsx
+++ b/client/components/mma/cancel/Cancellation.stories.tsx
@@ -9,6 +9,7 @@ import {
 	contributionPaidByPayPal,
 	guardianAdLite,
 	guardianAdLiteCancelled,
+	guardianAdLiteInCoolingOffPeriod,
 	guardianWeeklyPaidByCard,
 	supporterPlus,
 	supporterPlusAnnual,
@@ -119,6 +120,26 @@ export const ReviewWithReduceAmount: StoryObj<typeof CancellationContainer> = {
 			container: (
 				<CancellationContainer
 					productType={PRODUCT_TYPES.contributions}
+				/>
+			),
+		},
+	},
+};
+
+export const ReviewGuardianAdLiteInCoolingOffPeriod: StoryObj<
+	typeof CancellationContainer
+> = {
+	render: () => {
+		return <ConfirmCancellation />;
+	},
+	parameters: {
+		reactRouter: {
+			state: {
+				productDetail: guardianAdLiteInCoolingOffPeriod(),
+			},
+			container: (
+				<CancellationContainer
+					productType={PRODUCT_TYPES.guardianadlite}
 				/>
 			),
 		},

--- a/client/components/mma/cancel/Cancellation.stories.tsx
+++ b/client/components/mma/cancel/Cancellation.stories.tsx
@@ -23,9 +23,7 @@ import { CancelAlternativeOffer } from './cancellationSaves/CancelAlternativeOff
 import { CancelAlternativeReview } from './cancellationSaves/CancelAlternativeReview';
 import { contributionsCancellationReasons } from './contributions/ContributionsCancellationReasons';
 import { ConfirmCancellation } from './stages/ConfirmCancellation';
-import {
-	ExecuteCancellation,
-} from './stages/ExecuteCancellation';
+import { ExecuteCancellation } from './stages/ExecuteCancellation';
 import { otherCancellationReason } from './supporterplus/SupporterplusCancellationReasons';
 
 const contributions = PRODUCT_TYPES.contributions;

--- a/client/components/mma/cancel/CancellationJourneyFunnel.tsx
+++ b/client/components/mma/cancel/CancellationJourneyFunnel.tsx
@@ -58,5 +58,9 @@ export const CancellationJourneyFunnel = () => {
 		return <Navigate to="./landing" state={{ ...routerState }} />;
 	}
 
+	if (!productType.cancellation?.reasons) {
+		return <Navigate to="./confirm" state={{ ...routerState }} />;
+	}
+
 	return <CancellationReasonSelection />;
 };

--- a/client/components/mma/cancel/CancellationReasonReview.tsx
+++ b/client/components/mma/cancel/CancellationReasonReview.tsx
@@ -450,7 +450,7 @@ export const CancellationReasonReview = () => {
 		cancellationPolicy: string;
 	};
 
-	if (!routerState?.selectedReasonId) {
+	if (!routerState?.selectedReasonId || !productType.cancellation.reasons) {
 		return <Navigate to=".." />;
 	}
 	return <ValidatedCancellationReasonReview />;

--- a/client/components/mma/cancel/CancellationReasonReview.tsx
+++ b/client/components/mma/cancel/CancellationReasonReview.tsx
@@ -24,9 +24,11 @@ import { featureSwitches } from '@/shared/featureSwitches';
 import type { TrueFalsePending } from '@/shared/generalTypes';
 import { appendCorrectPluralisation } from '@/shared/generalTypes';
 import { DATE_FNS_INPUT_FORMAT, parseDate } from '../../../../shared/dates';
+import type { ProductDetail } from '../../../../shared/productResponse';
 import { MDA_TEST_USER_HEADER } from '../../../../shared/productResponse';
 import type {
 	ProductTypeWithCancellationFlow,
+	ProductTypeWithCancellationFlowMandatoryReasons,
 	WithProductType,
 } from '../../../../shared/productTypes';
 import { measure } from '../../../styles/typography';
@@ -450,17 +452,30 @@ export const CancellationReasonReview = () => {
 		cancellationPolicy: string;
 	};
 
-	if (!routerState?.selectedReasonId || !productType.cancellation.reasons) {
-		return <Navigate to=".." />;
-	}
-	return <ValidatedCancellationReasonReview />;
-};
-
-const ValidatedCancellationReasonReview = () => {
 	const { productDetail, productType } = useContext(
 		CancellationContext,
 	) as CancellationContextInterface;
 
+	if (!routerState?.selectedReasonId || !productType?.cancellation.reasons) {
+		return <Navigate to=".." />;
+	}
+	return (
+		<ValidatedCancellationReasonReview
+			productDetail={productDetail}
+			productType={
+				productType as ProductTypeWithCancellationFlowMandatoryReasons
+			}
+		/>
+	);
+};
+
+const ValidatedCancellationReasonReview = ({
+	productDetail,
+	productType,
+}: {
+	productDetail: ProductDetail;
+	productType: ProductTypeWithCancellationFlowMandatoryReasons;
+}) => {
 	const location = useLocation();
 	const routerState = location.state as {
 		selectedReasonId: OptionalCancellationReasonId;

--- a/client/components/mma/cancel/CancellationReasonSelection.tsx
+++ b/client/components/mma/cancel/CancellationReasonSelection.tsx
@@ -76,6 +76,12 @@ const ReasonPicker = ({
 		(featureSwitches.contributionCancellationPause &&
 			productType.productType === 'contributions');
 
+	if (!productType.cancellation.reasons) {
+		return (
+			<GenericErrorScreen loggingMessage="Got to the cancellation reasons selection page with a productType that doesn't have any cancellation reasons." />
+		);
+	}
+
 	return (
 		<>
 			{shouldUseProgressStepper ? (

--- a/client/components/mma/cancel/CancellationSummary.tsx
+++ b/client/components/mma/cancel/CancellationSummary.tsx
@@ -167,7 +167,7 @@ const actuallyCancelled = (
 								Support us another way
 							</h4>
 							<p>
-								{productType?.cancellation?.summaryReasonSpecificPara(
+								{productType?.cancellation?.summaryReasonSpecificPara?.(
 									cancellationReasonId,
 									currencySymbol,
 								) ||

--- a/client/components/mma/cancel/CancellationSummary.tsx
+++ b/client/components/mma/cancel/CancellationSummary.tsx
@@ -35,6 +35,7 @@ const actuallyCancelled = (
 ) => {
 	const isSupportPlus = productType.productType === 'supporterplus';
 	const isContribution = productType.productType === 'contributions';
+	const isGuardianAdLite = productType.productType === 'guardianadlite';
 
 	let showReminder: boolean = !!productType.cancellation?.shouldShowReminder;
 	if (isSupportPlus && eligableForOffer) {
@@ -63,6 +64,7 @@ const actuallyCancelled = (
 		<>
 			<WithStandardTopMargin>
 				<Heading
+					borderless
 					cssOverrides={[
 						measure.heading,
 						css`
@@ -70,10 +72,13 @@ const actuallyCancelled = (
 						`,
 					]}
 				>
-					{isSupportPlus && 'Your subscription has been cancelled'}
+					{isSupportPlus ||
+						(isGuardianAdLite &&
+							'Your subscription has been cancelled')}
 					{isContribution && contributionheadingCopy}
 					{!isSupportPlus &&
 						!isContribution &&
+						!isGuardianAdLite &&
 						`Your ${productType.friendlyName} is cancelled`}
 				</Heading>
 				{productType.cancellation &&

--- a/client/components/mma/cancel/cancellationSaves/SelectReason.tsx
+++ b/client/components/mma/cancel/cancellationSaves/SelectReason.tsx
@@ -89,10 +89,12 @@ const CancellationInfo = ({
 );
 
 const ReasonSelection = ({
-	productType,
+	groupedProductFriendlyName,
+	cancellationReasons,
 	setSelectedReasonId,
 }: {
-	productType: ProductTypeWithCancellationFlow;
+	groupedProductFriendlyName: string;
+	cancellationReasons: CancellationReason[];
 	setSelectedReasonId: React.Dispatch<React.SetStateAction<string>>;
 }) => {
 	return (
@@ -109,12 +111,7 @@ const ReasonSelection = ({
 			`}
 		>
 			<legend css={reasonLegendCss}>
-				Why did you cancel your{' '}
-				{
-					GROUPED_PRODUCT_TYPES[productType.groupedProductType]
-						.friendlyName
-				}{' '}
-				today?
+				Why did you cancel your {groupedProductFriendlyName} today?
 			</legend>
 			<RadioGroup
 				name="issue_type"
@@ -124,32 +121,30 @@ const ReasonSelection = ({
 					padding-top: ${space[4]}px;
 				`}
 			>
-				{productType.cancellation.reasons.map(
-					(reason: CancellationReason) => (
-						<div
-							key={reason.reasonId}
-							css={css`
-								border: 1px solid ${palette.neutral[86]};
-								border-radius: 4px;
-								padding: ${space[1]}px ${space[3]}px;
-								margin-bottom: ${space[3]}px;
+				{cancellationReasons.map((reason: CancellationReason) => (
+					<div
+						key={reason.reasonId}
+						css={css`
+							border: 1px solid ${palette.neutral[86]};
+							border-radius: 4px;
+							padding: ${space[1]}px ${space[3]}px;
+							margin-bottom: ${space[3]}px;
+						`}
+					>
+						<Radio
+							name="cancellation-reason"
+							value={reason.reasonId}
+							label={reason.linkLabel}
+							cssOverrides={css`
+								vertical-align: top;
+								text-transform: lowercase;
+								:checked + div label:first-of-type {
+									font-weight: bold;
+								}
 							`}
-						>
-							<Radio
-								name="cancellation-reason"
-								value={reason.reasonId}
-								label={reason.linkLabel}
-								cssOverrides={css`
-									vertical-align: top;
-									text-transform: lowercase;
-									:checked + div label:first-of-type {
-										font-weight: bold;
-									}
-								`}
-							/>
-						</div>
-					),
-				)}
+						/>
+					</div>
+				))}
 			</RadioGroup>
 		</fieldset>
 	);
@@ -266,6 +261,11 @@ export const SelectReason = () => {
 			<GenericErrorScreen loggingMessage="Cancel journey case id api call failed during the cancellation process" />
 		);
 	}
+	if (!productType.cancellation.reasons) {
+		return (
+			<GenericErrorScreen loggingMessage="Got to the cancellation /reasons page with a productType that doesn't have any cancellation reasons." />
+		);
+	}
 
 	return (
 		<section css={sectionSpacing}>
@@ -293,10 +293,16 @@ export const SelectReason = () => {
 					Please take a moment to tell us more about your decision.
 				</span>
 			</p>
-			<ReasonSelection
-				productType={productType}
-				setSelectedReasonId={setSelectedReasonId}
-			/>
+			{!!productType.cancellation.reasons && (
+				<ReasonSelection
+					groupedProductFriendlyName={
+						GROUPED_PRODUCT_TYPES[productType.groupedProductType]
+							.friendlyName
+					}
+					cancellationReasons={productType.cancellation.reasons}
+					setSelectedReasonId={setSelectedReasonId}
+				/>
+			)}
 			{inValidationErrorState && !selectedReasonId.length && (
 				<InlineError
 					cssOverrides={css`

--- a/client/components/mma/cancel/contributions/ContributionsCancellationFlowPaymentIssueSaveAttempt.tsx
+++ b/client/components/mma/cancel/contributions/ContributionsCancellationFlowPaymentIssueSaveAttempt.tsx
@@ -38,7 +38,11 @@ export const ContributionsCancellationFlowPaymentIssueSaveAttempt = (
 		CancellationContext,
 	) as CancellationContextInterface;
 
-	if (!productType || !productDetail || !routerState.selectedReasonId) {
+	if (
+		!productType.cancellation.reasons ||
+		!productDetail ||
+		!routerState.selectedReasonId
+	) {
 		return <Navigate to="../" />;
 	}
 
@@ -54,7 +58,7 @@ export const ContributionsCancellationFlowPaymentIssueSaveAttempt = (
 	};
 
 	const onUpdateConfirmed = (updatedAmount: number) => {
-		const reason = productType.cancellation.reasons.find(
+		const reason = productType.cancellation.reasons?.find(
 			(reason) => reason.reasonId === routerState.selectedReasonId,
 		) as CancellationReason;
 

--- a/client/components/mma/cancel/stages/ConfirmCancellation.tsx
+++ b/client/components/mma/cancel/stages/ConfirmCancellation.tsx
@@ -109,7 +109,8 @@ export const ConfirmCancellation = () => {
 
 	const productIsSubscription = productType.productType === 'supporterplus'; // will we migrate other product like Guardian weekly over to this cancellation flow at some point?
 	const productIsContribution = productType.productType === 'contributions';
-	const productIsGuardianLight = productType.productType === 'guardianlight';
+	const productIsGuardianAdLite =
+		productType.productType === 'guardianadlite';
 
 	const progressStepperArray = [
 		{},
@@ -180,7 +181,7 @@ export const ConfirmCancellation = () => {
 							journalism.
 						</p>
 					)) ||
-					(productIsGuardianLight && (
+					(productIsGuardianAdLite && (
 						<>
 							<p>
 								If you confirm your cancellation, you will lose
@@ -212,6 +213,7 @@ export const ConfirmCancellation = () => {
 					<Button
 						cssOverrides={ctaBtnCss}
 						onClick={() => {
+							console.log('confirm cancellation click!');
 							navigate('../confirmed', {
 								state: routerState,
 							});
@@ -226,7 +228,7 @@ export const ConfirmCancellation = () => {
 							navigate('/');
 						}}
 					>
-						{productIsSubscription || productIsGuardianLight
+						{productIsSubscription || productIsGuardianAdLite
 							? 'Keep my subscription'
 							: 'Keep supporting'}
 					</Button>

--- a/client/components/mma/cancel/stages/ConfirmCancellation.tsx
+++ b/client/components/mma/cancel/stages/ConfirmCancellation.tsx
@@ -35,6 +35,13 @@ interface RouterSate extends DiscountPreviewResponse {
 	eligibleForFreePeriodOffer: boolean;
 }
 
+const headingWithContentAbove = css`
+	margin-bottom: ${space[6]}px;
+`;
+const headingWithoutContentAbove = css`
+	margin: ${space[9]}px 0 ${space[6]}px;
+`;
+
 const copyCss = css`
 	${textEgyptian17};
 `;
@@ -100,8 +107,16 @@ export const ConfirmCancellation = () => {
 
 	const subscription = productDetail.subscription;
 
-	const alternativeIsOffer = productType.productType === 'supporterplus';
-	const alternativeIsPause = productType.productType === 'contributions';
+	const productIsSubscription = productType.productType === 'supporterplus'; // will we migrate other product like Guardian weekly over to this cancellation flow at some point?
+	const productIsContribution = productType.productType === 'contributions';
+	const productIsGuardianLight = productType.productType === 'guardianlight';
+
+	const progressStepperArray = [
+		{},
+		{},
+		{ isCurrentStep: !routerState.eligibleForFreePeriodOffer },
+		{ isCurrentStep: routerState.eligibleForFreePeriodOffer },
+	];
 
 	useEffect(() => {
 		pageTitleContext.setPageTitle(
@@ -111,30 +126,27 @@ export const ConfirmCancellation = () => {
 
 	return (
 		<>
-			<ProgressStepper
-				steps={[
-					{},
-					{},
-					{ isCurrentStep: !routerState.eligibleForFreePeriodOffer },
-					{ isCurrentStep: routerState.eligibleForFreePeriodOffer },
-				]}
-				additionalCSS={css`
-					margin: ${space[8]}px 0 ${space[9]}px;
-				`}
-			/>
+			{productType.cancellation?.reasons && (
+				<ProgressStepper
+					steps={progressStepperArray}
+					additionalCSS={css`
+						margin: ${space[8]}px 0 ${space[9]}px;
+					`}
+				/>
+			)}
 			<Heading
 				borderless
 				cssOverrides={[
 					measure.heading,
-					css`
-						margin-bottom: ${space[6]}px;
-					`,
+					productType.cancellation?.reasons
+						? headingWithContentAbove
+						: headingWithoutContentAbove,
 				]}
 			>
 				Is this really goodbye?
 			</Heading>
 			<div css={copyCss}>
-				{alternativeIsOffer && (
+				{(productIsSubscription && (
 					<>
 						<p>
 							If you confirm your cancellation, you will lose the
@@ -160,13 +172,19 @@ export const ConfirmCancellation = () => {
 							</p>
 						)}
 					</>
-				)}
-				{alternativeIsPause && (
-					<p>
-						If you confirm your cancellation, you will no longer be
-						supporting the Guardian's reader-funded journalism.
-					</p>
-				)}
+				)) ||
+					(productIsContribution && (
+						<p>
+							If you confirm your cancellation, you will no longer
+							be supporting the Guardian's reader-funded
+							journalism.
+						</p>
+					)) ||
+					(productIsGuardianLight && (
+						<p>
+							Specific message for Guardian Light product holders.
+						</p>
+					))}
 				<div css={buttonsCtaHolder}>
 					<Button
 						cssOverrides={ctaBtnCss}
@@ -185,8 +203,9 @@ export const ConfirmCancellation = () => {
 							navigate('/');
 						}}
 					>
-						{alternativeIsOffer && 'Keep my subscription'}
-						{alternativeIsPause && 'Keep supporting'}
+						{productIsSubscription
+							? 'Keep my subscription'
+							: 'Keep supporting'}
 					</Button>
 				</div>
 			</div>

--- a/client/components/mma/cancel/stages/ConfirmCancellation.tsx
+++ b/client/components/mma/cancel/stages/ConfirmCancellation.tsx
@@ -213,7 +213,6 @@ export const ConfirmCancellation = () => {
 					<Button
 						cssOverrides={ctaBtnCss}
 						onClick={() => {
-							console.log('confirm cancellation click!');
 							navigate('../confirmed', {
 								state: routerState,
 							});

--- a/client/components/mma/cancel/stages/ConfirmCancellation.tsx
+++ b/client/components/mma/cancel/stages/ConfirmCancellation.tsx
@@ -144,7 +144,9 @@ export const ConfirmCancellation = () => {
 						: headingWithoutContentAbove,
 				]}
 			>
-				Is this really goodbye?
+				{productIsGuardianAdLite
+					? `Cancel your ${productType.productTitle()} subscription`
+					: 'Is this really goodbye?'}
 			</Heading>
 			<div css={copyCss}>
 				{(productIsSubscription && (
@@ -184,27 +186,26 @@ export const ConfirmCancellation = () => {
 					(productIsGuardianAdLite && (
 						<>
 							<p>
-								If you confirm your cancellation, you will lose
-								the following benefits:
+								If you confirm your cancellation, we will ask
+								you for your consent and you will start to see
+								personalised advertising across your devices.
 							</p>
-							<ul css={youllLoseList}>
-								<li>Unlimited access to the Guardian app</li>
-								<li>Ad-free reading across all your devices</li>
-								<li>Exclusive supporter newsletter</li>
-								<li>
-									Far fewer asks for support when you're
-									signed in
-								</li>
-							</ul>
-							{subscription.potentialCancellationDate && (
-								<p css={loseDateCss}>
-									You will no longer have access to these
-									benefits from{' '}
-									{parseDate(
-										subscription.potentialCancellationDate,
-										'yyyy-MM-dd',
-									).dateStr(DATE_FNS_LONG_OUTPUT_FORMAT)}
-									.
+							{!productDetail.inCoolingOffPeriod &&
+								subscription.potentialCancellationDate && (
+									<p>
+										You will no longer have access to these
+										benefits from{' '}
+										{parseDate(
+											subscription.potentialCancellationDate,
+											'yyyy-MM-dd',
+										).dateStr(DATE_FNS_LONG_OUTPUT_FORMAT)}
+										.
+									</p>
+								)}
+							{productDetail.inCoolingOffPeriod && (
+								<p>
+									After you cancel you will no longer have
+									access to these benefits.
 								</p>
 							)}
 						</>

--- a/client/components/mma/cancel/stages/ConfirmCancellation.tsx
+++ b/client/components/mma/cancel/stages/ConfirmCancellation.tsx
@@ -181,9 +181,32 @@ export const ConfirmCancellation = () => {
 						</p>
 					)) ||
 					(productIsGuardianLight && (
-						<p>
-							Specific message for Guardian Light product holders.
-						</p>
+						<>
+							<p>
+								If you confirm your cancellation, you will lose
+								the following benefits:
+							</p>
+							<ul css={youllLoseList}>
+								<li>Unlimited access to the Guardian app</li>
+								<li>Ad-free reading across all your devices</li>
+								<li>Exclusive supporter newsletter</li>
+								<li>
+									Far fewer asks for support when you're
+									signed in
+								</li>
+							</ul>
+							{subscription.potentialCancellationDate && (
+								<p css={loseDateCss}>
+									You will no longer have access to these
+									benefits from{' '}
+									{parseDate(
+										subscription.potentialCancellationDate,
+										'yyyy-MM-dd',
+									).dateStr(DATE_FNS_LONG_OUTPUT_FORMAT)}
+									.
+								</p>
+							)}
+						</>
 					))}
 				<div css={buttonsCtaHolder}>
 					<Button
@@ -203,7 +226,7 @@ export const ConfirmCancellation = () => {
 							navigate('/');
 						}}
 					>
-						{productIsSubscription
+						{productIsSubscription || productIsGuardianLight
 							? 'Keep my subscription'
 							: 'Keep supporting'}
 					</Button>

--- a/client/components/mma/cancel/stages/ExecuteCancellation.tsx
+++ b/client/components/mma/cancel/stages/ExecuteCancellation.tsx
@@ -124,12 +124,12 @@ export const getCancellationSummaryWithReturnButton =
 
 const getCaseUpdatingCancellationSummary =
 	(
-		caseId: string,
 		productType: ProductTypeWithCancellationFlow,
 		productDetailBeforeCancelling: ProductDetail,
 		eligableForOffer?: boolean,
 		eligibleForPause?: boolean,
 		cancellationReasonId?: CancellationReasonId,
+		caseId?: string,
 	) =>
 	(mdapiResponse: MembersDataApiResponse) => {
 		const productDetail = (mdapiResponse.products[0] as ProductDetail) || {
@@ -179,13 +179,18 @@ export const ExecuteCancellation = () => {
 	) as CancellationContextInterface;
 
 	const cancellationReasonId = useContext(CancellationReasonContext);
+	const productHasReasonSelection = productType.cancellation.reasons?.length
+		? true
+		: false;
 
-	if (!routerState?.selectedReasonId || !routerState?.caseId) {
+	if (
+		productHasReasonSelection &&
+		(!routerState?.selectedReasonId || !routerState?.caseId)
+	) {
 		return <Navigate to="../" />;
 	}
 
 	const caseId = routerState.caseId;
-
 	const alternativeIsOffer = productType.productType === 'supporterplus';
 	const alternativeIsPause = productType.productType === 'contributions';
 
@@ -236,7 +241,7 @@ export const ExecuteCancellation = () => {
 				))}
 
 			{isProduct(productDetail) ? (
-				escalationCauses.length > 0 ? (
+				escalationCauses.length > 0 && caseId ? (
 					<CaseUpdateAsyncLoader
 						fetch={getCaseUpdateFuncForEscalation(
 							caseId,
@@ -260,12 +265,12 @@ export const ExecuteCancellation = () => {
 							),
 						)}
 						render={getCaseUpdatingCancellationSummary(
-							caseId,
 							productType,
 							productDetail,
 							routerState.eligibleForFreePeriodOffer,
 							routerState.eligibleForPause,
 							cancellationReasonId,
+							caseId,
 						)}
 						loadingMessage="Performing your cancellation..."
 					/>

--- a/client/components/mma/cancel/stages/SavedCancellation.tsx
+++ b/client/components/mma/cancel/stages/SavedCancellation.tsx
@@ -41,7 +41,7 @@ export const SavedCancellation = () => {
 		return <Navigate to="../" />;
 	}
 
-	const reason = productType.cancellation.reasons.find(
+	const reason = productType.cancellation.reasons?.find(
 		(reason) => reason.reasonId === selectedReasonId,
 	) as CancellationReason;
 

--- a/client/components/mma/shared/Card.tsx
+++ b/client/components/mma/shared/Card.tsx
@@ -9,18 +9,18 @@ export const Card = (props: { children: ReactNode }) => {
 Card.Header = (props: {
 	children: ReactNode;
 	backgroundColor?: string;
-	minHeightTablet?: boolean;
+	minHeightOverride?: string;
 }) => {
 	const headerCss = css`
 		position: relative;
 		padding: ${space[3]}px ${space[4]}px;
-		min-height: 64px;
+		min-height: ${props.minHeightOverride ?? '64px'};
 		background-color: ${props.backgroundColor ?? palette.neutral[97]};
 		border-top-left-radius: 8px;
 		border-top-right-radius: 8px;
 		${from.tablet} {
 			border-radius: 0;
-			min-height: ${props.minHeightTablet ? '128px' : 'auto'};
+			min-height: auto;
 		}
 	`;
 

--- a/client/components/mma/shared/benefits/BenefitsConfiguration.ts
+++ b/client/components/mma/shared/benefits/BenefitsConfiguration.ts
@@ -71,43 +71,44 @@ export function filterBenefitByRegion(
 
 export const supporterPlusSwitchBenefits = [newsApp, feastApp, adFree];
 
-export const benefitsConfiguration: Record<ProductTypeKeys,ProductBenefit[]> = {
-	contributions: [
-		supporterNewsletter,
-		uninterruptedReading,
-		{
-			...newsApp,
-			isUnavailable: true,
-		},
-	],
-	supporterplus: [
-		supporterNewsletter,
-		uninterruptedReading,
-		newsApp,
-		feastApp,
-		adFree,
-		partnerOffers,
-	],
-	tierthree: [
-		guardianWeekly,
-		supporterNewsletter,
-		uninterruptedReading,
-		newsApp,
-		feastApp,
-		adFree,
-		partnerOffers,
-	],
-	membership: [newsApp, uninterruptedReading, supporterNewsletter],
-	digipack: [],
-	digitalvoucher: [],
-	newspaper: [],
-	homedelivery: [],
-	nationaldelivery: [],
-	voucher: [],
-	guardianweekly: [],
-	guardianlight: [],
-	guardianpatron: [],
-};
+export const benefitsConfiguration: Record<ProductTypeKeys, ProductBenefit[]> =
+	{
+		contributions: [
+			supporterNewsletter,
+			uninterruptedReading,
+			{
+				...newsApp,
+				isUnavailable: true,
+			},
+		],
+		supporterplus: [
+			supporterNewsletter,
+			uninterruptedReading,
+			newsApp,
+			feastApp,
+			adFree,
+			partnerOffers,
+		],
+		tierthree: [
+			guardianWeekly,
+			supporterNewsletter,
+			uninterruptedReading,
+			newsApp,
+			feastApp,
+			adFree,
+			partnerOffers,
+		],
+		membership: [newsApp, uninterruptedReading, supporterNewsletter],
+		digipack: [],
+		digitalvoucher: [],
+		newspaper: [],
+		homedelivery: [],
+		nationaldelivery: [],
+		voucher: [],
+		guardianweekly: [],
+		guardianadlite: [],
+		guardianpatron: [],
+	};
 
 export function getUpgradeBenefits(
 	supportProduct: 'contributions' | 'supporterplus',

--- a/client/components/mma/shared/benefits/BenefitsConfiguration.ts
+++ b/client/components/mma/shared/benefits/BenefitsConfiguration.ts
@@ -105,6 +105,7 @@ export const benefitsConfiguration: Record<ProductTypeKeys,ProductBenefit[]> = {
 	nationaldelivery: [],
 	voucher: [],
 	guardianweekly: [],
+	guardianlight: [],
 	guardianpatron: [],
 };
 

--- a/client/fixtures/productBuilder/baseProducts.ts
+++ b/client/fixtures/productBuilder/baseProducts.ts
@@ -11,7 +11,7 @@ import type { ProductDetail } from '../../../shared/productResponse';
 // 	| 'digipack'
 // 	| 'supporterplus'
 // 	| 'guardianpatron';
-// 	| 'guardianlight';
+// 	| 'guardianadlite';
 
 export function baseMembership(): ProductDetail {
 	return {
@@ -508,9 +508,9 @@ export function baseNationalDelivery(): ProductDetail {
 	};
 }
 
-export function baseGuardianLight(): ProductDetail {
+export function baseGuardianAdLite(): ProductDetail {
 	return {
-		tier: 'Guardian Light',
+		tier: 'Guardian Ad-Lite',
 		isPaidTier: true,
 		selfServiceCancellation: {
 			isAllowed: true,

--- a/client/fixtures/productBuilder/baseProducts.ts
+++ b/client/fixtures/productBuilder/baseProducts.ts
@@ -11,6 +11,7 @@ import type { ProductDetail } from '../../../shared/productResponse';
 // 	| 'digipack'
 // 	| 'supporterplus'
 // 	| 'guardianpatron';
+// 	| 'guardianlight';
 
 export function baseMembership(): ProductDetail {
 	return {
@@ -502,6 +503,61 @@ export function baseNationalDelivery(): ProductDetail {
 			readerType: 'Direct',
 			accountId: '8ad0965d7dbcc507017dbe20afd33ac4',
 			deliveryAddressChangeEffectiveDate: '2022-02-11',
+		},
+		isTestUser: false,
+	};
+}
+
+export function baseGuardianLight(): ProductDetail {
+	return {
+		tier: 'Guardian Light',
+		isPaidTier: true,
+		selfServiceCancellation: {
+			isAllowed: true,
+			shouldDisplayEmail: true,
+			phoneRegionsToDisplay: ['UK & ROW', 'US', 'AUS'],
+		},
+		joinDate: '2022-07-20',
+		optIn: true,
+		subscription: {
+			contactId: '0039E00001KA26BQAT',
+			deliveryAddress: {
+				addressLine1: 'Kings Place',
+				addressLine2: '90 York Place',
+				town: 'London',
+				postcode: 'N1 9GU',
+				country: 'United Kingdom',
+			},
+			safeToUpdatePaymentMethod: true,
+			start: '2022-07-20',
+			end: '2022-08-20',
+			nextPaymentPrice: 700,
+			nextPaymentDate: '2022-08-20',
+			lastPaymentDate: '2022-07-20',
+			potentialCancellationDate: null,
+			chargedThroughDate: '2022-08-20',
+			renewalDate: '2023-07-20',
+			anniversaryDate: '2023-07-20',
+			cancelledAt: false,
+			subscriptionId: 'A-S00303371',
+			trialLength: -2,
+			autoRenew: true,
+			currentPlans: [
+				{
+					name: null,
+					start: '2022-07-20',
+					end: '2023-07-20',
+					shouldBeVisible: true,
+					chargedThrough: '2022-08-20',
+					price: 700,
+					currency: '£',
+					currencyISO: 'GBP',
+					billingPeriod: 'month',
+				},
+			],
+			futurePlans: [],
+			readerType: 'Direct',
+			accountId: '8ad09f8a7e25bda3017e296317464818',
 		},
 		isTestUser: false,
 	};

--- a/client/fixtures/productBuilder/productBuilder.ts
+++ b/client/fixtures/productBuilder/productBuilder.ts
@@ -117,6 +117,17 @@ export class ProductBuilder {
 		return this;
 	}
 
+	withPotentialCancellationDate() {
+		this.productToBuild.subscription.potentialCancellationDate =
+			'2025-02-20';
+		return this;
+	}
+
+	inCoolingOffPeriod() {
+		this.productToBuild.inCoolingOffPeriod = true;
+		return this;
+	}
+
 	asPatron() {
 		this.productToBuild.subscription.readerType = 'Patron';
 		return this;

--- a/client/fixtures/productBuilder/testProducts.ts
+++ b/client/fixtures/productBuilder/testProducts.ts
@@ -3,6 +3,7 @@ import {
 	baseContribution,
 	baseDigitalPack,
 	baseDigitalVoucher,
+	baseGuardianLight,
 	baseGuardianWeekly,
 	baseHomeDelivery,
 	baseMembership,
@@ -263,6 +264,12 @@ export function supporterPlusInOfferPeriod() {
 	return new ProductBuilder(baseSupporterPlus())
 		.payByCard()
 		.inOfferPeriod()
+		.getProductDetailObject();
+}
+
+export function guardianLight() {
+	return new ProductBuilder(baseGuardianLight())
+		.payByCard()
 		.getProductDetailObject();
 }
 

--- a/client/fixtures/productBuilder/testProducts.ts
+++ b/client/fixtures/productBuilder/testProducts.ts
@@ -273,6 +273,13 @@ export function guardianLight() {
 		.getProductDetailObject();
 }
 
+export function guardianLightCancelled() {
+	return new ProductBuilder(baseGuardianLight())
+		.payByCard()
+		.cancel()
+		.getProductDetailObject();
+}
+
 export function tierThree() {
 	return new ProductBuilder(baseTierThree())
 		.payByCard()

--- a/client/fixtures/productBuilder/testProducts.ts
+++ b/client/fixtures/productBuilder/testProducts.ts
@@ -270,6 +270,14 @@ export function supporterPlusInOfferPeriod() {
 export function guardianAdLite() {
 	return new ProductBuilder(baseGuardianAdLite())
 		.payByCard()
+		.withPotentialCancellationDate()
+		.getProductDetailObject();
+}
+
+export function guardianAdLiteInCoolingOffPeriod() {
+	return new ProductBuilder(baseGuardianAdLite())
+		.payByCard()
+		.inCoolingOffPeriod()
 		.getProductDetailObject();
 }
 

--- a/client/fixtures/productBuilder/testProducts.ts
+++ b/client/fixtures/productBuilder/testProducts.ts
@@ -3,7 +3,7 @@ import {
 	baseContribution,
 	baseDigitalPack,
 	baseDigitalVoucher,
-	baseGuardianLight,
+	baseGuardianAdLite,
 	baseGuardianWeekly,
 	baseHomeDelivery,
 	baseMembership,
@@ -267,14 +267,14 @@ export function supporterPlusInOfferPeriod() {
 		.getProductDetailObject();
 }
 
-export function guardianLight() {
-	return new ProductBuilder(baseGuardianLight())
+export function guardianAdLite() {
+	return new ProductBuilder(baseGuardianAdLite())
 		.payByCard()
 		.getProductDetailObject();
 }
 
-export function guardianLightCancelled() {
-	return new ProductBuilder(baseGuardianLight())
+export function guardianAdLiteCancelled() {
+	return new ProductBuilder(baseGuardianAdLite())
 		.payByCard()
 		.cancel()
 		.getProductDetailObject();

--- a/cypress/tests/mocked/parallel-1/updateContributionAmount.cy.ts
+++ b/cypress/tests/mocked/parallel-1/updateContributionAmount.cy.ts
@@ -1,10 +1,10 @@
+import { toMembersDataApiResponse } from '../../../../client/fixtures/mdapiResponse';
 import {
 	contributionPaidByCard,
 	supporterPlusCancelled,
 	supporterPlusMonthlyAllAccessDigital,
 	supporterPlusMonthlyAllAccessDigitalBeforePriceRise,
 } from '../../../../client/fixtures/productBuilder/testProducts';
-import { toMembersDataApiResponse } from '../../../../client/fixtures/mdapiResponse';
 import { signInAndAcceptCookies } from '../../../lib/signInAndAcceptCookies';
 
 describe('Update contribution amount', () => {

--- a/cypress/tests/mocked/parallel-1/updatePaymentDetails.cy.ts
+++ b/cypress/tests/mocked/parallel-1/updatePaymentDetails.cy.ts
@@ -346,7 +346,7 @@ describe('Update payment details', () => {
 		cy.findByText('Recaptcha has not been completed.');
 	});
 
-	it.only('allows payment update for Guardian light product', () => {
+	it('allows payment update for Guardian light product', () => {
 		cy.intercept('GET', '/api/me/mma*', {
 			statusCode: 200,
 			body: toMembersDataApiResponse(guardianLight()),

--- a/cypress/tests/mocked/parallel-1/updatePaymentDetails.cy.ts
+++ b/cypress/tests/mocked/parallel-1/updatePaymentDetails.cy.ts
@@ -1,18 +1,18 @@
 import { toMembersDataApiResponse } from '../../../../client/fixtures/mdapiResponse';
 import {
-	stripeSetupIntent,
-	executePaymentUpdateResponse,
 	ddPaymentMethod,
+	executePaymentUpdateResponse,
+	stripeSetupIntent,
 } from '../../../../client/fixtures/payment';
-import { paymentMethods } from '../../../../client/fixtures/stripe';
-import { signInAndAcceptCookies } from '../../../lib/signInAndAcceptCookies';
 import {
 	digitalPackPaidByCardWithPaymentFailure,
 	digitalPackPaidByDirectDebit,
-	guardianLight,
+	guardianAdLite,
 	guardianWeeklyPaidByCard,
 } from '../../../../client/fixtures/productBuilder/testProducts';
 import { singleContributionsAPIResponse } from '../../../../client/fixtures/singleContribution';
+import { paymentMethods } from '../../../../client/fixtures/stripe';
+import { signInAndAcceptCookies } from '../../../lib/signInAndAcceptCookies';
 
 describe('Update payment details', () => {
 	beforeEach(() => {
@@ -346,15 +346,15 @@ describe('Update payment details', () => {
 		cy.findByText('Recaptcha has not been completed.');
 	});
 
-	it('allows payment update for Guardian light product', () => {
+	it('allows payment update for Guardian ad-lite product', () => {
 		cy.intercept('GET', '/api/me/mma*', {
 			statusCode: 200,
-			body: toMembersDataApiResponse(guardianLight()),
+			body: toMembersDataApiResponse(guardianAdLite()),
 		}).as('product_detail');
 
 		cy.intercept('GET', '/api/me/mma/**', {
 			statusCode: 200,
-			body: toMembersDataApiResponse(guardianLight()),
+			body: toMembersDataApiResponse(guardianAdLite()),
 		}).as('refetch_subscription');
 
 		cy.intercept('GET', '/mpapi/user/mobile-subscriptions', {

--- a/cypress/tests/mocked/parallel-1/updatePaymentDetails.cy.ts
+++ b/cypress/tests/mocked/parallel-1/updatePaymentDetails.cy.ts
@@ -396,7 +396,7 @@ describe('Update payment details', () => {
 		cy.wait('@product_detail');
 		cy.wait('@mobile_subscriptions');
 		cy.wait('@single_contributions');
-		cy.findByText('Manage support').click();
+		cy.findByText('Manage subscription').click();
 		cy.wait('@cancelled');
 
 		cy.findByText('Update payment method').click();

--- a/cypress/tests/mocked/parallel-1/updatePaymentDetails.cy.ts
+++ b/cypress/tests/mocked/parallel-1/updatePaymentDetails.cy.ts
@@ -9,6 +9,7 @@ import { signInAndAcceptCookies } from '../../../lib/signInAndAcceptCookies';
 import {
 	digitalPackPaidByCardWithPaymentFailure,
 	digitalPackPaidByDirectDebit,
+	guardianLight,
 	guardianWeeklyPaidByCard,
 } from '../../../../client/fixtures/productBuilder/testProducts';
 import { singleContributionsAPIResponse } from '../../../../client/fixtures/singleContribution';
@@ -343,5 +344,88 @@ describe('Update payment details', () => {
 		cy.findByText('Update payment method').click();
 
 		cy.findByText('Recaptcha has not been completed.');
+	});
+
+	it.only('allows payment update for Guardian light product', () => {
+		cy.intercept('GET', '/api/me/mma*', {
+			statusCode: 200,
+			body: toMembersDataApiResponse(guardianLight()),
+		}).as('product_detail');
+
+		cy.intercept('GET', '/api/me/mma/**', {
+			statusCode: 200,
+			body: toMembersDataApiResponse(guardianLight()),
+		}).as('refetch_subscription');
+
+		cy.intercept('GET', '/mpapi/user/mobile-subscriptions', {
+			statusCode: 200,
+			body: { subscriptions: [] },
+		}).as('mobile_subscriptions');
+
+		cy.intercept('GET', '/api/me/one-off-contributions', {
+			statusCode: 200,
+			body: singleContributionsAPIResponse,
+		}).as('single_contributions');
+
+		cy.intercept('GET', '/api/cancelled/', {
+			statusCode: 200,
+			body: [],
+		}).as('cancelled');
+
+		cy.intercept('POST', '/api/payment/card', {
+			statusCode: 200,
+			body: stripeSetupIntent,
+		}).as('createSetupIntent');
+
+		cy.intercept('POST', '/api/payment/card/**', {
+			statusCode: 200,
+			body: executePaymentUpdateResponse,
+		}).as('update_payment');
+
+		cy.intercept('POST', 'https://api.stripe.com/v1/setup_intents/**', {
+			statusCode: 200,
+			body: { status: 'succeeded' },
+		}).as('confirmCardSetup');
+
+		cy.intercept('POST', 'https://api.stripe.com/v1/payment_methods', {
+			statusCode: 200,
+			body: paymentMethods,
+		});
+
+		cy.visit('/');
+		cy.wait('@product_detail');
+		cy.wait('@mobile_subscriptions');
+		cy.wait('@single_contributions');
+		cy.findByText('Manage support').click();
+		cy.wait('@cancelled');
+
+		cy.findByText('Update payment method').click();
+
+		cy.resolve('Stripe').should((value) => {
+			expect(value).to.be.ok;
+		});
+
+		cy.fillElementsInput('cardNumber', '4242424242424242');
+		cy.fillElementsInput('cardExpiry', '1025');
+		cy.fillElementsInput('cardCvc', '123');
+
+		cy.get('#recaptcha *> iframe').then(($iframe) => {
+			const $body = $iframe.contents().find('body');
+			cy.wrap($body)
+				.find('.recaptcha-checkbox-border')
+				.should('be.visible')
+				.click()
+				.then(() => {
+					// wait for recaptcha to resolve
+					cy.wait(1000);
+
+					cy.findByText('Update payment method').click();
+				});
+		});
+
+		cy.wait('@update_payment');
+		cy.wait('@refetch_subscription');
+
+		cy.findByText('Your payment details were updated successfully');
 	});
 });

--- a/cypress/tests/mocked/parallel-2/cancelGuardianAdLite.cy.ts
+++ b/cypress/tests/mocked/parallel-2/cancelGuardianAdLite.cy.ts
@@ -81,7 +81,7 @@ describe('Cancel Guardian Ad-Lite', () => {
 	it('user successfully cancels', () => {
 		setupCancellation();
 
-		cy.intercept('GET', '/api/me/mma?productType=GuardianAdLite', {
+		cy.intercept('GET', '/api/me/mma/**', {
 			statusCode: 200,
 			body: toMembersDataApiResponse(guardianAdLiteCancelled()),
 		}).as('get_cancelled_product');

--- a/cypress/tests/mocked/parallel-2/cancelGuardianAdLite.cy.ts
+++ b/cypress/tests/mocked/parallel-2/cancelGuardianAdLite.cy.ts
@@ -1,11 +1,11 @@
-import {
-	guardianLight,
-	guardianLightCancelled,
-} from '../../../../client/fixtures/productBuilder/testProducts';
 import { toMembersDataApiResponse } from '../../../../client/fixtures/mdapiResponse';
+import {
+	guardianAdLite,
+	guardianAdLiteCancelled,
+} from '../../../../client/fixtures/productBuilder/testProducts';
 import { signInAndAcceptCookies } from '../../../lib/signInAndAcceptCookies';
 
-describe('Cancel Guardian Light', () => {
+describe('Cancel Guardian Ad-Lite', () => {
 	const setupCancellation = () => {
 		cy.visit('/');
 
@@ -38,14 +38,14 @@ describe('Cancel Guardian Light', () => {
 			body: { message: 'success' },
 		}).as('create_case_in_salesforce');
 
-		cy.intercept('GET', '/api/me/mma?productType=GuardianLight', {
+		cy.intercept('GET', '/api/me/mma?productType=GuardianAdLite', {
 			statusCode: 200,
-			body: toMembersDataApiResponse(guardianLight()),
+			body: toMembersDataApiResponse(guardianAdLite()),
 		});
 
 		cy.intercept('GET', '/api/me/mma', {
 			statusCode: 200,
-			body: toMembersDataApiResponse(guardianLight()),
+			body: toMembersDataApiResponse(guardianAdLite()),
 		}).as('mma');
 
 		cy.intercept('GET', '/mpapi/user/mobile-subscriptions', {
@@ -60,7 +60,7 @@ describe('Cancel Guardian Light', () => {
 
 		cy.intercept('GET', '/api/me/mma/**', {
 			statusCode: 200,
-			body: toMembersDataApiResponse(guardianLight()),
+			body: toMembersDataApiResponse(guardianAdLite()),
 		}).as('new_product_detail');
 
 		cy.intercept('GET', '/api/cancelled/', {
@@ -75,26 +75,26 @@ describe('Cancel Guardian Light', () => {
 
 		cy.intercept('POST', '/api/cancel/**', {
 			statusCode: 200,
-		}).as('cancel_guardian_light');
+		}).as('cancel_guardian_ad_lite');
 	});
 
 	it('user successfully cancels', () => {
 		setupCancellation();
 
-		cy.intercept('GET', '/api/me/mma?productType=GuardianLight', {
+		cy.intercept('GET', '/api/me/mma?productType=GuardianAdLite', {
 			statusCode: 200,
-			body: toMembersDataApiResponse(guardianLightCancelled()),
+			body: toMembersDataApiResponse(guardianAdLiteCancelled()),
 		}).as('get_cancelled_product');
 
 		cy.findByText('Is this really goodbye?');
 
 		cy.findByRole('button', { name: 'Confirm cancellation' }).click();
 
-		cy.wait('@cancel_guardian_light');
+		cy.wait('@cancel_guardian_ad_lite');
 		cy.wait('@get_cancelled_product');
 
 		cy.findByRole('heading', {
-			name: 'Your guardian light is cancelled',
+			name: 'Your guardian ad-lite is cancelled',
 		});
 	});
 });

--- a/cypress/tests/mocked/parallel-2/cancelGuardianLight.cy.ts
+++ b/cypress/tests/mocked/parallel-2/cancelGuardianLight.cy.ts
@@ -14,10 +14,10 @@ describe('Cancel Guardian Light', () => {
 		cy.wait('@mobile_subscriptions');
 		cy.wait('@single_contributions');
 
-		cy.findByText('Manage support').click();
+		cy.findByText('Manage subscription').click();
 
 		cy.findByRole('link', {
-			name: 'Cancel support',
+			name: 'Cancel subscription',
 		}).click();
 	};
 

--- a/cypress/tests/mocked/parallel-2/cancelGuardianLight.cy.ts
+++ b/cypress/tests/mocked/parallel-2/cancelGuardianLight.cy.ts
@@ -1,4 +1,7 @@
-import { guardianLight, guardianLightCancelled } from '../../../../client/fixtures/productBuilder/testProducts';
+import {
+	guardianLight,
+	guardianLightCancelled,
+} from '../../../../client/fixtures/productBuilder/testProducts';
 import { toMembersDataApiResponse } from '../../../../client/fixtures/mdapiResponse';
 import { signInAndAcceptCookies } from '../../../lib/signInAndAcceptCookies';
 
@@ -75,7 +78,7 @@ describe('Cancel Guardian Light', () => {
 		}).as('cancel_guardian_light');
 	});
 
-	it.only('user successfully cancels', () => {
+	it('user successfully cancels', () => {
 		setupCancellation();
 
 		cy.intercept('GET', '/api/me/mma?productType=GuardianLight', {
@@ -83,7 +86,7 @@ describe('Cancel Guardian Light', () => {
 			body: toMembersDataApiResponse(guardianLightCancelled()),
 		}).as('get_cancelled_product');
 
-		cy.findByText('Specific message for Guardian Light product holders.');
+		cy.findByText('Is this really goodbye?');
 
 		cy.findByRole('button', { name: 'Confirm cancellation' }).click();
 
@@ -93,34 +96,5 @@ describe('Cancel Guardian Light', () => {
 		cy.findByRole('heading', {
 			name: 'Your guardian light is cancelled',
 		});
-		/*
-		cy.intercept('GET', '/api/me/mma/**', {
-			statusCode: 200,
-			body: toMembersDataApiResponse(supporterPlusCancelled()),
-		}).as('get_cancelled_product');
-
-		cy.findByRole('radio', {
-			name: 'I am unhappy with some editorial decisions',
-		}).click();
-		cy.findByRole('button', { name: 'Continue' }).click();
-
-		cy.wait('@get_case');
-
-		cy.findByRole('button', { name: 'Continue to cancellation' }).click();
-
-		cy.findByRole('button', {
-			name: 'Confirm cancellation',
-		}).click();
-
-		cy.wait('@create_case_in_salesforce');
-		cy.wait('@cancel_supporter_plus');
-		cy.wait('@get_cancelled_product');
-
-		cy.findByRole('heading', {
-			name: 'Your subscription has been cancelled',
-		});
-
-		cy.get('@get_cancellation_date.all').should('have.length', 0);
-		*/
 	});
 });

--- a/cypress/tests/mocked/parallel-2/cancelGuardianLight.cy.ts
+++ b/cypress/tests/mocked/parallel-2/cancelGuardianLight.cy.ts
@@ -1,0 +1,126 @@
+import { guardianLight, guardianLightCancelled } from '../../../../client/fixtures/productBuilder/testProducts';
+import { toMembersDataApiResponse } from '../../../../client/fixtures/mdapiResponse';
+import { signInAndAcceptCookies } from '../../../lib/signInAndAcceptCookies';
+
+describe('Cancel Guardian Light', () => {
+	const setupCancellation = () => {
+		cy.visit('/');
+
+		cy.wait('@mma');
+		cy.wait('@cancelled');
+		cy.wait('@mobile_subscriptions');
+		cy.wait('@single_contributions');
+
+		cy.findByText('Manage support').click();
+
+		cy.findByRole('link', {
+			name: 'Cancel support',
+		}).click();
+	};
+
+	beforeEach(() => {
+		cy.setCookie('GU_mvt_id', '0');
+
+		signInAndAcceptCookies();
+
+		cy.intercept('POST', '/api/case', {
+			statusCode: 200,
+			body: {
+				id: 'caseId',
+			},
+		}).as('get_case');
+
+		cy.intercept('PATCH', '/api/case/**', {
+			statusCode: 200,
+			body: { message: 'success' },
+		}).as('create_case_in_salesforce');
+
+		cy.intercept('GET', '/api/me/mma?productType=GuardianLight', {
+			statusCode: 200,
+			body: toMembersDataApiResponse(guardianLight()),
+		});
+
+		cy.intercept('GET', '/api/me/mma', {
+			statusCode: 200,
+			body: toMembersDataApiResponse(guardianLight()),
+		}).as('mma');
+
+		cy.intercept('GET', '/mpapi/user/mobile-subscriptions', {
+			statusCode: 200,
+			body: { subscriptions: [] },
+		}).as('mobile_subscriptions');
+
+		cy.intercept('GET', '/api/me/one-off-contributions', {
+			statusCode: 200,
+			body: [],
+		}).as('single_contributions');
+
+		cy.intercept('GET', '/api/me/mma/**', {
+			statusCode: 200,
+			body: toMembersDataApiResponse(guardianLight()),
+		}).as('new_product_detail');
+
+		cy.intercept('GET', '/api/cancelled/', {
+			statusCode: 200,
+			body: [],
+		}).as('cancelled');
+
+		cy.intercept('GET', 'api/cancellation-date/**', {
+			statusCode: 200,
+			body: { cancellationEffectiveDate: '2022-02-05' },
+		}).as('get_cancellation_date');
+
+		cy.intercept('POST', '/api/cancel/**', {
+			statusCode: 200,
+		}).as('cancel_guardian_light');
+	});
+
+	it.only('user successfully cancels', () => {
+		setupCancellation();
+
+		cy.intercept('GET', '/api/me/mma?productType=GuardianLight', {
+			statusCode: 200,
+			body: toMembersDataApiResponse(guardianLightCancelled()),
+		}).as('get_cancelled_product');
+
+		cy.findByText('Specific message for Guardian Light product holders.');
+
+		cy.findByRole('button', { name: 'Confirm cancellation' }).click();
+
+		cy.wait('@cancel_guardian_light');
+		cy.wait('@get_cancelled_product');
+
+		cy.findByRole('heading', {
+			name: 'Your guardian light is cancelled',
+		});
+		/*
+		cy.intercept('GET', '/api/me/mma/**', {
+			statusCode: 200,
+			body: toMembersDataApiResponse(supporterPlusCancelled()),
+		}).as('get_cancelled_product');
+
+		cy.findByRole('radio', {
+			name: 'I am unhappy with some editorial decisions',
+		}).click();
+		cy.findByRole('button', { name: 'Continue' }).click();
+
+		cy.wait('@get_case');
+
+		cy.findByRole('button', { name: 'Continue to cancellation' }).click();
+
+		cy.findByRole('button', {
+			name: 'Confirm cancellation',
+		}).click();
+
+		cy.wait('@create_case_in_salesforce');
+		cy.wait('@cancel_supporter_plus');
+		cy.wait('@get_cancelled_product');
+
+		cy.findByRole('heading', {
+			name: 'Your subscription has been cancelled',
+		});
+
+		cy.get('@get_cancellation_date.all').should('have.length', 0);
+		*/
+	});
+});

--- a/shared/ophanTypes.ts
+++ b/shared/ophanTypes.ts
@@ -12,6 +12,7 @@ export type OphanProduct =
 	| 'PAPER_SUBSCRIPTION_SUNDAY'
 	| 'PRINT_SUBSCRIPTION'
 	| 'APP_PREMIUM_TIER'
+	| 'GUARDIAN_LIGHT'
 	| 'GUARDIAN_PATRON';
 
 type OphanAction =

--- a/shared/ophanTypes.ts
+++ b/shared/ophanTypes.ts
@@ -12,7 +12,7 @@ export type OphanProduct =
 	| 'PAPER_SUBSCRIPTION_SUNDAY'
 	| 'PRINT_SUBSCRIPTION'
 	| 'APP_PREMIUM_TIER'
-	| 'GUARDIAN_LIGHT'
+	| 'GUARDIAN_AD_LITE'
 	| 'GUARDIAN_PATRON';
 
 type OphanAction =

--- a/shared/productResponse.ts
+++ b/shared/productResponse.ts
@@ -86,7 +86,7 @@ export const productTiers = [
 	'Newspaper Delivery',
 	'Patron',
 	'Partner',
-	'Guardian Light',
+	'Guardian Ad-Lite',
 ];
 
 export type ProductTier = typeof productTiers[number];
@@ -298,8 +298,8 @@ export function getSpecificProductTypeFromTier(
 		case 'Newspaper Digital Voucher':
 			productType = PRODUCT_TYPES.digitalvoucher;
 			break;
-		case 'Guardian Light':
-			productType = PRODUCT_TYPES.guardianlight;
+		case 'Guardian Ad-Lite':
+			productType = PRODUCT_TYPES.guardianadlite;
 			break;
 		case 'guardianpatron':
 			productType = PRODUCT_TYPES.guardianpatron;

--- a/shared/productResponse.ts
+++ b/shared/productResponse.ts
@@ -101,6 +101,7 @@ export interface ProductDetail extends WithSubscription {
 	joinDate: string;
 	alertText?: string;
 	selfServiceCancellation: SelfServiceCancellation;
+	inCoolingOffPeriod?: boolean;
 	billingCountry?: string;
 }
 

--- a/shared/productResponse.ts
+++ b/shared/productResponse.ts
@@ -86,6 +86,7 @@ export const productTiers = [
 	'Newspaper Delivery',
 	'Patron',
 	'Partner',
+	'Guardian Light',
 ];
 
 export type ProductTier = typeof productTiers[number];
@@ -296,6 +297,9 @@ export function getSpecificProductTypeFromTier(
 			break;
 		case 'Newspaper Digital Voucher':
 			productType = PRODUCT_TYPES.digitalvoucher;
+			break;
+		case 'Guardian Light':
+			productType = PRODUCT_TYPES.guardianlight;
 			break;
 		case 'guardianpatron':
 			productType = PRODUCT_TYPES.guardianpatron;

--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -92,7 +92,7 @@ export type AllProductsProductTypeFilterString =
 	| 'TierThree';
 
 interface CancellationFlowProperties {
-	reasons: CancellationReason[];
+	reasons?: CancellationReason[];
 	sfCaseProduct: SfCaseProduct;
 	checkForOutstandingCredits?: true;
 	flowWrapper?: (
@@ -104,12 +104,12 @@ interface CancellationFlowProperties {
 	hideReasonTitlePrefix?: true;
 	alternateSummaryMainPara?: string;
 	shouldHideSummaryMainPara?: true;
-	summaryReasonSpecificPara: (
+	summaryReasonSpecificPara?: (
 		reasonId: OptionalCancellationReasonId,
 		currencyISO?: CurrencyIso,
 	) => string | undefined;
 	onlyShowSupportSectionIfAlternateText: boolean;
-	alternateSupportButtonText: (
+	alternateSupportButtonText?: (
 		reasonId: OptionalCancellationReasonId,
 	) => string | undefined;
 	alternateSupportButtonUrlSuffix: (
@@ -728,33 +728,10 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 		cancellation: {
 			alternateSummaryMainPara:
 				'This is immediate and you will not be charged again.',
-			reasons: shuffledContributionsCancellationReasons,
 			sfCaseProduct: 'Guardian Light',
 			startPageBody: contributionsCancellationFlowStart,
 			shouldHideSummaryMainPara: true,
-			summaryReasonSpecificPara: (
-				reasonId: OptionalCancellationReasonId,
-			) => {
-				switch (reasonId) {
-					case 'mma_financial_circumstances':
-					case 'mma_value_for_money':
-						return 'You can support The Guardian’s independent journalism with a One-time contribution, from as little as £1 – and it only takes a minute.';
-					default:
-						return undefined;
-				}
-			},
 			onlyShowSupportSectionIfAlternateText: true,
-			alternateSupportButtonText: (
-				reasonId: OptionalCancellationReasonId,
-			) => {
-				switch (reasonId) {
-					case 'mma_financial_circumstances':
-					case 'mma_value_for_money':
-						return 'Make a One-time contribution';
-					default:
-						return undefined;
-				}
-			},
 			alternateSupportButtonUrlSuffix: () => undefined,
 			swapFeedbackAndContactUs: true,
 			shouldHideThrasher: true,

--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -717,7 +717,7 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 		productTitle: () => 'Guardian Light',
 		friendlyName: 'guardian light',
 		productType: 'guardianlight',
-		groupedProductType: 'recurringSupport',
+		groupedProductType: 'recurringSupportWithBenefits',
 		allProductsProductTypeFilterString: 'GuardianLight',
 		urlPart: 'guardianlight',
 		getOphanProductType: () => 'GUARDIAN_LIGHT',
@@ -726,16 +726,12 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 			SoftOptInIDs.SupporterNewsletter,
 		],
 		cancellation: {
-			alternateSummaryMainPara:
-				'This is immediate and you will not be charged again.',
 			sfCaseProduct: 'Guardian Light',
 			startPageBody: contributionsCancellationFlowStart,
-			shouldHideSummaryMainPara: true,
 			onlyShowSupportSectionIfAlternateText: true,
 			alternateSupportButtonUrlSuffix: () => undefined,
 			swapFeedbackAndContactUs: true,
 			shouldHideThrasher: true,
-			shouldShowReminder: true,
 		},
 	},
 };

--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -742,6 +742,8 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 			alternateSupportButtonUrlSuffix: () => undefined,
 			swapFeedbackAndContactUs: true,
 			shouldHideThrasher: true,
+			alternateSummaryMainPara:
+				"This is immediate and you will not be charged again. If you've cancelled within the first 14 days, we'll send you a full refund.",
 		},
 	},
 };

--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -48,7 +48,7 @@ type ProductFriendlyName =
 	| 'subscription'
 	| 'support'
 	| 'recurring support'
-	| 'guardian light'
+	| 'guardian ad-lite'
 	| 'guardian patron';
 type ProductUrlPart =
 	| 'membership'
@@ -64,7 +64,7 @@ type ProductUrlPart =
 	| 'digital+print'
 	| 'subscriptions'
 	| 'recurringsupport'
-	| 'guardianlight'
+	| 'guardianadlite'
 	| 'guardianpatron';
 type SfCaseProduct =
 	| 'Membership'
@@ -74,7 +74,7 @@ type SfCaseProduct =
 	| 'Digital Pack Subscriptions'
 	| 'Supporter Plus'
 	| 'Tier Three'
-	| 'Guardian Light'
+	| 'Guardian Ad-Lite'
 	| 'Guardian Patron';
 export type AllProductsProductTypeFilterString =
 	| 'Weekly'
@@ -88,7 +88,7 @@ export type AllProductsProductTypeFilterString =
 	| 'SupporterPlus'
 	| 'ContentSubscription'
 	| 'GuardianPatron'
-	| 'GuardianLight'
+	| 'GuardianAdLite'
 	| 'TierThree';
 
 interface CancellationFlowProperties {
@@ -118,6 +118,11 @@ interface CancellationFlowProperties {
 	swapFeedbackAndContactUs?: true;
 	shouldShowReminder?: true;
 	shouldHideThrasher?: true;
+}
+
+interface CancellationFlowPropertiesMandatoryReasons
+	extends CancellationFlowProperties {
+	reasons: CancellationReason[];
 }
 
 export interface HolidayStopFlowProperties {
@@ -209,6 +214,11 @@ export interface ProductTypeWithCancellationFlow extends ProductType {
 	cancellation: CancellationFlowProperties;
 }
 
+export interface ProductTypeWithCancellationFlowMandatoryReasons
+	extends ProductType {
+	cancellation: CancellationFlowPropertiesMandatoryReasons;
+}
+
 export interface ProductTypeWithDeliveryRecordsProperties extends ProductType {
 	delivery: {
 		records: DeliveryRecordsProperties;
@@ -267,7 +277,7 @@ export type ProductTypeKeys =
 	| 'digipack'
 	| 'supporterplus'
 	| 'tierthree'
-	| 'guardianlight'
+	| 'guardianadlite'
 	| 'guardianpatron';
 
 export type GroupedProductTypeKeys =
@@ -713,20 +723,20 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 			SoftOptInIDs.SupporterNewsletter,
 		],
 	},
-	guardianlight: {
-		productTitle: () => 'Guardian Light',
-		friendlyName: 'guardian light',
-		productType: 'guardianlight',
+	guardianadlite: {
+		productTitle: () => 'Guardian Ad-Lite',
+		friendlyName: 'guardian ad-lite',
+		productType: 'guardianadlite',
 		groupedProductType: 'recurringSupportWithBenefits',
-		allProductsProductTypeFilterString: 'GuardianLight',
-		urlPart: 'guardianlight',
-		getOphanProductType: () => 'GUARDIAN_LIGHT',
+		allProductsProductTypeFilterString: 'GuardianAdLite',
+		urlPart: 'guardianadlite',
+		getOphanProductType: () => 'GUARDIAN_AD_LITE',
 		softOptInIDs: [
 			SoftOptInIDs.SupportOnboarding,
 			SoftOptInIDs.SupporterNewsletter,
 		],
 		cancellation: {
-			sfCaseProduct: 'Guardian Light',
+			sfCaseProduct: 'Guardian Ad-Lite',
 			startPageBody: contributionsCancellationFlowStart,
 			onlyShowSupportSectionIfAlternateText: true,
 			alternateSupportButtonUrlSuffix: () => undefined,

--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -48,6 +48,7 @@ type ProductFriendlyName =
 	| 'subscription'
 	| 'support'
 	| 'recurring support'
+	| 'guardian light'
 	| 'guardian patron';
 type ProductUrlPart =
 	| 'membership'
@@ -63,6 +64,7 @@ type ProductUrlPart =
 	| 'digital+print'
 	| 'subscriptions'
 	| 'recurringsupport'
+	| 'guardianlight'
 	| 'guardianpatron';
 type SfCaseProduct =
 	| 'Membership'
@@ -72,6 +74,7 @@ type SfCaseProduct =
 	| 'Digital Pack Subscriptions'
 	| 'Supporter Plus'
 	| 'Tier Three'
+	| 'Guardian Light'
 	| 'Guardian Patron';
 export type AllProductsProductTypeFilterString =
 	| 'Weekly'
@@ -85,12 +88,12 @@ export type AllProductsProductTypeFilterString =
 	| 'SupporterPlus'
 	| 'ContentSubscription'
 	| 'GuardianPatron'
+	| 'GuardianLight'
 	| 'TierThree';
 
 interface CancellationFlowProperties {
 	reasons: CancellationReason[];
 	sfCaseProduct: SfCaseProduct;
-	linkOnProductPage?: true;
 	checkForOutstandingCredits?: true;
 	flowWrapper?: (
 		productDetail: ProductDetail,
@@ -177,7 +180,6 @@ export interface ProductType {
 	showSupporterId?: boolean;
 	tierLabel?: string;
 	renewalMetadata?: SupportTheGuardianButtonProps;
-	noProductSupportUrlSuffix?: string;
 	cancellation?: CancellationFlowProperties; // undefined 'cancellation' means no cancellation flow
 	cancelledCopy?: string;
 	showTrialRemainingIfApplicable?: true;
@@ -265,6 +267,7 @@ export type ProductTypeKeys =
 	| 'digipack'
 	| 'supporterplus'
 	| 'tierthree'
+	| 'guardianlight'
 	| 'guardianpatron';
 
 export type GroupedProductTypeKeys =
@@ -327,7 +330,6 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 		allProductsProductTypeFilterString: 'Contribution',
 		urlPart: 'contributions',
 		getOphanProductType: () => 'RECURRING_CONTRIBUTION',
-		noProductSupportUrlSuffix: '/contribute',
 		updateAmountMdaEndpoint: 'contribution-update-amount',
 		softOptInIDs: [
 			SoftOptInIDs.SupportOnboarding,
@@ -336,7 +338,6 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 		cancellation: {
 			alternateSummaryMainPara:
 				'This is immediate and you will not be charged again.',
-			linkOnProductPage: true,
 			reasons: shuffledContributionsCancellationReasons,
 			sfCaseProduct: 'Recurring - Contributions',
 			startPageBody: contributionsCancellationFlowStart,
@@ -502,7 +503,6 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 			enableDeliveryInstructionsUpdate: true,
 		},
 		cancellation: {
-			linkOnProductPage: true,
 			reasons: shuffledVoucherCancellationReasons,
 			sfCaseProduct: 'Voucher Subscriptions',
 			checkForOutstandingCredits: true,
@@ -574,7 +574,6 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 			},
 		},
 		cancellation: {
-			linkOnProductPage: true,
 			reasons: shuffledGWCancellationReasons,
 			sfCaseProduct: 'Guardian Weekly',
 			checkForOutstandingCredits: true,
@@ -620,7 +619,6 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 			},
 		},
 		cancellation: {
-			linkOnProductPage: true,
 			reasons: shuffledTierThreeCancellationReasons,
 			sfCaseProduct: 'Tier Three',
 			checkForOutstandingCredits: true,
@@ -659,7 +657,6 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 			SoftOptInIDs.SupporterNewsletter,
 		],
 		cancellation: {
-			linkOnProductPage: true,
 			reasons: shuffledDigipackCancellationReasons,
 			sfCaseProduct: 'Digital Pack Subscriptions',
 			startPageBody: digipackCancellationFlowStart,
@@ -690,7 +687,6 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 		cancellation: {
 			alternateSummaryMainPara:
 				"This is immediate and you will not be charged again. If you've cancelled within the first 14 days, we'll send you a full refund.",
-			linkOnProductPage: true,
 			reasons: shuffledSupporterPlusCancellationReasons,
 			sfCaseProduct: 'Supporter Plus',
 			startPageBody: supporterplusCancellationFlowStart,
@@ -716,6 +712,54 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 			SoftOptInIDs.DigitalSubscriberPreview,
 			SoftOptInIDs.SupporterNewsletter,
 		],
+	},
+	guardianlight: {
+		productTitle: () => 'Guardian Light',
+		friendlyName: 'guardian light',
+		productType: 'guardianlight',
+		groupedProductType: 'recurringSupport',
+		allProductsProductTypeFilterString: 'GuardianLight',
+		urlPart: 'guardianlight',
+		getOphanProductType: () => 'GUARDIAN_LIGHT',
+		softOptInIDs: [
+			SoftOptInIDs.SupportOnboarding,
+			SoftOptInIDs.SupporterNewsletter,
+		],
+		cancellation: {
+			alternateSummaryMainPara:
+				'This is immediate and you will not be charged again.',
+			reasons: shuffledContributionsCancellationReasons,
+			sfCaseProduct: 'Guardian Light',
+			startPageBody: contributionsCancellationFlowStart,
+			shouldHideSummaryMainPara: true,
+			summaryReasonSpecificPara: (
+				reasonId: OptionalCancellationReasonId,
+			) => {
+				switch (reasonId) {
+					case 'mma_financial_circumstances':
+					case 'mma_value_for_money':
+						return 'You can support The Guardian’s independent journalism with a One-time contribution, from as little as £1 – and it only takes a minute.';
+					default:
+						return undefined;
+				}
+			},
+			onlyShowSupportSectionIfAlternateText: true,
+			alternateSupportButtonText: (
+				reasonId: OptionalCancellationReasonId,
+			) => {
+				switch (reasonId) {
+					case 'mma_financial_circumstances':
+					case 'mma_value_for_money':
+						return 'Make a One-time contribution';
+					default:
+						return undefined;
+				}
+			},
+			alternateSupportButtonUrlSuffix: () => undefined,
+			swapFeedbackAndContactUs: true,
+			shouldHideThrasher: true,
+			shouldShowReminder: true,
+		},
 	},
 };
 export const GROUPED_PRODUCT_TYPES: Record<


### PR DESCRIPTION
### What does this PR change?
Add a new product 'Guardian Ad-Lite' to manage frontend.

The product has minimal functionality, users should be able to see the product in the account overview, manage product and billing pages. They should be able to update their payment details and cancel the product.

This pr adds the product to the relevant pages and allows the user to update their payment details.

### Images
![Screenshot 2024-10-24 at 10 32 39](https://github.com/user-attachments/assets/c42ea991-9cf4-42bd-b4e2-f09e12a7ae19)

<img width="1419" alt="Screenshot 2025-02-07 at 10 37 24" src="https://github.com/user-attachments/assets/10367277-bae4-47d4-ae1d-139ce750700e" />

<img width="1419" alt="Screenshot 2025-02-07 at 10 37 54" src="https://github.com/user-attachments/assets/bb7753c9-7e06-4e6b-8c09-146bf81f0d8d" />

<img width="1419" alt="Screenshot 2025-02-07 at 10 38 28" src="https://github.com/user-attachments/assets/e9c41890-afd0-4bb2-9054-31b1a53746d2" />

<img width="1419" alt="Screenshot 2025-02-07 at 10 44 51" src="https://github.com/user-attachments/assets/a4f76a59-e29e-4e79-98a6-0fe5a9ec39dc" />







