### PR TITLE
Add banner to help centre as US phone lines are currently down

### DIFF
--- a/client/components/helpCentre/HelpCentrePage.tsx
+++ b/client/components/helpCentre/HelpCentrePage.tsx
@@ -77,7 +77,13 @@ const HelpCentreRouter = () => {
 	]
 	*/
 
-	const knownIssues: KnownIssueObj[] = [];
+	const knownIssues: KnownIssueObj[] = [
+		{
+			date: '29 Jan 2024 12:00',
+			message:
+				'Due to a technical issue, Customer Service phonelines in the USA & Canada are currently not available. Live chat and email are unaffected.',
+		},
+	];
 
 	return (
 		<Main signInStatus={signInStatus} isHelpCentrePage>


### PR DESCRIPTION
### Current situation/background
There is currently a technical issue with the US contact centre phonelines, meaning they are temporarily unavailable.

### What does this PR change?
Adds a banner to the Help Centre to advise customers of the issue:

`Due to a technical issue, Customer Service phonelines in the USA & Canada are currently not available. Live chat and email are unaffected.`

<img width="795" alt="Screenshot 2025-01-29 at 12 12 33" src="https://github.com/user-attachments/assets/9b52ff07-cd2e-40bf-9072-df028a3aa584" />


### Next steps/further info
We'll revert this once the phonelines are available.