### PR TITLE
Stabilize help-centre Sentry fetch errors

### DIFF
--- a/client/components/helpCentre/HelpCentreArticle.tsx
+++ b/client/components/helpCentre/HelpCentreArticle.tsx
@@ -39,8 +39,11 @@ export const HelpCentreArticle = () => {
 	const navigate = useNavigate();
 
 	useEffect(() => {
+		const normalizedArticleCode = articleCode ?? '';
+		const requestPath = `/api/help-centre/article/${normalizedArticleCode}`;
+
 		setArticle(undefined);
-		fetch(`/api/help-centre/article/${articleCode}`)
+		fetch(requestPath)
 			.then((response) => {
 				if (response.ok) {
 					return response.json();
@@ -53,11 +56,9 @@ export const HelpCentreArticle = () => {
 							helpCentreFetch: {
 								contentType: 'article',
 								reason: 'non_ok_response',
-								articleCode: articleCode ?? 'unknown',
+								articleCode: normalizedArticleCode,
 								status: response.status,
-								requestPath: `/api/help-centre/article/${
-									articleCode ?? ''
-								}`,
+								requestPath,
 							},
 						},
 						extra: {
@@ -84,10 +85,8 @@ export const HelpCentreArticle = () => {
 						helpCentreFetch: {
 							contentType: 'article',
 							reason: 'request_error',
-							articleCode: articleCode ?? 'unknown',
-							requestPath: `/api/help-centre/article/${
-								articleCode ?? ''
-							}`,
+							articleCode: normalizedArticleCode,
+							requestPath,
 						},
 					},
 					extra: {

--- a/client/components/helpCentre/HelpCentreArticle.tsx
+++ b/client/components/helpCentre/HelpCentreArticle.tsx
@@ -45,18 +45,57 @@ export const HelpCentreArticle = () => {
 				if (response.ok) {
 					return response.json();
 				} else {
-					captureMessage(
-						`Fetching article ${articleCode} returned ${response.status}.`,
-					);
+					captureMessage('Help centre article fetch failed.', {
+						fingerprint: [
+							'help-centre-article-fetch-non_ok_response',
+						],
+						contexts: {
+							helpCentreFetch: {
+								contentType: 'article',
+								reason: 'non_ok_response',
+								articleCode: articleCode ?? 'unknown',
+								status: response.status,
+								requestPath: `/api/help-centre/article/${
+									articleCode ?? ''
+								}`,
+							},
+						},
+						extra: {
+							failureType: 'non_ok_response',
+						},
+					});
 					navigate('/help-centre');
+					return undefined;
 				}
 			})
-			.then((articleData) => setArticle(articleData as Article))
-			.catch((error) =>
-				captureException(
-					`Failed to fetch article ${articleCode}. Error: ${error}`,
-				),
-			);
+			.then((articleData) => {
+				if (articleData) {
+					setArticle(articleData as Article);
+				}
+			})
+			.catch((error) => {
+				const normalizedError =
+					error instanceof Error
+						? error
+						: new Error('Help centre article fetch failed');
+				captureException(normalizedError, {
+					fingerprint: ['help-centre-article-fetch-request_error'],
+					contexts: {
+						helpCentreFetch: {
+							contentType: 'article',
+							reason: 'request_error',
+							articleCode: articleCode ?? 'unknown',
+							requestPath: `/api/help-centre/article/${
+								articleCode ?? ''
+							}`,
+						},
+					},
+					extra: {
+						failureType: 'request_error',
+						errorValue: String(error),
+					},
+				});
+			});
 	}, [articleCode, navigate]);
 
 	const setSelectedTopicId = React.useContext(SelectedTopicObjectContext);

--- a/server/helpCentreApi.ts
+++ b/server/helpCentreApi.ts
@@ -18,6 +18,20 @@ const captureHelpCentreFetchFailure = ({
 	filePath: string;
 	error?: unknown;
 }) => {
+	const errorMetadata =
+		error instanceof Error
+			? {
+					errorName: error.name,
+					errorMessage: error.message,
+					errorCode:
+						typeof (error as { code?: unknown }).code ===
+							'string' ||
+						typeof (error as { code?: unknown }).code === 'number'
+							? String((error as { code?: unknown }).code)
+							: undefined,
+			  }
+			: undefined;
+
 	captureMessage(`Help centre ${contentType} fetch failed.`, {
 		fingerprint: [`help-centre-${contentType}-fetch-${reason}`],
 		contexts: {
@@ -27,9 +41,7 @@ const captureHelpCentreFetchFailure = ({
 				filePath,
 			},
 		},
-		extra: {
-			errorValue: error === undefined ? undefined : String(error),
-		},
+		extra: errorMetadata,
 	});
 };
 

--- a/server/helpCentreApi.ts
+++ b/server/helpCentreApi.ts
@@ -4,6 +4,35 @@ import { s3FilePromise } from './awsIntegration';
 import { conf } from './config';
 import { log } from './log';
 
+type HelpCentreContentType = 'article' | 'topic';
+type HelpCentreFailureReason = 'empty_file' | 'file_not_found';
+
+const captureHelpCentreFetchFailure = ({
+	contentType,
+	reason,
+	filePath,
+	error,
+}: {
+	contentType: HelpCentreContentType;
+	reason: HelpCentreFailureReason;
+	filePath: string;
+	error?: unknown;
+}) => {
+	captureMessage(`Help centre ${contentType} fetch failed.`, {
+		fingerprint: [`help-centre-${contentType}-fetch-${reason}`],
+		contexts: {
+			helpCentreFetch: {
+				contentType,
+				reason,
+				filePath,
+			},
+		},
+		extra: {
+			errorValue: error === undefined ? undefined : String(error),
+		},
+	});
+};
+
 export const getArticleHandler = async (req: Request, res: Response) => {
 	const { article } = req.params;
 	const bucketName = 'manage-help-content';
@@ -13,7 +42,11 @@ export const getArticleHandler = async (req: Request, res: Response) => {
 			if (!data) {
 				const errorMessage = `File ${filePath} was empty`;
 				log.error(errorMessage);
-				captureMessage(errorMessage);
+				captureHelpCentreFetchFailure({
+					contentType: 'article',
+					reason: 'empty_file',
+					filePath,
+				});
 			}
 			const statusCode = data ? 200 : 404;
 			res.status(statusCode).json(data || []);
@@ -21,7 +54,12 @@ export const getArticleHandler = async (req: Request, res: Response) => {
 		.catch((error) => {
 			const errorMessage = `File ${filePath} not found`;
 			log.error(errorMessage, error);
-			captureMessage(errorMessage);
+			captureHelpCentreFetchFailure({
+				contentType: 'article',
+				reason: 'file_not_found',
+				filePath,
+				error,
+			});
 			res.status(404).send();
 		});
 };
@@ -35,7 +73,11 @@ export const getTopicHandler = async (req: Request, res: Response) => {
 			if (!data) {
 				const errorMessage = `File ${filePath} was empty`;
 				log.error(errorMessage);
-				captureMessage(errorMessage);
+				captureHelpCentreFetchFailure({
+					contentType: 'topic',
+					reason: 'empty_file',
+					filePath,
+				});
 			}
 			const statusCode = data ? 200 : 404;
 			res.status(statusCode).json(data || []);
@@ -43,7 +85,12 @@ export const getTopicHandler = async (req: Request, res: Response) => {
 		.catch((error) => {
 			const errorMessage = `File ${filePath} not found`;
 			log.error(errorMessage, error);
-			captureMessage(errorMessage);
+			captureHelpCentreFetchFailure({
+				contentType: 'topic',
+				reason: 'file_not_found',
+				filePath,
+				error,
+			});
 			res.status(404).send();
 		});
 };


### PR DESCRIPTION
## Summary
The errors are reported to Sentry using the slug in the message title, which causes each article to be a separate Sentry event. This PR stabilizes that issue, keeping the slug and other data in the error context. I believe there are a number of deprecated/stale articles still being linked from different places. When the user clicks on these links, they will just get redirected to the Help Center homepage, so no user impact, but quite noisy in Sentry.

- Use stable Sentry fingerprints for help-centre article/topic fetch failures.
- Move dynamic slug/path/error details into structured metadata instead of message text.
- Keep bad-slug behavior unchanged by continuing to redirect non-OK article responses to `/help-centre`.

## Test plan
- [x] Pre-commit hooks passed (prettier, eslint, type-check)
- [ ] Verify grouped Sentry issues after deploy for help-centre fetch failures