### PR TITLE
ad-lite bug fixes

### DIFF
--- a/client/components/mma/accountoverview/AccountOverview.stories.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.stories.tsx
@@ -4,6 +4,7 @@ import { ReactRouterDecorator } from '@/.storybook/ReactRouterDecorator';
 import { featureSwitches } from '@/shared/featureSwitches';
 import {
 	cancelledContribution,
+	cancelledGuardianAdLite,
 	cancelledGuardianWeekly,
 } from '../../../fixtures/cancelledProductDetail';
 import {
@@ -18,6 +19,7 @@ import {
 	contributionPaidByPayPal,
 	digitalPackPaidByDirectDebit,
 	guardianAdLite,
+	guardianAdLiteCancelled,
 	guardianWeeklyCancelled,
 	guardianWeeklyGiftPurchase,
 	guardianWeeklyGiftRecipient,
@@ -234,6 +236,7 @@ export const WithCancelledSubscriptions: StoryObj<typeof AccountOverview> = {
 				return HttpResponse.json([
 					cancelledContribution,
 					cancelledGuardianWeekly,
+					cancelledGuardianAdLite,
 				]);
 			}),
 			http.get('/mpapi/user/mobile-subscriptions', () => {
@@ -246,6 +249,7 @@ export const WithCancelledSubscriptions: StoryObj<typeof AccountOverview> = {
 						guardianWeeklyCancelled(),
 						supporterPlusCancelled(),
 						supporterPlusAnnualCancelled(),
+						guardianAdLiteCancelled(),
 						tierThree(),
 					),
 				);

--- a/client/components/mma/billing/Billing.stories.tsx
+++ b/client/components/mma/billing/Billing.stories.tsx
@@ -13,6 +13,7 @@ import { toMembersDataApiResponse } from '../../../fixtures/mdapiResponse';
 import {
 	digitalPackPaidByDirectDebit,
 	guardianAdLite,
+	guardianAdLiteCancelled,
 	guardianWeeklyPaidByCard,
 	newspaperVoucherPaidByPaypal,
 	tierThree,
@@ -69,6 +70,7 @@ export const WithSubscriptions: StoryObj<typeof Billing> = {
 						newspaperVoucherPaidByPaypal(),
 						tierThree(),
 						guardianAdLite(),
+						guardianAdLiteCancelled(),
 					),
 				);
 			}),

--- a/client/fixtures/cancelledProductDetail.ts
+++ b/client/fixtures/cancelledProductDetail.ts
@@ -25,3 +25,16 @@ export const cancelledGuardianWeekly: CancelledProductDetail = {
 		accountId: '00000000',
 	},
 };
+
+export const cancelledGuardianAdLite: CancelledProductDetail = {
+	tier: 'Guardian Ad-Lite',
+	joinDate: '2022-01-05',
+	subscription: {
+		subscriptionId: 'A-S00000000',
+		cancellationEffectiveDate: '2023-02-28',
+		start: '2023-03-10',
+		end: '2023-03-10',
+		readerType: 'Direct',
+		accountId: '00000000',
+	},
+};

--- a/shared/productResponse.ts
+++ b/shared/productResponse.ts
@@ -105,7 +105,7 @@ export interface ProductDetail extends WithSubscription {
 }
 
 export interface CancelledProductDetail {
-	tier: string;
+	tier: ProductTier;
 	joinDate: string;
 	subscription: CancelledSubscription;
 }

--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -727,13 +727,11 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 		productTitle: () => 'Guardian Ad-Lite',
 		friendlyName: 'guardian ad-lite',
 		productType: 'guardianadlite',
-		groupedProductType: 'recurringSupportWithBenefits',
+		groupedProductType: 'subscriptions',
 		allProductsProductTypeFilterString: 'GuardianAdLite',
 		urlPart: 'guardianadlite',
 		getOphanProductType: () => 'GUARDIAN_AD_LITE',
-		softOptInIDs: [
-			SoftOptInIDs.SupportOnboarding,
-		],
+		softOptInIDs: [SoftOptInIDs.SupportOnboarding],
 		cancellation: {
 			sfCaseProduct: 'Guardian Ad-Lite',
 			startPageBody: contributionsCancellationFlowStart,


### PR DESCRIPTION
### What does this PR change?
'Supporter ID' should become 'Subscription ID' in the account overview, manage product and billing pages

Cancelled ad-lite should have a cancelled prefix sentence before the cancellation date is rendered on the billing page

### Images
Before             |  After
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/00559ac5-87aa-4b03-b391-eed5943a95ce)  |  ![](https://github.com/user-attachments/assets/1b2edba8-0322-47e2-a6ec-30ebb7c6e022)

Before             |  After
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/e32101af-a6ce-4f7d-9d40-986f0c44c733)  |  ![](https://github.com/user-attachments/assets/9071e0dc-093a-4558-a859-95506a8db03a)
