### PR TITLE
make sure the test user header is on preview as well as move endpoint

### DIFF
--- a/client/__tests__/components/updateAmount/contributionUpdateAmount.test.tsx
+++ b/client/__tests__/components/updateAmount/contributionUpdateAmount.test.tsx
@@ -50,6 +50,7 @@ it.each([
 					amountUpdateStateChange={jest.fn()}
 					nextPaymentDate="2050-10-29"
 					productType={productType}
+					isTestUser={false}
 				/>
 			</BrowserRouter>,
 		);
@@ -95,6 +96,7 @@ it.each([
 					amountUpdateStateChange={jest.fn()}
 					nextPaymentDate="2050-10-29"
 					productType={productType}
+					isTestUser={false}
 				/>
 			</BrowserRouter>,
 		);
@@ -135,6 +137,7 @@ it('renders validation error if blank input is provided', async () => {
 				amountUpdateStateChange={jest.fn()}
 				nextPaymentDate="2050-10-29"
 				productType={productType}
+				isTestUser={false}
 			/>
 		</BrowserRouter>,
 	);
@@ -172,6 +175,7 @@ it('renders validation error if a string is attempted to be input', async () => 
 				amountUpdateStateChange={jest.fn()}
 				nextPaymentDate="2050-10-29"
 				productType={productType}
+				isTestUser={false}
 			/>
 		</BrowserRouter>,
 	);
@@ -209,6 +213,7 @@ it('updates amount if valid value is input', async () => {
 				amountUpdateStateChange={jest.fn()}
 				nextPaymentDate="2050-10-29"
 				productType={productType}
+				isTestUser={false}
 			/>
 		</BrowserRouter>,
 	);

--- a/client/__tests__/components/updateAmount/supporterPlusUpdateAmount.test.tsx
+++ b/client/__tests__/components/updateAmount/supporterPlusUpdateAmount.test.tsx
@@ -48,6 +48,7 @@ it.each([
 				amountUpdateStateChange={jest.fn()}
 				nextPaymentDate="2050-10-29"
 				productType={productType}
+				isTestUser={false}
 			/>,
 		);
 
@@ -86,6 +87,7 @@ it.each([
 				amountUpdateStateChange={jest.fn()}
 				nextPaymentDate="2050-10-29"
 				productType={productType}
+				isTestUser={false}
 			/>,
 		);
 
@@ -120,6 +122,7 @@ it('renders validation error if blank input is provided', () => {
 			amountUpdateStateChange={jest.fn()}
 			nextPaymentDate="2050-10-29"
 			productType={productType}
+			isTestUser={false}
 		/>,
 	);
 
@@ -153,6 +156,7 @@ it('renders validation error if a string is attempted to be input', () => {
 			amountUpdateStateChange={jest.fn()}
 			nextPaymentDate="2050-10-29"
 			productType={productType}
+			isTestUser={false}
 		/>,
 	);
 
@@ -186,6 +190,7 @@ it('updates amount is valid value is input', async () => {
 			amountUpdateStateChange={jest.fn()}
 			nextPaymentDate="2050-10-29"
 			productType={productType}
+			isTestUser={false}
 		/>,
 	);
 

--- a/client/components/mma/accountoverview/ManageProduct.tsx
+++ b/client/components/mma/accountoverview/ManageProduct.tsx
@@ -176,6 +176,7 @@ const InnerContent = ({
 					productType={specificProductType}
 					nextPaymentDate={productDetail.subscription.nextPaymentDate}
 					amountUpdateStateChange={setOveriddenAmount}
+					isTestUser={productDetail.isTestUser}
 				/>
 			) : (
 				<BasicProductInfoTable

--- a/client/components/mma/accountoverview/updateAmount/SupporterPlusUpdateAmountForm.tsx
+++ b/client/components/mma/accountoverview/updateAmount/SupporterPlusUpdateAmountForm.tsx
@@ -18,6 +18,7 @@ import {
 } from '@guardian/source/react-components';
 import { useEffect, useState } from 'react';
 import type { PaidSubscriptionPlan } from '../../../../../shared/productResponse';
+import { MDA_TEST_USER_HEADER } from '../../../../../shared/productResponse';
 import { getBillingPeriodAdjective } from '../../../../../shared/productTypes';
 import { fetchWithDefaultParameters } from '../../../../utilities/fetch';
 import { getSupporterPlusSuggestedAmountsFromMainPlan } from '../../../../utilities/pricingConfig/suggestedAmounts';
@@ -50,12 +51,19 @@ const buttonCentredCss = css`
 	justify-content: center;
 `;
 
-const getAmountUpdater = (newAmount: number, subscriptionName: string) =>
+const getAmountUpdater = (
+	newAmount: number,
+	subscriptionName: string,
+	isTestUser: boolean,
+) =>
 	fetchWithDefaultParameters(
 		`/api/update-supporter-plus-amount/${subscriptionName}`,
 		{
 			method: 'POST',
 			body: JSON.stringify({ newPaymentAmount: newAmount }),
+			headers: {
+				[MDA_TEST_USER_HEADER]: `${isTestUser}`,
+			},
 		},
 	);
 
@@ -99,6 +107,7 @@ interface SupporterPlusUpdateAmountFormProps {
 	currentAmount: number;
 	nextPaymentDate: string | null;
 	onUpdateConfirmed: (updatedAmount: number) => void;
+	isTestUser: boolean;
 }
 
 export const SupporterPlusUpdateAmountForm = (
@@ -205,6 +214,7 @@ export const SupporterPlusUpdateAmountForm = (
 		const response = await getAmountUpdater(
 			pendingAmount,
 			props.subscriptionId,
+			props.isTestUser,
 		);
 
 		try {

--- a/client/components/mma/accountoverview/updateAmount/UpdateAmount.tsx
+++ b/client/components/mma/accountoverview/updateAmount/UpdateAmount.tsx
@@ -19,6 +19,7 @@ interface UpdateAmountProps {
 	productType: ProductType;
 	nextPaymentDate: string | null;
 	amountUpdateStateChange: Dispatch<SetStateAction<number | null>>;
+	isTestUser: boolean;
 }
 
 export const UpdateAmount = (props: UpdateAmountProps) => {

--- a/client/components/mma/cancel/cancellationSaves/membership/MembershipSwitch.tsx
+++ b/client/components/mma/cancel/cancellationSaves/membership/MembershipSwitch.tsx
@@ -13,7 +13,9 @@ import { Navigate, useLocation, useNavigate } from 'react-router';
 import { dateString, parseDate } from '../../../../../../shared/dates';
 import type {
 	PaidSubscriptionPlan,
-	Subscription,
+	Subscription} from '../../../../../../shared/productResponse';
+import {
+	MDA_TEST_USER_HEADER
 } from '../../../../../../shared/productResponse';
 import { getMainPlan } from '../../../../../../shared/productResponse';
 import type { ProductSwitchType } from '../../../../../../shared/productSwitchTypes';
@@ -232,6 +234,7 @@ export const MembershipSwitch = () => {
 				}),
 				headers: {
 					'Content-Type': 'application/json',
+					[MDA_TEST_USER_HEADER]: `${membership.isTestUser}`,
 				},
 			},
 		);

--- a/client/components/mma/switch/review/SwitchReview.tsx
+++ b/client/components/mma/switch/review/SwitchReview.tsx
@@ -16,6 +16,7 @@ import {
 import { useContext, useState } from 'react';
 import { Navigate, useLocation, useNavigate } from 'react-router';
 import { SwitchErrorSummary } from '@/client/components/shared/productSwitch/SwitchErrorSummary';
+import { MDA_TEST_USER_HEADER } from '@/shared/productResponse';
 import { dateString } from '../../../../../shared/dates';
 import type {
 	PreviewResponse,
@@ -127,6 +128,7 @@ export const SwitchReview = () => {
 				}),
 				headers: {
 					'Content-Type': 'application/json',
+					[MDA_TEST_USER_HEADER]: `${contributionToSwitch.isTestUser}`,
 				},
 			},
 		);


### PR DESCRIPTION
following PR https://github.com/guardian/manage-frontend/pull/1450
I found I added it to the Move endpoint but not the Preview endpoint, which is defined in another place in the code.

I also noticed that update-supporter-plus-amount didn't work with test users.

This PR adds it to the other places I could find.

Tested locally and seems OK. 