### PR TITLE
log if the test user header isn't set on the server side

### DIFF
--- a/server/apiGatewayDiscovery.ts
+++ b/server/apiGatewayDiscovery.ts
@@ -150,7 +150,10 @@ const getApiGateway = (
 			) =>
 			async (req: express.Request, res: express.Response) => {
 				const testUserHeader = req.header(MDA_TEST_USER_HEADER);
-				if (!['true', 'false'].includes(testUserHeader ?? '')) {
+				if (
+					testUserHeader === undefined ||
+					!['true', 'false'].includes(testUserHeader)
+				) {
 					log.error(
 						`${path} request will not work for test users - missing ${MDA_TEST_USER_HEADER} header: '${testUserHeader}'`,
 					);

--- a/server/apiGatewayDiscovery.ts
+++ b/server/apiGatewayDiscovery.ts
@@ -150,9 +150,9 @@ const getApiGateway = (
 			) =>
 			async (req: express.Request, res: express.Response) => {
 				const testUserHeader = req.header(MDA_TEST_USER_HEADER);
-				if (testUserHeader === undefined) {
+				if (!['true', 'false'].includes(testUserHeader ?? '')) {
 					log.error(
-						`${path} request will not work for test users - missing ${MDA_TEST_USER_HEADER} header`,
+						`${path} request will not work for test users - missing ${MDA_TEST_USER_HEADER} header: '${testUserHeader}'`,
 					);
 				}
 				const isTestUser = testUserHeader === 'true';

--- a/server/apiGatewayDiscovery.ts
+++ b/server/apiGatewayDiscovery.ts
@@ -149,7 +149,13 @@ const getApiGateway = (
 				shouldNotLogBody?: boolean,
 			) =>
 			async (req: express.Request, res: express.Response) => {
-				const isTestUser = req.header(MDA_TEST_USER_HEADER) === 'true';
+				const testUserHeader = req.header(MDA_TEST_USER_HEADER);
+				if (testUserHeader === undefined) {
+					log.error(
+						`${path} request will not work for test users - missing ${MDA_TEST_USER_HEADER} header`,
+					);
+				}
+				const isTestUser = testUserHeader === 'true';
 				const { host, apiKey } = await (isTestUser
 					? testModeConfigPromise
 					: normalModeConfigPromise);


### PR DESCRIPTION
We noticed the product-switch-api didn't work with test users because the header wasn't being set by the client side.

This change makes the server side log when it notices the missing header, so that we can fix them more easily.

Hopefully the messages will go to sentry so we have a chance of spotting them?  Otherwise we can look in cloudwatch.