### PR TITLE
fire custom quantum metric event at the start of the cancellation flow

### DIFF
--- a/client/components/mma/cancel/CancellationJourneyFunnel.tsx
+++ b/client/components/mma/cancel/CancellationJourneyFunnel.tsx
@@ -37,12 +37,19 @@ export const CancellationJourneyFunnel = () => {
 	const productTypeKey = productType.productType;
 
 	const possiblePaidPlan = productDetail.subscription.currentPlans[0];
-	const qmEventString = `cancellation start | ${productType.friendlyName}${
-		isPaidSubscriptionPlan(possiblePaidPlan)
-			? ` | billing period: ${possiblePaidPlan.billingPeriod}`
-			: ''
-	}`;
-	window.QuantumMetricAPI?.sendEvent(184, 0, qmEventString);
+	const qmEventId = 184;
+	const qmIsConversionEvent = 0;
+	const qmEvent = [
+		'cancellation start',
+		productType.friendlyName,
+		isPaidSubscriptionPlan(possiblePaidPlan) &&
+			`billing period: ${possiblePaidPlan.billingPeriod}`,
+	].filter(Boolean);
+	window.QuantumMetricAPI?.sendEvent(
+		qmEventId,
+		qmIsConversionEvent,
+		qmEvent.join(' | '),
+	);
 
 	if (
 		!routerState?.dontShowOffer &&

--- a/shared/globals.ts
+++ b/shared/globals.ts
@@ -28,7 +28,12 @@ export interface Globals extends CommonGlobals {
 	stripeKeyDefaultCurrencies?: StripePublicKeySet;
 }
 interface QuantumMetricAPIPartial {
-	sendEvent: (param1: number, param2: number, event: string) => void;
+	sendEvent: (
+		eventId: number | string,
+		conversion?: number | boolean,
+		eventValue?: number | string,
+		attributes?: Record<string, string | boolean | number | undefined>,
+	) => void;
 }
 declare global {
 	interface Window {

--- a/shared/globals.ts
+++ b/shared/globals.ts
@@ -27,9 +27,13 @@ export interface Globals extends CommonGlobals {
 	stripeKeyAustralia?: StripePublicKeySet;
 	stripeKeyDefaultCurrencies?: StripePublicKeySet;
 }
+interface QuantumMetricAPIPartial {
+	sendEvent: (param1: number, param2: number, event: string) => void;
+}
 declare global {
 	interface Window {
 		guardian: Globals;
+		QuantumMetricAPI: QuantumMetricAPIPartial;
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- assume we don't know the range of possible types for the embedded_svc attribute?
 		embedded_svc: any;
 	}


### PR DESCRIPTION
### What does this PR change?

Fire a custom Quantum metric event at the start of the cancellation journey.

This is so that we can identify the billing period of the product eg monthly or annual.

The event string sent will look something like this: 

`cancellation start | all-access digital subscription | billing period: month`