### PR TITLE
Update cookie names in diagnostics

### DIFF
--- a/client/components/helpCentre/diagnosticInformation/CookieInformation.tsx
+++ b/client/components/helpCentre/diagnosticInformation/CookieInformation.tsx
@@ -2,9 +2,9 @@ import { getCookie } from '../../../utilities/cookies';
 
 const cookieNames = [
 	'gu_hide_support_messaging',
-	'gu_digital_subscriber',
-	'gu_paying_member',
-	'gu_recurring_contributor',
+	'GU_AF1',
+	'gu_allow_reject_all',
+	'gu_user_benefits_expiry',
 ];
 
 /**


### PR DESCRIPTION
We don't use three of the ones that were there any more, but there are three new ones which we are interested in.