### PR TITLE
Switch discount financial reasons

### DIFF
--- a/client/components/mma/cancel/CancellationReasonReview.tsx
+++ b/client/components/mma/cancel/CancellationReasonReview.tsx
@@ -62,7 +62,10 @@ import type {
 	OptionalCancellationReasonId,
 	SaveBodyProps,
 } from './cancellationReason';
-import { reasonIsEligibleForSwitch } from './cancellationSaves/saveEligibilityCheck';
+import {
+	allowCountrySwitchDiscount,
+	reasonIsEligibleForSwitch,
+} from './cancellationSaves/saveEligibilityCheck';
 import { CaseUpdateAsyncLoader, getUpdateCasePromise } from './caseUpdate';
 
 const getPatchUpdateCaseFunc =
@@ -287,12 +290,9 @@ const ConfirmCancellationAndReturnRow = (
 	const isMonthlyBilling =
 		isPaidSubscriptionPlan(mainPlan) && mainPlan.billingPeriod === 'month';
 
-	const allowCountrySwitchDiscount =
-		productDetail.billingCountry === 'United Kingdom';
-
 	const isAnnualContributionAndDiscountIsActive =
 		productType.productType === 'contributions' &&
-		allowCountrySwitchDiscount &&
+		allowCountrySwitchDiscount(productDetail.billingCountry) &&
 		isAnnualBilling &&
 		reasonIsEligibleForSwitch(routerState.selectedReasonId);
 

--- a/client/components/mma/cancel/cancellationSaves/saveEligibilityCheck.ts
+++ b/client/components/mma/cancel/cancellationSaves/saveEligibilityCheck.ts
@@ -61,3 +61,7 @@ export const reasonIsEligibleForSwitch = (
 	selectedReasonId === 'mma_dont_read_enough' ||
 	selectedReasonId === 'mma_support_another_way' ||
 	selectedReasonId === 'mma_values';
+
+export const allowCountrySwitchDiscount = (
+	billingCountry: string | undefined,
+) => billingCountry === 'United Kingdom';

--- a/client/components/mma/cancel/contributions/ContributionsCancellationFlowFinancialSaveAttempt.tsx
+++ b/client/components/mma/cancel/contributions/ContributionsCancellationFlowFinancialSaveAttempt.tsx
@@ -26,7 +26,10 @@ import type {
 } from '../CancellationContainer';
 import { CancellationContext } from '../CancellationContainer';
 import type { SaveBodyProps } from '../cancellationReason';
-import { reasonIsEligibleForSwitch } from '../cancellationSaves/saveEligibilityCheck';
+import {
+	allowCountrySwitchDiscount,
+	reasonIsEligibleForSwitch,
+} from '../cancellationSaves/saveEligibilityCheck';
 import { getIsPayingMinAmount } from './utils';
 
 const container = css`
@@ -71,6 +74,7 @@ export const ContributionsCancellationFlowFinancialSaveAttempt: React.FC<
 		isPaidSubscriptionPlan(mainPlan) && mainPlan.billingPeriod === 'month';
 	const isAnnualContributionAndDiscountIsActive =
 		productType.productType === 'contributions' &&
+		allowCountrySwitchDiscount(productDetail.billingCountry) &&
 		isAnnualBilling &&
 		reasonIsEligibleForSwitch(routerState.selectedReasonId);
 	const isContributionAndBreakFeatureIsActive =

--- a/cypress/tests/mocked/parallel-2/cancelContribution.cy.ts
+++ b/cypress/tests/mocked/parallel-2/cancelContribution.cy.ts
@@ -320,6 +320,77 @@ describe('Cancel contribution', () => {
 		cy.get('@get_cancellation_date.all').should('have.length', 0);
 	});
 
+	it('user (annual) switches to supporter-plus at a discount instead of cancelling (choosing financial reasons)', () => {
+		const productSwitchPreviewWithSwitchDiscount = {
+			supporterPlusPurchaseAmount: 120,
+			nextPaymentDate: '2026-03-20',
+			amountPayableToday: 0,
+			contributionRefundAmount: -60,
+			discount: {
+				discountedPrice: 60,
+				discountPercentage: 50,
+				upToPeriods: 1,
+				upToPeriodsType: 'Years',
+			},
+		};
+		const switchContribution = toMembersDataApiResponse(
+			annualContributionPaidByCardWithCurrency(
+				'GBP',
+				'United Kingdom',
+				1200,
+			),
+		);
+
+		cy.intercept('GET', '/api/me/mma?productType=Contribution', {
+			statusCode: 200,
+			body: switchContribution,
+		});
+		cy.intercept('GET', '/api/me/mma', {
+			statusCode: 200,
+			body: switchContribution,
+		});
+
+		setupCancellation();
+
+		cy.intercept(
+			'POST',
+			'/api/product-move/recurring-contribution-to-supporter-plus/**',
+			(req) => {
+				if (req.body.preview === true) {
+					req.reply({
+						statusCode: 200,
+						body: productSwitchPreviewWithSwitchDiscount,
+					});
+				} else {
+					req.reply({
+						statusCode: 200,
+					});
+				}
+			},
+		).as('switch_discount');
+
+		cy.findByRole('radio', {
+			name: 'I can no longer afford to support you',
+		}).click();
+		cy.findByRole('button', { name: 'Continue' }).click();
+
+		cy.wait('@get_case');
+		cy.wait('@switch_discount');
+
+		cy.findByRole('button', {
+			name: 'I still want to cancel',
+		}).click();
+
+		cy.findByRole('button', { name: 'Redeem the offer' }).click();
+
+		cy.findByRole('button', {
+			name: 'Confirm your offer',
+		}).click();
+
+		cy.findByText('Thank you for choosing to stay with us');
+		cy.wait('@switch_discount');
+	});
+
 	it('user (annual) switches to supporter-plus at a discount instead of cancelling', () => {
 		const productSwitchPreviewWithSwitchDiscount = {
 			supporterPlusPurchaseAmount: 120,

--- a/cypress/tests/mocked/parallel-2/cancelContribution.cy.ts
+++ b/cypress/tests/mocked/parallel-2/cancelContribution.cy.ts
@@ -447,17 +447,15 @@ describe('Cancel contribution', () => {
 		setupCancellation();
 
 		cy.findByRole('radio', {
-			name: 'I am unhappy with some editorial decisions',
+			name: 'I can no longer afford to support you',
 		}).click();
 		cy.findByRole('button', { name: 'Continue' }).click();
 
 		cy.findByRole('button', {
-			name: 'Continue to cancellation',
+			name: 'I still want to cancel',
 		}).click();
 
-		cy.findByText(
-			"If you confirm your cancellation, you will no longer be supporting the Guardian's reader-funded journalism.",
-		).should('exist');
+		cy.findByText('Your yearly support has been cancelled').should('exist');
 
 		cy.get('@switch_discount.all').then((interceptions) => {
 			expect(interceptions).to.have.length(0);


### PR DESCRIPTION
### What does this PR change?
If you choose financial reasons like "I can no longer afford to support you" as the reason for cancelling then you are shown a custom page that asks if you would like to reduce your contribution amount before possibly being shown the switch discount offer. This page was missing the billing country validation (switch discount offer currently only applies to people in the UK) which determines whether a call to the switch-api is made or not.

### Images
![Screenshot 2025-05-27 at 10 17 50](https://github.com/user-attachments/assets/23ea711b-4a1e-45ef-8744-15e896b30323)

