### PR TITLE
point help centre CODE at the new live Chat testing sandbox

### DIFF
--- a/client/components/helpCentre/liveChat/LiveChat.tsx
+++ b/client/components/helpCentre/liveChat/LiveChat.tsx
@@ -183,20 +183,20 @@ const initESW = (
 		} else {
 			// Initialise live chat API for DEV1 test sandbox
 			liveChatAPI.init(
-				'https://gnmtouchpoint--dev1.sandbox.my.salesforce.com',
-				'https://gnmtouchpoint--dev1.sandbox.my.salesforce-sites.com/liveagent',
+				'https://gnmtouchpoint--livechat.sandbox.my.salesforce.com',
+				'https://gnmtouchpoint--livechat.sandbox.my.salesforce-sites.com/liveagent',
 				gslbBaseUrl,
-				'00D9E0000004jvh',
+				'00DVc000003BA0j',
 				'Chat_Team',
 				{
 					baseLiveAgentContentURL:
-						'https://c.la2-c1cs-fra.salesforceliveagent.com/content',
-					deploymentId: '5729E000000CbOY',
-					buttonId: '5739E0000008QCo',
+						'https://c.la12s-core1.sfdc-cehfhs.salesforceliveagent.com/content',
+					deploymentId: '5725I0000004RYv',
+					buttonId: '5735I0000004Rj7',
 					baseLiveAgentURL:
-						'https://d.la2-c1cs-fra.salesforceliveagent.com/chat',
+						'https://d.la12s-core1.sfdc-cehfhs.salesforceliveagent.com/chat',
 					eswLiveAgentDevName:
-						'EmbeddedServiceLiveAgent_Parent04I9E0000008OxDUAU_1797a576c18',
+						'EmbeddedServiceLiveAgent_Parent04I5I0000004LLTUA2_1797a9534a2',
 					isOfflineSupportEnabled: false,
 				},
 			);


### PR DESCRIPTION
### Current situation/background
The [Help Centre](https://manage.theguardian.com/help-centre) hosts our Live Chat implementation, which is powered by Salesforce. This current setup uses a legacy product (Live Agent) to configure Live Chat in Salesforce and Help Centre. Live Agent is being retired on February 14th 2026 and will need to be replaced with the newest configuration (Messaging for In App and Web). Messaging for In App and Web offers more advanced features and lays the groundwork for future use of bots and Agentic AI over the long term.

The following documentation provides an overview of the project as a whole:
[Trello Card](https://trello.com/c/RURR6iCM/65-sf-live-chat-deprecation-update) 
[SPIKE document into migration to Messaging for In App and Web](https://docs.google.com/document/d/1ZFCO9hcL8Ft2xZpt3dOhUPg7JSmpzKf9mZynse_ku5k/edit?tab=t.0#heading=h.f17exinaf1z)

### What does this PR change?
This PR points Help Centre CODE at a new Salesforce development environment (called LiveChat). This new development environment is to be used exclusively used for the migration of Live Chat from Live Agent to Messaging for In App and Web.

### Next steps/further info
Once we're happy that Help Centre CODE and the Salesforce LiveChat development environment are connected, we can begin with rebuilding Live Chat using Messaging for In App and Web.
