### PR TITLE
chromatic random content render fix

### DIFF
--- a/client/components/mma/cancel/Cancellation.stories.tsx
+++ b/client/components/mma/cancel/Cancellation.stories.tsx
@@ -19,12 +19,26 @@ import { CancelAlternativeOffer } from './cancellationSaves/CancelAlternativeOff
 import { CancelAlternativeReview } from './cancellationSaves/CancelAlternativeReview';
 import { getCancellationSummary } from './CancellationSummary';
 import { contributionsCancellationReasons } from './contributions/ContributionsCancellationReasons';
+import { gwCancellationReasons } from './gw/GwCancellationReasons';
 import { ConfirmCancellation } from './stages/ConfirmCancellation';
 import { getCancellationSummaryWithReturnButton } from './stages/ExecuteCancellation';
-import { otherCancellationReason } from './supporterplus/SupporterplusCancellationReasons';
+import {
+	otherCancellationReason,
+	supporterplusCancellationReasons,
+} from './supporterplus/SupporterplusCancellationReasons';
 
 const contributions = PRODUCT_TYPES.contributions;
 contributions.cancellation!.reasons = contributionsCancellationReasons.concat(
+	otherCancellationReason,
+);
+
+const guardianweekly = PRODUCT_TYPES.guardianweekly;
+guardianweekly.cancellation!.reasons = gwCancellationReasons.concat(
+	otherCancellationReason,
+);
+
+const supporterplus = PRODUCT_TYPES.supporterplus;
+supporterplus.cancellation!.reasons = supporterplusCancellationReasons.concat(
 	otherCancellationReason,
 );
 
@@ -53,11 +67,7 @@ export const ContactCustomerService: StoryObj<
 	parameters: {
 		reactRouter: {
 			state: { productDetail: guardianWeeklyPaidByCard() },
-			container: (
-				<CancellationContainer
-					productType={PRODUCT_TYPES.guardianweekly}
-				/>
-			),
+			container: <CancellationContainer productType={guardianweekly} />,
 		},
 	},
 };
@@ -125,11 +135,7 @@ export const OfferMonthly: StoryObj<typeof CancellationContainer> = {
 				nextNonDiscountedPaymentDate: '2024-07-30',
 				nonDiscountedPayments: [{ date: '2024-07-30', amount: 14.99 }],
 			},
-			container: (
-				<CancellationContainer
-					productType={PRODUCT_TYPES.supporterplus}
-				/>
-			),
+			container: <CancellationContainer productType={supporterplus} />,
 		},
 	},
 };
@@ -156,11 +162,7 @@ export const OfferYearly: StoryObj<typeof CancellationContainer> = {
 				nextNonDiscountedPaymentDate: '2025-05-30',
 				nonDiscountedPayments: [{ date: '2025-05-30', amount: 120 }],
 			},
-			container: (
-				<CancellationContainer
-					productType={PRODUCT_TYPES.supporterplus}
-				/>
-			),
+			container: <CancellationContainer productType={supporterplus} />,
 		},
 	},
 };
@@ -182,11 +184,7 @@ export const OfferReviewMonthly: StoryObj<typeof CancellationContainer> = {
 				nextNonDiscountedPaymentDate: '2024-07-30',
 				nonDiscountedPayments: [{ date: '2024-07-30', amount: 14.99 }],
 			},
-			container: (
-				<CancellationContainer
-					productType={PRODUCT_TYPES.supporterplus}
-				/>
-			),
+			container: <CancellationContainer productType={supporterplus} />,
 		},
 		msw: [
 			http.post('/api/discounts/apply-discount', () => {
@@ -215,11 +213,7 @@ export const OfferReviewYearly: StoryObj<typeof CancellationContainer> = {
 				nextNonDiscountedPaymentDate: '2025-05-30',
 				nonDiscountedPayments: [{ date: '2025-05-30', amount: 120 }],
 			},
-			container: (
-				<CancellationContainer
-					productType={PRODUCT_TYPES.supporterplus}
-				/>
-			),
+			container: <CancellationContainer productType={supporterplus} />,
 		},
 		msw: [
 			http.post('/api/discounts/apply-discount', () => {
@@ -243,11 +237,7 @@ export const OfferConfirmedMonthly: StoryObj<typeof CancellationContainer> = {
 				nextNonDiscountedPaymentDate: '2024-07-30',
 				nonDiscountedPayments: [{ date: '2024-07-30', amount: 14.99 }],
 			},
-			container: (
-				<CancellationContainer
-					productType={PRODUCT_TYPES.supporterplus}
-				/>
-			),
+			container: <CancellationContainer productType={supporterplus} />,
 		},
 	},
 };
@@ -268,11 +258,7 @@ export const OfferConfirmedYearly: StoryObj<typeof CancellationContainer> = {
 				nextNonDiscountedPaymentDate: '2025-05-30',
 				nonDiscountedPayments: [{ date: '2025-05-30', amount: 120 }],
 			},
-			container: (
-				<CancellationContainer
-					productType={PRODUCT_TYPES.supporterplus}
-				/>
-			),
+			container: <CancellationContainer productType={supporterplus} />,
 		},
 	},
 };
@@ -298,11 +284,7 @@ export const Pause: StoryObj<typeof CancellationContainer> = {
 				nextNonDiscountedPaymentDate: '2024-07-30',
 				nonDiscountedPayments: [{ date: '2024-07-30', amount: 14.99 }],
 			},
-			container: (
-				<CancellationContainer
-					productType={PRODUCT_TYPES.contributions}
-				/>
-			),
+			container: <CancellationContainer productType={contributions} />,
 		},
 	},
 };
@@ -323,11 +305,7 @@ export const PauseReview: StoryObj<typeof CancellationContainer> = {
 				nextNonDiscountedPaymentDate: '2024-07-30',
 				nonDiscountedPayments: [{ date: '2024-07-30', amount: 14.99 }],
 			},
-			container: (
-				<CancellationContainer
-					productType={PRODUCT_TYPES.contributions}
-				/>
-			),
+			container: <CancellationContainer productType={contributions} />,
 		},
 		msw: [
 			http.post('/api/discounts/apply-discount', () => {
@@ -351,11 +329,7 @@ export const PauseConfirmed: StoryObj<typeof CancellationContainer> = {
 				nextNonDiscountedPaymentDate: '2024-07-30',
 				nonDiscountedPayments: [{ date: '2024-07-30', amount: 14.99 }],
 			},
-			container: (
-				<CancellationContainer
-					productType={PRODUCT_TYPES.contributions}
-				/>
-			),
+			container: <CancellationContainer productType={contributions} />,
 		},
 	},
 };


### PR DESCRIPTION
### What does this PR change?
The cancellation reasons are rendered in a random order on the client to avoid people from clicking on the first option and throwing off any analysis we might be able to gather from the results. This however resulted in a visual regression change in chromatic every time a pull request was made to manage regardless of whether you had updated the cancellation reasons. 

This pr fixes the ordering of the cancellation reasons in storybook/chromatic so that they don't appear to change order.