### PR TITLE
[DNM] Fixes issue with cancellation endpoints not passing testUser headers

### DIFF
--- a/client/components/mma/cancel/CancellationReasonReview.tsx
+++ b/client/components/mma/cancel/CancellationReasonReview.tsx
@@ -356,6 +356,9 @@ const ConfirmCancellationAndReturnRow = (
 								subscriptionNumber:
 									productDetail.subscription.subscriptionId,
 							}),
+							headers: {
+								[MDA_TEST_USER_HEADER]: `${productDetail.isTestUser}`,
+							},
 						},
 					);
 

--- a/client/components/mma/cancel/CancellationReasonReview.tsx
+++ b/client/components/mma/cancel/CancellationReasonReview.tsx
@@ -357,6 +357,7 @@ const ConfirmCancellationAndReturnRow = (
 									productDetail.subscription.subscriptionId,
 							}),
 							headers: {
+								'Content-Type': 'application/json',
 								[MDA_TEST_USER_HEADER]: `${productDetail.isTestUser}`,
 							},
 						},

--- a/client/components/mma/cancel/stages/ExecuteCancellation.tsx
+++ b/client/components/mma/cancel/stages/ExecuteCancellation.tsx
@@ -9,7 +9,10 @@ import type {
 	MembersDataApiResponse,
 	ProductDetail,
 } from '../../../../../shared/productResponse';
-import { isProduct } from '../../../../../shared/productResponse';
+import {
+	isProduct,
+	MDA_TEST_USER_HEADER,
+} from '../../../../../shared/productResponse';
 import type {
 	ProductType,
 	ProductTypeWithCancellationFlow,
@@ -50,6 +53,7 @@ const getCancelFunc =
 		productType: ProductType,
 		reason: OptionalCancellationReasonId,
 		withSubscriptionResponseFetcher: () => Promise<Response>,
+		productDetail: ProductDetail,
 	) =>
 	async () => {
 		const isSupporterPlus =
@@ -62,7 +66,10 @@ const getCancelFunc =
 			{
 				method: 'POST',
 				body: JSON.stringify({ reason }),
-				headers: { 'Content-Type': 'application/json' },
+				headers: {
+					'Content-Type': 'application/json',
+					[MDA_TEST_USER_HEADER]: `${productDetail.isTestUser}`,
+				},
 			},
 		); // response is either empty or 404 - neither is useful so fetch subscription to determine cancellation result...
 
@@ -263,6 +270,7 @@ export const ExecuteCancellation = () => {
 								productType.allProductsProductTypeFilterString,
 								productDetail.subscription.subscriptionId,
 							),
+							productDetail,
 						)}
 						render={getCaseUpdatingCancellationSummary(
 							productType,


### PR DESCRIPTION
### Current situation/background

I noticed this issue while testing the new Student offer's cancellation journey. This is preventing me from testing in CODE at the moment.

### What does this PR change?

Fixes the issue with test user header not being passed properly for the cancellation and preview-discount endpoints.

### Next steps/further info

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->
