### PR TITLE
Add the holiday stop notice period for newspaper print delivery products

### DIFF
--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -73,7 +73,7 @@ type SfCaseProduct =
 	| 'Guardian Weekly'
 	| 'Digital Pack Subscriptions'
 	| 'Supporter Plus'
-	| 'Tier '
+	| 'Tier Three'
 	| 'Guardian Ad-Lite'
 	| 'Guardian Patron';
 export type AllProductsProductTypeFilterString =
@@ -89,7 +89,7 @@ export type AllProductsProductTypeFilterString =
 	| 'ContentSubscription'
 	| 'GuardianPatron'
 	| 'GuardianAdLite'
-	| 'Tier';
+	| 'TierThree';
 
 interface CancellationFlowProperties {
 	reasons?: CancellationReason[];
@@ -277,7 +277,7 @@ export type ProductTypeKeys =
 	| 'guardianweekly'
 	| 'digipack'
 	| 'supporterplus'
-	| 'tier'
+	| 'tierthree'
 	| 'guardianadlite'
 	| 'guardianpatron';
 

--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -73,7 +73,7 @@ type SfCaseProduct =
 	| 'Guardian Weekly'
 	| 'Digital Pack Subscriptions'
 	| 'Supporter Plus'
-	| 'Tier Three'
+	| 'Tier '
 	| 'Guardian Ad-Lite'
 	| 'Guardian Patron';
 export type AllProductsProductTypeFilterString =
@@ -89,7 +89,7 @@ export type AllProductsProductTypeFilterString =
 	| 'ContentSubscription'
 	| 'GuardianPatron'
 	| 'GuardianAdLite'
-	| 'TierThree';
+	| 'Tier';
 
 interface CancellationFlowProperties {
 	reasons?: CancellationReason[];
@@ -277,7 +277,7 @@ export type ProductTypeKeys =
 	| 'guardianweekly'
 	| 'digipack'
 	| 'supporterplus'
-	| 'tierthree'
+	| 'tier'
 	| 'guardianadlite'
 	| 'guardianpatron';
 
@@ -422,7 +422,7 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 		],
 		holidayStops: {
 			issueKeyword: 'paper',
-			alternateNoticeString: "three day's notice",
+			alternateNoticeString: "two working days' notice",
 		},
 		delivery: {
 			showAddress: showDeliveryAddressCheck,
@@ -463,7 +463,7 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 		],
 		holidayStops: {
 			issueKeyword: 'paper',
-			alternateNoticeString: "three day's notice",
+			alternateNoticeString: "three days' notice",
 		},
 		delivery: {
 			showAddress: showDeliveryAddressCheck,

--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -422,6 +422,7 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 		],
 		holidayStops: {
 			issueKeyword: 'paper',
+			alternateNoticeString: "three day's notice",
 		},
 		delivery: {
 			showAddress: showDeliveryAddressCheck,
@@ -462,6 +463,7 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 		],
 		holidayStops: {
 			issueKeyword: 'paper',
+			alternateNoticeString: "three day's notice",
 		},
 		delivery: {
 			showAddress: showDeliveryAddressCheck,


### PR DESCRIPTION
### Current situation/background

When a customer adds holiday stops, we only show the notice period for Paper Voucher and Subscription Card products:

<img width="828" alt="Screenshot 2025-04-02 at 12 17 45" src="https://github.com/user-attachments/assets/6e5fdd6d-1a22-4e39-899e-fa36154056a4" />

This is not shown for the other delivery products 😞 
![image](https://github.com/user-attachments/assets/792f4ef0-81b6-4117-897c-a8381b3f0d7e)

### What does this PR change?
Adds in the notice period for the Home Delivery and National Delivery products.

<img width="823" alt="Screenshot 2025-04-02 at 13 36 16" src="https://github.com/user-attachments/assets/f6a1fe39-0147-4367-ace0-60cd20b61347" />


### Next steps/further info
Check if there is a good way to word the Guardian Weekly product which I think is something like "earliest holiday stop date is a week on Saturday"? It's defined [here](https://github.com/guardian/support-service-lambdas/blob/main/handlers/fulfilment-date-calculator/src/main/scala/com/gu/supporter/fulfilment/GuardianWeekly.scala#L41).