### PR TITLE
chromatic regression fix for cancellation reasons

### DIFF
--- a/client/components/mma/cancel/Cancellation.stories.tsx
+++ b/client/components/mma/cancel/Cancellation.stories.tsx
@@ -29,28 +29,12 @@ import { CancelAlternativeReview } from './cancellationSaves/CancelAlternativeRe
 import { CancelAlternativeSwitch } from './cancellationSaves/CancelAlternativeSwitch';
 import { CancelAlternativeSwitchReview } from './cancellationSaves/CancelAlternativeSwitchReview';
 import { CancelSwitchConfirmed } from './cancellationSaves/CancelSwitchConfirmed';
-import { contributionsCancellationReasons } from './contributions/ContributionsCancellationReasons';
-import { gwCancellationReasons } from './gw/GwCancellationReasons';
 import { ConfirmCancellation } from './stages/ConfirmCancellation';
 import { ExecuteCancellation } from './stages/ExecuteCancellation';
-import {
-	otherCancellationReason,
-	supporterplusCancellationReasons,
-} from './supporterplus/SupporterplusCancellationReasons';
 
-const contributions = PRODUCT_TYPES.contributions;
-contributions.cancellation!.reasons = contributionsCancellationReasons.concat(
-	otherCancellationReason,
-);
-
-const guardianweekly = PRODUCT_TYPES.guardianweekly;
-guardianweekly.cancellation!.reasons = gwCancellationReasons.concat(
-	otherCancellationReason,
-);
-
-const supporterplus = PRODUCT_TYPES.supporterplus;
-supporterplus.cancellation!.reasons = supporterplusCancellationReasons.concat(
-	otherCancellationReason,
+const contributionWithSortedReasons = PRODUCT_TYPES.contributions;
+contributionWithSortedReasons.cancellation!.reasons?.sort((a, b) =>
+	a.reasonId.localeCompare(b.reasonId),
 );
 
 export default {
@@ -70,22 +54,24 @@ export const SelectReason: StoryObj<typeof CancellationReasonSelection> = {
 			state: { productDetail: contributionPaidByPayPal() },
 			container: (
 				<CancellationContainer
-					productType={PRODUCT_TYPES.contributions}
+					productType={contributionWithSortedReasons}
 				/>
 			),
 		},
 	},
 };
 
-export const ContactCustomerService: StoryObj<
-	typeof CancellationReasonSelection
-> = {
+export const ContactCustomerService: StoryObj<typeof CancellationContainer> = {
 	render: () => <CancellationJourneyFunnel />,
 
 	parameters: {
 		reactRouter: {
 			state: { productDetail: guardianWeeklyPaidByCard() },
-			container: <CancellationContainer productType={guardianweekly} />,
+			container: (
+				<CancellationContainer
+					productType={PRODUCT_TYPES.guardianweekly}
+				/>
+			),
 		},
 	},
 };
@@ -239,7 +225,11 @@ export const OfferMonthly: StoryObj<typeof CancellationContainer> = {
 				nextNonDiscountedPaymentDate: '2024-07-30',
 				nonDiscountedPayments: [{ date: '2024-07-30', amount: 14.99 }],
 			},
-			container: <CancellationContainer productType={supporterplus} />,
+			container: (
+				<CancellationContainer
+					productType={PRODUCT_TYPES.supporterplus}
+				/>
+			),
 		},
 	},
 };
@@ -266,7 +256,11 @@ export const OfferYearly: StoryObj<typeof CancellationContainer> = {
 				nextNonDiscountedPaymentDate: '2025-05-30',
 				nonDiscountedPayments: [{ date: '2025-05-30', amount: 120 }],
 			},
-			container: <CancellationContainer productType={supporterplus} />,
+			container: (
+				<CancellationContainer
+					productType={PRODUCT_TYPES.supporterplus}
+				/>
+			),
 		},
 	},
 };
@@ -301,7 +295,11 @@ export const SwitchYearly: StoryObj<typeof CancellationContainer> = {
 					upToPeriodsType: 'Years',
 				},
 			},
-			container: <CancellationContainer productType={contributions} />,
+			container: (
+				<CancellationContainer
+					productType={PRODUCT_TYPES.contributions}
+				/>
+			),
 		},
 	},
 };
@@ -331,7 +329,11 @@ export const SwitchYearlyOutsideUK: StoryObj<typeof CancellationContainer> = {
 					upToPeriodsType: 'Years',
 				},
 			},
-			container: <CancellationContainer productType={contributions} />,
+			container: (
+				<CancellationContainer
+					productType={PRODUCT_TYPES.contributions}
+				/>
+			),
 		},
 	},
 };
@@ -350,7 +352,11 @@ export const SwitchContactUs: StoryObj<typeof CancellationContainer> = {
 					6000,
 				),
 			},
-			container: <CancellationContainer productType={contributions} />,
+			container: (
+				<CancellationContainer
+					productType={PRODUCT_TYPES.contributions}
+				/>
+			),
 		},
 	},
 };
@@ -372,7 +378,11 @@ export const OfferReviewMonthly: StoryObj<typeof CancellationContainer> = {
 				nextNonDiscountedPaymentDate: '2024-07-30',
 				nonDiscountedPayments: [{ date: '2024-07-30', amount: 14.99 }],
 			},
-			container: <CancellationContainer productType={supporterplus} />,
+			container: (
+				<CancellationContainer
+					productType={PRODUCT_TYPES.supporterplus}
+				/>
+			),
 		},
 		msw: [
 			http.post('/api/discounts/apply-discount', () => {
@@ -401,7 +411,11 @@ export const OfferReviewYearly: StoryObj<typeof CancellationContainer> = {
 				nextNonDiscountedPaymentDate: '2025-05-30',
 				nonDiscountedPayments: [{ date: '2025-05-30', amount: 120 }],
 			},
-			container: <CancellationContainer productType={supporterplus} />,
+			container: (
+				<CancellationContainer
+					productType={PRODUCT_TYPES.supporterplus}
+				/>
+			),
 		},
 		msw: [
 			http.post('/api/discounts/apply-discount', () => {
@@ -437,7 +451,11 @@ export const SwitchReviewYearly: StoryObj<typeof CancellationContainer> = {
 					upToPeriodsType: 'Years',
 				},
 			},
-			container: <CancellationContainer productType={contributions} />,
+			container: (
+				<CancellationContainer
+					productType={PRODUCT_TYPES.contributions}
+				/>
+			),
 		},
 		msw: [
 			http.post('/api/discounts/apply-discount', () => {
@@ -462,7 +480,11 @@ export const OfferConfirmedMonthly: StoryObj<typeof CancellationContainer> = {
 				nextNonDiscountedPaymentDate: '2024-07-30',
 				nonDiscountedPayments: [{ date: '2024-07-30', amount: 14.99 }],
 			},
-			container: <CancellationContainer productType={supporterplus} />,
+			container: (
+				<CancellationContainer
+					productType={PRODUCT_TYPES.supporterplus}
+				/>
+			),
 		},
 	},
 };
@@ -483,7 +505,11 @@ export const OfferConfirmedYearly: StoryObj<typeof CancellationContainer> = {
 				nextNonDiscountedPaymentDate: '2025-05-30',
 				nonDiscountedPayments: [{ date: '2025-05-30', amount: 120 }],
 			},
-			container: <CancellationContainer productType={supporterplus} />,
+			container: (
+				<CancellationContainer
+					productType={PRODUCT_TYPES.supporterplus}
+				/>
+			),
 		},
 	},
 };
@@ -510,7 +536,11 @@ export const Pause: StoryObj<typeof CancellationContainer> = {
 				nextNonDiscountedPaymentDate: '2024-07-30',
 				nonDiscountedPayments: [{ date: '2024-07-30', amount: 14.99 }],
 			},
-			container: <CancellationContainer productType={contributions} />,
+			container: (
+				<CancellationContainer
+					productType={PRODUCT_TYPES.contributions}
+				/>
+			),
 		},
 	},
 };
@@ -532,7 +562,11 @@ export const PauseReview: StoryObj<typeof CancellationContainer> = {
 				nextNonDiscountedPaymentDate: '2024-07-30',
 				nonDiscountedPayments: [{ date: '2024-07-30', amount: 14.99 }],
 			},
-			container: <CancellationContainer productType={contributions} />,
+			container: (
+				<CancellationContainer
+					productType={PRODUCT_TYPES.contributions}
+				/>
+			),
 		},
 		msw: [
 			http.post('/api/discounts/apply-discount', () => {
@@ -557,7 +591,11 @@ export const PauseConfirmed: StoryObj<typeof CancellationContainer> = {
 				nextNonDiscountedPaymentDate: '2024-07-30',
 				nonDiscountedPayments: [{ date: '2024-07-30', amount: 14.99 }],
 			},
-			container: <CancellationContainer productType={contributions} />,
+			container: (
+				<CancellationContainer
+					productType={PRODUCT_TYPES.contributions}
+				/>
+			),
 		},
 	},
 };
@@ -613,7 +651,11 @@ export const SwitchYearlyConfirmed: StoryObj<typeof CancellationContainer> = {
 					upToPeriodsType: 'Years',
 				},
 			},
-			container: <CancellationContainer productType={contributions} />,
+			container: (
+				<CancellationContainer
+					productType={PRODUCT_TYPES.contributions}
+				/>
+			),
 		},
 	},
 };

--- a/client/components/mma/cancel/cancellationSaves/digipack/DigiSubSaves.stories.tsx
+++ b/client/components/mma/cancel/cancellationSaves/digipack/DigiSubSaves.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
 import { ReactRouterDecorator } from '@/.storybook/ReactRouterDecorator';
 import { CancellationContainer } from '@/client/components/mma/cancel/CancellationContainer';
@@ -11,6 +11,11 @@ import {
 } from '@/client/fixtures/productBuilder/testProducts';
 import { PRODUCT_TYPES } from '@/shared/productTypes';
 import { SelectReason } from '../SelectReason';
+
+const digiSubWithSortedReasons = PRODUCT_TYPES.digipack;
+digiSubWithSortedReasons.cancellation!.reasons?.sort((a, b) =>
+	a.reasonId.localeCompare(b.reasonId),
+);
 
 export default {
 	title: 'Pages/DigiSubSaves',
@@ -103,6 +108,16 @@ export const ConfirmCancellation: StoryObj<typeof ConfirmDigiSubCancellation> =
 		},
 	};
 
-export const DigiSubCancellationReason: StoryFn<typeof SelectReason> = () => {
-	return <SelectReason />;
+export const DigiSubCancellationReason: StoryObj<typeof SelectReason> = {
+	render: () => <SelectReason />,
+	parameters: {
+		reactRouter: {
+			state: {
+				productDetail: digitalPackPaidByDirectDebit(),
+			},
+			container: (
+				<CancellationContainer productType={digiSubWithSortedReasons} />
+			),
+		},
+	},
 };

--- a/client/components/mma/cancel/cancellationSaves/membership/MembershipSaves.stories.tsx
+++ b/client/components/mma/cancel/cancellationSaves/membership/MembershipSaves.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryFn } from '@storybook/react';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react';
 import { ReactRouterDecorator } from '../../../../../../.storybook/ReactRouterDecorator';
 import { PRODUCT_TYPES } from '../../../../../../shared/productTypes';
 import { membershipSupporterCurrencyUSD } from '../../../../../fixtures/productBuilder/testProducts';
@@ -10,6 +10,11 @@ import { MembershipSwitch } from './MembershipSwitch';
 import { SaveOptions } from './SaveOptions';
 import { SwitchThankYou } from './SwitchThankYou';
 import { ValueOfSupport } from './ValueOfSupport';
+
+const membershipWithSortedReasons = PRODUCT_TYPES.membership;
+membershipWithSortedReasons.cancellation!.reasons?.sort((a, b) =>
+	a.reasonId.localeCompare(b.reasonId),
+);
 
 export default {
 	title: 'Pages/MembershipSave',
@@ -41,8 +46,19 @@ export const SwitchOptions: StoryFn<typeof SaveOptions> = () => {
 	return <SaveOptions />;
 };
 
-export const Reasons: StoryFn<typeof SelectReason> = () => {
-	return <SelectReason />;
+export const Reasons: StoryObj<typeof SelectReason> = {
+	render: () => <SelectReason />,
+
+	parameters: {
+		reactRouter: {
+			state: { productDetail: membershipSupporterCurrencyUSD() },
+			container: (
+				<CancellationContainer
+					productType={membershipWithSortedReasons}
+				/>
+			),
+		},
+	},
 };
 
 export const ContinueMembership: StoryFn<


### PR DESCRIPTION
### What does this PR change?
Supply a sorted cancellation reasons array to storybook stories so that we don't trip the chromatic visual regression tests everytime we make any change in manage.

The reason chromatic was reporting a visual regression/diff is because on the site the cancellation reasons order in randomized so as not to skew the options people select.

An alternative approach so sorting the reasons in storybook might have been to add the `data-chromatic=ignore` attribute to the components that render the reasons. I didn't choose this option as I thought it was better not to pollute the dom with test attributes.

### Images
![Screenshot 2025-05-20 at 15 48 01](https://github.com/user-attachments/assets/6e94d064-6435-45da-a2fa-40c4da772749)
