### PR TITLE
Direct Debit Gateway Owner Support for Sunday/Observer Subscriptions

### DIFF
--- a/client/components/mma/paymentUpdate/PaymentDetailUpdate.tsx
+++ b/client/components/mma/paymentUpdate/PaymentDetailUpdate.tsx
@@ -20,6 +20,7 @@ import type * as React from 'react';
 import { useCallback, useContext, useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { isSundayTheObserverSubscription } from '@/client/utilities/sundayTheObserverSubscription';
+import { DirectDebitGatewayOwner } from '@/shared/directDebit';
 import { featureSwitches } from '@/shared/featureSwitches';
 import {
 	getScopeFromRequestPathOrEmptyString,
@@ -446,6 +447,15 @@ export const PaymentDetailUpdate = (props: WithProductType<ProductType>) => {
 						}
 						testUser={isTestUser}
 						executePaymentUpdate={executePaymentUpdate}
+						gatewayOwner={
+							featureSwitches.tortoiseStripeCheckout &&
+							isSundayTheObserverSubscription(
+								props.productType,
+								productDetail,
+							)
+								? DirectDebitGatewayOwner.TortoiseMedia
+								: undefined
+						}
 					/>
 				);
 			case PaymentMethod.Unknown:

--- a/client/components/mma/paymentUpdate/dd/DirectDebitInputForm.tsx
+++ b/client/components/mma/paymentUpdate/dd/DirectDebitInputForm.tsx
@@ -7,6 +7,7 @@ import {
 } from '@guardian/source/react-components';
 import { ErrorSummary } from '@guardian/source-development-kitchen/react-components';
 import { useState } from 'react';
+import type { DirectDebitGatewayOwner } from '@/shared/directDebit';
 import { processResponse } from '../../../../utilities/utils';
 import { cleanSortCode } from '../../shared/DirectDebitDisplay';
 import type { FieldChangeEvent } from '../FieldWrapper';
@@ -50,6 +51,7 @@ interface DirectDebitUpdateFormProps {
 	executePaymentUpdate: (
 		newPaymentMethodDetail: NewPaymentMethodDetail,
 	) => Promise<unknown>;
+	gatewayOwner?: DirectDebitGatewayOwner;
 }
 
 export const DirectDebitInputForm = (props: DirectDebitUpdateFormProps) => {
@@ -112,6 +114,7 @@ export const DirectDebitInputForm = (props: DirectDebitUpdateFormProps) => {
 			accountName,
 			accountNumber,
 			sortCode,
+			gatewayOwner: props.gatewayOwner,
 		});
 
 		props.newPaymentMethodDetailUpdater(newPaymentMethod);

--- a/client/fixtures/productBuilder/testProducts.ts
+++ b/client/fixtures/productBuilder/testProducts.ts
@@ -174,6 +174,12 @@ export function homeDeliverySunday() {
 		.getProductDetailObject();
 }
 
+export function homeDeliverySundayPaidByDirectDebit() {
+	return new ProductBuilder(baseHomeDeliverySunday())
+		.payByDirectDebit()
+		.getProductDetailObject();
+}
+
 export function nationalDelivery() {
 	return new ProductBuilder(baseNationalDelivery())
 		.payByCard()

--- a/shared/directDebit.ts
+++ b/shared/directDebit.ts
@@ -1,0 +1,4 @@
+export enum DirectDebitGatewayOwner {
+	TheGuardian = 'the-guardian',
+	TortoiseMedia = 'tortoise-media',
+}

--- a/shared/directDebit.ts
+++ b/shared/directDebit.ts
@@ -1,4 +1,3 @@
 export enum DirectDebitGatewayOwner {
-	TheGuardian = 'the-guardian',
 	TortoiseMedia = 'tortoise-media',
 }

--- a/shared/productResponse.ts
+++ b/shared/productResponse.ts
@@ -4,6 +4,7 @@ import type { CurrencyIso } from '@/client/utilities/currencyIso';
 import type { DeliveryRecordDetail } from '../client/components/mma/delivery/records/deliveryRecordsApi';
 import { AsyncLoader } from '../client/components/mma/shared/AsyncLoader';
 import type { CardProps } from '../client/components/mma/shared/CardDisplay';
+import type { DirectDebitGatewayOwner } from './directDebit';
 import { PRODUCT_TYPES } from './productTypes';
 import type { ProductType } from './productTypes';
 
@@ -125,6 +126,7 @@ export interface DirectDebitDetails {
 	accountName: string;
 	accountNumber: string;
 	sortCode: string;
+	gatewayOwner?: DirectDebitGatewayOwner;
 }
 
 export interface SubscriptionPlan {


### PR DESCRIPTION
### Current situation/background
Currently, our payment processing system handles Direct Debit payments through a single gateway owned by The Guardian. However, for Sunday The Observer subscriptions, we need to support an alternative payment gateway owned by Tortoise Media when the feature flag tortoiseStripeCheckout is enabled.

### What does this PR change?
This PR:
- Creates a new DirectDebitGatewayOwner enum in a shared location to identify different payment gateways
- Adds an optional gatewayOwner field to the DirectDebitDetails interface
- Updates the PaymentDetailUpdate component to conditionally set the gateway owner to Tortoise Media for Sunday/Observer subscriptions when the feature flag is enabled
- Modifies the Direct Debit input form to pass the gateway owner information during payment method updates
These changes allow us to route Direct Debit payments for Sunday/Observer subscriptions through the Tortoise Media payment gateway when the feature flag is active, while maintaining the default Guardian gateway for all other subscription types.

### Next steps/further info
The backend services will need to be updated to handle the new gatewayOwner field and route payment processing accordingly. Additionally, we should:
- Monitor payment success rates after deployment to ensure the Tortoise Media gateway is functioning correctly
- Document the new gateway integration for the team
