### PR TITLE
Canada Strike Message

### DIFF
--- a/client/components/mma/accountoverview/AccountOverview.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.tsx
@@ -55,6 +55,7 @@ import { NewspaperArchiveCta } from '../shared/NewspaperArchiveCta';
 import { nonServiceableCountries } from '../shared/NonServiceableCountries';
 import { PaymentFailureAlertIfApplicable } from '../shared/PaymentFailureAlertIfApplicable';
 import { ProblemAlert } from '../shared/ProblemAlert';
+import { CanadaStrike } from './CanadaStrike';
 import { CancelledProductCard } from './CancelledProductCard';
 import { EmptyAccountOverview } from './EmptyAccountOverview';
 import { InAppPurchaseCard } from './InAppPurchaseCard';
@@ -255,6 +256,18 @@ const AccountOverviewPage = ({ isFromApp }: IsFromAppProps) => {
 		return specificProductType.groupedProductType;
 	};
 
+	const possiblyAffectedByCanadaPostStrike = allActiveProductDetails.some(
+		(product) => {
+			const deliveryCountry =
+				product.subscription.deliveryAddress?.country.toUpperCase();
+			return (
+				(product.mmaProductKey === 'Tier Three' ||
+					product.mmaProductKey === 'Guardian Weekly - ROW') &&
+				(deliveryCountry === 'CANADA' || deliveryCountry === 'CA')
+			);
+		},
+	);
+
 	return (
 		<>
 			<PersonalisedHeader
@@ -279,6 +292,7 @@ const AccountOverviewPage = ({ isFromApp }: IsFromAppProps) => {
 					}
 				/>
 			)}
+			{possiblyAffectedByCanadaPostStrike && <CanadaStrike />}
 			{uniqueProductCategories.map((category) => {
 				const groupedProductType = GROUPED_PRODUCT_TYPES[category];
 				const activeProductsInCategory = allActiveProductDetails.filter(

--- a/client/components/mma/accountoverview/CanadaStrike.tsx
+++ b/client/components/mma/accountoverview/CanadaStrike.tsx
@@ -1,0 +1,37 @@
+import { css } from '@emotion/react';
+import { Link } from '@guardian/source/react-components';
+import { ProblemAlert } from '../shared/ProblemAlert';
+
+export const CanadaStrike = () => (
+	<ProblemAlert
+		message={
+			<div>
+				<p>
+					Due to industrial action by Canada Post, it is not possible
+					to deliver your copies of the Guardian Weekly. You are
+					welcome to pause your subscription during the period of
+					industrial action, details on how to do so can be found{' '}
+					<Link
+						href="https://manage.theguardian.com/help-centre/article/i-need-to-pause-my-delivery"
+						priority="primary"
+					>
+						here
+					</Link>
+					.
+				</p>
+				<p>
+					If you have reached your allowance limit please contact{' '}
+					<Link
+						href="mailto:customer.help@theguardian.com"
+						priority="primary"
+					>
+						customer.help@theguardian.com
+					</Link>
+				</p>
+			</div>
+		}
+		additionalcss={css`
+			margin-top: 30px;
+		`}
+	/>
+);


### PR DESCRIPTION
### Current situation/background

Add a message/alert to the top of the account overview page for Canadian customers who have a Guardian Weekly or Tier Three subscription while the Canadian post strike is active informing them that they can suspend their deliveries.

<img width="2750" height="1082" alt="image" src="https://github.com/user-attachments/assets/fdbcc6e7-62e7-436a-9aeb-9df8e45a431f" />