### PR TITLE
account overview offer period restriction

### DIFF
--- a/client/__tests__/components/updateAmount/contributionUpdateAmount.test.tsx
+++ b/client/__tests__/components/updateAmount/contributionUpdateAmount.test.tsx
@@ -1,10 +1,11 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import type { CurrencyIso } from '@/client/utilities/currencyIso';
+import type { BillingPeriod } from '@/shared/productResponse';
 import { PRODUCT_TYPES } from '../../../../shared/productTypes';
 import { UpdateAmount } from '../../../components/mma/accountoverview/updateAmount/UpdateAmount';
 
-const mainPlan = (billingPeriod: string) => ({
+const mainPlan = (billingPeriod: BillingPeriod) => ({
 	start: '2019-10-30',
 	end: '2050-10-30',
 	price: 500,
@@ -45,7 +46,7 @@ it.each([
 			<BrowserRouter>
 				<UpdateAmount
 					subscriptionId="A-123"
-					mainPlan={mainPlan(billingPeriod)}
+					mainPlan={mainPlan(billingPeriod as BillingPeriod)}
 					amountUpdateStateChange={jest.fn()}
 					nextPaymentDate="2050-10-29"
 					productType={productType}
@@ -90,7 +91,7 @@ it.each([
 			<BrowserRouter>
 				<UpdateAmount
 					subscriptionId="A-123"
-					mainPlan={mainPlan(billingPeriod)}
+					mainPlan={mainPlan(billingPeriod as BillingPeriod)}
 					amountUpdateStateChange={jest.fn()}
 					nextPaymentDate="2050-10-29"
 					productType={productType}

--- a/client/__tests__/components/updateAmount/supporterPlusUpdateAmount.test.tsx
+++ b/client/__tests__/components/updateAmount/supporterPlusUpdateAmount.test.tsx
@@ -1,9 +1,10 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import type { CurrencyIso } from '@/client/utilities/currencyIso';
+import type { BillingPeriod } from '@/shared/productResponse';
 import { PRODUCT_TYPES } from '../../../../shared/productTypes';
 import { UpdateAmount } from '../../../components/mma/accountoverview/updateAmount/UpdateAmount';
 
-const mainPlan = (billingPeriod: string) => ({
+const mainPlan = (billingPeriod: BillingPeriod) => ({
 	start: '2019-10-30',
 	end: '2050-10-30',
 	name: '',
@@ -43,7 +44,7 @@ it.each([
 		render(
 			<UpdateAmount
 				subscriptionId="A-123"
-				mainPlan={mainPlan(billingPeriod)}
+				mainPlan={mainPlan(billingPeriod as BillingPeriod)}
 				amountUpdateStateChange={jest.fn()}
 				nextPaymentDate="2050-10-29"
 				productType={productType}
@@ -81,7 +82,7 @@ it.each([
 		render(
 			<UpdateAmount
 				subscriptionId="A-123"
-				mainPlan={mainPlan(billingPeriod)}
+				mainPlan={mainPlan(billingPeriod as BillingPeriod)}
 				amountUpdateStateChange={jest.fn()}
 				nextPaymentDate="2050-10-29"
 				productType={productType}

--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -27,6 +27,7 @@ import {
 	getMainPlan,
 	getSpecificProductTypeFromTier,
 	isGift,
+	isPaidSubscriptionPlan,
 } from '@/shared/productResponse';
 import { GROUPED_PRODUCT_TYPES } from '@/shared/productTypes';
 import { wideButtonLayoutCss } from '../../../styles/ButtonStyles';
@@ -224,30 +225,33 @@ export const ProductCard = ({
 					}
 				/>
 			)}
-			{canBeInOfferPeriod && isInOfferOrPausePeriod && (
-				<SuccessSummary
-					message="Your offer is active"
-					context={
-						<>
-							Your two months free is now active until{' '}
-							{nextPaymentDetails?.nextPaymentDateValue}. If you
-							have any questions, feel free to{' '}
-							{
-								<Link
-									to="/help-centre#contact-options"
-									css={css`
-										text-decoration: underline;
-										color: ${palette.brand[500]};
-									`}
-								>
-									contact our support team
-								</Link>
-							}
-							.
-						</>
-					}
-				/>
-			)}
+			{canBeInOfferPeriod &&
+				isInOfferOrPausePeriod &&
+				isPaidSubscriptionPlan(mainPlan) &&
+				mainPlan.billingPeriod === 'month' && (
+					<SuccessSummary
+						message="Your offer is active"
+						context={
+							<>
+								Your two months free is now active until{' '}
+								{nextPaymentDetails?.nextPaymentDateValue}. If
+								you have any questions, feel free to{' '}
+								{
+									<Link
+										to="/help-centre#contact-options"
+										css={css`
+											text-decoration: underline;
+											color: ${palette.brand[500]};
+										`}
+									>
+										contact our support team
+									</Link>
+								}
+								.
+							</>
+						}
+					/>
+				)}
 			{canBeInPausePeriod && isInOfferOrPausePeriod && (
 				<SuccessSummary
 					message="You have paused your support"

--- a/client/components/mma/shared/NextPaymentDetails.tsx
+++ b/client/components/mma/shared/NextPaymentDetails.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import { palette, space } from '@guardian/source/foundations';
 import { parseDate } from '../../../../shared/dates';
 import type {
+	BillingPeriod,
 	Subscription,
 	SubscriptionPlan,
 } from '../../../../shared/productResponse';
@@ -13,7 +14,7 @@ import {
 import { InfoIconDark } from './assets/InfoIconDark';
 
 export interface NextPaymentDetails {
-	paymentInterval: string;
+	paymentInterval: BillingPeriod;
 	paymentKey: string;
 	paymentValue: string;
 	paymentValueShort: string;

--- a/client/components/mma/shared/SupporterPlusTsAndCs.tsx
+++ b/client/components/mma/shared/SupporterPlusTsAndCs.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import { space, textSans12 } from '@guardian/source/foundations';
 import * as Sentry from '@sentry/browser';
 import { Link } from 'react-router-dom';
+import type { BillingPeriod } from '@/shared/productResponse';
 import { getBillingPeriodAdjective } from '../../../../shared/productTypes';
 import {
 	convertCurrencyToSymbol,
@@ -29,7 +30,7 @@ export const SupporterPlusTsAndCs = ({
 	billingPeriod,
 }: {
 	currencyISO: string;
-	billingPeriod: string;
+	billingPeriod: BillingPeriod;
 }) => {
 	if (!isCurrencyIso(currencyISO)) {
 		Sentry.captureException(`Invalid currency: ${currencyISO}`);

--- a/client/components/mma/upgrade/ConfirmForm.tsx
+++ b/client/components/mma/upgrade/ConfirmForm.tsx
@@ -24,6 +24,7 @@ import { useNavigate } from 'react-router';
 import { formatAmount } from '@/client/utilities/utils';
 import { dateString } from '../../../../shared/dates';
 import type {
+	BillingPeriod,
 	PaidSubscriptionPlan,
 	Subscription,
 } from '../../../../shared/productResponse';
@@ -169,7 +170,7 @@ const RoundUp = ({
 	thresholdAmount: number;
 	chosenAmountPreRoundup: number;
 	currencySymbol: string;
-	billingPeriod: string;
+	billingPeriod: BillingPeriod;
 }) => {
 	const [hasRoundedUp, setHasRoundedUp] = useState<boolean>(false);
 

--- a/client/components/shared/productSwitch/SwitchPaymentInfo.tsx
+++ b/client/components/shared/productSwitch/SwitchPaymentInfo.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { space } from '@guardian/source/foundations';
+import type { BillingPeriod } from '@/shared/productResponse';
 import { getBillingPeriodAdjective } from '../../../../shared/productTypes';
 import { formatAmount } from '../../../utilities/utils';
 
@@ -15,7 +16,7 @@ export const SwitchPaymentInfo = ({
 	alreadyPayingAboveThreshold: boolean;
 	currencySymbol: string;
 	supporterPlusPurchaseAmount: number;
-	billingPeriod: string;
+	billingPeriod: BillingPeriod;
 	nextPaymentDate: string;
 }) => {
 	const monthlyOrAnnual =

--- a/client/fixtures/productBuilder/productBuilder.ts
+++ b/client/fixtures/productBuilder/productBuilder.ts
@@ -1,4 +1,5 @@
 import type {
+	BillingPeriod,
 	Card,
 	PaidSubscriptionPlan,
 	ProductDetail,
@@ -166,7 +167,7 @@ export class ProductBuilder {
 		return this;
 	}
 
-	withBillingPeriod(billingPeriod: 'month' | 'year' | 'quarter') {
+	withBillingPeriod(billingPeriod: BillingPeriod) {
 		const { plan, currentPlans, futurePlans } =
 			this.productToBuild.subscription;
 		if (plan) {

--- a/shared/productResponse.ts
+++ b/shared/productResponse.ts
@@ -138,14 +138,16 @@ interface SepaDetails {
 	iban: string;
 }
 
+export type BillingPeriod = 'month' | '6 weeks' | 'quarter' | 'year';
+
 interface CurrencyAndBillingPeriodDetail {
 	currency: string;
 	currencyISO: CurrencyIso;
-	billingPeriod: string;
+	billingPeriod: BillingPeriod;
 }
 
 // 6 weeks billingPeriod referes to GW 6 for 6 up front payment (not to be confused with one off contributions which don't come through in this response
-export const augmentBillingPeriod = (billingPeriod: string) =>
+export const augmentBillingPeriod = (billingPeriod: BillingPeriod) =>
 	billingPeriod === '6 weeks' ? 'one-off' : `${billingPeriod}ly`;
 
 export const isSixForSix = (planName: string | null) =>

--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -24,6 +24,7 @@ import { shuffledVoucherCancellationReasons } from '../client/components/mma/can
 import type { SupportTheGuardianButtonProps } from '../client/components/shared/SupportTheGuardianButton';
 import type { OphanProduct } from './ophanTypes';
 import type {
+	BillingPeriod,
 	PaidSubscriptionPlan,
 	ProductDetail,
 	Subscription,
@@ -235,7 +236,7 @@ const calculateProductTitle =
 		baseProductTitle + (mainPlan?.name ? ` - ${mainPlan.name}` : '');
 
 export function getBillingPeriodAdjective(
-	billingPeriod: string | undefined,
+	billingPeriod?: BillingPeriod,
 ): 'Monthly' | 'Annual' | 'Quarterly' {
 	if (billingPeriod === 'month') {
 		return 'Monthly';
@@ -243,7 +244,7 @@ export function getBillingPeriodAdjective(
 	if (billingPeriod === 'year') {
 		return 'Annual';
 	}
-	if (billingPeriod === 'quarterly') {
+	if (billingPeriod === 'quarter') {
 		return 'Quarterly';
 	}
 


### PR DESCRIPTION
### What does this PR change?
Restrict the account overview 'Your offer is active' message to monthly customers (until we have a more detailed response from mdapi about the offer status of a product to allow us to distinguish between offer types). 

This should stop annual users from seeing a monthly offer message on the account overview.

A later pr will add the annual offer message in once more work has been done in mdapi to return the info needed to display the message.

### Images
![Screenshot 2024-11-26 at 15 03 32](https://github.com/user-attachments/assets/3913088e-7c90-4276-b762-c34fa395b1a8)
