### PR TITLE
Delivery records instructions refactor

### DIFF
--- a/client/components/mma/delivery/records/DeliveryAddressStep.tsx
+++ b/client/components/mma/delivery/records/DeliveryAddressStep.tsx
@@ -70,6 +70,11 @@ export const DeliveryAddressStep = (props: DeliveryAddressStepProps) => {
 		Error,
 	}
 
+	console.log(
+		'props.enableDeliveryInstructions = ',
+		props.enableDeliveryInstructions,
+	);
+
 	const [status, setStatus] = useState(Status.ReadOnly);
 
 	const deliveryAddressContext = useContext(DeliveryRecordsAddressContext);
@@ -649,6 +654,7 @@ export const DeliveryAddressStep = (props: DeliveryAddressStepProps) => {
 						deliveryAddressContext.address?.instructions) ||
 					undefined
 				}
+				promptIfInstructionsNotSet
 			/>
 			{isNationalDelivery && (
 				<div

--- a/client/components/mma/delivery/records/DeliveryAddressStep.tsx
+++ b/client/components/mma/delivery/records/DeliveryAddressStep.tsx
@@ -629,7 +629,9 @@ export const DeliveryAddressStep = (props: DeliveryAddressStepProps) => {
 						deliveryAddressContext.address?.instructions) ||
 					undefined
 				}
-				promptIfInstructionsNotSet
+				promptIfInstructionsNotSet={
+					props.enableDeliveryInstructions || undefined
+				}
 			/>
 			{isNationalDelivery && (
 				<div

--- a/client/components/mma/delivery/records/DeliveryAddressStep.tsx
+++ b/client/components/mma/delivery/records/DeliveryAddressStep.tsx
@@ -5,6 +5,7 @@ import {
 	space,
 	textSans15,
 	textSans17,
+	until,
 } from '@guardian/source/foundations';
 import {
 	Button,
@@ -69,11 +70,6 @@ export const DeliveryAddressStep = (props: DeliveryAddressStepProps) => {
 		Confirmation,
 		Error,
 	}
-
-	console.log(
-		'props.enableDeliveryInstructions = ',
-		props.enableDeliveryInstructions,
-	);
 
 	const [status, setStatus] = useState(Status.ReadOnly);
 
@@ -199,6 +195,15 @@ export const DeliveryAddressStep = (props: DeliveryAddressStepProps) => {
 			.some(({ productType }) => {
 				return productType.productType === 'nationaldelivery';
 			});
+
+		const deliveryInstructionsInfoCss = css`
+			margin-top: ${space[3]}px;
+			${from.wide} {
+				display: inline-block;
+				margin: ${space[1]}px 0 ${space[3]}px ${space[3]}px;
+				width: calc(100% - (30ch + ${space[3]}px + 2px));
+			}
+		`;
 
 		if (hasNationalDelivery) {
 			return (
@@ -401,47 +406,15 @@ export const DeliveryAddressStep = (props: DeliveryAddressStepProps) => {
 											characters remaining
 										</span>
 									</div>
-									<p
-										css={css`
-											display: block;
-											${textSans17};
-											border: 4px solid
-												${palette.brand[500]};
-											padding: ${space[5]}px ${space[5]}px
-												${space[5]}px 49px;
-											margin: ${space[3]}px 0;
-											position: relative;
-											${from.tablet} {
-												display: inline-block;
-												margin: 2px 0 ${space[3]}px
-													${space[3]}px;
-												width: calc(
-													100% -
-														(
-															30ch + ${space[3]}px +
-																2px
-														)
-												);
-											}
-										`}
+									<InfoSection
+										additionalCSS={
+											deliveryInstructionsInfoCss
+										}
 									>
-										<i
-											css={css`
-												width: 17px;
-												height: 17px;
-												position: absolute;
-												top: ${space[5]}px;
-												left: ${space[5]}px;
-											`}
-										>
-											<InfoIconDark
-												fillColor={palette.brand[500]}
-											/>
-										</i>
 										Delivery instructions are only
 										applicable for newspaper deliveries.
 										They do not apply to Guardian Weekly.
-									</p>
+									</InfoSection>
 								</div>
 							</label>
 						)}
@@ -507,7 +480,9 @@ export const DeliveryAddressStep = (props: DeliveryAddressStepProps) => {
 								setStatus(Status.ReadOnly);
 							}}
 							cssOverrides={css`
-								margin-top: ${space[5]}px;
+								${until.mobileLandscape} {
+									margin-top: ${space[5]}px;
+								}
 								color: ${palette.brand[400]};
 								background-color: transparent;
 								:hover {

--- a/client/components/mma/delivery/records/DeliveryRecords.stories.tsx
+++ b/client/components/mma/delivery/records/DeliveryRecords.stories.tsx
@@ -4,11 +4,17 @@ import { ReactRouterDecorator } from '../../../../../.storybook/ReactRouterDecor
 import type { ProductTypeWithDeliveryRecordsProperties } from '../../../../../shared/productTypes';
 import { PRODUCT_TYPES } from '../../../../../shared/productTypes';
 import { deliveryRecordsWithDelivery } from '../../../../fixtures/deliveryRecords';
-import { guardianWeeklyPaidByCard } from '../../../../fixtures/productBuilder/testProducts';
+import {
+	guardianWeeklyPaidByCard,
+	homeDelivery,
+} from '../../../../fixtures/productBuilder/testProducts';
 import { DeliveryRecords } from './DeliveryRecords';
 import { DeliveryRecordsContainer } from './DeliveryRecordsContainer';
 import { DeliveryRecordsProblemConfirmation } from './DeliveryRecordsProblemConfirmation';
 import { DeliveryRecordsProblemReview } from './DeliveryRecordsProblemReview';
+
+const deliveryRecordsGW = deliveryRecordsWithDelivery();
+const deliveryRecordsHomeDelivery = deliveryRecordsWithDelivery(true);
 
 export default {
 	component: DeliveryRecordsContainer,
@@ -28,7 +34,7 @@ export default {
 	},
 } as Meta<typeof DeliveryRecordsContainer>;
 
-export const DeliveryHistory: StoryObj<typeof DeliveryRecords> = {
+export const DeliveryHistoryGuardianWeekly: StoryObj<typeof DeliveryRecords> = {
 	render: () => {
 		return <DeliveryRecords />;
 	},
@@ -36,13 +42,15 @@ export const DeliveryHistory: StoryObj<typeof DeliveryRecords> = {
 	parameters: {
 		msw: [
 			http.get('/api/delivery-records/*', () => {
-				return HttpResponse.json(deliveryRecordsWithDelivery)
+				return HttpResponse.json(deliveryRecordsGW);
 			}),
 		],
 	},
 };
 
-export const Review: StoryObj<typeof DeliveryRecordsProblemReview> = {
+export const ReviewGuardianWeekly: StoryObj<
+	typeof DeliveryRecordsProblemReview
+> = {
 	render: () => {
 		return <DeliveryRecordsProblemReview />;
 	},
@@ -50,29 +58,56 @@ export const Review: StoryObj<typeof DeliveryRecordsProblemReview> = {
 	parameters: {
 		msw: [
 			http.get('/api/delivery-records/*', () => {
-				return HttpResponse.json(deliveryRecordsWithDelivery)
+				return HttpResponse.json(deliveryRecordsGW);
 			}),
 		],
 		reactRouter: {
-			state: { affectedRecords: deliveryRecordsWithDelivery.results },
+			state: { affectedRecords: deliveryRecordsGW.results },
 		},
 	},
 };
 
-export const Confirmation: StoryObj<typeof DeliveryRecordsProblemConfirmation> =
-	{
-		render: () => {
-			return <DeliveryRecordsProblemConfirmation />;
-		},
+export const ConfirmationGuardianWeekly: StoryObj<
+	typeof DeliveryRecordsProblemConfirmation
+> = {
+	render: () => {
+		return <DeliveryRecordsProblemConfirmation />;
+	},
 
-		parameters: {
-			msw: [
-				http.get('/api/delivery-records/*', () => {
-					return HttpResponse.json(deliveryRecordsWithDelivery)
-				}),
-				http.post('/api/delivery-records/*', () => {
-					return HttpResponse.json(deliveryRecordsWithDelivery)
-				}),
-			],
+	parameters: {
+		msw: [
+			http.get('/api/delivery-records/*', () => {
+				return HttpResponse.json(deliveryRecordsGW);
+			}),
+			http.post('/api/delivery-records/*', () => {
+				return HttpResponse.json(deliveryRecordsGW);
+			}),
+		],
+	},
+};
+
+export const DeliveryHistoryNewspaperDelivery: StoryObj<
+	typeof DeliveryRecords
+> = {
+	render: () => {
+		return <DeliveryRecords />;
+	},
+
+	parameters: {
+		msw: [
+			http.get('/api/delivery-records/*', () => {
+				return HttpResponse.json(deliveryRecordsHomeDelivery);
+			}),
+		],
+		reactRouter: {
+			state: { productDetail: homeDelivery() },
+			container: (
+				<DeliveryRecordsContainer
+					productType={
+						PRODUCT_TYPES.homedelivery as ProductTypeWithDeliveryRecordsProperties
+					}
+				/>
+			),
 		},
-	};
+	},
+};

--- a/client/components/mma/delivery/records/DeliveryRecords.stories.tsx
+++ b/client/components/mma/delivery/records/DeliveryRecords.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
+import { toMembersDataApiResponse } from '@/client/fixtures/mdapiResponse';
 import { ReactRouterDecorator } from '../../../../../.storybook/ReactRouterDecorator';
 import type { ProductTypeWithDeliveryRecordsProperties } from '../../../../../shared/productTypes';
 import { PRODUCT_TYPES } from '../../../../../shared/productTypes';
@@ -7,14 +8,16 @@ import { deliveryRecordsWithDelivery } from '../../../../fixtures/deliveryRecord
 import {
 	guardianWeeklyPaidByCard,
 	homeDelivery,
+	homeDeliveryWithInstructions,
 } from '../../../../fixtures/productBuilder/testProducts';
 import { DeliveryRecords } from './DeliveryRecords';
 import { DeliveryRecordsContainer } from './DeliveryRecordsContainer';
 import { DeliveryRecordsProblemConfirmation } from './DeliveryRecordsProblemConfirmation';
 import { DeliveryRecordsProblemReview } from './DeliveryRecordsProblemReview';
 
+const exampleDeliveryInstructions = 'example delivery instructions';
+
 const deliveryRecordsGW = deliveryRecordsWithDelivery();
-const deliveryRecordsHomeDelivery = deliveryRecordsWithDelivery(true);
 
 export default {
 	component: DeliveryRecordsContainer,
@@ -86,7 +89,7 @@ export const ConfirmationGuardianWeekly: StoryObj<
 	},
 };
 
-export const DeliveryHistoryNewspaperDelivery: StoryObj<
+export const DeliveryHistoryNewspaperDeliveryWithInstructions: StoryObj<
 	typeof DeliveryRecords
 > = {
 	render: () => {
@@ -96,7 +99,53 @@ export const DeliveryHistoryNewspaperDelivery: StoryObj<
 	parameters: {
 		msw: [
 			http.get('/api/delivery-records/*', () => {
-				return HttpResponse.json(deliveryRecordsHomeDelivery);
+				return HttpResponse.json(
+					deliveryRecordsWithDelivery(exampleDeliveryInstructions),
+				);
+			}),
+			http.get('/api/me/mma?productType=ContentSubscription', () => {
+				return HttpResponse.json(
+					toMembersDataApiResponse(
+						homeDeliveryWithInstructions(
+							exampleDeliveryInstructions,
+						),
+					),
+				);
+			}),
+		],
+		reactRouter: {
+			state: {
+				productDetail: homeDeliveryWithInstructions(
+					exampleDeliveryInstructions,
+				),
+			},
+			container: (
+				<DeliveryRecordsContainer
+					productType={
+						PRODUCT_TYPES.homedelivery as ProductTypeWithDeliveryRecordsProperties
+					}
+				/>
+			),
+		},
+	},
+};
+
+export const DeliveryHistoryNewspaperDeliveryWithoutInstructions: StoryObj<
+	typeof DeliveryRecords
+> = {
+	render: () => {
+		return <DeliveryRecords />;
+	},
+
+	parameters: {
+		msw: [
+			http.get('/api/delivery-records/*', () => {
+				return HttpResponse.json(deliveryRecordsWithDelivery());
+			}),
+			http.get('/api/me/mma?productType=ContentSubscription', () => {
+				return HttpResponse.json(
+					toMembersDataApiResponse(homeDelivery()),
+				);
 			}),
 		],
 		reactRouter: {

--- a/client/components/mma/delivery/records/DeliveryRecords.tsx
+++ b/client/components/mma/delivery/records/DeliveryRecords.tsx
@@ -430,10 +430,6 @@ export const DeliveryRecords = () => {
 						{(pageStatus === PageStatus.ReportIssueStep1 ||
 							pageStatus === PageStatus.ReportIssueStep2) && (
 							<>
-								<p>
-									Have you tried updating your delivery
-									instructions
-								</p>
 								<DeliveryRecordProblemForm
 									showNextStepButton={
 										pageStatus !==

--- a/client/components/mma/delivery/records/DeliveryRecords.tsx
+++ b/client/components/mma/delivery/records/DeliveryRecords.tsx
@@ -429,23 +429,30 @@ export const DeliveryRecords = () => {
 						)}
 						{(pageStatus === PageStatus.ReportIssueStep1 ||
 							pageStatus === PageStatus.ReportIssueStep2) && (
-							<DeliveryRecordProblemForm
-								showNextStepButton={
-									pageStatus !== PageStatus.ReportIssueStep2
-								}
-								onResetDeliveryRecordsPage={
-									resetDeliveryRecordsPage
-								}
-								onFormSubmit={step1FormSubmitListener}
-								inValidationState={step1formValidationState}
-								updateValidationStatusCallback={
-									step1FormUpdateCallback
-								}
-								updateRadioSelectionCallback={
-									step1FormRadioOptionCallback
-								}
-								problemTypes={problemTypes}
-							/>
+							<>
+								<p>
+									Have you tried updating your delivery
+									instructions
+								</p>
+								<DeliveryRecordProblemForm
+									showNextStepButton={
+										pageStatus !==
+										PageStatus.ReportIssueStep2
+									}
+									onResetDeliveryRecordsPage={
+										resetDeliveryRecordsPage
+									}
+									onFormSubmit={step1FormSubmitListener}
+									inValidationState={step1formValidationState}
+									updateValidationStatusCallback={
+										step1FormUpdateCallback
+									}
+									updateRadioSelectionCallback={
+										step1FormRadioOptionCallback
+									}
+									problemTypes={problemTypes}
+								/>
+							</>
 						)}
 					</div>
 				</>

--- a/client/components/mma/delivery/records/ReadOnlyAddressDisplay.tsx
+++ b/client/components/mma/delivery/records/ReadOnlyAddressDisplay.tsx
@@ -3,6 +3,7 @@ import { from, palette, space, textSans17 } from '@guardian/source/foundations';
 import { Button } from '@guardian/source/react-components';
 import Color from 'color';
 import type { DeliveryAddress } from '../../../../../shared/productResponse';
+import { InfoSection } from '../../shared/InfoSection';
 import { DeliveryAddressDisplay } from '../address/DeliveryAddressDisplay';
 
 interface ReadOnlyAddressDisplayProps {
@@ -41,6 +42,8 @@ export const ReadOnlyAddressDisplay = (props: ReadOnlyAddressDisplayProps) => {
 				margin: 0;
 				padding: ${space[3]}px;
 				display: table;
+				border-collapse: seperate;
+				border-spacing: 0 ${space[5]}px;
 				${from.tablet} {
 					padding: ${space[5]}px;
 				}
@@ -105,13 +108,18 @@ export const ReadOnlyAddressDisplay = (props: ReadOnlyAddressDisplayProps) => {
 							${ddCss}
 						`}
 					>
-						{props.instructions || "No delivery instructions set. Have you thought about setting some?"}
+						{props.instructions || (
+							<InfoSection>
+								No delivery instructions set. Have you thought
+								about adding some?
+							</InfoSection>
+						)}
 						{props.showEditButton && (
 							<Button
 								onClick={() => props.editButtonCallback?.()}
 								cssOverrides={css`
 									display: block;
-									margin-top: ${space[5]}px;
+									margin-top: ${space[8]}px;
 									color: ${palette.brand[400]};
 									background-color: ${palette.brand[800]};
 									:hover {
@@ -124,7 +132,7 @@ export const ReadOnlyAddressDisplay = (props: ReadOnlyAddressDisplayProps) => {
 									}
 								`}
 							>
-								Update
+								Edit
 							</Button>
 						)}
 					</dd>

--- a/client/components/mma/delivery/records/ReadOnlyAddressDisplay.tsx
+++ b/client/components/mma/delivery/records/ReadOnlyAddressDisplay.tsx
@@ -10,6 +10,7 @@ interface ReadOnlyAddressDisplayProps {
 	editButtonCallback?: () => void;
 	address: DeliveryAddress;
 	instructions?: string;
+	promptIfInstructionsNotSet?: true;
 }
 export const ReadOnlyAddressDisplay = (props: ReadOnlyAddressDisplayProps) => {
 	const dtCss = (ignoreMinWidthAtNonMobile?: boolean) => `
@@ -30,6 +31,10 @@ export const ReadOnlyAddressDisplay = (props: ReadOnlyAddressDisplayProps) => {
     vertical-align: top;
     margin-left: 0;
 `;
+
+	const showInstructions =
+		!!props.instructions || props.promptIfInstructionsNotSet;
+
 	return (
 		<dl
 			css={css`
@@ -59,7 +64,7 @@ export const ReadOnlyAddressDisplay = (props: ReadOnlyAddressDisplayProps) => {
 					`}
 				>
 					<DeliveryAddressDisplay {...props.address} />
-					{!props.instructions && props.showEditButton && (
+					{!showInstructions && props.showEditButton && (
 						<Button
 							onClick={() => props.editButtonCallback?.()}
 							cssOverrides={css`
@@ -82,7 +87,7 @@ export const ReadOnlyAddressDisplay = (props: ReadOnlyAddressDisplayProps) => {
 					)}
 				</dd>
 			</div>
-			{props.instructions && (
+			{showInstructions && (
 				<div
 					css={css`
 						display: table-row;
@@ -100,7 +105,7 @@ export const ReadOnlyAddressDisplay = (props: ReadOnlyAddressDisplayProps) => {
 							${ddCss}
 						`}
 					>
-						{props.instructions}
+						{props.instructions || "No delivery instructions set. Have you thought about setting some?"}
 						{props.showEditButton && (
 							<Button
 								onClick={() => props.editButtonCallback?.()}

--- a/client/components/mma/delivery/records/ReadOnlyAddressDisplay.tsx
+++ b/client/components/mma/delivery/records/ReadOnlyAddressDisplay.tsx
@@ -108,6 +108,11 @@ export const ReadOnlyAddressDisplay = (props: ReadOnlyAddressDisplayProps) => {
 							${ddCss}
 						`}
 					>
+						{!!props.instructions && (
+							<InfoSection>
+								Please make sure these instructions are correct
+							</InfoSection>
+						)}
 						{props.instructions || (
 							<InfoSection>
 								No delivery instructions set. Have you thought

--- a/client/components/mma/shared/InfoSection.tsx
+++ b/client/components/mma/shared/InfoSection.tsx
@@ -1,3 +1,4 @@
+import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { palette, space, textSans17 } from '@guardian/source/foundations';
 import type * as React from 'react';
@@ -5,17 +6,21 @@ import { InfoIconDark } from './assets/InfoIconDark';
 
 interface InfoSectionProps {
 	children: React.ReactNode;
+	additionalCSS?: SerializedStyles;
 }
 
 export const InfoSection = (props: InfoSectionProps) => (
 	<p
-		css={css`
-			${textSans17};
-			background-color: ${palette.neutral[97]};
-			padding: ${space[5]}px ${space[5]}px ${space[5]}px 49px;
-			margin-bottom: 12px;
-			position: relative;
-		`}
+		css={[
+			css`
+				${textSans17};
+				background-color: ${palette.neutral[97]};
+				padding: ${space[5]}px ${space[5]}px ${space[5]}px 49px;
+				margin-bottom: 12px;
+				position: relative;
+			`,
+			props.additionalCSS,
+		]}
 	>
 		<i
 			css={css`

--- a/client/fixtures/deliveryRecords.ts
+++ b/client/fixtures/deliveryRecords.ts
@@ -10,35 +10,40 @@ export const deliveryRecordsWithNoDeliveries = {
 	},
 };
 
-export const deliveryRecordsWithDelivery = {
-	results: [
-		{
-			id: 'a339E000000KDOMQA4',
-			deliveryDate: '2022-04-15',
-			deliveryInstruction: null,
-			deliveryAddress: 'Kings Place, London, 90 York Way',
-			addressLine1: 'Kings Place',
-			addressLine2: null,
-			addressLine3: null,
-			addressTown: 'London',
-			addressCountry: null,
-			addressPostcode: '90 York Way',
-			hasHolidayStop: false,
-			bulkSuspensionReason: null,
-			problemCaseId: null,
-			isChangedAddress: false,
-			isChangedDeliveryInstruction: null,
-			credit: null,
+export const deliveryRecordsWithDelivery = (
+	withDeliveryInstructions: boolean = false,
+) => {
+	return {
+		results: [
+			{
+				id: 'a339E000000KDOMQA4',
+				deliveryDate: '2022-04-15',
+				deliveryInstruction:
+					withDeliveryInstructions && 'example delivery instructions',
+				deliveryAddress: 'Kings Place, London, 90 York Way',
+				addressLine1: 'Kings Place',
+				addressLine2: null,
+				addressLine3: null,
+				addressTown: 'London',
+				addressCountry: null,
+				addressPostcode: '90 York Way',
+				hasHolidayStop: false,
+				bulkSuspensionReason: null,
+				problemCaseId: null,
+				isChangedAddress: false,
+				isChangedDeliveryInstruction: null,
+				credit: null,
+			},
+		],
+		deliveryProblemMap: {},
+		contactPhoneNumbers: {
+			Id: '0039E00001Mw6DCQAZ',
+			Phone: null,
+			HomePhone: null,
+			MobilePhone: null,
+			OtherPhone: null,
 		},
-	],
-	deliveryProblemMap: {},
-	contactPhoneNumbers: {
-		Id: '0039E00001Mw6DCQAZ',
-		Phone: null,
-		HomePhone: null,
-		MobilePhone: null,
-		OtherPhone: null,
-	},
+	};
 };
 
 export const deliveryRecordsWithReportedProblem = {

--- a/client/fixtures/deliveryRecords.ts
+++ b/client/fixtures/deliveryRecords.ts
@@ -10,16 +10,13 @@ export const deliveryRecordsWithNoDeliveries = {
 	},
 };
 
-export const deliveryRecordsWithDelivery = (
-	withDeliveryInstructions: boolean = false,
-) => {
+export const deliveryRecordsWithDelivery = (deliveryInstructions?: string) => {
 	return {
 		results: [
 			{
 				id: 'a339E000000KDOMQA4',
 				deliveryDate: '2022-04-15',
-				deliveryInstruction:
-					withDeliveryInstructions && 'example delivery instructions',
+				deliveryInstruction: deliveryInstructions,
 				deliveryAddress: 'Kings Place, London, 90 York Way',
 				addressLine1: 'Kings Place',
 				addressLine2: null,

--- a/client/fixtures/productBuilder/productBuilder.ts
+++ b/client/fixtures/productBuilder/productBuilder.ts
@@ -103,6 +103,14 @@ export class ProductBuilder {
 		return this;
 	}
 
+	withDeliveryInstructions(instructions: string) {
+		if (this.productToBuild.subscription.deliveryAddress) {
+			this.productToBuild.subscription.deliveryAddress.instructions =
+				instructions;
+		}
+		return this;
+	}
+
 	cancel() {
 		this.productToBuild.subscription.cancelledAt = true;
 		this.productToBuild.subscription.cancellationEffectiveDate =

--- a/client/fixtures/productBuilder/testProducts.ts
+++ b/client/fixtures/productBuilder/testProducts.ts
@@ -176,6 +176,13 @@ export function homeDelivery() {
 		.getProductDetailObject();
 }
 
+export function homeDeliveryWithInstructions(instructions: string) {
+	return new ProductBuilder(baseHomeDelivery())
+		.withDeliveryInstructions(instructions)
+		.payByCard()
+		.getProductDetailObject();
+}
+
 export function observerDelivery() {
 	return new ProductBuilder(baseObserverDelivery())
 		.payByCard()

--- a/cypress/tests/mocked/parallel-4/deliveryRecords.cy.ts
+++ b/cypress/tests/mocked/parallel-4/deliveryRecords.cy.ts
@@ -29,7 +29,7 @@ describe('Delivery records', () => {
 
 		cy.intercept('GET', '/api/delivery-records/*', {
 			statusCode: 200,
-			body: deliveryRecordsWithDelivery,
+			body: deliveryRecordsWithDelivery(),
 		}).as('delivery_records');
 
 		cy.intercept('GET', '/api/holidays/*/potential?*', {
@@ -78,7 +78,7 @@ describe('Delivery records', () => {
 			`/api/delivery-records/${secondarySubscriptionId}`,
 			{
 				statusCode: 200,
-				body: deliveryRecordsWithDelivery,
+				body: deliveryRecordsWithDelivery(),
 			},
 		).as('fetch_potential_holidays_for_secondary_sub');
 
@@ -175,7 +175,7 @@ describe('Delivery records', () => {
 
 		deliveryRecordsWithDeliveryProblem.results = [
 			...deliveryRecordsWithDeliveryProblem.results,
-			...deliveryRecordsWithDelivery.results,
+			...deliveryRecordsWithDelivery().results,
 		];
 
 		cy.intercept('GET', '/api/delivery-records/A-S00293857', {


### PR DESCRIPTION
### What does this PR change?

Make the delivery instructions input clearer to the user when they are reporting a delivery issue.

This will hopefully reduce the number of issues reported in the future for deliveries that may have been made correctly if delivery instructions were available.

### Images

#### without existing delivery instructions

Before             |  After
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/96ce55d2-0e76-485b-bcff-6a05af031eb1)  |  ![](https://github.com/user-attachments/assets/a330f8be-be49-48e7-9007-b65cefc70c16)

Before             |  After
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/84324789-9663-4fc7-9a09-233dba42eda7)  |  ![](https://github.com/user-attachments/assets/0885e9bd-d77d-4db1-9688-07504c43fe63)


Before             |  After
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/b61bc2e9-306f-45c4-ac04-9e9fc0a615d9)  |  ![](https://github.com/user-attachments/assets/2bdb1d8d-e137-4bc2-ad13-1d5e29d710cc)


#### with existing delivery instructions


Before             |  After
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/3870f7f2-d3ef-4b1d-89a5-6a8593695262)  |  ![](https://github.com/user-attachments/assets/6e5a4f4e-f2f0-40e6-8d45-7855a9d98031)


Before             |  After
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/e681a6bd-ee88-44f4-9e6e-c14576bde545)  |  ![](https://github.com/user-attachments/assets/26472337-95e1-4edd-b4a2-1c1af3465b2a)


Before             |  After
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/685f4c63-4f0a-4e03-aa57-e200671654ec)  |  ![](https://github.com/user-attachments/assets/4939ac14-916b-40cd-ac93-48bbe41a2026)





