### PR TITLE
remove xmas 2024 opening times banner from the help centre

### DIFF
--- a/client/components/helpCentre/HelpCentrePage.tsx
+++ b/client/components/helpCentre/HelpCentrePage.tsx
@@ -77,13 +77,7 @@ const HelpCentreRouter = () => {
 	]
 	*/
 
-	const knownIssues: KnownIssueObj[] = [
-		{
-			date: '23rd Dec 2024 13:00',
-			message:
-				'Our customer service contact centre, including phone lines & live chat, is closed on Christmas Day, Boxing Day and New Year’s Day UK time. Replies to emails may take a little longer during this period.',
-		},
-	];
+	const knownIssues: KnownIssueObj[] = [];
 
 	return (
 		<Main signInStatus={signInStatus} isHelpCentrePage>


### PR DESCRIPTION
### What does this PR change?

It's not xmas anymore!

<img width="1380" alt="xmasOpening" src="https://github.com/user-attachments/assets/cb3aebca-6af0-4d6d-ae8e-081662aef672" />
