### PR TITLE
allow test users to work with product-switch-api

### DIFF
--- a/client/components/mma/upgrade/ConfirmForm.tsx
+++ b/client/components/mma/upgrade/ConfirmForm.tsx
@@ -261,7 +261,7 @@ export const ConfirmForm = ({
 	previewResponse,
 	previewLoadingState,
 }: ConfirmFormProps) => {
-	const { mainPlan, subscription, inPaymentFailure } = useContext(
+	const { mainPlan, subscription, inPaymentFailure, isTestUser } = useContext(
 		UpgradeSupportContext,
 	) as UpgradeSupportInterface;
 
@@ -334,6 +334,7 @@ export const ConfirmForm = ({
 					'recurring-contribution-to-supporter-plus',
 					checkChargeAmount,
 					false,
+					isTestUser,
 				).then((r) => JsonResponseHandler(r));
 
 				if (data === null) {

--- a/client/components/mma/upgrade/UpgradeSupport.tsx
+++ b/client/components/mma/upgrade/UpgradeSupport.tsx
@@ -21,7 +21,7 @@ import type { UpgradeSupportInterface } from './UpgradeSupportContainer';
 import { UpgradeSupportContext } from './UpgradeSupportContainer';
 
 export const UpgradeSupport = () => {
-	const { mainPlan, subscription } = useContext(
+	const { mainPlan, subscription, isTestUser } = useContext(
 		UpgradeSupportContext,
 	) as UpgradeSupportInterface;
 
@@ -48,6 +48,7 @@ export const UpgradeSupport = () => {
 					'recurring-contribution-to-supporter-plus',
 					false,
 					true,
+					isTestUser,
 				),
 			JsonResponseHandler,
 		);

--- a/client/components/mma/upgrade/UpgradeSupportContainer.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportContainer.tsx
@@ -28,6 +28,7 @@ export interface UpgradeSupportInterface {
 	subscription: Subscription;
 	inPaymentFailure: boolean;
 	user?: MembersDataApiUser;
+	isTestUser: boolean;
 }
 
 export interface UpgradeRouterState {
@@ -127,6 +128,7 @@ export const UpgradeSupportContainer = () => {
 					subscription: contribution.subscription,
 					inPaymentFailure,
 					user: data.user,
+					isTestUser: contribution.isTestUser,
 				}}
 			>
 				<Outlet />

--- a/client/utilities/productUtils.ts
+++ b/client/utilities/productUtils.ts
@@ -3,6 +3,7 @@ import {
 	X_GU_ID_FORWARDED_SCOPE,
 } from '../../shared/identity';
 import type { ProductDetail } from '../../shared/productResponse';
+import { MDA_TEST_USER_HEADER } from '../../shared/productResponse';
 import type { ProductSwitchType } from '../../shared/productSwitchTypes';
 import type {
 	AllProductsProductTypeFilterString,
@@ -24,6 +25,7 @@ export const productMoveFetch = (
 	productSwitchType: ProductSwitchType,
 	checkChargeAmountBeforeUpdate: boolean,
 	preview: boolean,
+	isTestUser: boolean,
 ) =>
 	fetch(`/api/product-move/${productSwitchType}/${subscriptionId}`, {
 		method: 'POST',
@@ -34,6 +36,7 @@ export const productMoveFetch = (
 		}),
 		headers: {
 			'Content-Type': 'application/json',
+			[MDA_TEST_USER_HEADER]: `${isTestUser}`,
 		},
 	});
 


### PR DESCRIPTION
I noticed that I couldn't switch product as a test user in PROD, this was because it was trying to hit the PROD endpoint.  It looked like the extra header to flag whether it's a test user subscription wasn't being sent to manage-frontend backend.

This PR adds the extra header for product switches.

There may be other ones that are missing (TODO add logging in another PR)