### PR TITLE
Display future product tier

### DIFF
--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -442,7 +442,7 @@ export const ProductCard = ({
 									)}
 								{futureProductTitle && (
 									<div>
-										<dt>Next product</dt>
+										<dt>Switching to</dt>
 										<dd>{futureProductTitle}</dd>
 									</div>
 								)}

--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -204,13 +204,13 @@ export const ProductCard = ({
 		productDetail.subscription.nextPaymentDate !==
 			productDetail.subscription.potentialCancellationDate;
 
-	const futureProductType =
+	const futureProductTitle =
 		productDetail.subscription.futurePlans.length > 0 &&
 		productDetail.subscription.futurePlans[0].tier &&
-		getSpecificProductType(productDetail.subscription.futurePlans[0].tier);
-	const futureProductTitle =
-		futureProductType && futureProductType !== specificProductType
-			? futureProductType.productTitle(mainPlan)
+		productDetail.tier
+			? getSpecificProductType(
+					productDetail.subscription.futurePlans[0].tier,
+			  ).productTitle(mainPlan)
 			: null;
 
 	return (

--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -204,6 +204,15 @@ export const ProductCard = ({
 		productDetail.subscription.nextPaymentDate !==
 			productDetail.subscription.potentialCancellationDate;
 
+	const futureProductType =
+		productDetail.subscription.futurePlans.length > 0 &&
+		productDetail.subscription.futurePlans[0].tier &&
+		getSpecificProductType(productDetail.subscription.futurePlans[0].tier);
+	const futureProductTitle =
+		futureProductType && futureProductType !== specificProductType
+			? futureProductType.productTitle(mainPlan)
+			: null;
+
 	return (
 		<Stack space={4}>
 			{hasCancellationPending && productDetail.subscription.end && (
@@ -303,7 +312,7 @@ export const ProductCard = ({
 					<Card.Section backgroundColor="#edf5fA">
 						<p css={benefitsTextCss}>
 							You’re supporting the Guardian with{' '}
-							{nextPaymentDetails.paymentValue} per{' '}
+							{nextPaymentDetails.currentPriceValue} per{' '}
 							{nextPaymentDetails.paymentInterval}, and have
 							access to exclusive extras.
 						</p>
@@ -431,6 +440,12 @@ export const ProductCard = ({
 											</dd>
 										</div>
 									)}
+								{futureProductTitle && (
+									<div>
+										<dt>Next product</dt>
+										<dd>{futureProductTitle}</dd>
+									</div>
+								)}
 							</dl>
 						</div>
 						<div css={wideButtonLayoutCss}>

--- a/client/components/mma/cancel/cancellationSaves/membership/MembershipSwitch.tsx
+++ b/client/components/mma/cancel/cancellationSaves/membership/MembershipSwitch.tsx
@@ -13,10 +13,9 @@ import { Navigate, useLocation, useNavigate } from 'react-router';
 import { dateString, parseDate } from '../../../../../../shared/dates';
 import type {
 	PaidSubscriptionPlan,
-	Subscription} from '../../../../../../shared/productResponse';
-import {
-	MDA_TEST_USER_HEADER
+	Subscription,
 } from '../../../../../../shared/productResponse';
+import { MDA_TEST_USER_HEADER } from '../../../../../../shared/productResponse';
 import { getMainPlan } from '../../../../../../shared/productResponse';
 import type { ProductSwitchType } from '../../../../../../shared/productSwitchTypes';
 import { getBillingPeriodAdjective } from '../../../../../../shared/productTypes';
@@ -262,6 +261,17 @@ export const MembershipSwitch = () => {
 			setSwitchingError(true);
 		}
 	};
+
+	if (
+		membership.subscription.futurePlans.length > 0 &&
+		membership.subscription.futurePlans[0].tier &&
+		membership.subscription.futurePlans[0].tier === 'Contributor'
+	) {
+		// Switch already planned, so navigate to Overview
+		navigate('/');
+		return null;
+	}
+
 	return (
 		<>
 			<section css={sectionSpacing}>

--- a/client/components/mma/cancel/cancellationSaves/membership/SaveOptions.tsx
+++ b/client/components/mma/cancel/cancellationSaves/membership/SaveOptions.tsx
@@ -173,57 +173,64 @@ export const SaveOptions = () => {
 						</section>
 					</Card.Section>
 				</Card>
-				<section css={sectionSpacing}>
-					<Heading sansSerif>
-						Stay a supporter at no extra cost
-					</Heading>
-				</section>
-				<p
-					css={css`
-						${textSans17};
-					`}
-				>
-					You will lose access to some of your benefits, but will keep
-					funding Guardian journalism.
-				</p>
-				<Card>
-					<Card.Header backgroundColor={palette.brand[400]}>
-						<div css={cardHeaderDivCss}>
-							<h3 css={productTitleCss}>
-								{monthlyOrAnnual} contribution
-							</h3>
-							<p css={productSubtitleCss}>
-								{oldPriceDisplay}/{billingPeriod}
-							</p>
-						</div>
-					</Card.Header>
-					<Card.Section>
-						<BenefitsSection
-							benefits={benefitsConfiguration[
-								'contributions'
-							].filter((benefit) =>
-								filterBenefitByRegion(
-									benefit,
-									mainPlan.currencyISO,
-								),
-							)}
-						/>
-						<section css={[cardSectionCss, buttonContainerCss]}>
-							<Button
-								theme={themeButtonReaderRevenueBrand}
-								cssOverrides={buttonCentredCss}
-								size="small"
-								onClick={() =>
-									navigate('../switch-offer', {
-										state: { ...routerState },
-									})
-								}
-							>
-								Become a recurring contributor
-							</Button>
+				{membership.subscription.futurePlans[0]?.tier !==
+					'Contributor' && (
+					<>
+						<section css={sectionSpacing}>
+							<Heading sansSerif>
+								Stay a supporter at no extra cost
+							</Heading>
 						</section>
-					</Card.Section>
-				</Card>
+						<p
+							css={css`
+								${textSans17};
+							`}
+						>
+							You will lose access to some of your benefits, but
+							will keep funding Guardian journalism.
+						</p>
+						<Card>
+							<Card.Header backgroundColor={palette.brand[400]}>
+								<div css={cardHeaderDivCss}>
+									<h3 css={productTitleCss}>
+										{monthlyOrAnnual} contribution
+									</h3>
+									<p css={productSubtitleCss}>
+										{oldPriceDisplay}/{billingPeriod}
+									</p>
+								</div>
+							</Card.Header>
+							<Card.Section>
+								<BenefitsSection
+									benefits={benefitsConfiguration[
+										'contributions'
+									].filter((benefit) =>
+										filterBenefitByRegion(
+											benefit,
+											mainPlan.currencyISO,
+										),
+									)}
+								/>
+								<section
+									css={[cardSectionCss, buttonContainerCss]}
+								>
+									<Button
+										theme={themeButtonReaderRevenueBrand}
+										cssOverrides={buttonCentredCss}
+										size="small"
+										onClick={() =>
+											navigate('../switch-offer', {
+												state: { ...routerState },
+											})
+										}
+									>
+										Become a recurring contributor
+									</Button>
+								</section>
+							</Card.Section>
+						</Card>
+					</>
+				)}
 				<section css={sectionSpacing}>
 					<Heading sansSerif>Cancel your Membership</Heading>
 					<p

--- a/client/components/mma/shared/NextPaymentDetails.tsx
+++ b/client/components/mma/shared/NextPaymentDetails.tsx
@@ -21,6 +21,7 @@ export interface NextPaymentDetails {
 	isNewPaymentValue?: boolean;
 	nextPaymentDateKey: string;
 	nextPaymentDateValue?: string;
+	currentPriceValue?: string;
 }
 
 export const getNextPaymentDetails = (
@@ -89,6 +90,9 @@ export const getNextPaymentDetails = (
 			isNewPaymentValue,
 			nextPaymentDateKey: 'Next payment date',
 			nextPaymentDateValue,
+			currentPriceValue: `${mainPlan.currency}${(
+				(subscription.plan?.price ?? 0) / 100
+			).toFixed(2)} ${mainPlan.currencyISO}`,
 		};
 	}
 };

--- a/client/components/mma/shared/NextPaymentDetails.tsx
+++ b/client/components/mma/shared/NextPaymentDetails.tsx
@@ -83,6 +83,12 @@ export const getNextPaymentDetails = (
 			mainPlan.price !== planAfterMainPlan.price &&
 			!isSixForSix(mainPlan.name);
 
+		const currentPaidSubscriptionPlan: PaidSubscriptionPlan | undefined = (
+			subscription.currentPlans[0] as PaidSubscriptionPlan
+		)?.price
+			? (subscription.currentPlans[0] as PaidSubscriptionPlan)
+			: undefined;
+
 		return {
 			paymentInterval,
 			paymentKey,
@@ -91,14 +97,11 @@ export const getNextPaymentDetails = (
 			isNewPaymentValue,
 			nextPaymentDateKey: 'Next payment date',
 			nextPaymentDateValue,
-			currentPriceValue: (
-				subscription.currentPlans?.[0] as PaidSubscriptionPlan
-			)?.price
-				? `${mainPlan.currency}${(
-						(subscription.currentPlans[0] as PaidSubscriptionPlan)
-							.price / 100
-				  ).toFixed(2)} ${mainPlan.currencyISO}`
-				: 'not available',
+			currentPriceValue: currentPaidSubscriptionPlan
+				? `${currentPaidSubscriptionPlan.currency}${(
+						currentPaidSubscriptionPlan.price / 100
+				  ).toFixed(2)} ${currentPaidSubscriptionPlan.currencyISO}`
+				: getPaymentValue(),
 		};
 	}
 };

--- a/client/components/mma/shared/NextPaymentDetails.tsx
+++ b/client/components/mma/shared/NextPaymentDetails.tsx
@@ -3,6 +3,7 @@ import { palette, space } from '@guardian/source/foundations';
 import { parseDate } from '../../../../shared/dates';
 import type {
 	BillingPeriod,
+	PaidSubscriptionPlan,
 	Subscription,
 	SubscriptionPlan,
 } from '../../../../shared/productResponse';
@@ -90,9 +91,14 @@ export const getNextPaymentDetails = (
 			isNewPaymentValue,
 			nextPaymentDateKey: 'Next payment date',
 			nextPaymentDateValue,
-			currentPriceValue: `${mainPlan.currency}${(
-				(subscription.plan?.price ?? 0) / 100
-			).toFixed(2)} ${mainPlan.currencyISO}`,
+			currentPriceValue: (
+				subscription.currentPlans?.[0] as PaidSubscriptionPlan
+			)?.price
+				? `${mainPlan.currency}${(
+						(subscription.currentPlans[0] as PaidSubscriptionPlan)
+							.price / 100
+				  ).toFixed(2)} ${mainPlan.currencyISO}`
+				: 'not available',
 		};
 	}
 };

--- a/shared/productResponse.ts
+++ b/shared/productResponse.ts
@@ -222,6 +222,10 @@ export interface Subscription {
 	autoRenew: boolean;
 	currentPlans: Array<SubscriptionPlan | PaidSubscriptionPlan>;
 	futurePlans: Array<SubscriptionPlan | PaidSubscriptionPlan>;
+
+	/**
+	 * @deprecated
+	 */
 	plan?: PaidSubscriptionPlan; // this is used for memberships (remove when memberships no longer exist)
 	trialLength: number;
 	readerType: ReaderType;

--- a/shared/productResponse.ts
+++ b/shared/productResponse.ts
@@ -139,6 +139,7 @@ export interface DirectDebitDetails {
 }
 
 export interface SubscriptionPlan {
+	tier?: ProductTier;
 	name: string | null;
 	start?: string;
 	shouldBeVisible: boolean;


### PR DESCRIPTION
### Current situation/background

Currently, when a user has scheduled a future change to their subscription (such as downgrading from a higher tier membership to Contributor), this information is not displayed in the Account Overview page. Additionally, the system is incorrectly allowing users to navigate to the Membership Switch flow even when they already have a future plan change scheduled.

### What does this PR change?

This PR makes several improvements to how we handle and display future subscription plans:

1. Added a `futureProductTitle` variable in ProductCard that determines if there's a future plan change scheduled
2. Modified the product details section to display the "Next product" information when a future plan change exists
3. Updated the MembershipSwitch component to redirect users to the Overview page if they already have a future plan change to Contributor tier
4. Fixed an issue in NextPaymentDetails where we were displaying `paymentValue` instead of the current price
5. Added the tier property to the SubscriptionPlan interface to properly support future plan changes

#### Visual Changes
| Before | After |
|--------|--------|
| <img width="845" alt="Screenshot 2025-05-09 at 15 19 56" src="https://github.com/user-attachments/assets/fb69e9d6-4da7-43dd-ab7f-20f568ff9b00" /> | <img width="845" alt="Screenshot 2025-05-09 at 15 20 28" src="https://github.com/user-attachments/assets/df181528-8e1b-47a6-a93c-1d67e900f9b8" /> |
* NOTE: "Next product" changed to "Switching to" by indication of @Alexguild 

### Next steps/further info

- We may want to add more comprehensive information about planned subscription changes, including when the change will take effect
- Consider adding visual indicators or badges to make future plan changes more noticeable
- We should test this thoroughly across different subscription types to ensure all edge cases are handled correctly
- Documentation should be updated to reflect these changes for the support team
