### PR TITLE
Fix Cypress tests

### DIFF
--- a/server/routes/mpapi.ts
+++ b/server/routes/mpapi.ts
@@ -41,6 +41,7 @@ router.get(
 				`Missing identity ID on the request object when fetching mobile subscriptions`,
 			);
 			res.status(500).send();
+			return;
 		}
 
 		const options = getOptions('GET', config, res.locals.identity.userId);


### PR DESCRIPTION
### What does this PR change?

Expicitly returns after an MPAPI endpoint sends a 500 response (if it doesn't have access to idenity details). This stops the subsequent lines of code from running which are dependant on those idientity details being present.

This affected cypress integration tests that were asserting a redirect at the end of the test back to the account overview but not mocking the subsequent MDAPI and MPAPI api calls that would then be made.
