### PR TITLE
Add billing frequency preview response handler to manage Sentry alerts

### DIFF
--- a/client/components/mma/accountoverview/ManageProduct.tsx
+++ b/client/components/mma/accountoverview/ManageProduct.tsx
@@ -435,13 +435,18 @@ const billingFrequencyPreviewResponseHandler = (
 	response: Response | Response[],
 ): Promise<BillingFrequencySwitchPreview | null> => {
 	const r = Array.isArray(response) ? response[0] : response;
+	if (!r) {
+		return Promise.reject(
+			new Error('Expected billing frequency preview response'),
+		);
+	}
 	// A 400 means the user is ineligible (e.g. non-zero contribution amount).
 	// Treat this as "no preview available" rather than an error to avoid
 	// spurious Sentry noise for an expected business condition.
 	if (r.status === 400) {
 		return Promise.resolve(null);
 	}
-	return JsonResponseHandler(response);
+	return JsonResponseHandler(r);
 };
 
 const AsyncLoadedSwitchBillingFrequencyPreview = ({

--- a/client/components/mma/accountoverview/ManageProduct.tsx
+++ b/client/components/mma/accountoverview/ManageProduct.tsx
@@ -452,7 +452,7 @@ const AsyncLoadedSwitchBillingFrequencyPreview = ({
 	productDetail: ProductDetail;
 }) => {
 	const { data, loadingState } =
-		useAsyncLoader<BillingFrequencySwitchPreview>(
+		useAsyncLoader<BillingFrequencySwitchPreview | null>(
 			() =>
 				changeSubscriptionBillingFrequencyFetch(
 					productDetail.isTestUser,
@@ -480,7 +480,7 @@ const AsyncLoadedSwitchBillingFrequencyPreview = ({
 		<InnerContent
 			manageProductProps={manageProductProps}
 			productDetail={productDetail}
-			billingFrequencySwitchPreview={data!}
+			billingFrequencySwitchPreview={data ?? undefined}
 		/>
 	);
 };

--- a/client/components/mma/accountoverview/ManageProduct.tsx
+++ b/client/components/mma/accountoverview/ManageProduct.tsx
@@ -431,6 +431,19 @@ interface ManageProductRouterState {
 	productDetail: ProductDetail;
 }
 
+const billingFrequencyPreviewResponseHandler = (
+	response: Response | Response[],
+): Promise<BillingFrequencySwitchPreview | null> => {
+	const r = Array.isArray(response) ? response[0] : response;
+	// A 400 means the user is ineligible (e.g. non-zero contribution amount).
+	// Treat this as "no preview available" rather than an error to avoid
+	// spurious Sentry noise for an expected business condition.
+	if (r.status === 400) {
+		return Promise.resolve(null);
+	}
+	return JsonResponseHandler(response);
+};
+
 const AsyncLoadedSwitchBillingFrequencyPreview = ({
 	manageProductProps,
 	productDetail,
@@ -447,7 +460,7 @@ const AsyncLoadedSwitchBillingFrequencyPreview = ({
 					true,
 					'Annual',
 				),
-			JsonResponseHandler,
+			billingFrequencyPreviewResponseHandler,
 		);
 
 	if (loadingState == LoadingState.HasError) {


### PR DESCRIPTION
### Current situation/background

Since January 12, 2026, the Switch Billing Frequency (SBF) feature began firing a high volume of `"Invalid API response"` exceptions in Sentry. These were caused by `POST /api/product-switch/billing-frequency/{subscriptionId}` returning a `400` for SupporterPlus Monthly subscribers who have a non-zero extra contribution amount (a valid business eligibility condition meaning the user cannot switch billing frequency).

The endpoint handles both preview and execute via a `preview: boolean` field in the request body. The contribution check is on the shared code path (`selectCandidateSubscriptionCharge`) that runs before the preview/execute branch, so both calls would return 400 for ineligible users. In practice the first call from the UI would be with `preview: true`.

The `AsyncLoadedSwitchBillingFrequencyPreview` component in ManageProduct.tsx used `JsonResponseHandler` to process the response. That handler throws on **any** non-2xx status, and `useAsyncLoader` unconditionally calls `Sentry.captureException` on every thrown error — with no distinction between an unexpected error and an expected eligibility rejection.

The component already handled the error state gracefully (falling back silently to the regular manage product UI), but Sentry was still flooded with noise for every ineligible user who visited their account overview.

> **Note:** The above description of `AsyncLoadedSwitchBillingFrequencyPreview`, `JsonResponseHandler`, `useAsyncLoader`, and the Sentry call behaviour is based on the frontend repo and has not been independently verified from this backend repo.

### What does this PR change?

Replaces `JsonResponseHandler` with a purpose-built `billingFrequencyPreviewResponseHandler` in `AsyncLoadedSwitchBillingFrequencyPreview`. The new handler:

- Returns `null` (resolved, not rejected) for `400` responses, treating ineligibility as a known non-error outcome
- Delegates to `JsonResponseHandler` for all other status codes, preserving Sentry reporting for genuine unexpected errors (4xx other than 400, 5xx, network failures)

No change to user-visible behaviour — ineligible users already saw the normal product management UI. This purely stops the spurious Sentry noise.

### Next steps/further info

- The backend `frequencySwitchHandler` is the only endpoint in this repo that returns `{ "reason": "..." }` JSON on a `400` instead of the plain string that the `Router` returns for all other `ValidationError`s. This inconsistency is harmless after this fix but could be cleaned up for consistency
- Longer term, the API could return a `200` with `{ eligible: false }` for eligibility checks, which is semantically cleaner than using a `400` for an expected business state