### PR TITLE
add help centre banner for Editions App access changes

### DIFF
--- a/client/components/helpCentre/HelpCentrePage.tsx
+++ b/client/components/helpCentre/HelpCentrePage.tsx
@@ -78,7 +78,14 @@ const HelpCentreRouter = () => {
 	]
 	*/
 
-	const knownIssues: KnownIssueObj[] = [];
+	const knownIssues: KnownIssueObj[] = [
+		{
+			date: '26 May 2026 12:00',
+			message:
+				'We are updating our app experience. From 26th May, you will be required to sign in to access the Editions app. Access is included with Digital Plus, Print, and Guardian Weekly subscriptions, or those with a direct app store subscription.',
+			link: 'https://manage.theguardian.com/help-centre/article/guardian-editions-app',
+		},
+	];
 
 	return (
 		<Main signInStatus={signInStatus} isHelpCentrePage>


### PR DESCRIPTION
### Current situation/background
From 26th May, users will be required to sign in to access the Editions app. This PR is to include a banner on the help centre page to inform the users about this change. 

### What does this PR change?
Adds a help banner on the https://manage.theguardian.com/help-centre to inform the user about upcoming changes to the sign-in requirement in the Editions app. 

### Next steps/further info
Tested on CODE.
<img width="1032" height="281" alt="image" src="https://github.com/user-attachments/assets/5f76dc93-51c5-4dbe-9e68-ad1167289822" />

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214638043673961