### PR TITLE
Add concent UUID cookie value to diagnostics information

### DIFF
--- a/client/components/helpCentre/diagnosticInformation/CookieInformation.tsx
+++ b/client/components/helpCentre/diagnosticInformation/CookieInformation.tsx
@@ -4,6 +4,7 @@ const cookieNames = [
 	'gu_hide_support_messaging',
 	'GU_AF1',
 	'gu_allow_reject_all',
+	'consentUUID',
 	'gu_user_benefits_expiry',
 ];
 


### PR DESCRIPTION
Adds the Sourcepoint consentUUID cookie to the list rendered by CookieInformation on the Help Centre Diagnostic Information page.

User Help asked for this so they can include the consentUUID when escalating consent banner issues to Identity & Trust. Surfacing it alongside the other consent-related cookies (GU_AF1, gu_allow_reject_all) means it's automatically captured by the existing "Copy to clipboard" flow.

