### PR TITLE
Product name typo fix

### DIFF
--- a/client/components/mma/cancel/cancellationSaves/CancelAlternativeSwitchReview.tsx
+++ b/client/components/mma/cancel/cancellationSaves/CancelAlternativeSwitchReview.tsx
@@ -259,7 +259,7 @@ export const CancelAlternativeSwitchReview = () => {
 					<div css={yourOfferBoxCss}>
 						<div css={[yourOfferBoxFlexCss]}>
 							<h3 css={yourOfferBoxHeaderCss}>
-								One year of All access digital for{' '}
+								One year of All-access digital for{' '}
 								{mainPlan.currency}
 								{routerState.amountPayableToday}
 							</h3>


### PR DESCRIPTION
### What does this PR change?
adds a missing hyphen in All-access digital product name in the cancel switch offer review page

### images
