### PR TITLE
Restrict supporter plus offers to those with monthly billing periods

### DIFF
--- a/client/components/mma/cancel/CancellationReasonReview.tsx
+++ b/client/components/mma/cancel/CancellationReasonReview.tsx
@@ -15,7 +15,11 @@ import { cancelAlternativeUrlPartLookup } from '@/shared/cancellationUtilsAndTyp
 import { featureSwitches } from '@/shared/featureSwitches';
 import type { TrueFalsePending } from '@/shared/generalTypes';
 import { DATE_FNS_INPUT_FORMAT, parseDate } from '../../../../shared/dates';
-import { MDA_TEST_USER_HEADER } from '../../../../shared/productResponse';
+import {
+	getMainPlan,
+	isPaidSubscriptionPlan,
+	MDA_TEST_USER_HEADER,
+} from '../../../../shared/productResponse';
 import type {
 	ProductTypeWithCancellationFlow,
 	WithProductType,
@@ -261,9 +265,12 @@ const ConfirmCancellationAndReturnRow = (
 	const { productDetail, productType } = useContext(
 		CancellationContext,
 	) as CancellationContextInterface;
+	const mainPlan = getMainPlan(productDetail.subscription);
 	const isSupporterPlusAndFreePeriodOfferIsActive =
 		featureSwitches.supporterplusCancellationOffer &&
-		productType.productType === 'supporterplus';
+		productType.productType === 'supporterplus' &&
+		isPaidSubscriptionPlan(mainPlan) &&
+		mainPlan.billingPeriod.toLowerCase() === 'month';
 
 	const isContributionAndBreakFeatureIsActive =
 		featureSwitches.contributionCancellationPause &&


### PR DESCRIPTION
### What does this PR change?

Restricts the user from progressing down the cancellation offer journey if they have an annual support plus product. This is a temporary fix until we release the annual supporter plus offer.

Currently (before this pr) the client side would check whether of not the user has a support plus product (regardless of the billing period) and then proceed to call the discount api to find out if the user is eligable for the offer. The client was reliant on the api to return a falsey response for any billing periods that we don't yet support. It looks as though the api was changed to support annual offers, but the journey on the frontend and possibly the braze campaign haven't yet been set up to support this.

This is a temporary fix on the frontend to stop annual users from proceeding down an incomplete path.