### PR TITLE
Add Canada Post strike Help Centre banner

### DIFF
--- a/client/components/helpCentre/HelpCentrePage.tsx
+++ b/client/components/helpCentre/HelpCentrePage.tsx
@@ -81,7 +81,7 @@ const HelpCentreRouter = () => {
 		{
 			date: '7th Oct 2025 11:30 am',
 			message:
-				'Due to industrial action by Canada Post, it is currently not possible to deliver copies of the Guardian Weekly for Canadian subscribers. Subscribers are welcome to pause subscriptions during the period of industrial action, details on how to do so can be found <a href="https://manage.theguardian.com/help-centre/article/i-need-to-pause-my-delivery">here</a>.',
+				'Due to industrial action by Canada Post, it is currently not possible to deliver copies of the Guardian Weekly for Canadian subscribers. Subscribers are welcome to pause subscriptions during the period of industrial action.',
 		},
 	];
 

--- a/client/components/helpCentre/HelpCentrePage.tsx
+++ b/client/components/helpCentre/HelpCentrePage.tsx
@@ -77,7 +77,13 @@ const HelpCentreRouter = () => {
 	]
 	*/
 
-	const knownIssues: KnownIssueObj[] = [];
+	const knownIssues: KnownIssueObj[] = [
+		{
+			date: '7th Oct 2025 11:30 am',
+			message:
+				'Due to industrial action by Canada Post, it is currently not possible to deliver copies of the Guardian Weekly for Canadian subscribers. Subscribers are welcome to pause subscriptions during the period of industrial action, details on how to do so can be found <a href="https://manage.theguardian.com/help-centre/article/i-need-to-pause-my-delivery">here</a>.',
+		},
+	];
 
 	return (
 		<Main signInStatus={signInStatus} isHelpCentrePage>


### PR DESCRIPTION
### Current situation/background

Ongoing postal strikes in Canada mean that Guardian Weekly subscribers are currently not receiving their publications.

### What does this PR change?

Adds a banner to the Help Centre with some basic information about the situation:

<img width="868" height="667" alt="Screenshot 2025-10-07 at 15 11 27" src="https://github.com/user-attachments/assets/166aad07-4f29-4e9a-b1d4-eb3dfbdd4201" />

> [!NOTE]
> We also plan to add a banner to the MMA account overview specifically for Canadian GW subscribers, see #1558  

### Next steps/further info

When the strikes are resolved, we will remove the banner again.