### PR TITLE
Removes canada banner to solve potential bug with country

### DIFF
--- a/client/components/mma/accountoverview/AccountOverview.tsx
+++ b/client/components/mma/accountoverview/AccountOverview.tsx
@@ -55,7 +55,6 @@ import { NewspaperArchiveCta } from '../shared/NewspaperArchiveCta';
 import { nonServiceableCountries } from '../shared/NonServiceableCountries';
 import { PaymentFailureAlertIfApplicable } from '../shared/PaymentFailureAlertIfApplicable';
 import { ProblemAlert } from '../shared/ProblemAlert';
-import { CanadaStrike } from './CanadaStrike';
 import { CancelledProductCard } from './CancelledProductCard';
 import { EmptyAccountOverview } from './EmptyAccountOverview';
 import { InAppPurchaseCard } from './InAppPurchaseCard';
@@ -256,18 +255,6 @@ const AccountOverviewPage = ({ isFromApp }: IsFromAppProps) => {
 		return specificProductType.groupedProductType;
 	};
 
-	const possiblyAffectedByCanadaPostStrike = allActiveProductDetails.some(
-		(product) => {
-			const deliveryCountry =
-				product.subscription.deliveryAddress?.country.toUpperCase();
-			return (
-				(product.mmaProductKey === 'Tier Three' ||
-					product.mmaProductKey === 'Guardian Weekly - ROW') &&
-				(deliveryCountry === 'CANADA' || deliveryCountry === 'CA')
-			);
-		},
-	);
-
 	return (
 		<>
 			<PersonalisedHeader
@@ -292,7 +279,6 @@ const AccountOverviewPage = ({ isFromApp }: IsFromAppProps) => {
 					}
 				/>
 			)}
-			{possiblyAffectedByCanadaPostStrike && <CanadaStrike />}
 			{uniqueProductCategories.map((category) => {
 				const groupedProductType = GROUPED_PRODUCT_TYPES[category];
 				const activeProductsInCategory = allActiveProductDetails.filter(


### PR DESCRIPTION
### Current situation/background

The Cannada Strike banner introduced last week might be causing an issue in MMA, as it's expecting `country` when deliveryAddress is present for a subscription. I've been advised to remove the banner for now.

### What does this PR change?

- Removes the CanadaStrike banner condition for eligibility

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->
