### PR TITLE
add wording for GW holiday stop notice period

### DIFF
--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -582,6 +582,7 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 		},
 		holidayStops: {
 			issueKeyword: 'issue',
+			alternateNoticeString: "notice by the Tuesday of the week before your issue is due",
 		},
 		delivery: {
 			showAddress: showDeliveryAddressCheck,


### PR DESCRIPTION
branched off https://github.com/guardian/manage-frontend/pull/1487

This adds extra wording to the above PR for GW

The rules are gained from here:
https://github.com/guardian/support-service-lambdas/blob/e7412c4581cfa0103e1f9b9aa1bab4f8744c4970/handlers/fulfilment-date-calculator/src/test/scala/com/gu/supporter/fulfilment/GuardianWeeklyFulfilmentDatesSpec.scala#L88-L101
And see the dates here
<img width="235" alt="image" src="https://github.com/user-attachments/assets/a1801a18-72fc-41b9-8bfc-0c8f7add1b51" />
