### PR TITLE
fix subscribe again url to not have a double slash

### DIFF
--- a/client/components/mma/accountoverview/CancelledProductCard.tsx
+++ b/client/components/mma/accountoverview/CancelledProductCard.tsx
@@ -99,7 +99,7 @@ export const CancelledProductCard = ({
 						<div css={wideButtonLayoutCss}>
 							{showSubscribeAgainButton && (
 								<LinkButton
-									href={`https://support.theguardian.com/${specificProductType.checkoutUrlPart}`}
+									href={`https://support.theguardian.com${specificProductType.checkoutUrlPart}`}
 									size="small"
 									cssOverrides={css`
 										justify-content: center;


### PR DESCRIPTION
The support again url is broken on manage, due to a double slash inadvertantly added in https://github.com/guardian/manage-frontend/pull/1472

This PR takes out the slash from the template so that there should only be one