### PR TITLE
Add user-benefits information to the diagnostic information page

### DIFF
--- a/client/components/helpCentre/diagnosticInformation/DiagnosticInformation.tsx
+++ b/client/components/helpCentre/diagnosticInformation/DiagnosticInformation.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import { space } from '@guardian/source/foundations';
 import { Button } from '@guardian/source/react-components';
 import { useRef, useState } from 'react';
+import { UserBenefitsInformation } from '@/client/components/helpCentre/diagnosticInformation/UserBenefitsInformation';
 import { h2Css } from '../HelpCentreStyles';
 import { AccountInformation } from './AccountInformation';
 import { BrowserInformation } from './BrowserInformation';
@@ -78,6 +79,7 @@ export const DiagnosticInformation = () => {
 				<BrowserInformation />
 				<CookieInformation />
 				<AccountInformation />
+				<UserBenefitsInformation />
 				<SubscriptionInformation />
 			</div>
 			<Button

--- a/client/components/helpCentre/diagnosticInformation/UserBenefitsInformation.tsx
+++ b/client/components/helpCentre/diagnosticInformation/UserBenefitsInformation.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import { z } from 'zod';
+import { fetchWithDefaultParameters } from '../../../utilities/fetch';
+
+const userBenefitsSchema = z.object({
+	benefits: z.array(z.string()),
+});
+type UserBenefits = z.infer<typeof userBenefitsSchema>;
+
+async function fetchUserBenefitsData(): Promise<UserBenefits | 'failed'> {
+	const response = await fetchWithDefaultParameters('/api/benefits/me');
+	if (response.ok) {
+		const json = await response.json();
+		return userBenefitsSchema.parse(json);
+	}
+	return 'failed';
+}
+
+export const UserBenefitsInformation = () => {
+	const [userBenefits, setUserBenefits] = useState<
+		UserBenefits | 'failed' | 'loading'
+	>('loading');
+
+	useEffect(() => {
+		fetchUserBenefitsData()
+			.then((userBenefitsData) => setUserBenefits(userBenefitsData))
+			.catch((e) => {
+				setUserBenefits('failed');
+				console.error(e);
+			});
+	}, []);
+
+	if (userBenefits === 'loading') {
+		return (
+			<>
+				<h3>Account Information</h3>
+				<p>Loading...</p>
+			</>
+		);
+	}
+
+	if (userBenefits === 'failed') {
+		return (
+			<>
+				<h3>User Benefits Information</h3>
+				<p>
+					User is not logged in / no user benefits information
+					available
+				</p>
+			</>
+		);
+	}
+
+	return (
+		<>
+			<h3>User Benefits Information:</h3>
+			<ul>
+				{userBenefits.benefits.map((benefit) => (
+					<li key={benefit}>{benefit}</li>
+				))}
+			</ul>
+		</>
+	);
+};

--- a/server/apiProxy.ts
+++ b/server/apiProxy.ts
@@ -200,3 +200,6 @@ export const customMembersDataApiHandler = proxyApiHandler(
 export const membersDataApiHandler = customMembersDataApiHandler(
 	straightThroughBodyHandler,
 );
+export const userBenefitsApiHandler = proxyApiHandler(
+	'user-benefits.' + conf.API_DOMAIN,
+)(straightThroughBodyHandler);

--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -17,6 +17,7 @@ import {
 	membersDataApiHandler,
 	proxyApiHandler,
 	straightThroughBodyHandler,
+	userBenefitsApiHandler,
 } from '../apiProxy';
 import { s3FilePromise } from '../awsIntegration';
 import { conf } from '../config';
@@ -358,5 +359,10 @@ router.post('/csp-audit-report-endpoint', (req, res) => {
 	log.warn(JSON.stringify(parsedBody));
 	res.status(204).end();
 });
+
+router.get(
+	'/benefits/me',
+	userBenefitsApiHandler('benefits/me', 'USER_BENEFITS'),
+);
 
 export { router };


### PR DESCRIPTION
### Current situation/background
The diagnostics information page at `/help-centre/diagnostic-information` allows us to retrieve debug information for users who are experiencing issues. Up until now this page has not had any information from the user-benefits API.

### What does this PR change?
This PR adds information from the user-benefits API
### Screenshot
![Screenshot 2025-03-20 at 16 12 51](https://github.com/user-attachments/assets/c1dc594c-c105-4144-98be-fe880ea5575f)
