### PR TITLE
update setup-node action version

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           cache: yarn
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: './.nvmrc'
           cache: 'yarn'

--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -24,7 +24,7 @@ jobs:
           aws-region: eu-west-1
 
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           cache: yarn
 

--- a/.github/workflows/cypress-mocked.yml
+++ b/.github/workflows/cypress-mocked.yml
@@ -25,7 +25,7 @@ jobs:
           aws-region: eu-west-1
 
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           cache: yarn
 


### PR DESCRIPTION
### What does this PR change?

We noticed that our chromatic action was failing with a 422 error code:

<img width="583" alt="Screenshot 2025-04-17 at 12 06 03" src="https://github.com/user-attachments/assets/550b59ea-b327-4356-bc20-b2b8411efe78" />

`setup-node@v2` relies on a deprecated version of `@actions/cache`. Upgrading to v4 will hopefully fix this issue.

#### Reference
https://github.com/actions/setup-node/issues/1275#issuecomment-2788204086

