### PR TITLE
Revert "PLAT-516: Add help centre banner for potential delivery issues on London Marathon route"

### DIFF
--- a/client/components/helpCentre/HelpCentrePage.tsx
+++ b/client/components/helpCentre/HelpCentrePage.tsx
@@ -78,14 +78,7 @@ const HelpCentreRouter = () => {
 	]
 	*/
 
-	const knownIssues: KnownIssueObj[] = [
-		{
-			date: '21st April 2026 2:15 pm',
-			message:
-				'The London Marathon will take place on Sunday 26th of April, 2026 and road closures may impact newspaper delivery routes in the surrounding area. Subscribers affected can pause their delivery in Manage My Account.',
-			link: 'https://manage.theguardian.com',
-		},
-	];
+	const knownIssues: KnownIssueObj[] = [];
 
 	return (
 		<Main signInStatus={signInStatus} isHelpCentrePage>

--- a/client/components/helpCentre/KnownIssues.tsx
+++ b/client/components/helpCentre/KnownIssues.tsx
@@ -157,7 +157,7 @@ export const KnownIssues = (props: KnownIssuesProp) => {
 										rel="noreferrer"
 										target="_blank"
 									>
-										Click here to go to Manage My Account
+										Click here for more information
 									</a>
 								)}
 							</div>


### PR DESCRIPTION
Reverts guardian/manage-frontend#1635 because the London Marathon is now complete.