### PR TITLE
Offer period copy changes

### DIFF
--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -197,7 +197,7 @@ export const ProductCard = ({
 						message="Your offer is active"
 						context={
 							<>
-								Your two months free is now active until{' '}
+								Your free offer is active until{' '}
 								{nextPaymentDetails?.nextPaymentDateValue}. If
 								you have any questions, feel free to{' '}
 								{

--- a/client/components/mma/shared/NextPaymentDetails.tsx
+++ b/client/components/mma/shared/NextPaymentDetails.tsx
@@ -56,7 +56,7 @@ export const getNextPaymentDetails = (
 			}
 			const amount =
 				overiddenAmount ||
-				(subscription.nextPaymentPrice ?? mainPlan.price) / 100;
+				(subscription.nextPaymentPrice ?? mainPlan.price) / 100; // we have kept the null coalessing check in here incase MDAPI returns a null value for nextPaymentPrice (not expected)
 			if (shortVersion === 'short') {
 				return `${mainPlan.currency}${
 					Number.isInteger(amount) ? amount : amount.toFixed(2)

--- a/shared/productResponse.ts
+++ b/shared/productResponse.ts
@@ -224,7 +224,7 @@ export interface Subscription {
 	lastPaymentDate: string | null;
 	potentialCancellationDate: string | null;
 	chargedThroughDate: string | null;
-	nextPaymentPrice: number | null;
+	nextPaymentPrice: number;
 	paymentMethod?: string;
 	stripePublicKeyForCardAddition?: string;
 	safeToUpdatePaymentMethod: boolean;


### PR DESCRIPTION
### What does this PR change?

Make the offer period copy more generic to handle any length of offer, eg 2 months or 24month.

Change the subscription (MDAPI) 'nextPaymentPrice' property to expect a value and not be null, however this is based on the response from an API and so cannot be guaranteed hence we kept the null coalessing check when rendering the price (with an additional comment)


### Images
Before             |  After
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/437b4e26-8ef5-4334-b1fb-b45f4aca3b98)  |  ![](https://github.com/user-attachments/assets/66cfa7bd-a6aa-4494-b530-a339fe75dde3)


