### PR TITLE
Fixes the Reporting of CSP

### DIFF
--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -368,7 +368,7 @@ router.post('/reminders/reactivate', reactivateReminderHandler);
 
 router.post('/csp-audit-report-endpoint', (req, res) => {
 	const parsedBody = JSON.parse(req.body.toString());
-	log.warn(JSON.stringify(parsedBody));
+	log.warn(`CSP Violation Report: ${JSON.stringify(parsedBody)}`);
 	res.status(204).end();
 });
 

--- a/server/server.ts
+++ b/server/server.ts
@@ -58,6 +58,7 @@ export const createCsp = (hashes: string[]) => {
 		`script-src ${prefixedHashes.join(' ')} 'strict-dynamic'`,
 		`style-src 'unsafe-inline'`,
 		`object-src 'none'`,
+		`report-uri /api/csp-audit-report-endpoint`,
 	];
 	return csp.join('; ');
 };


### PR DESCRIPTION
### Current situation/background

We are currently running our Content Security Policy (CSP) in Report-Only mode to monitor potential violations before moving into enforced mode. However, we’ve noticed the following warning in the browser console:

> "Content-Security-Policy: This site (https://manage.code.dev-theguardian.com/) has a Report-Only policy without a report-uri directive nor a report-to directive. CSP will not block and cannot report violations of this policy."

This means that although CSP is technically enabled in Report-Only mode, violations are not being logged anywhere, making it impossible to evaluate or act on them.

This PR resolves the issue by adding the appropriate report-uri directive to the CSP headers, ensuring that any violations are correctly captured and sent to our reporting endpoint. This will allow us to monitor and analyse CSP data in the logs as intended before switching to enforced mode.

### What does this PR change?

- Adds `CSP Violation Report:` to the logged string for easier filtering in the logs
- Adds report-uri directive to the CSP headers

### Next steps/further info

- We will let this sit for 2 week, as was originally planned here: https://trello.com/c/52IsZfXi/146-add-content-security-policy-to-mma
- Review the logs of the last two weeks and solve the CSP violations before moving into enforced mode.

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->
