### PR TITLE
fairer array sorting algorithm

### DIFF
--- a/client/__tests__/utils.test.ts
+++ b/client/__tests__/utils.test.ts
@@ -1,0 +1,13 @@
+import { shuffleArray } from '../utilities/utils';
+
+describe('shuffleArray', () => {
+	it('randomizes the positions of the elements in the passed array', () => {
+		const inputArrString = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].toString();
+		let a;
+		for (a = 0; a < 100; a++) {
+			expect(
+				shuffleArray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).toString(),
+			).not.toEqual(inputArrString);
+		}
+	});
+});

--- a/client/utilities/utils.ts
+++ b/client/utilities/utils.ts
@@ -6,8 +6,27 @@ export function flattenEquivalent<T>(x: T): T {
 	return x;
 }
 
-export const shuffleArray = (array: unknown[]) =>
-	[...array].sort(() => 0.5 - Math.random());
+/*
+ * implementation of the Fisher–Yates Shuffle algorithm
+ * example here: https://bost.ocks.org/mike/shuffle/
+ */
+export const shuffleArray = (array: unknown[]) => {
+	let currentIndex = array.length;
+
+	// While there remain elements to shuffle...
+	while (currentIndex != 0) {
+		// Pick a remaining element...
+		const randomIndex = Math.floor(Math.random() * currentIndex);
+		currentIndex--;
+
+		// And swap it with the current element.
+		[array[currentIndex], array[randomIndex]] = [
+			array[randomIndex],
+			array[currentIndex],
+		];
+	}
+	return array;
+};
 
 export function formatAmount(amount: number) {
 	return Number.isInteger(amount) ? amount : amount.toFixed(2);


### PR DESCRIPTION
### What does this PR change?

Replace the existing shuffle array sort function with an algorithm that fairly randomises the contents. The new approach is based on the fisher-yates algothrithm (https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle) a nice example of which you can see here: [Fisher–Yates Shuffle](https://bost.ocks.org/mike/shuffle/)

### Current situation/background

@johnduffell rightly pointed out in a previous pr (https://github.com/guardian/manage-frontend/pull/1415#discussion_r1846461396) that the randomisation of the output array wasn't all that random; 

results from his testing: 

```
Object.entries([...Array(1000000).keys().map(() => [1,2,3,4,5,6,7,8,9,10].sort( () => .5 - Math.random() )[0])].sort().reduce((acc, num) => {const e = {...acc};e[num]=acc[num] + 1; return e;}, {1:0,2:0,3:0,4:0,5:0,6:0,7:0,8:0,9:0,10:0})).map(([num, count]) => `${num}: ${count/10000}%`).map((a) => console.log(a))
1: 19.5461%
2: 7.2563%
3: 9.6343%
4: 12.8512%
5: 8.3207%
6: 8.9094%
7: 9.9178%
8: 11.1279%
9: 6.0317%
10: 6.4046%
```

It shows a weighting more specifically to the first element in the array (ideally these figures ought to be as close to 10% each in order to show a fair distribution)

and with the new Fisher–Yates Shuffle algorithm we can see the results much more evenly distributed:

```
1: 9.9887%
2: 10.0008%
3: 9.9885%
4: 10.0155%
5: 10.0069%
6: 9.9565%
7: 9.9425%
8: 9.9936%
9: 10.0209%
10: 10.0861%
```