### PR TITLE
Show singular cancelled subscription

### DIFF
--- a/client/components/mma/accountoverview/AccountOverview.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.tsx
@@ -155,6 +155,7 @@ const AccountOverviewPage = ({ isFromApp }: IsFromAppProps) => {
 
 	if (
 		allActiveProductDetails.length === 0 &&
+		allCancelledProductDetails.length === 0 &&
 		appSubscriptions.length === 0 &&
 		singleContributions.length === 0
 	) {


### PR DESCRIPTION
### Context
You have only 1 product and it is cancelled and therefore returned in the `/cancelled` api response on the account overview.

![Screenshot 2025-02-19 at 10 20 07](https://github.com/user-attachments/assets/9c9e6531-09db-44ae-b9a2-609e633d49e6)


### What does this PR change?
If you have only 1 product and it it cancelled then it should still show up in the account overview if it is returned in the '/cancelled' api response. Before if you didn't also have an active pruduct then it would render the empty account overview component

### Images
Before             |  After
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/bdf0ba24-0507-43ac-b9df-60aa493e2d26)  |  ![](https://github.com/user-attachments/assets/90b7a82f-ea82-429b-b97d-fde3cc8f83fd)





