### PR TITLE
remove Observer product softOptInIDs

### DIFF
--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -462,11 +462,7 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 		checkoutUrlPart: '/subscribe', // https://support.theguardian.com/uk/subscribe
 		getOphanProductType: () => 'PRINT_SUBSCRIPTION',
 		productPageNewsletterIDs: [FRONT_PAGE_NEWSLETTER_ID],
-		softOptInIDs: [
-			SoftOptInIDs.SupportOnboarding,
-			SoftOptInIDs.SubscriberPreview,
-			SoftOptInIDs.SupporterNewsletter,
-		],
+		softOptInIDs: [],
 		holidayStops: {
 			issueKeyword: 'paper',
 			alternateNoticeString: "two working days' notice",
@@ -592,11 +588,7 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 		checkoutUrlPart: '/subscribe', // https://support.theguardian.com/uk/subscribe
 		getOphanProductType: () => 'PRINT_SUBSCRIPTION',
 		productPageNewsletterIDs: [FRONT_PAGE_NEWSLETTER_ID],
-		softOptInIDs: [
-			SoftOptInIDs.SupportOnboarding,
-			SoftOptInIDs.SubscriberPreview,
-			SoftOptInIDs.SupporterNewsletter,
-		],
+		softOptInIDs: [],
 		holidayStops: {
 			issueKeyword: 'voucher',
 			alternateNoticeString: "one day's notice",
@@ -667,11 +659,7 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 		legacyUrlPart: 'digitalvoucher',
 		getOphanProductType: () => 'PRINT_SUBSCRIPTION',
 		productPageNewsletterIDs: [FRONT_PAGE_NEWSLETTER_ID],
-		softOptInIDs: [
-			SoftOptInIDs.SupportOnboarding,
-			SoftOptInIDs.SubscriberPreview,
-			SoftOptInIDs.SupporterNewsletter,
-		],
+		softOptInIDs: [],
 		holidayStops: {
 			issueKeyword: 'issue',
 			alternateNoticeString: "one day's notice",


### PR DESCRIPTION
### What does this PR change?
Removes any elements from the `softOptInIDs` array in the productTypes file for all Observer products. The consequence of doing this is to remove the supporter email opt ins from the emails and marketting page for people that only have Observer products ... these emails are Guardian related.

### Images
Before             |  After
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/2d9bb755-308a-4ce1-bc0a-ba0f61a543c1)  |  ![](https://github.com/user-attachments/assets/ea853b28-4e0f-4264-a875-e2b37aaf40b1)
