### PR TITLE
Sentry crashes caused by brittle date/state handling in MMA

### DIFF
--- a/client/__tests__/components/mma/accountoverview/inAppPurchaseCard.test.tsx
+++ b/client/__tests__/components/mma/accountoverview/inAppPurchaseCard.test.tsx
@@ -1,0 +1,56 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { InAppPurchaseCard } from '../../../../components/mma/accountoverview/InAppPurchaseCard';
+import {
+	CancelledInAppPurchase,
+	InAppPurchase,
+} from '../../../../fixtures/inAppPurchase';
+
+describe('InAppPurchaseCard', () => {
+	it('does not render cancellation copy when cancellation timestamp is invalid', () => {
+		const subscription = {
+			...CancelledInAppPurchase,
+			cancellationTimestamp: 'invalid-date',
+		};
+
+		expect(() =>
+			render(
+				<MemoryRouter>
+					<InAppPurchaseCard subscription={subscription} />
+				</MemoryRouter>,
+			),
+		).not.toThrow();
+
+		expect(
+			screen.queryByText(/Your app subscription was cancelled in/i),
+		).not.toBeInTheDocument();
+	});
+
+	it('renders cancellation copy when cancellation timestamp is valid', () => {
+		render(
+			<MemoryRouter>
+				<InAppPurchaseCard subscription={CancelledInAppPurchase} />
+			</MemoryRouter>,
+		);
+
+		expect(
+			screen.getByText(
+				'Your app subscription was cancelled in January 2023.',
+			),
+		).toBeInTheDocument();
+	});
+
+	it('renders card without cancellation copy for active subscriptions', () => {
+		render(
+			<MemoryRouter>
+				<InAppPurchaseCard subscription={InAppPurchase} />
+			</MemoryRouter>,
+		);
+
+		expect(screen.getByText('News app')).toBeInTheDocument();
+		expect(
+			screen.queryByText(/Your app subscription was cancelled in/i),
+		).not.toBeInTheDocument();
+	});
+});

--- a/client/__tests__/components/mma/accountoverview/personalisedHeader.test.tsx
+++ b/client/__tests__/components/mma/accountoverview/personalisedHeader.test.tsx
@@ -1,0 +1,53 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import type { MPAPIResponse } from '../../../../../shared/mpapiResponse';
+import { PersonalisedHeader } from '../../../../components/mma/accountoverview/PersonalisedHeader';
+import { toMembersDataApiResponse } from '../../../../fixtures/mdapiResponse';
+import { monthlyContributionPaidByCard } from '../../../../fixtures/productBuilder/testProducts';
+
+describe('PersonalisedHeader', () => {
+	it('renders nothing when there are no products and app subscriptions cannot be loaded', () => {
+		const mdapiResponse = toMembersDataApiResponse();
+
+		expect(() =>
+			render(
+				<PersonalisedHeader
+					mdapiResponse={mdapiResponse}
+					mpapiResponse={null}
+				/>,
+			),
+		).not.toThrow();
+
+		expect(screen.queryByText(/^Hi,/)).not.toBeInTheDocument();
+	});
+
+	it('ignores invalid dates and still renders when a valid product date exists', () => {
+		const product = monthlyContributionPaidByCard();
+		product.joinDate = '2023-04-01';
+
+		const mpapiResponse = {
+			subscriptions: [
+				{
+					subscriptionId: 'sub-id',
+					valid: true,
+					from: 'not-a-date',
+					productId: 'uk.co.guardian.gia.1month',
+				},
+			],
+		} as MPAPIResponse;
+
+		render(
+			<PersonalisedHeader
+				mdapiResponse={toMembersDataApiResponse(product)}
+				mpapiResponse={mpapiResponse}
+			/>,
+		);
+
+		expect(screen.getByText('Hi, test')).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				"Thank you for funding the Guardian's independent journalism since April 2023",
+			),
+		).toBeInTheDocument();
+	});
+});

--- a/client/__tests__/components/mma/cancel/stages/cancellationRouteStateGuards.test.tsx
+++ b/client/__tests__/components/mma/cancel/stages/cancellationRouteStateGuards.test.tsx
@@ -1,0 +1,66 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Outlet, Route, Routes } from 'react-router-dom';
+import { PRODUCT_TYPES } from '../../../../../../shared/productTypes';
+import {
+	CancellationContext,
+	CancellationPageTitleContext,
+} from '../../../../../components/mma/cancel/CancellationContainer';
+import { CancellationReasonContext } from '../../../../../components/mma/cancel/cancellationContexts';
+import { ConfirmCancellation } from '../../../../../components/mma/cancel/stages/ConfirmCancellation';
+import { ExecuteCancellation } from '../../../../../components/mma/cancel/stages/ExecuteCancellation';
+import { monthlyContributionPaidByCard } from '../../../../../fixtures/productBuilder/testProducts';
+
+const renderWithCancellationContext = (initialPath: string) => {
+	const productDetail = monthlyContributionPaidByCard();
+	const productType = PRODUCT_TYPES.contributions;
+
+	return render(
+		<MemoryRouter initialEntries={[initialPath]}>
+			<CancellationPageTitleContext.Provider
+				value={{ setPageTitle: jest.fn() }}
+			>
+				<CancellationContext.Provider
+					value={{ productDetail, productType }}
+				>
+					<CancellationReasonContext.Provider value={undefined}>
+						<Routes>
+							<Route
+								path="/cancel/contributions"
+								element={
+									<>
+										<div>Cancellation start page</div>
+										<Outlet />
+									</>
+								}
+							>
+								<Route
+									path="confirm"
+									element={<ConfirmCancellation />}
+								/>
+								<Route
+									path="confirmed"
+									element={<ExecuteCancellation />}
+								/>
+							</Route>
+						</Routes>
+					</CancellationReasonContext.Provider>
+				</CancellationContext.Provider>
+			</CancellationPageTitleContext.Provider>
+		</MemoryRouter>,
+	);
+};
+
+describe('Cancellation route state guards', () => {
+	it('redirects from confirm stage when router state is missing', () => {
+		renderWithCancellationContext('/cancel/contributions/confirm');
+
+		expect(screen.getByText('Cancellation start page')).toBeInTheDocument();
+	});
+
+	it('redirects from execute stage when router state is missing', () => {
+		renderWithCancellationContext('/cancel/contributions/confirmed');
+
+		expect(screen.getByText('Cancellation start page')).toBeInTheDocument();
+	});
+});

--- a/client/components/mma/accountoverview/InAppPurchaseCard.tsx
+++ b/client/components/mma/accountoverview/InAppPurchaseCard.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import { space, textSans17 } from '@guardian/source/foundations';
 import { Button, Stack } from '@guardian/source/react-components';
 import { InfoSummary } from '@guardian/source-development-kitchen/react-components';
+import { isValid } from 'date-fns';
 import { capitalize } from 'lodash';
 import { useNavigate } from 'react-router';
 import { dateString } from '../../../../shared/dates';
@@ -57,12 +58,17 @@ export const InAppPurchaseCard = ({
 	}
 
 	const appStore = determineAppStore(subscription);
+	const cancellationDate = subscription.cancellationTimestamp
+		? new Date(subscription.cancellationTimestamp)
+		: null;
+	const hasValidCancellationDate =
+		!!cancellationDate && isValid(cancellationDate);
 	return (
 		<Stack space={4}>
-			{subscription.cancellationTimestamp && (
+			{hasValidCancellationDate && (
 				<InfoSummary
 					message={`Your app subscription was cancelled in ${dateString(
-						new Date(subscription.cancellationTimestamp),
+						cancellationDate,
 						'MMMM yyyy',
 					)}.`}
 					context={cancelledAppSubscriptionMessage()}

--- a/client/components/mma/accountoverview/InAppPurchaseCard.tsx
+++ b/client/components/mma/accountoverview/InAppPurchaseCard.tsx
@@ -58,6 +58,8 @@ export const InAppPurchaseCard = ({
 	}
 
 	const appStore = determineAppStore(subscription);
+	// Date construction can still yield an "Invalid Date" object for malformed
+	// timestamps, so we validate immediately and only use the value when valid.
 	const cancellationDate = subscription.cancellationTimestamp
 		? new Date(subscription.cancellationTimestamp)
 		: null;

--- a/client/components/mma/accountoverview/PersonalisedHeader.tsx
+++ b/client/components/mma/accountoverview/PersonalisedHeader.tsx
@@ -7,7 +7,7 @@ import {
 	textSans15,
 	textSans17,
 } from '@guardian/source/foundations';
-import { min } from 'date-fns';
+import { isValid, min } from 'date-fns';
 import { dateString } from '@/shared/dates';
 import type { AppSubscription, MPAPIResponse } from '@/shared/mpapiResponse';
 import type { MembersDataApiResponse } from '@/shared/productResponse';
@@ -28,22 +28,26 @@ export const PersonalisedHeader = ({
 	if (
 		!userDetails ||
 		(mdapiResponse.products.length === 0 &&
-			mpapiResponse?.subscriptions.length === 0)
+			(!mpapiResponse || mpapiResponse.subscriptions.length === 0))
 	) {
 		return null;
 	}
 
 	const productDetails = mdapiResponse.products.filter(isProduct);
-
-	const oldestDate = min([
+	const oldestDateCandidates = [
 		...productDetails.map((p) => new Date(p.joinDate)),
 		...(mpapiResponse
 			? mpapiResponse.subscriptions.map(
 					(s: AppSubscription) => new Date(s.from),
 			  )
 			: []),
-	]);
+	].filter((date) => isValid(date));
 
+	if (oldestDateCandidates.length === 0) {
+		return null;
+	}
+
+	const oldestDate = min(oldestDateCandidates);
 	const supportStartYear = dateString(oldestDate, 'MMMM yyyy');
 
 	const onlyHasObserverProducts =

--- a/client/components/mma/cancel/stages/ConfirmCancellation.tsx
+++ b/client/components/mma/cancel/stages/ConfirmCancellation.tsx
@@ -7,7 +7,7 @@ import {
 } from '@guardian/source/foundations';
 import { Button } from '@guardian/source/react-components';
 import { useContext, useEffect } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { Navigate, useLocation, useNavigate } from 'react-router-dom';
 import { measure } from '@/client/styles/typography';
 import type { DiscountPreviewResponse } from '@/client/utilities/discountPreview';
 import { DATE_FNS_LONG_OUTPUT_FORMAT, parseDate } from '@/shared/dates';
@@ -89,7 +89,7 @@ const ctaBtnCss = css`
 
 export const ConfirmCancellation = () => {
 	const location = useLocation();
-	const routerState = location.state as RouterSate;
+	const routerState = location.state as RouterSate | null;
 	const navigate = useNavigate();
 
 	const cancellationContext = useContext(
@@ -114,18 +114,22 @@ export const ConfirmCancellation = () => {
 
 	const isInTrialPeriod = subscription.trialLength > 0;
 
+	useEffect(() => {
+		pageTitleContext.setPageTitle(
+			`Cancel ${groupedProductType.friendlyName}`,
+		);
+	}, [groupedProductType.friendlyName, pageTitleContext]);
+
+	if (!routerState) {
+		return <Navigate to="../" />;
+	}
+
 	const progressStepperArray = [
 		{},
 		{},
 		{ isCurrentStep: !routerState.eligibleForFreePeriodOffer },
 		{ isCurrentStep: routerState.eligibleForFreePeriodOffer },
 	];
-
-	useEffect(() => {
-		pageTitleContext.setPageTitle(
-			`Cancel ${groupedProductType.friendlyName}`,
-		);
-	}, [groupedProductType.friendlyName, pageTitleContext]);
 
 	return (
 		<>

--- a/client/components/mma/cancel/stages/ExecuteCancellation.tsx
+++ b/client/components/mma/cancel/stages/ExecuteCancellation.tsx
@@ -172,7 +172,7 @@ const escalatedConfirmationBody = (
 
 export const ExecuteCancellation = () => {
 	const location = useLocation();
-	const routerState = location.state as RouterState;
+	const routerState = location.state as RouterState | null;
 
 	const { productDetail, productType } = useContext(
 		CancellationContext,
@@ -184,8 +184,9 @@ export const ExecuteCancellation = () => {
 		: false;
 
 	if (
-		productHasReasonSelection &&
-		(!routerState?.selectedReasonId || !routerState?.caseId)
+		!routerState ||
+		(productHasReasonSelection &&
+			(!routerState.selectedReasonId || !routerState.caseId))
 	) {
 		return <Navigate to="../" />;
 	}


### PR DESCRIPTION
### Current situation/background

This PR fixes two Sentry crashes caused by brittle date/state handling in MMA flows.

Background: we saw production errors from account/cancellation journeys when APIs returned partial data (or route state was missing after hash/deep-link style navigation), which led to runtime exceptions instead of graceful fallbacks.

https://the-guardian.sentry.io/issues/7257798041/?environment=theguardian.com&project=1208603&query=is%3Aunresolved&referrer=issue-stream&sort=freq
https://the-guardian.sentry.io/issues/6542307010/?environment=theguardian.com&project=1208603&query=is%3Aunresolved&referrer=issue-stream&sort=freq

### What does this PR change?

- Hardened account overview date handling, guarded PersonalisedHeader against empty/invalid date inputs, guarded InAppPurchaseCard cancellation-date formatting
- Hardened cancellation flow routing, added null-safe guards in ConfirmCancellation and ExecuteCancellation for missing location.state, redirecting safely instead of crashing
- Added regression tests for invalid/missing dates in account overview components, missing route state in cancellation confirm/execute stages


<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->
