### PR TITLE
Allows United States based users to get the cancellation switch offer

### DIFF
--- a/client/components/mma/cancel/cancellationSaves/CancelAlternativeSwitchReview.tsx
+++ b/client/components/mma/cancel/cancellationSaves/CancelAlternativeSwitchReview.tsx
@@ -363,9 +363,10 @@ export const CancelAlternativeSwitchReview = () => {
 							Your payment of {mainPlan.currency}
 							{routerState.amountPayableToday} will be taken on{' '}
 							{humanReadableNextPaymentDate} for the next 12
-							months then {mainPlan.currency}
-							{routerState.supporterPlusPurchaseAmount}/year. Auto
-							renews every year until you cancel.
+							months. After that, you will be charged the standard
+							pricing, using your chosen payment method at each
+							renewal, at the rate then in effect, unless you
+							cancel.
 						</li>
 						<li>You may cancel your subscription at any time.</li>
 					</ul>

--- a/client/components/mma/cancel/cancellationSaves/saveEligibilityCheck.ts
+++ b/client/components/mma/cancel/cancellationSaves/saveEligibilityCheck.ts
@@ -69,4 +69,4 @@ export const reasonIsEligibleForSwitch = (
 
 export const allowCountrySwitchDiscount = (
 	billingCountry: string | undefined,
-) => billingCountry === 'United Kingdom';
+) => ['United Kingdom', 'United States'].includes(billingCountry || '');


### PR DESCRIPTION
### Current situation/background

We need to expand our cancellation journey incentives to the US for Recurring contributor annual users. The offer, switch to All Access Digital (Supporter Plus) is currently only available in the UK and we now have agreement we can make this available in the US.

### What does this PR change?

- Extends the switch discount availability to United States based users
- Updates the corresponding copy in the Switch Review page

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->
