### PR TITLE
Implements digital benefits to weekly product and refactors benefits copy logic

### DIFF
--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -293,24 +293,19 @@ export const ProductCard = ({
 					)}
 				</Card.Header>
 
-				{(cardConfig.showBenefitsSection ||
-					cardConfig.showDigitalBenefitsSection ||
-					cardConfig.showUnlimitedDigitalBenefitsSection) &&
-					nextPaymentDetails && (
-						<Card.Section backgroundColor="#edf5fA" removeBorders>
-							<p css={benefitsTextCss}>
-								{cardConfig.showDigitalBenefitsSection
-									? `You’re supporting the Guardian with ${nextPaymentDetails.currentPriceValue} per ${nextPaymentDetails.paymentInterval}, and have unlocked the full digital experience:`
-									: cardConfig.showUnlimitedDigitalBenefitsSection
-									? `You’re subscribed to the Guardian for ${nextPaymentDetails.currentPriceValue} per ${nextPaymentDetails.paymentInterval}, unlocking unlimited digital benefits.`
-									: `You’re supporting the Guardian with ${nextPaymentDetails.currentPriceValue} per ${nextPaymentDetails.paymentInterval}, and have access to exclusive extras.`}
-							</p>
-							<BenefitsToggle
-								productType={specificProductType.productType}
-								subscriptionPlan={mainPlan}
-							/>
-						</Card.Section>
-					)}
+				{cardConfig.getBenefitsSectionCopy && nextPaymentDetails && (
+					<Card.Section backgroundColor="#edf5fA" removeBorders>
+						<p css={benefitsTextCss}>
+							{cardConfig.getBenefitsSectionCopy(
+								nextPaymentDetails,
+							)}
+						</p>
+						<BenefitsToggle
+							productType={specificProductType.productType}
+							subscriptionPlan={mainPlan}
+						/>
+					</Card.Section>
+				)}
 				{specificProductType.productType === 'guardianadlite' &&
 					nextPaymentDetails && (
 						<Card.Section backgroundColor="#edf5fA">

--- a/client/components/mma/accountoverview/ProductCardConfiguration.ts
+++ b/client/components/mma/accountoverview/ProductCardConfiguration.ts
@@ -1,5 +1,6 @@
 import { palette } from '@guardian/source/foundations';
 import type { ProductTypeKeys } from '@/shared/productTypes';
+import type { NextPaymentDetails } from '../shared/NextPaymentDetails';
 
 export const textColour = {
 	light: palette.neutral[100],
@@ -19,36 +20,28 @@ export const productColour = {
 	recurringContribution: palette.brand[600],
 	newspaper: palette.brand[400],
 	digital: palette.brand[300],
-	guardianWeekly: '#cadbe8',
+	guardianWeekly: palette.brand[500],
 	puzzleApp: palette.lifestyle[300],
 	feastApp: palette.brand[800], // Same color as Live app (inAppPurchase)
 };
 
-type ExclusiveBenefitsSections =
-	| {
-			showBenefitsSection: true;
-			showDigitalBenefitsSection: false;
-			showUnlimitedDigitalBenefitsSection: false;
-	  }
-	| {
-			showBenefitsSection: false;
-			showDigitalBenefitsSection: true;
-			showUnlimitedDigitalBenefitsSection: false;
-	  }
-	| {
-			showBenefitsSection: false;
-			showDigitalBenefitsSection: false;
-			showUnlimitedDigitalBenefitsSection: true;
-	  };
-
-interface ProductCardBase {
+interface ProductCardConfiguration {
 	colour: string;
 	invertText?: boolean;
+	getBenefitsSectionCopy?: (nextPaymentDetails: NextPaymentDetails) => string;
 }
 
-// Type enforces XOR options on the benefits section
-type ProductCardConfiguration = ProductCardBase &
-	Partial<ExclusiveBenefitsSections>;
+const supporterBenefitsCopy = (npd: NextPaymentDetails) =>
+	`You're supporting the Guardian with ${npd.currentPriceValue} per ${npd.paymentInterval}, and have access to exclusive extras.`;
+
+const digitalBenefitsCopy = (npd: NextPaymentDetails) =>
+	`You're supporting the Guardian with ${npd.currentPriceValue} per ${npd.paymentInterval}, and have unlocked the full digital experience:`;
+
+const unlimitedDigitalBenefitsCopy = (npd: NextPaymentDetails) =>
+	`You're subscribed to the Guardian for ${npd.currentPriceValue} per ${npd.paymentInterval}, unlocking unlimited digital benefits.`;
+
+const guardianWeeklyBenefitsCopy = (npd: NextPaymentDetails) =>
+	`You're subscribed to The Guardian Weekly for ${npd.currentPriceValue} per ${npd.paymentInterval} and receive a curated news magazine featuring our best global journalism in print, as well as unlimited access to our full suite of digital benefits.`;
 
 /**
  * In-app purchases have their own dedicated product card component so are not
@@ -68,25 +61,25 @@ export const productCardConfiguration: Record<
 	},
 	supporterplus: {
 		colour: productColour.supporterPlus,
-		showBenefitsSection: true,
+		getBenefitsSectionCopy: supporterBenefitsCopy,
 	},
 	guardianadlite: {
 		colour: productColour.supporterPlus,
 	},
 	tierthree: {
 		colour: productColour.supporterPlus,
-		showBenefitsSection: true,
+		getBenefitsSectionCopy: supporterBenefitsCopy,
 	},
 	digipack: {
 		colour: productColour.digital,
-		showUnlimitedDigitalBenefitsSection: true,
+		getBenefitsSectionCopy: unlimitedDigitalBenefitsCopy,
 	},
 	digitalvoucher: {
 		colour: productColour.newspaper,
 	},
 	digitalvoucherplusdigital: {
 		colour: productColour.newspaper,
-		showDigitalBenefitsSection: true,
+		getBenefitsSectionCopy: digitalBenefitsCopy,
 	},
 	newspaper: {
 		colour: productColour.newspaper,
@@ -96,29 +89,29 @@ export const productCardConfiguration: Record<
 	},
 	homedeliveryplusdigital: {
 		colour: productColour.newspaper,
-		showDigitalBenefitsSection: true,
+		getBenefitsSectionCopy: digitalBenefitsCopy,
 	},
 	nationaldelivery: {
 		colour: productColour.newspaper,
 	},
 	nationaldeliveryplusdigital: {
 		colour: productColour.newspaper,
-		showDigitalBenefitsSection: true,
+		getBenefitsSectionCopy: digitalBenefitsCopy,
 	},
 	voucher: {
 		colour: productColour.newspaper,
 	},
 	voucherplusdigital: {
 		colour: productColour.newspaper,
-		showDigitalBenefitsSection: true,
+		getBenefitsSectionCopy: digitalBenefitsCopy,
 	},
 	guardianweekly: {
 		colour: productColour.guardianWeekly,
-		invertText: true,
+		getBenefitsSectionCopy: guardianWeeklyBenefitsCopy,
 	},
 	membership: {
 		colour: productColour.membership,
-		showBenefitsSection: true,
+		getBenefitsSectionCopy: supporterBenefitsCopy,
 	},
 	guardianpatron: {
 		colour: productColour.membership,

--- a/client/components/mma/shared/benefits/BenefitsConfiguration.ts
+++ b/client/components/mma/shared/benefits/BenefitsConfiguration.ts
@@ -32,8 +32,8 @@ const adFree = {
 };
 
 const guardianWeekly = {
-	name: 'Guardian Weekly.',
-	description: 'Print magazine delivered to your door every week',
+	name: 'The Guardian Weekly',
+	description: 'magazine, delivered to your door every week',
 };
 
 const partnerOffers: ProductBenefit = {
@@ -42,30 +42,34 @@ const partnerOffers: ProductBenefit = {
 	specificToRegions: ['AUD'],
 };
 
+const newspaperArchiveBenefit = {
+	description: "Digital access to the Guardian's 200-year newspaper archive",
+};
+
 const productPlusdigitalBenefits = [
 	{
+		name: 'Ad-free reading',
 		description:
-			'Unlimited access to the refreshed Guardian app and Guardian Feast app',
+			'and fewer asks of support on the Guardian app and website',
 	},
 	{
 		description:
-			'Unlimited access to the Guardian Editions app so you can enjoy newspapers on your mobile and tablet',
+			'Unlimited access to the Guardian app and Guardian Feast app',
 	},
-	{ description: 'Ad-free reading on all your devices' },
 	{
 		description:
-			'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
+			'Exclusive supporter newsletters, and a weekly newsletter from The Guardian Weekly editor',
 	},
-	{ description: 'Far fewer asks for support' },
+	{
+		description:
+			'Access to the Guardian Editions app, where you can enjoy digital versions of our newspapers and magazines on your phone or tablet',
+	},
 ];
 
 const digitalPlusBenefits = [
 	{ description: 'Guardian Weekly e-magazine' },
 	{ description: 'The Long Read e-magazine' },
-	{
-		description:
-			"Digital access to the Guardian's 200 year newspaper archive",
-	},
+	newspaperArchiveBenefit,
 	{ description: 'Far fewer asks for support' },
 	{ description: 'Ad-free reading on all your devices' },
 	{ description: 'Unlimited access to the premium Guardian app' },
@@ -142,7 +146,11 @@ export const benefitsConfiguration: Record<ProductTypeKeys, ProductBenefit[]> =
 		nationaldeliveryplusdigital: [...productPlusdigitalBenefits],
 		voucher: [],
 		voucherplusdigital: [...productPlusdigitalBenefits],
-		guardianweekly: [],
+		guardianweekly: [
+			guardianWeekly,
+			...productPlusdigitalBenefits,
+			newspaperArchiveBenefit,
+		],
 		guardianadlite: [],
 		guardianpatron: [],
 		observer: [],
@@ -190,10 +198,7 @@ export const getUpsellBenefits = (
 				{
 					description: 'The Long Read e-magazine',
 				},
-				{
-					description:
-						'Digital access to the Guardian’s 200 year newspaper archive',
-				},
+				newspaperArchiveBenefit,
 				{
 					description: 'Daily digital Guardian newspaper',
 				},


### PR DESCRIPTION
### Current situation/background

The benefits section in the product card uses three mutually exclusive boolean flags (showBenefitsSection, showDigitalBenefitsSection, showUnlimitedDigitalBenefitsSection) with a nested ternary in JSX to select the correct copy. Guardian Weekly had no benefits listed and no dedicated copy.

### What does this PR change?

- Replaces the three boolean flags with a single getBenefitsSectionCopy function on the product card config, which receives nextPaymentDetails and returns the appropriate copy string. This simplifies the JSX from a nested ternary to a single function call.
- Adds dedicated benefits copy for Guardian Weekly describing the print magazine and digital benefits.
- Populates Guardian Weekly's benefits list with the weekly magazine, digital benefits, and newspaper archive.
- Extracts newspaperArchiveBenefit as a shared constant to avoid duplication.
- Updates Guardian Weekly product card colour and removes invertText.

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->
