### PR TITLE
Only UK billing country contributions should be able to switch with a discount to supporter plus (via cancellation journey)

### DIFF
--- a/client/components/mma/cancel/CancellationReasonReview.tsx
+++ b/client/components/mma/cancel/CancellationReasonReview.tsx
@@ -288,7 +288,6 @@ const ConfirmCancellationAndReturnRow = (
 		isPaidSubscriptionPlan(mainPlan) && mainPlan.billingPeriod === 'month';
 
 	const allowCountrySwitchDiscount =
-		isPaidSubscriptionPlan(mainPlan) &&
 		productDetail.billingCountry === 'United Kingdom';
 
 	const isAnnualContributionAndDiscountIsActive =

--- a/client/components/mma/cancel/CancellationReasonReview.tsx
+++ b/client/components/mma/cancel/CancellationReasonReview.tsx
@@ -287,8 +287,13 @@ const ConfirmCancellationAndReturnRow = (
 	const isMonthlyBilling =
 		isPaidSubscriptionPlan(mainPlan) && mainPlan.billingPeriod === 'month';
 
+	const allowCountrySwitchDiscount =
+		isPaidSubscriptionPlan(mainPlan) &&
+		productDetail.billingCountry === 'United Kingdom';
+
 	const isAnnualContributionAndDiscountIsActive =
 		productType.productType === 'contributions' &&
+		allowCountrySwitchDiscount &&
 		isAnnualBilling &&
 		reasonIsEligibleForSwitch(routerState.selectedReasonId);
 


### PR DESCRIPTION
### What does this PR change?
Temporarily disable contribution cancellation switch discount offer for people with a billing country outside of the UK ... until we are ready to launch worldwide.

This is a soft validation block on the client and just serves to reduce/stop calls out to the switch api for customers outside of the UK ... the switch api isn't currently setup to handle billing countries outside of the UK yet so the switch discount wouldn't have worked for them anyway.