### PR TITLE
Update Copy in YourDataSection

### DIFF
--- a/client/__tests__/components/dataPrivacy/YourDataSection.test.tsx
+++ b/client/__tests__/components/dataPrivacy/YourDataSection.test.tsx
@@ -12,7 +12,7 @@ describe('YourDataSection', () => {
 			id: 'personalised_advertising',
 			isChannel: false,
 			isProduct: false,
-			name: 'Allow personalised advertising using this data - this supports the Guardian',
+			name: 'Allow personalised advertising using this data',
 			subscribed: false,
 			type: ConsentOptionType.OPT_OUT,
 		},
@@ -49,7 +49,7 @@ describe('YourDataSection', () => {
 		);
 		expect(
 			screen.getAllByText(
-				'Allow personalised advertising using this data - this supports the Guardian',
+				'Allow personalised advertising using this data',
 			),
 		).toBeDefined();
 		expect(

--- a/client/components/mma/dataPrivacy/YourDataSection.tsx
+++ b/client/components/mma/dataPrivacy/YourDataSection.tsx
@@ -66,19 +66,18 @@ export const YourDataSection = (props: YourDataSectionProps) => {
 			<p css={dataPrivacyParagraphCss}>We do this by:</p>
 			<ul css={dataPrivacyUnorderedListCss}>
 				<li>
-					Analysing your account data to predict what you might be
-					interested in
-				</li>
-				<li>
 					Checking if you are already a customer of other trusted
 					partners
+				</li>
+				<li>
+					Generating random identifiers based on your email address
+					for advertising and marketing
 				</li>
 			</ul>
 
 			<p css={dataPrivacyParagraphCss}>
 				Advertising is a crucial source of our funding. You won't see
-				more ads, but your advertising may be more relevant. We don’t
-				share your email with third parties.
+				more ads, but your advertising may be more relevant.
 			</p>
 		</>
 	);

--- a/client/fixtures/consents.ts
+++ b/client/fixtures/consents.ts
@@ -102,7 +102,7 @@ export const consents = [
 		isOptOut: false,
 		isChannel: false,
 		isProduct: false,
-		name: 'Allow personalised advertising using this data - this supports the Guardian',
+		name: 'Allow personalised advertising using this data',
 	},
 	{
 		id: 'supporter',


### PR DESCRIPTION
### Current situation/background
Data Privacy has asked us to change the copy in the Data Privacy page.
### What does this PR change?

- Removes "this supports the Guardian" from  Allow personalised advertising using this data - this supports the Guardian
- Removes "Analysing your account data to predict what you might be interested in" in the "We do this by:" list
- Adds "Generating random identifiers based on your email address for advertising and marketing" to "We do this by:" list
- Removes "We don’t share your email with third parties." from "Advertising is a crucial source of our funding. You won't see more ads, but your advertising may be more relevant. We don’t share your email with third parties."

### Screenshots
 Screenshot of Old Copy
<img width="1496" alt="Screenshot 2025-06-27 at 12 44 36" src="https://github.com/user-attachments/assets/50f4dd42-a0e5-4ce5-b402-64077d477399" />

Screenshot of New Copy
![Screenshot 2025-06-27 at 12 40 36](https://github.com/user-attachments/assets/b10bc3fa-d795-4655-92ec-576ee1be6b6d)

