### PR TITLE
Update Marketing analysis copy

### DIFF
--- a/client/components/mma/dataPrivacy/YourDataSection.tsx
+++ b/client/components/mma/dataPrivacy/YourDataSection.tsx
@@ -51,7 +51,7 @@ export const YourDataSection = (props: YourDataSectionProps) => {
 			<h3 css={dataPrivacyHeadingCss}>Your account data</h3>
 			<p css={dataPrivacyParagraphCss}>
 				What we mean by your account data is information you provide
-				when you register with us:
+				when you create an account:
 			</p>
 			<ul css={dataPrivacyUnorderedListCss}>
 				<li>First name and last name</li>

--- a/client/components/mma/dataPrivacy/YourDataSection.tsx
+++ b/client/components/mma/dataPrivacy/YourDataSection.tsx
@@ -50,20 +50,12 @@ export const YourDataSection = (props: YourDataSectionProps) => {
 		<>
 			<h3 css={dataPrivacyHeadingCss}>Your account data</h3>
 			<p css={dataPrivacyParagraphCss}>
-				What we mean by your account data
+				What we mean by your account data is information you provide
+				when you register with us:
 			</p>
 			<ul css={dataPrivacyUnorderedListCss}>
-				<li>
-					Information you provide when you register with us e.g. email
-					address
-				</li>
-				<li>
-					Information about the products or services you buy from us
-				</li>
-				<li>
-					Pages you view on theguardian.com or other Guardian websites
-					when signed in and your region
-				</li>
+				<li>First name and last name</li>
+				<li>Email address</li>
 			</ul>
 
 			<Lines n={1} />


### PR DESCRIPTION
### Current situation/background

We've had a request to change the marketing analysis consent copy to:

```
What we mean by your account data is information you provide when you register with us:
  - First name and last name
  - Email address
```

### Next steps/further info

| Before | After |
|--------|--------|
| <img width="742" alt="image" src="https://github.com/user-attachments/assets/e4ab40c7-5a81-41fc-a19c-f61dae32a38f" /> | <img width="710" alt="image" src="https://github.com/user-attachments/assets/8bbc71b7-e41a-4dd3-8a4f-6134a97a9b59" /> | 


