### PR TITLE
Update baseLiveAgent URLs for SF sandbox

### DIFF
--- a/client/components/helpCentre/liveChat/LiveChat.tsx
+++ b/client/components/helpCentre/liveChat/LiveChat.tsx
@@ -190,11 +190,11 @@ const initESW = (
 				'Chat_Team',
 				{
 					baseLiveAgentContentURL:
-						'https://c.la2-c1cs-fra.salesforceliveagent.com/content',
+						'https://c.la12s-core1.sfdc-cehfhs.salesforceliveagent.com/content',
 					deploymentId: '5729E000000CbOY',
 					buttonId: '5739E0000008QCo',
 					baseLiveAgentURL:
-						'https://d.la2-c1cs-fra.salesforceliveagent.com/chat',
+						'https://d.la12s-core1.sfdc-cehfhs.salesforceliveagent.com/chat',
 					eswLiveAgentDevName:
 						'EmbeddedServiceLiveAgent_Parent04I9E0000008OxDUAU_1797a576c18',
 					isOfflineSupportEnabled: false,

--- a/client/components/helpCentre/liveChat/LiveChat.tsx
+++ b/client/components/helpCentre/liveChat/LiveChat.tsx
@@ -191,7 +191,7 @@ const initESW = (
 				{
 					baseLiveAgentContentURL:
 						'https://c.la12s-core1.sfdc-cehfhs.salesforceliveagent.com/content',
-					deploymentId: '5729E000000CbOY',
+					deploymentId: '5729E0000008PBe',
 					buttonId: '5739E0000008QCo',
 					baseLiveAgentURL:
 						'https://d.la12s-core1.sfdc-cehfhs.salesforceliveagent.com/chat',


### PR DESCRIPTION
### Current situation/background
We've noticed that the Live Chat function doesn't seem to be working on CODE.

### What does this PR change?
I think there's been a site switch in our sandbox, which usually we ignore as we don't usually hardcode references to our instance type. But turns out [it is important](https://issues.salesforce.com/issue/a028c00000gAw7DAAS/embedded-chat-may-fail-to-initiate-after-liveagent-server-switch) for Live Chat!

### Next steps/further info
We'll look out for any future site switches that would impact Production