### PR TITLE
Newspaper archive auth - add query params override, validate return URL

### DIFF
--- a/server/routes/newspaperArchive.ts
+++ b/server/routes/newspaperArchive.ts
@@ -82,11 +82,7 @@ router.get('/auth', async (req: Request, res: Response) => {
 
 			const archiveReturnUrl = new URL(archiveReturnUrlString);
 
-			if (
-				!archiveReturnUrl.hostname.endsWith(
-					'theguardian.newspapers.com',
-				)
-			) {
+			if (archiveReturnUrl.hostname !== 'theguardian.newspapers.com') {
 				log.error('Invalid ncom return URL hostname');
 				return res.redirect(responseJson.url);
 			}

--- a/server/routes/newspaperArchive.ts
+++ b/server/routes/newspaperArchive.ts
@@ -36,7 +36,7 @@ const newspaperArchiveConfigPromise: Promise<
 
 const router = Router();
 
-router.use(withIdentity(401));
+router.use(withIdentity(401, true));
 
 router.get('/auth', async (req: Request, res: Response) => {
 	try {
@@ -81,6 +81,16 @@ router.get('/auth', async (req: Request, res: Response) => {
 			const tpaToken = new URL(responseJson.url).searchParams.get('tpa');
 
 			const archiveReturnUrl = new URL(archiveReturnUrlString);
+
+			if (
+				!archiveReturnUrl.hostname.endsWith(
+					'theguardian.newspapers.com',
+				)
+			) {
+				log.error('Invalid ncom return URL hostname');
+				return res.redirect(responseJson.url);
+			}
+
 			archiveReturnUrl.searchParams.set('tpa', tpaToken ?? '');
 			return res.redirect(archiveReturnUrl.toString());
 		}


### PR DESCRIPTION
### Current situation/background

We have an authentication endpoint to redirect users to newspapers dot com. This allows us to deliver a new benefit to subscribers of the Digital + Print product. The endpoint includes a feature that allows users to go back to the same page they were looking at, included as a link on a n com sign in modal. At the moment this doesn't work because the query param gets stripped out by our authentication middleware. 

Modal with sign in link:
![image](https://github.com/user-attachments/assets/6ac4b1ea-009a-4a42-a469-bcdde2df313b)

Example URL:
https://manage.theguardian.com/newspaperArchive/auth?ncom-return-url=https%3A%2F%2Ftheguardian.newspapers.com%2Fimage%2F259880906%2F%3Fmatch%3D1%26terms%3Dking%2527s%2520place

### What does this PR change?

This PR adds an override to the URL sanitisation in order to preserve the `ncom-return-url` query param, and a check that the hostname is indeed newspapers dot com.

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->
