### PR TITLE
mitgate cross-spawn dependency vulnerability

### DIFF
--- a/cdk/package.json
+++ b/cdk/package.json
@@ -12,7 +12,7 @@
     "deploy-code": "cdk deploy --path-metadata false --version-reporting false ManageFrontend-CODE"
   },
   "devDependencies": {
-    "@guardian/cdk": "50.10.6",
+    "@guardian/cdk": "60.1.3",
     "@guardian/eslint-config-typescript": "1.0.7",
     "@guardian/prettier": "1.0.0",
     "@types/jest": "^27.5.0",
@@ -60,5 +60,8 @@
       "@typescript-eslint/no-inferrable-types": 0,
       "import/no-namespace": 2
     }
+  },
+  "resolutions": {
+    "cross-spawn": "^7.0.5"
   }
 }


### PR DESCRIPTION
### What does this PR change?
Update peer dependency `@guardian/cdk` and use the package.json resolutions to force a patched version of cross-spawn

Should fix vulnerability reported by dependabot and snyk:

https://github.com/guardian/manage-frontend/security/dependabot/164
https://app.snyk.io/org/guardian-value/project/8acda083-6b55-431d-a2e0-a985b2349e78
