### PR TITLE
Identity | Registration Location State

### DIFF
--- a/client/components/mma/identity/idapi/user.ts
+++ b/client/components/mma/identity/idapi/user.ts
@@ -25,6 +25,7 @@ type UserPrivateFields = Partial<
 		| 'postcode'
 		| 'country'
 		| 'registrationLocation'
+		| 'registrationLocationState'
 	>
 > & {
 	telephoneNumber?: {
@@ -39,6 +40,10 @@ const userErrorMessageMap = new Map([
 	[
 		'user.privateFields.registrationLocation',
 		'Please select a location from the list or "I prefer not to say"',
+	],
+	[
+		'user.privateFields.registrationLocationState',
+		'Please select a state/territory from the list or "I prefer not to say"',
 	],
 ]);
 
@@ -111,6 +116,7 @@ const toUserApiRequest = (user: Partial<User>): UserAPIRequest => {
 			country: user.country,
 			telephoneNumber,
 			registrationLocation: user.registrationLocation,
+			registrationLocationState: user.registrationLocationState,
 		},
 		primaryEmailAddress: user.primaryEmailAddress,
 	};
@@ -136,6 +142,9 @@ export const toUser = (response: UserAPIResponse): User => {
 		countryCode: getFromUser('privateFields.telephoneNumber.countryCode'),
 		localNumber: getFromUser('privateFields.telephoneNumber.localNumber'),
 		registrationLocation: getFromUser('privateFields.registrationLocation'),
+		registrationLocationState: getFromUser(
+			'privateFields.registrationLocationState',
+		),
 		consents,
 		// We don't always receive a full user response from IDAPI, so we shouldn't
 		// assume that the statusFields object is always present.

--- a/client/components/mma/identity/models.ts
+++ b/client/components/mma/identity/models.ts
@@ -43,6 +43,7 @@ export interface User {
 	countryCode: string;
 	localNumber: number;
 	registrationLocation: registrationLocationType;
+	registrationLocationState: RegistrationLocationState;
 }
 
 export interface UserError {
@@ -106,6 +107,101 @@ export enum RegistrationLocations {
 	NEW_ZEALAND = 'New Zealand',
 	OTHER = 'Other',
 }
+
+export const RegistrationLocationStatesByLocation = {
+	[RegistrationLocations.AUSTRALIA]: [
+		// Australia - https://en.wikipedia.org/wiki/ISO_3166-2:AU
+		// Australian States
+		'New South Wales', // AU-NSW
+		'Victoria', // AU-VIC
+		'Queensland', // AU-QLD
+		'South Australia', // AU-SA
+		'Western Australia', // AU-WA
+		'Tasmania', // AU-TAS
+		// Australian Territories
+		'Australian Capital Territory', // AU-ACT
+		'Northern Territory', // AU-NT
+	],
+	[RegistrationLocations.UNITED_STATES]: [
+		// United States - https://en.wikipedia.org/wiki/ISO_3166-2:US
+		// US States
+		'Alabama', // US-AL
+		'Alaska', // US-AK
+		'Arizona', // US-AZ
+		'Arkansas', // US-AR
+		'California', // US-CA
+		'Colorado', // US-CO
+		'Connecticut', // US-CT
+		'Delaware', // US-DE
+		'Florida', // US-FL
+		'Georgia', // US-GA
+		'Hawaii', // US-HI
+		'Idaho', // US-ID
+		'Illinois', // US-IL
+		'Indiana', // US-IN
+		'Iowa', // US-IA
+		'Kansas', // US-KS
+		'Kentucky', // US-KY
+		'Louisiana', // US-LA
+		'Maine', // US-ME
+		'Maryland', // US-MD
+		'Massachusetts', // US-MA
+		'Michigan', // US-MI
+		'Minnesota', // US-MN
+		'Mississippi', // US-MS
+		'Missouri', // US-MO
+		'Montana', // US-MT
+		'Nebraska', // US-NE
+		'Nevada', // US-NV
+		'New Hampshire', // US-NH
+		'New Jersey', // US-NJ
+		'New Mexico', // US-NM
+		'New York', // US-NY
+		'North Carolina', // US-NC
+		'North Dakota', // US-ND
+		'Ohio', // US-OH
+		'Oklahoma', // US-OK
+		'Oregon', // US-OR
+		'Pennsylvania', // US-PA
+		'Rhode Island', // US-RI
+		'South Carolina', // US-SC
+		'South Dakota', // US-SD
+		'Tennessee', // US-TN
+		'Texas', // US-TX
+		'Utah', // US-UT
+		'Vermont', // US-VT
+		'Virginia', // US-VA
+		'Washington', // US-WA
+		'West Virginia', // US-WV
+		'Wisconsin', // US-WI
+		'Wyoming', // US-WY
+		// US Districts
+		'District of Columbia', // US-DC
+		// US Outlying Areas
+		'American Samoa', // US-AS
+		'Guam', // US-GU
+		'Northern Mariana Islands', // US-MP
+		'Puerto Rico', // US-PR
+		'United States Minor Outlying Islands', // US-UM
+		'Virgin Islands', // US-VI
+	],
+	general: [
+		// General
+		'Other', // Other
+		'Prefer not to say', // Prefer not to say
+	],
+} as const;
+
+export const RegistrationLocationStates = [
+	...RegistrationLocationStatesByLocation[RegistrationLocations.AUSTRALIA],
+	...RegistrationLocationStatesByLocation[
+		RegistrationLocations.UNITED_STATES
+	],
+	...RegistrationLocationStatesByLocation.general,
+	'',
+] as const;
+export type RegistrationLocationState =
+	typeof RegistrationLocationStates[number];
 
 export enum Titles {
 	MR = 'Mr',

--- a/client/fixtures/user.ts
+++ b/client/fixtures/user.ts
@@ -19,6 +19,7 @@ export const user = {
 			firstName: 'Test',
 			secondName: 'User',
 			registrationLocation: 'Other',
+			registrationLocationState: 'Other',
 			legacyPackages: 'CRE,RCO',
 			legacyProducts: 'CRE,RCO',
 		},

--- a/cypress/tests/mocked/parallel-6/identitySettingsForm.cy.ts
+++ b/cypress/tests/mocked/parallel-6/identitySettingsForm.cy.ts
@@ -37,12 +37,14 @@ describe('Settings Form', () => {
 
 		// Check form correctly submits text field and dropdown value
 		cy.findAllByLabelText('Last Name').type('NewSurname');
-		cy.findByLabelText('Location').select('Prefer not to say');
+		cy.findByLabelText('Location').select('United States');
+		cy.findByLabelText('State/Territory').select('California');
 		cy.findAllByText('Save changes').click();
 		cy.wait('@updatedUserResponse')
 			.its('request.body')
 			.should('have.deep.property', 'privateFields', {
-				registrationLocation: 'Prefer not to say',
+				registrationLocation: 'United States',
+				registrationLocationState: 'California',
 				secondName: 'UserNewSurname',
 			});
 


### PR DESCRIPTION
## What does this change?

Adds the ability for users to select/manage their state/territory location in the Settings tab when the user has the Location `Australia` or `United States`.

This new field is called `registrationLocationState`.

It only shows when the user has `Australia` or `United States` location selected. When a user changes location away from either of those two, we set the `registrationLocationState` to be blank (`''`) to remove this field from their profile.

<table>
<tr>
<th>Example
<tr>
<td>

https://github.com/user-attachments/assets/70f8e8d0-ac5f-4ffc-addd-349733b2be91

</table>

## Tested

- [x] CODE


## Context

Guardian readers in Australia and the United States are bound by and impacted by state specific regulations and laws. Without this information we are unable to send state specific service emails, editorial newsletters, or marketing emails. In addition, adding state location can inform personalised advertising and partner emails, making advertising more relevant and making partner emails a more relevant perk for our readers.

https://trello.com/c/Hn2lBRSK/1445-scoping-add-state-location-data-point

## Related PRs

- Identity Platform - Okta: https://github.com/guardian/identity-platform/pull/803
- Identity Platform - Fastly: https://github.com/guardian/identity-platform/pull/804
- Identity API: https://github.com/guardian/identity/pull/2697
- Gatehouse: https://github.com/guardian/gatehouse/pull/133
- Identity API Fix:  https://github.com/guardian/identity/pull/2703
- ***Manage Frontend: https://github.com/guardian/manage-frontend/pull/1479***
