### PR TITLE
supporterplus and tier three feast app benefit

### DIFF
--- a/client/components/mma/shared/benefits/BenefitsConfiguration.ts
+++ b/client/components/mma/shared/benefits/BenefitsConfiguration.ts
@@ -21,6 +21,11 @@ const newsApp = {
 	description: 'Read our reporting on the go',
 };
 
+const feastApp = {
+	name: 'Unlimited access to the Guardian Feast App',
+	description: 'Make a feast out of anything with the Guardian’s recipe app',
+};
+
 const adFree = {
 	name: 'Ad-free reading.',
 	description: 'Avoid ads on all your devices',
@@ -64,7 +69,7 @@ export function filterBenefitByRegion(
 	return benefit.specificToRegions === undefined;
 }
 
-export const supporterPlusSwitchBenefits = [newsApp, adFree];
+export const supporterPlusSwitchBenefits = [newsApp, feastApp, adFree];
 
 export const benefitsConfiguration: {
 	[productType in ProductTypeKeys]: ProductBenefit[];
@@ -81,6 +86,7 @@ export const benefitsConfiguration: {
 		supporterNewsletter,
 		uninterruptedReading,
 		newsApp,
+		feastApp,
 		adFree,
 		partnerOffers,
 	],
@@ -89,6 +95,7 @@ export const benefitsConfiguration: {
 		supporterNewsletter,
 		uninterruptedReading,
 		newsApp,
+		feastApp,
 		adFree,
 		partnerOffers,
 	],


### PR DESCRIPTION
### What does this PR change?

Add's the feast app to the list of benefits for All access digital (supporter plus) and Tier three customers.

The benefits lists show up in the product card in the account overview and manage product pages as well as the product switch journey from contribution to all access digital.

### Images
Before             |  After
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/9048b325-3910-4200-9901-1143a1c65372)  |  ![](https://github.com/user-attachments/assets/aea83437-9749-483f-8746-0723d88cd150)

Before             |  After
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/6ec37742-2507-462c-9f80-98356ec63958)  |  ![](https://github.com/user-attachments/assets/f09979db-3e59-4130-b0f9-da48c500a287)




