### PR TITLE
Make ELB to use a restricted cypher list in order to pass Nessus

### DIFF
--- a/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/manage-frontend.test.ts.snap
@@ -1913,7 +1913,7 @@ Object {
         },
         "Port": 443,
         "Protocol": "HTTPS",
-        "SslPolicy": "ELBSecurityPolicy-TLS13-1-2-2021-06",
+        "SslPolicy": "ELBSecurityPolicy-TLS13-1-2-Res-2021-06",
       },
       "Type": "AWS::ElasticLoadBalancingV2::Listener",
     },

--- a/cdk/lib/manage-frontend.ts
+++ b/cdk/lib/manage-frontend.ts
@@ -19,7 +19,8 @@ import {
 	InstanceType,
 	UserData,
 } from 'aws-cdk-lib/aws-ec2';
-import { Protocol } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import type { CfnListener } from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import { Protocol, SslPolicy } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { CfnRecordSet } from 'aws-cdk-lib/aws-route53';
 
@@ -193,6 +194,8 @@ systemctl start manage-frontend
 			timeout: Duration.seconds(5),
 			protocol: Protocol.HTTP,
 		});
+
+		(nodeApp.listener.node.defaultChild as CfnListener).sslPolicy = SslPolicy.TLS13_RES;
 
 		new CfnRecordSet(this, 'AliasRecord', {
 			name: props.domain,


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What and why are you doing in this PR?
This PR changes the manage-frontend ELB to use a restricted cypher list in order to pass our Tenable/nessus PCI testing. 

Currently it is complaining with this issue: https://www.tenable.com/plugins/nessus/159543

This [AWS doc](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/describe-ssl-policies.html) explains the options available, and the only list that is a subset of the Tenable list is: `ELBSecurityPolicy-TLS13-1-2-Res-2021-06`
 
<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)
[none]

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- [ ] 1. Run Tenable against manage-frontend CODE ELB, see failure
- [ ] 2. Deploy PR to CODE (not late in Friday!), check site works OK in browser via ELB and Fastly.
- [ ] 3. Run Tenable against support-frontend CODE ELB, see pass
- [ ] 4. Merge to Prod
- [ ] 5. Run Tenable against support-frontend PROD ELB, see pass

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Tenable scan passes.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
Fastly might not work with reduced cypher suite.

