### PR TITLE
Fix Sign In Tests

### DIFF
--- a/cypress/lib/signInOkta.ts
+++ b/cypress/lib/signInOkta.ts
@@ -19,6 +19,8 @@ export const signInOkta = () => {
 		doNotSetUsername: true,
 	})?.then(({ emailAddress, finalPassword }) => {
 		cy.get('input[name=email]').type(emailAddress);
+		cy.get('[data-cy="main-form-submit-button"]').click();
+		cy.contains('Sign in with password instead').click();
 		cy.get('input[name=password]').type(finalPassword);
 		cy.get('[data-cy="main-form-submit-button"]').click();
 	});


### PR DESCRIPTION
### Current situation/background

In Gateway we've now changed the way that sign in works, making passcodes the default option in https://github.com/guardian/gateway/pull/3035. So the sign in screen/flow has changed.

Instead to sign in with a password we have to navigate to a separate page to do so, which is what this PR does.

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->
