### PR TITLE
Upgrade to v4 of upload-artifact task in cypress workflow

### DIFF
--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -62,7 +62,7 @@ jobs:
           browser: chrome
           spec: cypress/tests/e2e/*.cy.ts
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: cypress-screenshots


### PR DESCRIPTION
The cypress e2e GitHub action workflow uses the v3 of the `upload-artifact` task which is being [deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/).

This upgrades to v4.
