### PR TITLE
hide the support cta's from the help centre footer

### DIFF
--- a/client/components/shared/Main.tsx
+++ b/client/components/shared/Main.tsx
@@ -75,7 +75,11 @@ export const Main = ({
 						{children}
 					</main>
 				</div>
-				{hasMinimalFooter ? <MinimalFooter /> : <Footer />}
+				{hasMinimalFooter ? (
+					<MinimalFooter />
+				) : (
+					<Footer hideSupport={!!isHelpCentrePage} />
+				)}
 			</div>
 		</HasMinimalFooterContext.Provider>
 	);

--- a/client/components/shared/footer/Footer.stories.tsx
+++ b/client/components/shared/footer/Footer.stories.tsx
@@ -15,4 +15,8 @@ export default {
 
 export const Default: StoryFn<typeof Footer> = () => <Footer />;
 
+export const WithoutSupport: StoryFn<typeof Footer> = () => (
+	<Footer hideSupport />
+);
+
 export const Minimal: StoryFn<typeof MinimalFooter> = () => <MinimalFooter />;

--- a/client/components/shared/footer/Footer.tsx
+++ b/client/components/shared/footer/Footer.tsx
@@ -171,7 +171,7 @@ const fillEmailSignup = (_: SyntheticEvent<HTMLIFrameElement>) => {
 	return;
 };
 
-export const Footer = () => {
+export const Footer = ({ hideSupport }: { hideSupport?: boolean }) => {
 	const TODAY = new Date(Date.now());
 
 	const [isInUSA, setIsInUSA] = useState<boolean>(false);
@@ -255,19 +255,21 @@ export const Footer = () => {
 									</ul>
 								))}
 
-								<div css={supportStyles}>
-									<div css={supportTitleStyles}>
-										Support the&nbsp;Guardian
+								{!hideSupport && (
+									<div css={supportStyles}>
+										<div css={supportTitleStyles}>
+											Support the&nbsp;Guardian
+										</div>
+										<div css={supportButtonContainerStyles}>
+											<SupportTheGuardianButton
+												supportReferer="footer_support_contribute"
+												alternateButtonText="Support us"
+												theme="brand"
+												size="small"
+											/>
+										</div>
 									</div>
-									<div css={supportButtonContainerStyles}>
-										<SupportTheGuardianButton
-											supportReferer="footer_support_contribute"
-											alternateButtonText="Support us"
-											theme="brand"
-											size="small"
-										/>
-									</div>
-								</div>
+								)}
 							</div>
 						</div>
 


### PR DESCRIPTION
### What does this PR change?
Removes the support CTA from the footer in the help centre for the sake of app stores.

### Images
Before             |  After
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/6c0bd5df-08bf-4cee-b0f7-6ad91f5ed271)  |  ![](https://github.com/user-attachments/assets/2d116be0-19a7-4b0a-9485-8a4f246d2534)

#### example of mobile breakpoint without CTA:
![Screenshot 2024-12-20 at 11 48 26](https://github.com/user-attachments/assets/0dcc7c7f-b013-484e-8002-35b8bce30a0e)


