### PR TITLE
Add support for Feast app in InAppPurchaseCard

### DIFF
--- a/client/components/mma/accountoverview/InAppPurchaseCard.tsx
+++ b/client/components/mma/accountoverview/InAppPurchaseCard.tsx
@@ -79,7 +79,7 @@ export const InAppPurchaseCard = ({
 							: productColour.inAppPurchase
 					}
 				>
-					<h3 css={productCardTitleCss(!isPuzzleApp && !isFeastApp)}>
+					<h3 css={productCardTitleCss(!isPuzzleApp)}>
 						{capitalize(appType)} app
 					</h3>
 				</Card.Header>

--- a/client/components/mma/accountoverview/InAppPurchaseCard.tsx
+++ b/client/components/mma/accountoverview/InAppPurchaseCard.tsx
@@ -9,6 +9,7 @@ import type { AppSubscription } from '../../../../shared/mpapiResponse';
 import {
 	AppStore,
 	determineAppStore,
+	isFeast,
 	isPuzzle,
 } from '../../../../shared/mpapiResponse';
 import { Card } from '../shared/Card';
@@ -42,7 +43,19 @@ export const InAppPurchaseCard = ({
 	const navigate = useNavigate();
 
 	const isPuzzleApp = isPuzzle(subscription);
-	const puzzleOrNews = isPuzzleApp ? 'puzzle' : 'news';
+	const isFeastApp = isFeast(subscription);
+
+	let appType = 'news';
+	let appDescription = 'news';
+
+	if (isPuzzleApp) {
+		appType = 'puzzle';
+		appDescription = 'puzzle';
+	} else if (isFeastApp) {
+		appType = 'Feast';
+		appDescription = 'Feast';
+	}
+
 	const appStore = determineAppStore(subscription);
 	return (
 		<Stack space={4}>
@@ -60,11 +73,14 @@ export const InAppPurchaseCard = ({
 					backgroundColor={
 						isPuzzleApp
 							? productColour.puzzleApp
+							: isFeastApp
+							? productColour.feastApp ||
+							  productColour.inAppPurchase
 							: productColour.inAppPurchase
 					}
 				>
-					<h3 css={productCardTitleCss(!isPuzzleApp)}>
-						{capitalize(puzzleOrNews)} app
+					<h3 css={productCardTitleCss(!isPuzzleApp && !isFeastApp)}>
+						{capitalize(appType)} app
 					</h3>
 				</Card.Header>
 				<Card.Section>
@@ -83,8 +99,8 @@ export const InAppPurchaseCard = ({
 						>
 							You have unlimited access to the Guardian{' '}
 							{appStore === AppStore.ANDROID && 'Android'}
-							{appStore === AppStore.IOS && 'iOS'} {puzzleOrNews}{' '}
-							app.
+							{appStore === AppStore.IOS && 'iOS'}{' '}
+							{appDescription} app.
 						</div>
 						<div
 							css={css`

--- a/client/components/mma/accountoverview/ProductCardConfiguration.ts
+++ b/client/components/mma/accountoverview/ProductCardConfiguration.ts
@@ -21,7 +21,7 @@ export const productColour = {
 	digital: palette.sport[100],
 	guardianWeekly: '#cadbe8',
 	puzzleApp: palette.lifestyle[300],
-	feastApp: '#FF9500', // Orange color for Feast app
+	feastApp: palette.brand[800], // Same color as Live app (inAppPurchase)
 };
 
 type ExclusiveBenefitsSections =

--- a/client/components/mma/accountoverview/ProductCardConfiguration.ts
+++ b/client/components/mma/accountoverview/ProductCardConfiguration.ts
@@ -21,6 +21,7 @@ export const productColour = {
 	digital: palette.sport[100],
 	guardianWeekly: '#cadbe8',
 	puzzleApp: palette.lifestyle[300],
+	feastApp: '#FF9500', // Orange color for Feast app
 };
 
 type ExclusiveBenefitsSections =

--- a/shared/mpapiResponse.ts
+++ b/shared/mpapiResponse.ts
@@ -56,5 +56,8 @@ export function isPuzzle(subscription: AppSubscription) {
 }
 
 export function isFeast(subscription: AppSubscription) {
-	return subscription.productId.includes('Feast');
+	return (
+		subscription.productId.includes('Feast') ||
+		subscription.productId.includes('feast')
+	);
 }

--- a/shared/mpapiResponse.ts
+++ b/shared/mpapiResponse.ts
@@ -54,3 +54,7 @@ export function determineAppStore(subscription: AppSubscription) {
 export function isPuzzle(subscription: AppSubscription) {
 	return subscription.productId.includes('puzzles');
 }
+
+export function isFeast(subscription: AppSubscription) {
+	return subscription.productId.includes('Feast');
+}


### PR DESCRIPTION
## Problem
Users with Feast app subscriptions (productId: `uk.co.guardian.Feast.yearly`) were incorrectly seeing "Live App" subscription status in MMA instead of being properly identified as Feast app subscribers. The frontend was treating all mobile subscriptions uniformly without distinguishing between news app, puzzle app, and Feast app products. This situation is described by this [card](https://trello.com/c/wL1CcDxM/469-filter-out-feast-subscriptions-from-mdapi-when-checking-for-live-app-subs) and its associated [conversation thread](https://chat.google.com/room/AAAAuotUxTg/ei-7b301LDA/ei-7b301LDA?cls=10). The backend change that allows this new implementation to work can be tracked to this [pull request](https://github.com/guardian/members-data-api/pull/1142).

<img width="1496" height="727" alt="Screenshot 2025-08-01 at 13 51 35" src="https://github.com/user-attachments/assets/00e58bc6-c37c-4181-8e87-93edc3be7859" />

## Analysis
The issue stemmed from the lack of product-specific detection and UI handling in the frontend components. The `InAppPurchaseCard` component was only differentiating between puzzle and non-puzzle apps, lumping all other mobile subscriptions (including Feast) under the "Live App" category.

## Solution
This PR implements comprehensive Feast app subscription support:

<img width="1496" height="727" alt="Screenshot 2025-08-01 at 15 31 21 (1)" src="https://github.com/user-attachments/assets/0a676466-560c-4c48-ac3a-37de3af6cdda" />

### Detection Utilities (`shared/mpapiResponse.ts`)
- Added `isFeast()` function to identify Feast subscriptions by productId pattern
- Follows existing pattern used by `isPuzzle()` function

### UI Components (`components/mma/accountoverview/InAppPurchaseCard.tsx`)
- Extended subscription type detection to handle Feast apps
- Added conditional logic to display "Feast" app type for Feast subscriptions

### Styling (`components/mma/accountoverview/ProductCardConfiguration.ts`)
- Kept the same product color palette
- Ensures Feast app cards have the same theming as the Live App

## Expected Outcome
- Feast app subscribers will see accurate "Feast" subscription type instead of "Live App"
- Feast subscription cards will display with the Live App theming
- No impact on existing news app or puzzle app subscription displays

## Testing
- [ ] Verify Feast subscriptions display as "Feast" app type
- [ ] Confirm Live App color theming is applied to Feast subscription cards
- [ ] Ensure existing Live app and Puzzle app displays remain unchanged