### PR TITLE
Change Cancellation Message for one-off payment and renewal status in ProductCard

### DIFF
--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -566,17 +566,24 @@ export const ProductCard = ({
 											max-width: 350px;
 										`}
 									>
-										{!productDetail.subscription.autoRenew &&
+										{!productDetail.subscription
+											.autoRenew &&
 										!productDetail.subscription
-											.nextPaymentDate ? (<>
-												This is a one-off payment and will
-												not renew. You’ll continue to enjoy
-												your benefits until the end of the
-												current billing period.
-											</>) : (<>
-												Stop your recurring payment, at the
-												end of current billing period.
-											</>)}
+											.nextPaymentDate ? (
+											<>
+												This is a one-off payment and
+												will not renew. You’ll continue
+												to enjoy your benefits until the
+												end of the current billing
+												period.
+											</>
+										) : (
+											<>
+												Stop your recurring payment, at
+												the end of current billing
+												period.
+											</>
+										)}
 									</p>
 								</div>
 								<div css={wideButtonLayoutCss}>

--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -561,29 +561,23 @@ export const ProductCard = ({
 									<h4 css={sectionHeadingCss}>
 										Cancel {groupedProductType.friendlyName}
 									</h4>
-									{!productDetail.subscription.autoRenew &&
-									!productDetail.subscription
-										.nextPaymentDate ? (
-										<p
-											css={css`
-												max-width: 350px;
-											`}
-										>
-											This is a one-off payment and will
-											not renew. You’ll continue to enjoy
-											your benefits until the end of the
-											current billing period.
-										</p>
-									) : (
-										<p
-											css={css`
-												max-width: 350px;
-											`}
-										>
-											Stop your recurring payment, at the
-											end of current billing period.
-										</p>
-									)}
+									<p
+										css={css`
+											max-width: 350px;
+										`}
+									>
+										{!productDetail.subscription.autoRenew &&
+										!productDetail.subscription
+											.nextPaymentDate ? (<>
+												This is a one-off payment and will
+												not renew. You’ll continue to enjoy
+												your benefits until the end of the
+												current billing period.
+											</>) : (<>
+												Stop your recurring payment, at the
+												end of current billing period.
+											</>)}
+									</p>
 								</div>
 								<div css={wideButtonLayoutCss}>
 									<Button

--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -563,7 +563,7 @@ export const ProductCard = ({
 									</h4>
 									{!productDetail.subscription.autoRenew &&
 									!productDetail.subscription
-										.chargedThroughDate ? (
+										.nextPaymentDate ? (
 										<p
 											css={css`
 												max-width: 350px;
@@ -584,14 +584,6 @@ export const ProductCard = ({
 											end of current billing period.
 										</p>
 									)}
-									<p
-										css={css`
-											max-width: 350px;
-										`}
-									>
-										Stop your recurring payment, at the end
-										of current billing period.
-									</p>
 								</div>
 								<div css={wideButtonLayoutCss}>
 									<Button

--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -561,6 +561,29 @@ export const ProductCard = ({
 									<h4 css={sectionHeadingCss}>
 										Cancel {groupedProductType.friendlyName}
 									</h4>
+									{!productDetail.subscription.autoRenew &&
+									!productDetail.subscription
+										.chargedThroughDate ? (
+										<p
+											css={css`
+												max-width: 350px;
+											`}
+										>
+											This is a one-off payment and will
+											not renew. You’ll continue to enjoy
+											your benefits until the end of the
+											current billing period.
+										</p>
+									) : (
+										<p
+											css={css`
+												max-width: 350px;
+											`}
+										>
+											Stop your recurring payment, at the
+											end of current billing period.
+										</p>
+									)}
 									<p
 										css={css`
 											max-width: 350px;


### PR DESCRIPTION
### Current situation/background

After an e2e testing for the student page, a reference to recurring payment and cancellation on MMA was spotted. After some research we found out that the "Cancellation Subscription" feature only is displayed for subscriptions with United States as billing country, making it the reason why we missed this to begin with.

### What does this PR change?

Changes the copywriting of this feature when a subscription as no auto-renew and as no next Payment Date.

### Next steps/further info

The original conversation could be read [here](https://chat.google.com/room/AAQAK5a5stM/aE9hJ-FO4dw/aE9hJ-FO4dw?cls=10).

### New appearance
| Before    | After |
| -------- | ------- |
| <img width="898" height="807" alt="Screenshot 2025-09-17 at 15 04 35" src="https://github.com/user-attachments/assets/be7ed23a-be35-41e9-b061-eb0a0f5c3672" /> | <img width="1438" height="1012" alt="Screenshot 2025-09-17 at 16 03 13" src="https://github.com/user-attachments/assets/33c3ddc8-7004-48e8-a17b-d13617747ce0" /> |