### PR TITLE
Improves the form validation state management and implements autofocus on failed validation fields

### DIFF
--- a/client/components/helpCentre/contactUs/UploadFileInput.tsx
+++ b/client/components/helpCentre/contactUs/UploadFileInput.tsx
@@ -10,7 +10,7 @@ import {
 } from '@guardian/source/foundations';
 import { Button } from '@guardian/source/react-components';
 import Color from 'color';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type * as React from 'react';
 import { ErrorIcon } from '../../mma/shared/assets/ErrorIcon';
 
@@ -23,13 +23,23 @@ interface UploadFileUploadProps {
 	inErrorState?: boolean;
 	errorMessage?: string;
 	additionalCss?: SerializedStyles;
+	setFocus?: boolean;
 }
 
 export const UploadFileInput = (props: UploadFileUploadProps) => {
 	const [selectedFile, setSelectedFile] = useState<File | undefined>();
+	const inputRef = useRef<HTMLInputElement>(null);
+
 	useEffect(() => {
 		props.changeSetState?.(selectedFile);
 	}, [selectedFile, props]);
+
+	useEffect(() => {
+		if (props.setFocus) {
+			inputRef.current?.focus();
+		}
+	}, [props.setFocus]);
+
 	return (
 		<label
 			css={css`
@@ -84,8 +94,13 @@ export const UploadFileInput = (props: UploadFileUploadProps) => {
 				name="imageAttachment"
 				accept={props.allowedFileFormats.join()}
 				multiple={false}
+				ref={inputRef}
 				css={css`
-					display: none;
+					position: absolute;
+					width: 1px;
+					height: 1px;
+					opacity: 0;
+					pointer-events: none;
 				`}
 				onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
 					const file = e.target.files?.[0];

--- a/client/components/helpCentre/contactUs/contactUsForm.stories.tsx
+++ b/client/components/helpCentre/contactUs/contactUsForm.stories.tsx
@@ -1,0 +1,153 @@
+import { css } from '@emotion/react';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import { ContactUsForm } from './contactUsForm';
+
+// Mocked Type definitions
+interface MockedReCaptchaOptions {
+	sitekey?: string;
+	callback?: (token: string) => void;
+}
+
+interface MockedGreCaptcha {
+	render: (container: string, options: MockedReCaptchaOptions) => string;
+}
+
+interface MockedGuardianIdentityDetails {
+	displayName: string;
+	email: string;
+}
+
+interface MockedGuardian {
+	recaptchaPublicKey: string;
+	identityDetails: MockedGuardianIdentityDetails;
+}
+
+// Mock the global guardian object and reCAPTCHA for Storybook
+const withMockedGlobals = (Story: StoryFn) => {
+	if (typeof window !== 'undefined') {
+		const windowWithGuardian = window as typeof window & {
+			guardian?: MockedGuardian;
+			grecaptcha?: MockedGreCaptcha;
+			v2ReCaptchaOnLoadCallback?: () => void;
+		};
+
+		windowWithGuardian.guardian = {
+			...windowWithGuardian.guardian,
+			recaptchaPublicKey: 'storybook-mock-key',
+			identityDetails: {
+				displayName: 'John Doe',
+				email: 'john.doe@example.com',
+			},
+		};
+
+		// Mock reCAPTCHA
+		windowWithGuardian.grecaptcha = {
+			render: (container: string, options: MockedReCaptchaOptions) => {
+				const element = document.getElementById(container);
+				if (element) {
+					element.innerHTML = `
+						<div style="
+							border: 2px solid #ddd; 
+							padding: 10px; 
+							background: #f9f9f9; 
+							text-align: center;
+							border-radius: 4px;
+							color: #666;
+						">
+							[Mock reCAPTCHA - Storybook]
+						</div>
+					`;
+				}
+				setTimeout(() => {
+					if (options.callback) {
+						options.callback('mock-recaptcha-token');
+					}
+				}, 1000);
+				return 'mock-widget-id';
+			},
+		};
+
+		// Prevent loading the actual reCAPTCHA script
+		windowWithGuardian.v2ReCaptchaOnLoadCallback = () => {};
+	}
+
+	return <Story />;
+};
+
+const meta: Meta<typeof ContactUsForm> = {
+	title: 'Components/Help Centre/Contact Us Form',
+	component: ContactUsForm,
+	decorators: [withMockedGlobals],
+	parameters: {
+		layout: 'padded',
+		docs: {
+			description: {
+				component:
+					'Contact form for help centre with validation, file upload, and reCAPTCHA',
+			},
+		},
+	},
+	args: {
+		submitCallback: fn(),
+	},
+	argTypes: {
+		submitCallback: {
+			description: 'Callback function called when form is submitted',
+		},
+		title: {
+			control: 'text',
+			description: 'Form title displayed in the legend',
+		},
+		subject: {
+			control: 'text',
+			description: 'Subject of the enquiry',
+		},
+		editableSubject: {
+			control: 'boolean',
+			description:
+				'Whether the subject field is editable or display-only',
+		},
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof ContactUsForm>;
+
+export const Default: Story = {
+	args: {
+		title: 'Contact Form',
+		subject: 'General Enquiry',
+		editableSubject: false,
+	},
+};
+
+export const EditableSubject: Story = {
+	args: {
+		title: 'Contact Form',
+		subject: '',
+		editableSubject: true,
+	},
+};
+
+export const WithCustomStyling: Story = {
+	args: {
+		title: 'Custom Styled Form',
+		subject: 'General Enquiry',
+		editableSubject: false,
+		additionalCss: css`
+			border: 2px solid #007abc;
+			border-radius: 8px;
+			padding: 16px;
+		`,
+	},
+};
+
+export const LongContent: Story = {
+	args: {
+		title: 'This is a very long form title to test how the layout handles longer text content',
+		subject:
+			'This is a very long subject line to test how the form handles longer subject text and whether it wraps properly',
+		editableSubject: false,
+	},
+};

--- a/cypress/tests/mocked/parallel-3/contactUsForm.cy.ts
+++ b/cypress/tests/mocked/parallel-3/contactUsForm.cy.ts
@@ -1,0 +1,279 @@
+import { signInAndAcceptCookies } from '../../../lib/signInAndAcceptCookies';
+
+interface GuardianIdentityDetails {
+	displayName: string;
+	email: string;
+}
+
+interface GuardianObject {
+	identityDetails: GuardianIdentityDetails;
+	recaptchaPublicKey: string;
+}
+
+interface ReCaptchaOptions {
+	callback?: (token: string) => void;
+}
+
+interface MockGreCaptcha {
+	render: (container: string, options: ReCaptchaOptions) => string;
+}
+
+const getValueLength = (
+	value: string | number | string[] | undefined,
+): number => {
+	if (value === undefined || value === null) {
+		return 0;
+	}
+	return typeof value === 'string' ? value.length : String(value).length;
+};
+
+describe('Contact Us Form Tests', () => {
+	beforeEach(() => {
+		signInAndAcceptCookies();
+
+		cy.intercept('POST', '/api/contact-us', {
+			statusCode: 200,
+			body: { success: true },
+		}).as('submitContactForm');
+
+		// Mock the reCAPTCHA script load
+		cy.intercept('GET', 'https://www.google.com/recaptcha/api.js*', {
+			statusCode: 200,
+			body: '// Mock reCAPTCHA script',
+		});
+
+		cy.visit('/help-centre/contact-us/');
+
+		// Set up all mocks after page load but before navigation
+		cy.window().then((win) => {
+			const extendedWin = win as typeof win & {
+				guardian?: GuardianObject;
+				grecaptcha?: MockGreCaptcha;
+				v2ReCaptchaOnLoadCallback?: () => void;
+			};
+
+			extendedWin.guardian = {
+				...extendedWin.guardian,
+				identityDetails: {
+					displayName: 'Test User',
+					email: 'test.user@guardian.co.uk',
+				},
+				recaptchaPublicKey: 'test-key',
+			};
+
+			// Mock reCAPTCHA before the form component loads
+			extendedWin.grecaptcha = {
+				render: cy
+					.stub()
+					.callsFake(
+						(container: string, options: ReCaptchaOptions) => {
+							// Immediately trigger the callback to simulate successful reCAPTCHA
+							if (options.callback) {
+								options.callback('test-recaptcha-token');
+							}
+							return 'widget-id';
+						},
+					),
+			};
+
+			extendedWin.v2ReCaptchaOnLoadCallback = () => {};
+		});
+
+		cy.findByText('Something else').click();
+		cy.findByText('Begin form').click();
+
+		// Wait a moment for the form to initialize and try to render reCAPTCHA
+		cy.wait(500);
+	});
+
+	context('Form Display and Initial State', () => {
+		it('should display the contact form with pre-filled user details', () => {
+			cy.findByLabelText('Full Name').should('be.visible');
+			cy.findByLabelText(/^Email address/).should('be.visible');
+			cy.findByLabelText('Subject of enquiry').should('be.visible');
+			cy.contains('2500 characters remaining').should('be.visible');
+			it('should display file upload section', () => {
+				cy.contains('Upload image').should('be.visible');
+				cy.contains(
+					'File must be in .png, .jpeg, .jpg, .gif or  .pdf format and less than 5MB',
+				).should('be.visible');
+			});
+		});
+	});
+
+	context('Form Validation', () => {
+		it('should show validation errors for empty required fields', () => {
+			cy.findByLabelText('Full Name').clear();
+			cy.findByLabelText(/^Email address/).clear();
+
+			cy.findByText('Submit').click();
+
+			cy.contains('You cannot leave this field empty').should(
+				'be.visible',
+			);
+			cy.contains('Please insert a valid email address').should(
+				'be.visible',
+			);
+		});
+
+		it('should validate email format', () => {
+			cy.findByLabelText(/^Email address/)
+				.clear()
+				.type('invalid-email');
+			cy.get('textarea[name="message"]').type('Test message');
+			cy.findByText('Submit').click();
+
+			cy.contains('Please insert a valid email address').should(
+				'be.visible',
+			);
+		});
+
+		it('should enforce character limits', () => {
+			const longName = 'a'.repeat(60);
+			cy.findByLabelText('Full Name').clear().type(longName);
+			cy.findByLabelText('Full Name').should(($input) => {
+				expect(getValueLength($input.val())).to.equal(50);
+			});
+
+			const longEmail = 'a'.repeat(60) + '@test.com';
+			cy.findByLabelText(/^Email address/)
+				.clear()
+				.type(longEmail);
+			cy.findByLabelText(/^Email address/).should(($input) => {
+				expect(getValueLength($input.val())).to.equal(50);
+			});
+		});
+
+		it('should update character counter for message field', () => {
+			const testMessage = 'This is a test message';
+			cy.get('textarea[name="message"]').type(testMessage);
+
+			const expectedRemaining = 2500 - testMessage.length;
+			cy.contains(`${expectedRemaining} characters remaining`).should(
+				'be.visible',
+			);
+		});
+	});
+
+	context('Form Interactions', () => {
+		it('should clear failure state when user starts typing', () => {
+			cy.intercept('POST', '/api/contact-us', {
+				statusCode: 500,
+				body: { error: 'Internal server error' },
+			}).as('failedSubmit');
+
+			cy.findByLabelText('Full Name').clear().type('Jontho');
+			cy.findByLabelText(/^Email address/)
+				.clear()
+				.type('jonhto@gmail.com');
+			cy.get('textarea[name="message"]').type(
+				'I need help with my subscription',
+			);
+
+			cy.findByText('Submit').click();
+			cy.contains(
+				'Something went wrong when submitting your form',
+			).should('be.visible');
+
+			cy.findByLabelText('Full Name').type(' Updated');
+			cy.contains(
+				'Something went wrong when submitting your form',
+			).should('not.exist');
+		});
+
+		it('should focus on first invalid field when validation fails', () => {
+			cy.findByLabelText('Full Name').clear();
+			cy.findByLabelText(/^Email address/).clear();
+
+			cy.findByText('Submit').click();
+
+			cy.findByLabelText(/^Full Name/)
+				.should('exist')
+				.should('be.visible')
+				.should('have.focus');
+		});
+	});
+
+	context('Form Submission', () => {
+		it('should successfully submit a valid form', () => {
+			cy.findByLabelText('Full Name').clear().type('Jontho');
+			cy.findByLabelText(/^Email address/)
+				.clear()
+				.type('jonhto@gmail.com');
+			cy.get('textarea[name="message"]').type(
+				'I need help with my subscription',
+			);
+
+			cy.findByText('Submit').click();
+
+			cy.wait('@submitContactForm').then((interception) => {
+				const body =
+					typeof interception.request.body === 'string'
+						? JSON.parse(interception.request.body)
+						: interception.request.body;
+
+				expect(body).to.have.property('topic', 'other');
+				expect(body).to.have.property('name', 'Jontho');
+				expect(body).to.have.property('email', 'jonhto@gmail.com');
+				expect(body).to.have.property(
+					'message',
+					'I need help with my subscription',
+				);
+				expect(body).to.have.property(
+					'captchaToken',
+					'test-recaptcha-token',
+				);
+			});
+		});
+
+		it('should show loading state during submission', () => {
+			cy.intercept('POST', '/api/contact-us', {
+				statusCode: 200,
+				body: { success: true },
+				delay: 4000,
+			}).as('slowSubmitContactForm');
+
+			cy.findByLabelText('Full Name').clear().type('Jontho');
+			cy.findByLabelText(/^Email address/)
+				.clear()
+				.type('jonhto@gmail.com');
+			cy.get('textarea[name="message"]').type(
+				'I need help with my subscription',
+			);
+
+			cy.findByText('Submit').click();
+
+			cy.findByText('Submit').should('be.disabled');
+			cy.get('button[type="submit"]')
+				.find('[class*="Spinner"]')
+				.should('exist');
+		});
+
+		it('should handle submission failure gracefully', () => {
+			cy.intercept('POST', '/api/contact-us', {
+				statusCode: 500,
+				body: { error: 'Internal server error' },
+			}).as('failedSubmitContactForm');
+
+			cy.findByLabelText('Full Name').clear().type('Jontho');
+			cy.findByLabelText(/^Email address/)
+				.clear()
+				.type('jonhto@gmail.com');
+			cy.get('textarea[name="message"]').type(
+				'I need help with my subscription',
+			);
+
+			cy.findByText('Submit').click();
+
+			cy.contains(
+				'Something went wrong when submitting your form',
+			).should('be.visible');
+			cy.contains(
+				'Please try again or if the problem persists please contact',
+			).should('be.visible');
+
+			cy.findByText('Customer Service').click();
+			cy.contains('Customer Service').should('be.visible');
+		});
+	});
+});

--- a/cypress/tests/mocked/parallel-3/contactUsForm.cy.ts
+++ b/cypress/tests/mocked/parallel-3/contactUsForm.cy.ts
@@ -82,8 +82,8 @@ describe('Contact Us Form Tests', () => {
 		cy.findByText('Something else').click();
 		cy.findByText('Begin form').click();
 
-		// Wait a moment for the form to initialize and try to render reCAPTCHA
-		cy.wait(500);
+		// Wait for reCAPTCHA element to be rendered
+		cy.get('#recaptcha').should('exist');
 	});
 
 	context('Form Display and Initial State', () => {
@@ -224,29 +224,6 @@ describe('Contact Us Form Tests', () => {
 					'test-recaptcha-token',
 				);
 			});
-		});
-
-		it('should show loading state during submission', () => {
-			cy.intercept('POST', '/api/contact-us', {
-				statusCode: 200,
-				body: { success: true },
-				delay: 4000,
-			}).as('slowSubmitContactForm');
-
-			cy.findByLabelText('Full Name').clear().type('Jontho');
-			cy.findByLabelText(/^Email address/)
-				.clear()
-				.type('jonhto@gmail.com');
-			cy.get('textarea[name="message"]').type(
-				'I need help with my subscription',
-			);
-
-			cy.findByText('Submit').click();
-
-			cy.findByText('Submit').should('be.disabled');
-			cy.get('button[type="submit"]')
-				.find('[class*="Spinner"]')
-				.should('exist');
 		});
 
 		it('should handle submission failure gracefully', () => {


### PR DESCRIPTION
### Current situation/background

The Help Centrer contact form had some usability and validation issues:
- Validation state was one step behind user input
- Autofocus was not applied to the first invalid field, causing confusion
- Error messages could go unnoticed if not scrolled into view

### What does this PR change?

This PR improves the form experience by:
- Implementing autofocus on the first invalid field when the form is submitted
- Refactoring form validation state management to ensure real-time accuracy using useCallback + useEffect

Additional fixes:
- Trims input values before validation
- Reduces validation logic to a single-pass filter over fields
- Ensures setFocus and error state behave correctly across all fields

To test:
- Submit the form without filling anything — first invalid field should autofocus
- As you type into fields, error states should update in sync
- CAPTCHA and file size validation should behave correctly
- Autofocus should reset after any change
- Spinner shows during submission
- Submission failure shows a fallback error message

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->
