### PR TITLE
Send clientId to gateway when reseting password

### DIFF
--- a/client/components/mma/identity/IdentityLocations.ts
+++ b/client/components/mma/identity/IdentityLocations.ts
@@ -25,7 +25,7 @@ const getIdentityLocations = (domain: string) => ({
 		'/help-centre/article/i-need-to-change-my-delivery-address',
 	),
 	CHANGE_EMAIL: url('profile', domain, '/account/edit'),
-	RESET_PASSWORD: url('profile', domain, '/reset'),
+	RESET_PASSWORD: url('profile', domain, '/reset?clientId=web'),
 	MANAGE_JOB_ALERTS: url('jobs', domain, '/your-jobs/?ActiveSection=JbeList'),
 	VERIFY_EMAIL: url('profile', domain, '/verify-email'),
 	IDAPI: IDAPI_URL,


### PR DESCRIPTION
### What does this PR change?
Sends a parameter `clientId=web` to gateway when a user changes their password from MMA.

## Why?
We need to be able to distinguish between requests coming from the web and the app to the reset password flow. When a user is in the web we want to change the copy of the passcode sent page to "Please check your inbox **in a separate window**" because our less tech-savvy users sometimes try to retrieve their passcode by going to their email in the same window as the passcode page, and lose the page and repeat the flow.

This PR will be followed by:
* https://github.com/guardian/gateway/pull/3402

## Testing
| Before | <img width="563" height="298" alt="Screenshot 2026-04-30 at 09 37 51" src="https://github.com/user-attachments/assets/0304a0c3-17ad-4bf0-be9c-46a2193012af" />  |<img width="491" height="314" alt="Screenshot 2026-04-30 at 09 46 27" src="https://github.com/user-attachments/assets/2d73b9ec-57b6-4d10-acc7-28e3e8c249fb" /> |
|--------|---|---|
| After  | <img width="563" height="298" alt="Screenshot 2026-04-30 at 09 37 51" src="https://github.com/user-attachments/assets/0304a0c3-17ad-4bf0-be9c-46a2193012af" />  |  <img width="566" height="480" alt="Screenshot 2026-04-30 at 09 38 09" src="https://github.com/user-attachments/assets/62ab359e-52eb-4d16-9393-f97544728110" /> |

--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->
