### PR TITLE
subscribe/support again cta

### DIFF
--- a/client/components/mma/accountoverview/AccountOverview.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.tsx
@@ -111,6 +111,10 @@ const AccountOverviewPage = ({ isFromApp }: IsFromAppProps) => {
 		.filter(isProduct)
 		.sort(sortByJoinDate);
 
+	const activeProductsNotPendingCancellation = allActiveProductDetails.filter(
+		(product: ProductDetail) => !product.subscription.cancelledAt,
+	);
+
 	const allCancelledProductDetails = cancelledProductsResponse.sort(
 		(a: CancelledProductDetail, b: CancelledProductDetail) =>
 			b.subscription.start.localeCompare(a.subscription.start),
@@ -252,6 +256,9 @@ const AccountOverviewPage = ({ isFromApp }: IsFromAppProps) => {
 												.subscriptionId
 										}
 										productDetail={cancelledProductDetail}
+										hasOtherActiveSubs={
+											!!activeProductsNotPendingCancellation.length
+										}
 									/>
 								),
 							)}

--- a/client/components/mma/accountoverview/CancelledProductCard.tsx
+++ b/client/components/mma/accountoverview/CancelledProductCard.tsx
@@ -18,8 +18,10 @@ import {
 
 export const CancelledProductCard = ({
 	productDetail,
+	hasOtherActiveSubs,
 }: {
 	productDetail: CancelledProductDetail;
+	hasOtherActiveSubs: boolean;
 }) => {
 	const specificProductType = getSpecificProductTypeFromTier(
 		productDetail.tier,
@@ -31,10 +33,7 @@ export const CancelledProductCard = ({
 		productCardConfiguration[specificProductType.productType];
 
 	const showSubscribeAgainButton =
-		specificProductType.groupedProductType !== 'membership' &&
-		specificProductType.groupedProductType !== 'recurringSupport' &&
-		specificProductType.groupedProductType !==
-			'recurringSupportWithBenefits';
+		!!specificProductType.checkoutUrlPart && !hasOtherActiveSubs;
 
 	return (
 		<Stack space={4}>
@@ -100,7 +99,7 @@ export const CancelledProductCard = ({
 						<div css={wideButtonLayoutCss}>
 							{showSubscribeAgainButton && (
 								<LinkButton
-									href="https://support.theguardian.com/uk/subscribe"
+									href={`https://support.theguardian.com/${specificProductType.checkoutUrlPart}`}
 									size="small"
 									cssOverrides={css`
 										justify-content: center;
@@ -110,11 +109,18 @@ export const CancelledProductCard = ({
 										trackEvent({
 											eventCategory: 'href',
 											eventAction: 'click',
-											eventLabel: 'subscribe_again',
+											eventLabel: `${
+												groupedProductType.showSupporterId
+													? 'support'
+													: 'subscribe'
+											}_again`,
 										});
 									}}
 								>
-									Subscribe again
+									{groupedProductType.showSupporterId
+										? 'Support'
+										: 'Subscribe'}{' '}
+									again
 								</LinkButton>
 							)}
 						</div>

--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -175,6 +175,7 @@ export interface ProductType {
 	shortFriendlyName?: string;
 	productType: ProductTypeKeys;
 	groupedProductType: GroupedProductTypeKeys;
+	checkoutUrlPart?: string;
 	allProductsProductTypeFilterString: AllProductsProductTypeFilterString;
 	urlPart: ProductUrlPart;
 	softOptInIDs: string[];
@@ -339,6 +340,7 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 		groupedProductType: 'recurringSupport',
 		allProductsProductTypeFilterString: 'Contribution',
 		urlPart: 'contributions',
+		checkoutUrlPart: '/contribute', // https://support.theguardian.com/uk/contribute
 		getOphanProductType: () => 'RECURRING_CONTRIBUTION',
 		updateAmountMdaEndpoint: 'contribution-update-amount',
 		softOptInIDs: [
@@ -389,6 +391,7 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 		groupedProductType: 'subscriptions',
 		allProductsProductTypeFilterString: 'Paper',
 		urlPart: 'paper',
+		checkoutUrlPart: '/subscribe', // https://support.theguardian.com/uk/subscribe
 		getOphanProductType: () => 'PRINT_SUBSCRIPTION',
 		productPageNewsletterIDs: [FRONT_PAGE_NEWSLETTER_ID],
 		delivery: {
@@ -409,6 +412,7 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 		groupedProductType: 'subscriptions',
 		allProductsProductTypeFilterString: 'HomeDelivery',
 		urlPart: 'homedelivery',
+		checkoutUrlPart: '/subscribe', // https://support.theguardian.com/uk/subscribe
 		getOphanProductType: () => 'PRINT_SUBSCRIPTION',
 		productPageNewsletterIDs: [FRONT_PAGE_NEWSLETTER_ID],
 		softOptInIDs: [
@@ -448,6 +452,7 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 		groupedProductType: 'subscriptions',
 		allProductsProductTypeFilterString: 'HomeDelivery',
 		urlPart: 'nationaldelivery',
+		checkoutUrlPart: '/subscribe', // https://support.theguardian.com/uk/subscribe
 		getOphanProductType: () => 'PRINT_SUBSCRIPTION',
 		productPageNewsletterIDs: [FRONT_PAGE_NEWSLETTER_ID],
 		softOptInIDs: [
@@ -487,6 +492,7 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 		groupedProductType: 'subscriptions',
 		allProductsProductTypeFilterString: 'Voucher',
 		urlPart: 'voucher',
+		checkoutUrlPart: '/subscribe', // https://support.theguardian.com/uk/subscribe
 		getOphanProductType: () => 'PRINT_SUBSCRIPTION',
 		productPageNewsletterIDs: [FRONT_PAGE_NEWSLETTER_ID],
 		softOptInIDs: [
@@ -533,6 +539,7 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 		groupedProductType: 'subscriptions',
 		allProductsProductTypeFilterString: 'DigitalVoucher',
 		urlPart: 'subscriptioncard',
+		checkoutUrlPart: '/subscribe', // https://support.theguardian.com/uk/subscribe
 		legacyUrlPart: 'digitalvoucher',
 		getOphanProductType: () => 'PRINT_SUBSCRIPTION',
 		productPageNewsletterIDs: [FRONT_PAGE_NEWSLETTER_ID],
@@ -560,6 +567,7 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 		groupedProductType: 'subscriptions',
 		allProductsProductTypeFilterString: 'Weekly',
 		urlPart: 'guardianweekly',
+		checkoutUrlPart: '/subscribe', // https://support.theguardian.com/uk/subscribe
 		softOptInIDs: [
 			SoftOptInIDs.SupportOnboarding,
 			SoftOptInIDs.GuardianWeeklyNewsletter,
@@ -608,6 +616,7 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 		groupedProductType: 'recurringSupportWithBenefits',
 		allProductsProductTypeFilterString: 'TierThree',
 		urlPart: 'digital+print',
+		checkoutUrlPart: '/support', // https://support.theguardian.com/uk/support
 		softOptInIDs: [
 			SoftOptInIDs.SupportOnboarding,
 			SoftOptInIDs.SupporterNewsletter,
@@ -685,6 +694,7 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 		groupedProductType: 'recurringSupportWithBenefits',
 		allProductsProductTypeFilterString: 'SupporterPlus',
 		urlPart: 'support',
+		checkoutUrlPart: '/support', // https://support.theguardian.com/uk/support
 		getOphanProductType: () => 'SUPPORTER_PLUS',
 		showTrialRemainingIfApplicable: true,
 		softOptInIDs: [
@@ -730,6 +740,7 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 		groupedProductType: 'subscriptions',
 		allProductsProductTypeFilterString: 'GuardianAdLite',
 		urlPart: 'guardianadlite',
+		checkoutUrlPart: '/guardian-ad-lite', // https://support.theguardian.com/uk/guardian-ad-lite
 		getOphanProductType: () => 'GUARDIAN_AD_LITE',
 		softOptInIDs: [SoftOptInIDs.SupportOnboarding],
 		cancellation: {


### PR DESCRIPTION
### What does this PR change?

Display a subscribe/support again CTA in the cancelled product card on the account overview if the customer has no other active products.

### Images

with other active products:
![Screenshot 2025-03-04 at 17 58 22](https://github.com/user-attachments/assets/fb199f4a-8742-406b-bf8a-12c0d2b2e2f8)

with no other active products:
![Screenshot 2025-03-04 at 18 01 47](https://github.com/user-attachments/assets/f6d890aa-8ff6-4282-8265-2e16edc5f30e)


