### PR TITLE
Add cloudwatch metric for redirecting from ncom

### DIFF
--- a/server/routes/newspaperArchive.ts
+++ b/server/routes/newspaperArchive.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { authorizationOrCookieHeader } from '../apiProxy';
 import { s3ConfigPromise } from '../awsIntegration';
 import { conf } from '../config';
-import { log } from '../log';
+import { log, putMetric } from '../log';
 import { withIdentity } from '../middleware/identityMiddleware';
 
 type NewspapersRequestBody = {
@@ -78,6 +78,10 @@ router.get('/auth', async (req: Request, res: Response) => {
 			archiveReturnUrlString &&
 			typeof archiveReturnUrlString === 'string'
 		) {
+			putMetric({
+				loggingCode: 'REDIRECT_FROM_NEWSPAPERS_COM',
+				isOK: true,
+			});
 			const tpaToken = new URL(responseJson.url).searchParams.get('tpa');
 
 			const archiveReturnUrl = new URL(archiveReturnUrlString);


### PR DESCRIPTION
### Current situation/background

We have an endpoint to redirect users from newspapers.com back again with a third party authentication token

### What does this PR change?
This PR adds a cloudwatch metric to track this happening

![image](https://github.com/user-attachments/assets/4ba5264d-5bdf-4d09-a529-fc3714c237df)


### Next steps/further info
Possibly add an alarm if this hasn't happened in a while?

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->
