### PR TITLE
Remove UK Phoneline banner

### DIFF
--- a/client/components/helpCentre/HelpCentrePage.tsx
+++ b/client/components/helpCentre/HelpCentrePage.tsx
@@ -77,13 +77,7 @@ const HelpCentreRouter = () => {
 	]
 	*/
 
-	const knownIssues: KnownIssueObj[] = [
-		{
-			date: '25th Mar 2025 10:30 am',
-			message:
-				'We are experiencing an issue with our Telephone lines and are currently unable to answer your call.  You can continue to contact us via Email or Live Chat.  Thank you for your patience while we investigate the issue.',
-		},
-	];
+	const knownIssues: KnownIssueObj[] = [];
 
 	return (
 		<Main signInStatus={signInStatus} isHelpCentrePage>


### PR DESCRIPTION
### Current situation/background
The UK Phone line issue with our contact centre is now resolved, so we can remove the banner added this morning.
### What does this PR change?
Reverts #1484, thus removing the banner.
### Next steps/further info

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->
