### PR TITLE
conditional logic refactor (cencellation journey)

### DIFF
--- a/client/components/mma/cancel/Cancellation.stories.tsx
+++ b/client/components/mma/cancel/Cancellation.stories.tsx
@@ -17,6 +17,7 @@ import {
 	supporterPlusMonthlyAllAccessDigital,
 } from '../../../fixtures/productBuilder/testProducts';
 import { CancellationContainer } from './CancellationContainer';
+import { CancellationJourneyFunnel } from './CancellationJourneyFunnel';
 import { CancellationReasonReview } from './CancellationReasonReview';
 import { CancellationReasonSelection } from './CancellationReasonSelection';
 import { CancelAlternativeConfirmed } from './cancellationSaves/CancelAlternativeConfirmed';
@@ -75,7 +76,7 @@ export const SelectReason: StoryObj<typeof CancellationReasonSelection> = {
 export const ContactCustomerService: StoryObj<
 	typeof CancellationReasonSelection
 > = {
-	render: () => <CancellationReasonSelection />,
+	render: () => <CancellationJourneyFunnel />,
 
 	parameters: {
 		reactRouter: {

--- a/client/components/mma/cancel/CancellationJourneyFunnel.tsx
+++ b/client/components/mma/cancel/CancellationJourneyFunnel.tsx
@@ -1,17 +1,20 @@
 import { useContext } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
+import { hasCancellationFlow } from '@/client/utilities/productUtils';
 import { featureSwitches } from '@/shared/featureSwitches';
 import {
 	getSpecificProductTypeFromTier,
 	isPaidSubscriptionPlan,
 } from '@/shared/productResponse';
 import type { ProductTypeKeys } from '@/shared/productTypes';
+import { GROUPED_PRODUCT_TYPES } from '@/shared/productTypes';
 import { CancellationContext } from './CancellationContainer';
 import type {
 	CancellationContextInterface,
 	CancellationRouterState,
 } from './CancellationContainer';
 import { CancellationReasonSelection } from './CancellationReasonSelection';
+import { ContactUsToCancel } from './ContactUsToCancel';
 
 function productHasEarlySaveJourney(productTypeKey: ProductTypeKeys): boolean {
 	return (
@@ -59,7 +62,22 @@ export const CancellationJourneyFunnel = () => {
 	}
 
 	if (
-		Object.hasOwn(productType, 'cancellation') &&
+		!productDetail.selfServiceCancellation.isAllowed ||
+		!hasCancellationFlow(productType)
+	) {
+		return (
+			<ContactUsToCancel
+				selfServiceCancellation={productDetail.selfServiceCancellation}
+				subscriptionId={productDetail.subscription.subscriptionId}
+				groupedProductType={
+					GROUPED_PRODUCT_TYPES[productType.groupedProductType]
+				}
+			/>
+		);
+	}
+
+	if (
+		hasCancellationFlow(productType) &&
 		!productType.cancellation?.reasons
 	) {
 		return <Navigate to="./confirm" state={{ ...routerState }} />;

--- a/client/components/mma/cancel/CancellationReasonSelection.tsx
+++ b/client/components/mma/cancel/CancellationReasonSelection.tsx
@@ -23,12 +23,10 @@ import {
 } from '../../../../shared/dates';
 import type { ProductDetail } from '../../../../shared/productResponse';
 import type { ProductTypeWithCancellationFlow } from '../../../../shared/productTypes';
-import { GROUPED_PRODUCT_TYPES } from '../../../../shared/productTypes';
 import {
 	LoadingState,
 	useAsyncLoader,
 } from '../../../utilities/hooks/useAsyncLoader';
-import { hasCancellationFlow } from '../../../utilities/productUtils';
 import { GenericErrorScreen } from '../../shared/GenericErrorScreen';
 import { WithStandardTopMargin } from '../../shared/WithStandardTopMargin';
 import { JsonResponseHandler } from '../shared/asyncComponents/DefaultApiResponseHandler';
@@ -44,7 +42,6 @@ import {
 import type { CancellationDateResponse } from './cancellationDateResponse';
 import { cancellationDateFetcher } from './cancellationDateResponse';
 import type { CancellationReason } from './cancellationReason';
-import { ContactUsToCancel } from './ContactUsToCancel';
 
 interface ReasonPickerProps {
 	productType: ProductTypeWithCancellationFlow;
@@ -382,21 +379,6 @@ export const CancellationReasonSelection = () => {
 	const { productDetail, productType } = useContext(
 		CancellationContext,
 	) as CancellationContextInterface;
-
-	if (
-		!productDetail.selfServiceCancellation.isAllowed ||
-		!hasCancellationFlow(productType)
-	) {
-		return (
-			<ContactUsToCancel
-				selfServiceCancellation={productDetail.selfServiceCancellation}
-				subscriptionId={productDetail.subscription.subscriptionId}
-				groupedProductType={
-					GROUPED_PRODUCT_TYPES[productType.groupedProductType]
-				}
-			/>
-		);
-	}
 
 	if (productType.cancellation.startPageOfferEffectiveDateOptions) {
 		return (


### PR DESCRIPTION
### What does this PR change?
I've moved the conditional logic to check to see if we should render the 'contact us to cancel' component out of the 'cancellation reason selection' component as we don't render the reasons to these users/products anyway.

It's been moved over to the 'CancellationJourneyFunnel' component which works as a conduit for various products cancellation journey and which path they should take.

Hopefully this change makes it more obvious that there are products that we need to show the 'contact us to cancel' component to and that this has nothing to do with the reason selection component.
