### PR TITLE
Moves code to the use of new property mmaProductKey

### DIFF
--- a/client/components/helpCentre/KnownIssues.tsx
+++ b/client/components/helpCentre/KnownIssues.tsx
@@ -29,7 +29,7 @@ export interface KnownIssueObj {
 	date: string; // "29 Aug 1997 02:40"
 	message: string;
 	link?: string; // optional href that is rendered after the message
-	affectedProducts?: string[]; // maps to productDetail.tier property
+	affectedProducts?: string[]; // maps to productDetail.mmaProductKey property
 }
 
 interface KnownIssuesProp {
@@ -72,7 +72,7 @@ export const KnownIssues = (props: KnownIssuesProp) => {
 						await productDetailsResponse.json();
 					const userProductNames = mdapiResponse.products
 						.filter(isProduct)
-						.map((productDetail) => productDetail.tier);
+						.map((productDetail) => productDetail.mmaProductKey);
 
 					const productIssues = unfilteredDateSortedIssues.filter(
 						(issue) =>

--- a/client/components/helpCentre/diagnosticInformation/SubscriptionInformation.tsx
+++ b/client/components/helpCentre/diagnosticInformation/SubscriptionInformation.tsx
@@ -1,6 +1,6 @@
 import type { MembersDataApiResponse } from '../../../../shared/productResponse';
 import {
-	getSpecificProductTypeFromTier,
+	getSpecificProductTypeFromProductKey,
 	isProduct,
 } from '../../../../shared/productResponse';
 import {
@@ -48,10 +48,12 @@ export const SubscriptionInformation = () => {
 					data.products.map((product) => {
 						if (isProduct(product)) {
 							const specificProductType =
-								getSpecificProductTypeFromTier(product.tier);
+								getSpecificProductTypeFromProductKey(
+									product.mmaProductKey,
+								);
 							return (
 								<li>
-									{product.tier} -{' '}
+									{product.mmaProductKey} -{' '}
 									{specificProductType.groupedProductType} -{' '}
 									{product.subscription.subscriptionId}
 								</li>

--- a/client/components/mma/accountoverview/AccountOverview.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.tsx
@@ -21,7 +21,7 @@ import type {
 } from '../../../../shared/productResponse';
 import { isProductResponse } from '../../../../shared/productResponse';
 import {
-	getSpecificProductTypeFromTier,
+	getSpecificProductTypeFromProductKey,
 	isProduct,
 	isSpecificProductType,
 	sortByJoinDate,
@@ -168,8 +168,8 @@ const AccountOverviewPage = ({ isFromApp }: IsFromAppProps) => {
 		...allActiveProductDetails,
 		...allCancelledProductDetails,
 	].map((product: ProductDetail | CancelledProductDetail) => {
-		const specificProductType = getSpecificProductTypeFromTier(
-			product.tier,
+		const specificProductType = getSpecificProductTypeFromProductKey(
+			product.mmaProductKey,
 		);
 		if (
 			specificProductType.groupedProductType ===
@@ -238,8 +238,8 @@ const AccountOverviewPage = ({ isFromApp }: IsFromAppProps) => {
 	const visualProductGroupingCategory = (
 		product: ProductDetail | CancelledProductDetail,
 	): GroupedProductTypeKeys => {
-		const specificProductType = getSpecificProductTypeFromTier(
-			product.tier,
+		const specificProductType = getSpecificProductTypeFromProductKey(
+			product.mmaProductKey,
 		);
 		if (
 			specificProductType.groupedProductType ===

--- a/client/components/mma/accountoverview/CancelledProductCard.tsx
+++ b/client/components/mma/accountoverview/CancelledProductCard.tsx
@@ -3,7 +3,7 @@ import { LinkButton, Stack } from '@guardian/source/react-components';
 import { InfoSummary } from '@guardian/source-development-kitchen/react-components';
 import { parseDate } from '@/shared/dates';
 import type { CancelledProductDetail } from '@/shared/productResponse';
-import { getSpecificProductTypeFromTier } from '@/shared/productResponse';
+import { getSpecificProductTypeFromProductKey } from '@/shared/productResponse';
 import { GROUPED_PRODUCT_TYPES } from '@/shared/productTypes';
 import { wideButtonLayoutCss } from '../../../styles/ButtonStyles';
 import { trackEvent } from '../../../utilities/analytics';
@@ -23,8 +23,8 @@ export const CancelledProductCard = ({
 	productDetail: CancelledProductDetail;
 	hasOtherActiveSubs: boolean;
 }) => {
-	const specificProductType = getSpecificProductTypeFromTier(
-		productDetail.tier,
+	const specificProductType = getSpecificProductTypeFromProductKey(
+		productDetail.mmaProductKey,
 	);
 	const groupedProductType =
 		GROUPED_PRODUCT_TYPES[specificProductType.groupedProductType];
@@ -67,7 +67,7 @@ export const CancelledProductCard = ({
 								{groupedProductType.tierLabel && (
 									<div>
 										<dt>{groupedProductType.tierLabel}</dt>
-										<dd>{productDetail.tier}</dd>
+										<dd>{productDetail.mmaProductKey}</dd>
 									</div>
 								)}
 								{productDetail.subscription.start && (

--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -24,7 +24,7 @@ import type {
 } from '@/shared/productResponse';
 import {
 	getMainPlan,
-	getSpecificProductTypeFromTier,
+	getSpecificProductTypeFromProductKey,
 	isGift,
 	isPaidSubscriptionPlan,
 } from '@/shared/productResponse';
@@ -79,8 +79,8 @@ export const ProductCard = ({
 		throw new Error('mainPlan does not exist in ProductCard');
 	}
 
-	const specificProductType = getSpecificProductTypeFromTier(
-		productDetail.tier,
+	const specificProductType = getSpecificProductTypeFromProductKey(
+		productDetail.mmaProductKey,
 	);
 	const groupedProductType =
 		GROUPED_PRODUCT_TYPES[specificProductType.groupedProductType];
@@ -88,7 +88,7 @@ export const ProductCard = ({
 	const isPatron = productDetail.subscription.readerType === 'Patron';
 
 	const entitledToEvents =
-		['Partner', 'Patron'].includes(productDetail.tier) &&
+		['Partner', 'Patron'].includes(productDetail.mmaProductKey) &&
 		(mainPlan as PaidSubscriptionPlan).features.includes('Events');
 
 	const productTitle = `${specificProductType.productTitle(mainPlan)}${
@@ -162,11 +162,11 @@ export const ProductCard = ({
 			productDetail.subscription.potentialCancellationDate;
 
 	const futureProductTitle =
-		productDetail.subscription.futurePlans[0]?.tier &&
-		productDetail.tier &&
+		productDetail.subscription.futurePlans[0]?.mmaProductKey &&
+		productDetail.mmaProductKey &&
 		productDetail.subscription.currentPlans.length > 0
-			? getSpecificProductTypeFromTier(
-					productDetail.subscription.futurePlans[0].tier,
+			? getSpecificProductTypeFromProductKey(
+					productDetail.subscription.futurePlans[0].mmaProductKey,
 			  ).productTitle(mainPlan)
 			: null;
 
@@ -312,7 +312,7 @@ export const ProductCard = ({
 								{groupedProductType.tierLabel && (
 									<div>
 										<dt>{groupedProductType.tierLabel}</dt>
-										<dd>{productDetail.tier}</dd>
+										<dd>{productDetail.mmaProductKey}</dd>
 									</div>
 								)}
 								{subscriptionStartDate && shouldShowStartDate && (

--- a/client/components/mma/billing/Billing.tsx
+++ b/client/components/mma/billing/Billing.tsx
@@ -29,7 +29,7 @@ import type {
 } from '../../../../shared/productResponse';
 import {
 	getMainPlan,
-	getSpecificProductTypeFromTier,
+	getSpecificProductTypeFromProductKey,
 	isGift,
 	isProduct,
 	sortByJoinDate,
@@ -124,8 +124,8 @@ function joinInvoicesWithProductsInCategories(
 
 function organiseProductsIntoCategory(allProductDetails: ProductDetail[]) {
 	return allProductDetails.reduce((accumulator, productDetail) => {
-		const specificProductType = getSpecificProductTypeFromTier(
-			productDetail.tier,
+		const specificProductType = getSpecificProductTypeFromProductKey(
+			productDetail.mmaProductKey,
 		);
 		return {
 			...accumulator,
@@ -151,9 +151,10 @@ function renderProductBillingInfo([productGrouping, productDetails]: [
 							'mainPlan does not exist for product in billing page',
 						);
 					}
-					const specificProductType = getSpecificProductTypeFromTier(
-						productDetail.tier,
-					);
+					const specificProductType =
+						getSpecificProductTypeFromProductKey(
+							productDetail.mmaProductKey,
+						);
 					const groupedProductType =
 						GROUPED_PRODUCT_TYPES[
 							specificProductType.groupedProductType

--- a/client/components/mma/cancel/CancellationJourneyFunnel.tsx
+++ b/client/components/mma/cancel/CancellationJourneyFunnel.tsx
@@ -3,7 +3,7 @@ import { Navigate, useLocation } from 'react-router-dom';
 import { hasCancellationFlow } from '@/client/utilities/productUtils';
 import { featureSwitches } from '@/shared/featureSwitches';
 import {
-	getSpecificProductTypeFromTier,
+	getSpecificProductTypeFromProductKey,
 	isPaidSubscriptionPlan,
 } from '@/shared/productResponse';
 import type { ProductTypeKeys } from '@/shared/productTypes';
@@ -36,7 +36,9 @@ export const CancellationJourneyFunnel = () => {
 		return <Navigate to="/" />;
 	}
 
-	const productType = getSpecificProductTypeFromTier(productDetail.tier);
+	const productType = getSpecificProductTypeFromProductKey(
+		productDetail.mmaProductKey,
+	);
 	const productTypeKey = productType.productType;
 
 	const possiblePaidPlan = productDetail.subscription.currentPlans[0];

--- a/client/components/mma/cancel/cancellationSaves/CancellationLanding.tsx
+++ b/client/components/mma/cancel/cancellationSaves/CancellationLanding.tsx
@@ -8,7 +8,7 @@ import type {
 	MembersDataApiResponse,
 	ProductDetail,
 } from '../../../../../shared/productResponse';
-import { getSpecificProductTypeFromTier } from '../../../../../shared/productResponse';
+import { getSpecificProductTypeFromProductKey } from '../../../../../shared/productResponse';
 import { headingCss } from '../../../../styles/GenericStyles';
 import {
 	LoadingState,
@@ -27,8 +27,8 @@ import { CancellationContext } from '../CancellationContainer';
 import { ineligibleForSave } from './saveEligibilityCheck';
 
 function getNextRoute(productToCancel: ProductDetail): string {
-	const specificProductTypeKey = getSpecificProductTypeFromTier(
-		productToCancel.tier,
+	const specificProductTypeKey = getSpecificProductTypeFromProductKey(
+		productToCancel.mmaProductKey,
 	).productType;
 
 	switch (specificProductTypeKey) {

--- a/client/components/mma/cancel/cancellationSaves/membership/MembershipSwitch.tsx
+++ b/client/components/mma/cancel/cancellationSaves/membership/MembershipSwitch.tsx
@@ -249,8 +249,8 @@ export const MembershipSwitch = () => {
 
 	if (
 		membership.subscription.futurePlans.length > 0 &&
-		membership.subscription.futurePlans[0].tier &&
-		membership.subscription.futurePlans[0].tier === 'Contributor'
+		membership.subscription.futurePlans[0].mmaProductKey &&
+		membership.subscription.futurePlans[0].mmaProductKey === 'Contributor'
 	) {
 		// Switch already planned, so navigate to Overview
 		navigate('/');

--- a/client/components/mma/cancel/cancellationSaves/membership/SaveOptions.tsx
+++ b/client/components/mma/cancel/cancellationSaves/membership/SaveOptions.tsx
@@ -173,7 +173,7 @@ export const SaveOptions = () => {
 						</section>
 					</Card.Section>
 				</Card>
-				{membership.subscription.futurePlans[0]?.tier !==
+				{membership.subscription.futurePlans[0]?.mmaProductKey !==
 					'Contributor' && (
 					<>
 						<section css={sectionSpacing}>

--- a/client/components/mma/cancel/cancellationSaves/saveEligibilityCheck.ts
+++ b/client/components/mma/cancel/cancellationSaves/saveEligibilityCheck.ts
@@ -5,7 +5,7 @@ import type {
 } from '@/shared/productResponse';
 import {
 	getMainPlan,
-	getSpecificProductTypeFromTier,
+	getSpecificProductTypeFromProductKey,
 } from '@/shared/productResponse';
 import type { OptionalCancellationReasonId } from '../cancellationReason';
 
@@ -13,7 +13,9 @@ export function ineligibleForSave(
 	products: ProductDetail[],
 	productToCancel: ProductDetail,
 ): boolean {
-	const productType = getSpecificProductTypeFromTier(productToCancel.tier);
+	const productType = getSpecificProductTypeFromProductKey(
+		productToCancel.mmaProductKey,
+	);
 	if (productType.productType === 'membership') {
 		return isMembershipIneligible(products, productToCancel);
 	}
@@ -28,14 +30,17 @@ function isMembershipIneligible(
 	const inPaymentFailure = !!products.find((product) => product.alertText);
 
 	const hasOtherProduct = !!products.find((product) => {
-		const productType = getSpecificProductTypeFromTier(product.tier);
+		const productType = getSpecificProductTypeFromProductKey(
+			product.mmaProductKey,
+		);
 		return (
 			productType.productType != 'membership' &&
 			!product.subscription.cancelledAt
 		);
 	});
 
-	const membershipTierIsNotSupporter = productToCancel.tier !== 'Supporter';
+	const membershipTierIsNotSupporter =
+		productToCancel.mmaProductKey !== 'Supporter';
 
 	const mainPlan = getMainPlan(
 		productToCancel.subscription,

--- a/client/components/mma/delivery/address/DeliveryAddressForm.tsx
+++ b/client/components/mma/delivery/address/DeliveryAddressForm.tsx
@@ -21,7 +21,7 @@ import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { addressChangeAffectedInfo } from '@/client/utilities/deliveryAddress';
 import { flattenEquivalent } from '@/client/utilities/utils';
 import type { DeliveryAddress } from '@/shared/productResponse';
-import { getSpecificProductTypeFromTier } from '@/shared/productResponse';
+import { getSpecificProductTypeFromProductKey } from '@/shared/productResponse';
 import type { ProductType, WithProductType } from '@/shared/productTypes';
 import { CallCentreEmailAndNumbers } from '../../../shared/CallCenterEmailAndNumbers';
 import { CallCentreNumbers } from '../../../shared/CallCentreNumbers';
@@ -100,8 +100,8 @@ const Form = (props: FormProps) => {
 	)
 		.flatMap(flattenEquivalent)
 		.map(({ productDetail }) => {
-			const specificProductType = getSpecificProductTypeFromTier(
-				productDetail.tier,
+			const specificProductType = getSpecificProductTypeFromProductKey(
+				productDetail.mmaProductKey,
 			);
 			const friendlyProductName = specificProductType.friendlyName;
 			return `${friendlyProductName}`;

--- a/client/components/mma/delivery/records/DeliveryAddressStep.tsx
+++ b/client/components/mma/delivery/records/DeliveryAddressStep.tsx
@@ -22,7 +22,7 @@ import type {
 	ProductDetail,
 } from '../../../../../shared/productResponse';
 import {
-	getSpecificProductTypeFromTier,
+	getSpecificProductTypeFromProductKey,
 	isProduct,
 	MembersDataApiAsyncLoader,
 } from '../../../../../shared/productResponse';
@@ -89,8 +89,8 @@ export const DeliveryAddressStep = (props: DeliveryAddressStepProps) => {
 		isValid: false,
 	});
 
-	const specificProductType = getSpecificProductTypeFromTier(
-		props.productDetail.tier,
+	const specificProductType = getSpecificProductTypeFromProductKey(
+		props.productDetail.mmaProductKey,
 	);
 
 	const isNationalDelivery =
@@ -181,9 +181,10 @@ export const DeliveryAddressStep = (props: DeliveryAddressStepProps) => {
 		)
 			.flatMap(flattenEquivalent)
 			.map(({ productDetail }) => {
-				const specificProductType = getSpecificProductTypeFromTier(
-					productDetail.tier,
-				);
+				const specificProductType =
+					getSpecificProductTypeFromProductKey(
+						productDetail.mmaProductKey,
+					);
 				const friendlyProductName = specificProductType.friendlyName;
 				return `${friendlyProductName}`;
 			});

--- a/client/components/mma/holiday/HolidayReview.tsx
+++ b/client/components/mma/holiday/HolidayReview.tsx
@@ -297,7 +297,7 @@ export const HolidayReview = () => {
 	};
 
 	return isHolidayStopsResponse(holidayStopResponse) &&
-		productDetail?.tier &&
+		productDetail?.mmaProductKey &&
 		selectedRange &&
 		publicationsImpacted ? (
 		buildActualRenderer(

--- a/client/components/mma/identity/emailAndMarketing/EmailAndMarketing.tsx
+++ b/client/components/mma/identity/emailAndMarketing/EmailAndMarketing.tsx
@@ -14,7 +14,7 @@ import type {
 	ProductDetail,
 	SingleProductDetail,
 } from '../../../../../shared/productResponse';
-import { getSpecificProductTypeFromTier } from '../../../../../shared/productResponse';
+import { getSpecificProductTypeFromProductKey } from '../../../../../shared/productResponse';
 import { fetchWithDefaultParameters } from '../../../../utilities/fetch';
 import {
 	allRecurringProductsDetailFetcher,
@@ -220,8 +220,8 @@ function userHasProductWithConsent(
 	consent: ConsentOption,
 ) {
 	return productDetails.some((productDetail) => {
-		const specificProductType = getSpecificProductTypeFromTier(
-			productDetail.tier,
+		const specificProductType = getSpecificProductTypeFromProductKey(
+			productDetail.mmaProductKey,
 		);
 		return specificProductType.softOptInIDs.includes(consent.id);
 	});

--- a/client/components/mma/paymentUpdate/CurrentPaymentDetail.tsx
+++ b/client/components/mma/paymentUpdate/CurrentPaymentDetail.tsx
@@ -11,7 +11,7 @@ import { InlineError } from '@guardian/source/react-components';
 import type { ProductDetail } from '../../../../shared/productResponse';
 import {
 	getMainPlan,
-	getSpecificProductTypeFromTier,
+	getSpecificProductTypeFromProductKey,
 } from '../../../../shared/productResponse';
 import { PaypalLogo } from '../shared/assets/PaypalLogo';
 import { CardDisplay } from '../shared/CardDisplay';
@@ -34,8 +34,8 @@ export const CurrentPaymentDetails = (productDetail: ProductDetail) => {
 	const mainPlan = getMainPlan(subscription);
 	const hasCancellationPending: boolean = subscription.cancelledAt;
 
-	const specificProductType = getSpecificProductTypeFromTier(
-		productDetail.tier,
+	const specificProductType = getSpecificProductTypeFromProductKey(
+		productDetail.mmaProductKey,
 	);
 
 	const keyValuePairCss = css`

--- a/client/components/mma/paymentUpdate/PaymentDetailUpdateConfirmation.tsx
+++ b/client/components/mma/paymentUpdate/PaymentDetailUpdateConfirmation.tsx
@@ -25,7 +25,7 @@ import type {
 import {
 	formatDate,
 	getMainPlan,
-	getSpecificProductTypeFromTier,
+	getSpecificProductTypeFromProductKey,
 	isPaidSubscriptionPlan,
 } from '../../../../shared/productResponse';
 import { GenericErrorScreen } from '../../shared/GenericErrorScreen';
@@ -102,8 +102,8 @@ export const ConfirmedNewPaymentDetailsRenderer = ({
 	previousProductDetail,
 }: ConfirmedNewPaymentDetailsRendererProps) => {
 	const mainPlan = getMainPlan(subscription);
-	const specificProductType = getSpecificProductTypeFromTier(
-		previousProductDetail.tier,
+	const specificProductType = getSpecificProductTypeFromProductKey(
+		previousProductDetail.mmaProductKey,
 	);
 	if (subHasExpectedPaymentType && isPaidSubscriptionPlan(mainPlan)) {
 		return (

--- a/client/components/mma/shared/BasicProductInfoTable.tsx
+++ b/client/components/mma/shared/BasicProductInfoTable.tsx
@@ -22,7 +22,7 @@ export const BasicProductInfoTable = (props: BasicProductInfoTableProps) => {
 					? [
 							{
 								title: props.groupedProductType.tierLabel,
-								value: props.productDetail.tier,
+								value: props.productDetail.mmaProductKey,
 							},
 					  ]
 					: []),

--- a/client/components/mma/shared/PaymentFailureAlertIfApplicable.tsx
+++ b/client/components/mma/shared/PaymentFailureAlertIfApplicable.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import type { ProductDetail } from '../../../../shared/productResponse';
-import { getSpecificProductTypeFromTier } from '../../../../shared/productResponse';
+import { getSpecificProductTypeFromProductKey } from '../../../../shared/productResponse';
 import type { IsFromAppProps } from './IsFromAppProps';
 import { ProblemAlert } from './ProblemAlert';
 
@@ -30,7 +30,9 @@ export const PaymentFailureAlertIfApplicable = ({
 			button={{
 				title: 'Update payment method',
 				link: `/payment/${
-					getSpecificProductTypeFromTier(productDetail.tier).urlPart
+					getSpecificProductTypeFromProductKey(
+						productDetail.mmaProductKey,
+					).urlPart
 				}`,
 				state: { productDetail, isFromApp },
 			}}

--- a/client/components/mma/switch/options/SwitchOptions.tsx
+++ b/client/components/mma/switch/options/SwitchOptions.tsx
@@ -130,7 +130,7 @@ export const SwitchOptions = () => {
 
 	const navigate = useNavigate();
 
-	if (contributionToSwitch.tier === 'Supporter Plus') {
+	if (contributionToSwitch.mmaProductKey === 'Supporter Plus') {
 		return (
 			<section css={sectionSpacing}>
 				<ErrorSummary

--- a/client/fixtures/cancelledProductDetail.ts
+++ b/client/fixtures/cancelledProductDetail.ts
@@ -1,7 +1,7 @@
 import type { CancelledProductDetail } from '../../shared/productResponse';
 
 export const cancelledContribution: CancelledProductDetail = {
-	tier: 'Contributor',
+	mmaProductKey: 'Contributor',
 	joinDate: '2022-01-05',
 	subscription: {
 		subscriptionId: 'A-S00000000',
@@ -14,7 +14,7 @@ export const cancelledContribution: CancelledProductDetail = {
 };
 
 export const cancelledGuardianWeekly: CancelledProductDetail = {
-	tier: 'Guardian Weekly - Domestic',
+	mmaProductKey: 'Guardian Weekly - Domestic',
 	joinDate: '2022-01-05',
 	subscription: {
 		subscriptionId: 'A-S00000000',
@@ -27,7 +27,7 @@ export const cancelledGuardianWeekly: CancelledProductDetail = {
 };
 
 export const cancelledGuardianAdLite: CancelledProductDetail = {
-	tier: 'Guardian Ad-Lite',
+	mmaProductKey: 'Guardian Ad-Lite',
 	joinDate: '2022-01-05',
 	subscription: {
 		subscriptionId: 'A-S00000000',

--- a/client/fixtures/productBuilder/baseProducts.ts
+++ b/client/fixtures/productBuilder/baseProducts.ts
@@ -15,7 +15,7 @@ import type { ProductDetail } from '../../../shared/productResponse';
 
 export function baseMembership(): ProductDetail {
 	return {
-		tier: 'Supporter',
+		mmaProductKey: 'Supporter',
 		isPaidTier: true,
 		selfServiceCancellation: {
 			isAllowed: true,
@@ -75,7 +75,7 @@ export function baseMembership(): ProductDetail {
 
 export function basePatron(): ProductDetail {
 	return {
-		tier: 'guardianpatron',
+		mmaProductKey: 'guardianpatron',
 		isPaidTier: true,
 		selfServiceCancellation: {
 			isAllowed: true,
@@ -143,7 +143,7 @@ export function basePatron(): ProductDetail {
 
 export function baseGuardianWeekly(): ProductDetail {
 	return {
-		tier: 'Guardian Weekly - Domestic',
+		mmaProductKey: 'Guardian Weekly - Domestic',
 		isPaidTier: true,
 		selfServiceCancellation: {
 			isAllowed: false,
@@ -199,7 +199,7 @@ export function baseGuardianWeekly(): ProductDetail {
 
 export function baseDigitalPack(): ProductDetail {
 	return {
-		tier: 'Digital Pack',
+		mmaProductKey: 'Digital Pack',
 		isPaidTier: true,
 		selfServiceCancellation: {
 			isAllowed: true,
@@ -263,7 +263,7 @@ export function baseDigitalPack(): ProductDetail {
 
 export function baseContribution(): ProductDetail {
 	return {
-		tier: 'Contributor',
+		mmaProductKey: 'Contributor',
 		isPaidTier: true,
 		selfServiceCancellation: {
 			isAllowed: true,
@@ -319,7 +319,7 @@ export function baseContribution(): ProductDetail {
 
 export function baseVoucher(): ProductDetail {
 	return {
-		tier: 'Newspaper Voucher',
+		mmaProductKey: 'Newspaper Voucher',
 		isPaidTier: true,
 		selfServiceCancellation: {
 			isAllowed: false,
@@ -383,7 +383,7 @@ export function baseVoucher(): ProductDetail {
 
 export function baseVoucherObserver(): ProductDetail {
 	return {
-		tier: 'Newspaper Voucher - Observer',
+		mmaProductKey: 'Newspaper Voucher - Observer',
 		isPaidTier: true,
 		selfServiceCancellation: {
 			isAllowed: false,
@@ -419,7 +419,7 @@ export function baseVoucherObserver(): ProductDetail {
 			currentPlans: [],
 			futurePlans: [
 				{
-					tier: 'Newspaper Voucher - Observer',
+					mmaProductKey: 'Newspaper Voucher - Observer',
 					name: 'Sunday',
 					start: '2025-06-15',
 					end: '2026-05-16',
@@ -442,7 +442,7 @@ export function baseVoucherObserver(): ProductDetail {
 
 export function baseDigitalVoucherObserver(): ProductDetail {
 	return {
-		tier: 'Newspaper Digital Voucher - Observer',
+		mmaProductKey: 'Newspaper Digital Voucher - Observer',
 		isPaidTier: true,
 		selfServiceCancellation: {
 			isAllowed: false,
@@ -498,7 +498,7 @@ export function baseDigitalVoucherObserver(): ProductDetail {
 
 export function baseDigitalVoucher(): ProductDetail {
 	return {
-		tier: 'Newspaper Digital Voucher',
+		mmaProductKey: 'Newspaper Digital Voucher',
 		isPaidTier: true,
 		selfServiceCancellation: {
 			isAllowed: false,
@@ -562,7 +562,7 @@ export function baseDigitalVoucher(): ProductDetail {
 
 export function baseObserverDelivery(): ProductDetail {
 	return {
-		tier: 'Newspaper Delivery - Observer',
+		mmaProductKey: 'Newspaper Delivery - Observer',
 		isPaidTier: true,
 		selfServiceCancellation: {
 			isAllowed: false,
@@ -644,7 +644,7 @@ export function baseObserverDelivery(): ProductDetail {
 
 export function baseHomeDeliverySundayPlus(): ProductDetail {
 	return {
-		tier: 'Newspaper Delivery',
+		mmaProductKey: 'Newspaper Delivery',
 		isPaidTier: true,
 		selfServiceCancellation: {
 			isAllowed: false,
@@ -702,7 +702,7 @@ export function baseHomeDeliverySundayPlus(): ProductDetail {
 
 export function baseHomeDelivery(): ProductDetail {
 	return {
-		tier: 'Newspaper Delivery',
+		mmaProductKey: 'Newspaper Delivery',
 		isPaidTier: true,
 		selfServiceCancellation: {
 			isAllowed: false,
@@ -768,7 +768,7 @@ export function baseHomeDelivery(): ProductDetail {
 
 export function baseNationalDelivery(): ProductDetail {
 	return {
-		tier: 'Newspaper - National Delivery',
+		mmaProductKey: 'Newspaper - National Delivery',
 		isPaidTier: true,
 		selfServiceCancellation: {
 			isAllowed: false,
@@ -833,7 +833,7 @@ export function baseNationalDelivery(): ProductDetail {
 
 export function baseGuardianAdLite(): ProductDetail {
 	return {
-		tier: 'Guardian Ad-Lite',
+		mmaProductKey: 'Guardian Ad-Lite',
 		isPaidTier: true,
 		selfServiceCancellation: {
 			isAllowed: true,
@@ -888,7 +888,7 @@ export function baseGuardianAdLite(): ProductDetail {
 
 export function baseSupporterPlus(): ProductDetail {
 	return {
-		tier: 'Supporter Plus',
+		mmaProductKey: 'Supporter Plus',
 		isPaidTier: true,
 		isTestUser: false,
 		selfServiceCancellation: {
@@ -936,7 +936,7 @@ export function baseSupporterPlus(): ProductDetail {
 
 export function baseTierThree(): ProductDetail {
 	return {
-		tier: 'Tier Three',
+		mmaProductKey: 'Tier Three',
 		isPaidTier: true,
 		selfServiceCancellation: {
 			isAllowed: true,

--- a/client/fixtures/productBuilder/productBuilder.ts
+++ b/client/fixtures/productBuilder/productBuilder.ts
@@ -46,8 +46,8 @@ export class ProductBuilder {
 		return this.productToBuild;
 	}
 
-	tier(tier: string) {
-		this.productToBuild.tier = tier;
+	product(productKey: string) {
+		this.productToBuild.mmaProductKey = productKey;
 		return this;
 	}
 
@@ -142,7 +142,7 @@ export class ProductBuilder {
 	}
 
 	asPatronTier() {
-		this.productToBuild.tier = 'Patron';
+		this.productToBuild.mmaProductKey = 'Patron';
 		return this;
 	}
 

--- a/client/fixtures/productBuilder/testProducts.ts
+++ b/client/fixtures/productBuilder/testProducts.ts
@@ -251,7 +251,7 @@ export function membershipSupporterCurrencyUSD() {
 export function membershipStaff() {
 	return new ProductBuilder(baseMembership())
 		.payByCard()
-		.tier('Staff Membership')
+		.product('Staff Membership')
 		.withNoCurrentPlans()
 		.getProductDetailObject();
 }

--- a/client/utilities/deliveryAddress.ts
+++ b/client/utilities/deliveryAddress.ts
@@ -1,7 +1,7 @@
 import { capitalize } from 'lodash';
 import { parseDate } from '../../shared/dates';
 import type { ProductDetail, Subscription } from '../../shared/productResponse';
-import { getSpecificProductTypeFromTier } from '../../shared/productResponse';
+import { getSpecificProductTypeFromProductKey } from '../../shared/productResponse';
 import type { ProductType } from '../../shared/productTypes';
 import type { SubscriptionEffectiveData } from '../components/mma/delivery/address/DeliveryAddressFormContext';
 import { flattenEquivalent } from './utils';
@@ -35,7 +35,9 @@ export const getValidDeliveryAddressChangeEffectiveDates = (
 		.filter(hasContactId)
 		.map((productDetail) => ({
 			productDetail,
-			productType: getSpecificProductTypeFromTier(productDetail.tier),
+			productType: getSpecificProductTypeFromProductKey(
+				productDetail.mmaProductKey,
+			),
 		}))
 		.filter((_) => _.productType.delivery?.showAddress)
 		.reduce(

--- a/cypress/tests/mocked/parallel-1/updatePaymentDetails.cy.ts
+++ b/cypress/tests/mocked/parallel-1/updatePaymentDetails.cy.ts
@@ -318,7 +318,7 @@ describe('Update payment details', () => {
 					},
 					products: [
 						{
-							tier: 'Newspaper Digital Voucher',
+							mmaProductKey: 'Newspaper Digital Voucher',
 							isPaidTier: true,
 							selfServiceCancellation: {
 								isAllowed: false,
@@ -622,16 +622,12 @@ describe('Update payment details', () => {
 	it('Complete direct debit payment update for Observer - Sunday Only', () => {
 		cy.intercept('GET', '/api/me/mma?productType=*', {
 			statusCode: 200,
-			body: toMembersDataApiResponse(
-				observerDeliveryPaidByDirectDebit(),
-			),
+			body: toMembersDataApiResponse(observerDeliveryPaidByDirectDebit()),
 		}).as('product_detail');
 
 		cy.intercept('GET', '/api/me/mma/**', {
 			statusCode: 200,
-			body: toMembersDataApiResponse(
-				observerDeliveryPaidByDirectDebit(),
-			),
+			body: toMembersDataApiResponse(observerDeliveryPaidByDirectDebit()),
 		}).as('refetch_subscription');
 
 		cy.intercept('POST', '/api/validate/payment/**', {

--- a/server/fulfilmentDateCalculatorReader.ts
+++ b/server/fulfilmentDateCalculatorReader.ts
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/browser';
 import type { ProductDetail } from '../shared/productResponse';
 import {
 	getMainPlan,
-	getSpecificProductTypeFromTier,
+	getSpecificProductTypeFromProductKey,
 } from '../shared/productResponse';
 import { s3FilePromise } from './awsIntegration';
 import { conf } from './config';
@@ -45,8 +45,8 @@ const getDeliveryAddressChangeEffectiveDateForToday = async (
 
 export const augmentProductDetailWithDeliveryAddressChangeEffectiveDateForToday =
 	async (productDetail: ProductDetail) => {
-		const specificProductType = getSpecificProductTypeFromTier(
-			productDetail.tier,
+		const specificProductType = getSpecificProductTypeFromProductKey(
+			productDetail.mmaProductKey,
 		);
 		if (specificProductType.groupedProductType !== 'subscriptions') {
 			return productDetail;

--- a/shared/productResponse.ts
+++ b/shared/productResponse.ts
@@ -101,7 +101,7 @@ export interface ProductDetail extends WithSubscription {
 	regNumber?: string;
 	optIn?: boolean;
 	key?: string;
-	tier: ProductTier;
+	mmaProductKey: ProductTier;
 	joinDate: string;
 	alertText?: string;
 	selfServiceCancellation: SelfServiceCancellation;
@@ -109,7 +109,7 @@ export interface ProductDetail extends WithSubscription {
 }
 
 export interface CancelledProductDetail {
-	tier: ProductTier;
+	mmaProductKey: ProductTier;
 	joinDate: string;
 	subscription: CancelledSubscription;
 }
@@ -123,14 +123,15 @@ export function isProductResponse(
 export function isProduct(
 	data: MembersDataApiItem | undefined,
 ): data is ProductDetail {
-	return productTiers.includes((data as ProductDetail)?.tier);
+	return productTiers.includes((data as ProductDetail)?.mmaProductKey);
 }
 
 export const isObserverProduct = (productDetail: ProductDetail): boolean => {
 	return (
-		productDetail.tier === 'Newspaper Delivery - Observer' ||
-		productDetail.tier === 'Newspaper Digital Voucher - Observer' ||
-		productDetail.tier === 'Newspaper Voucher - Observer'
+		productDetail.mmaProductKey === 'Newspaper Delivery - Observer' ||
+		productDetail.mmaProductKey ===
+			'Newspaper Digital Voucher - Observer' ||
+		productDetail.mmaProductKey === 'Newspaper Voucher - Observer'
 	);
 };
 
@@ -147,7 +148,7 @@ export interface DirectDebitDetails {
 }
 
 export interface SubscriptionPlan {
-	tier?: ProductTier;
+	mmaProductKey?: ProductTier;
 	name: string | null;
 	start?: string;
 	shouldBeVisible: boolean;
@@ -291,7 +292,7 @@ export const getMainPlan: (subscription: Subscription) => SubscriptionPlan = (
 	};
 };
 
-export function getSpecificProductTypeFromTier(
+export function getSpecificProductTypeFromProductKey(
 	productTier: ProductTier,
 ): ProductType {
 	let productType: ProductType = {} as ProductType;
@@ -355,8 +356,8 @@ export function isSpecificProductType(
 	productDetail: ProductDetail,
 	targetProductType: ProductType,
 ): boolean {
-	const specificProductType = getSpecificProductTypeFromTier(
-		productDetail.tier,
+	const specificProductType = getSpecificProductTypeFromProductKey(
+		productDetail.mmaProductKey,
 	);
 	return specificProductType === targetProductType;
 }

--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -302,7 +302,7 @@ export const PRODUCT_TYPES: Record<ProductTypeKeys, ProductType> = {
 		allProductsProductTypeFilterString: 'Membership',
 		urlPart: 'membership',
 		getOphanProductType: (productDetail: ProductDetail) => {
-			switch (productDetail.tier) {
+			switch (productDetail.mmaProductKey) {
 				case 'Supporter':
 					return 'MEMBERSHIP_SUPPORTER';
 				case 'Partner':


### PR DESCRIPTION
### Current situation/background

PR makes the shift from the previously used `tier` property to the new `mmaProductTier`, as part of the effort to release newspaper+digital benefits.

### What does this PR change?

Changes to use the new property, naming of some functions and everything needed to support that change.

### Next steps/further info

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->
