### PR TITLE
Revert QM hash change

### DIFF
--- a/client/utilities/hooks/useAnalytics.ts
+++ b/client/utilities/hooks/useAnalytics.ts
@@ -12,7 +12,7 @@ export const useAnalytics = () => {
 				{
 					async: true,
 					integrity:
-						'sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb',
+						'sha384-VMLIC70VzACtZAEkPaL+7xW+v0+UjkIUuGxlArtIG+Pzqlp5DkbfVG9tRm75Liwx',
 					crossOrigin: 'anonymous',
 				},
 			).catch(() => {


### PR DESCRIPTION
### Current situation/background

No traffic has been going to Quantum Metric since July 15.

### What does this PR change?

This reverts the Quantum Metric hash that was changed here https://github.com/guardian/manage-frontend/pull/1531 and caused the issue.

### Next steps/further info

Tested in CODE

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->
