### PR TITLE
Fix Subscription Amount Update state change

### DIFF
--- a/client/components/mma/accountoverview/updateAmount/UpdateAmount.tsx
+++ b/client/components/mma/accountoverview/updateAmount/UpdateAmount.tsx
@@ -42,6 +42,7 @@ export const UpdateAmount = (props: UpdateAmountProps) => {
 				currentAmount={currentAmount}
 				onUpdateConfirmed={(updatedAmount) => {
 					setConfirmedAmount(updatedAmount);
+					props.amountUpdateStateChange(updatedAmount);
 					setStatus(Status.CONFIRMED);
 				}}
 			/>
@@ -52,6 +53,7 @@ export const UpdateAmount = (props: UpdateAmountProps) => {
 				mode="MANAGE"
 				onUpdateConfirmed={(updatedAmount) => {
 					setConfirmedAmount(updatedAmount);
+					props.amountUpdateStateChange(updatedAmount);
 					setStatus(Status.CONFIRMED);
 				}}
 			/>


### PR DESCRIPTION
### Current situation/background
The amountUpdateStateChange function in the UpdateAmount component stopped being called after a refactoring on December 9, 2020. During that refactoring, Tom Pretty restructured the page but inadvertently removed the calls to amountUpdateStateChange in the component's two update pathways. This omission has been causing state inconsistencies whenever users update their contribution amounts, as the parent component isn't notified about the changes.

### What does this PR change?
This PR reintroduces the missing amountUpdateStateChange calls in both update flow paths within the UpdateAmount component:
1. Added props.amountUpdateStateChange(updatedAmount) in the update confirmation handler

These changes ensure that when a user confirms an amount update, the parent component is properly notified via the callback prop, restoring the intended behavior that was lost during the 2020 refactoring.

### Next steps/further info
Consider adding proper TypeScript prop validation to prevent similar issues in the future
This fix addresses the specific bug reported in [this](https://trello.com/c/3p7ltEYP/764-bug-make-sure-contribution-amount-changes-show-immediatley-in-the-manage-product-page-mma) issue related to make sure contribution amount changes show immediately in the manage product page.

### Video

https://github.com/user-attachments/assets/fc8a3889-d8e9-4aca-90c3-40f159d26cb3


