### PR TITLE
Update US and Canada Phone Line copy

### DIFF
--- a/client/__tests__/components/helpCentre/__snapshots__/helpCentreContactOptions.test.tsx.snap
+++ b/client/__tests__/components/helpCentre/__snapshots__/helpCentreContactOptions.test.tsx.snap
@@ -378,7 +378,7 @@ exports[`HelpCentreContactOptions Help Centre landing page Help Centre article (
                 className="emotion-20"
               >
                  
-                (toll free USA)
+                (toll free CAN/USA)
               </span>
             </span>
             <span
@@ -389,7 +389,7 @@ exports[`HelpCentreContactOptions Help Centre landing page Help Centre article (
                 className="emotion-20"
               >
                  
-                (outside USA)
+                (outside CAN/USA)
               </span>
             </span>
             <span
@@ -783,7 +783,7 @@ exports[`HelpCentreContactOptions Help Centre landing page with live chat featur
                 className="emotion-20"
               >
                  
-                (toll free USA)
+                (toll free CAN/USA)
               </span>
             </span>
             <span
@@ -794,7 +794,7 @@ exports[`HelpCentreContactOptions Help Centre landing page with live chat featur
                 className="emotion-20"
               >
                  
-                (outside USA)
+                (outside CAN/USA)
               </span>
             </span>
             <span
@@ -1666,7 +1666,7 @@ html:not(.src-focus-disabled) .emotion-7:focus {
                   className="emotion-32"
                 >
                    
-                  (toll free USA)
+                  (toll free CAN/USA)
                 </span>
               </span>
               <span
@@ -1677,7 +1677,7 @@ html:not(.src-focus-disabled) .emotion-7:focus {
                   className="emotion-32"
                 >
                    
-                  (outside USA)
+                  (outside CAN/USA)
                 </span>
               </span>
               <span

--- a/client/components/shared/callCentreData.ts
+++ b/client/components/shared/callCentreData.ts
@@ -46,11 +46,11 @@ export const phoneData: PhoneRegion[] = [
 		phoneNumbers: [
 			{
 				phoneNumber: '1-844-632-2010',
-				suffix: '(toll free USA)',
+				suffix: '(toll free CAN/USA)',
 			},
 			{
 				phoneNumber: '+1 917-900-4663',
-				suffix: '(outside USA)',
+				suffix: '(outside CAN/USA)',
 			},
 		],
 	},


### PR DESCRIPTION
### What does this PR change?
This updates the copy for contacting our contact centre over the phone from the US and Canada to reflect that the toll free number is applicable to both the US and Canada. This came as a [request from CX](https://trello.com/c/AwdguSBd/118-update-the-descriptions-for-the-us-canada-phone-lines-toll-free-covers-canada-as-well-as-us) following a report from a customer.
