### PR TITLE
Fix crash on /upgrade-support/thank-you when router state is missing

### DIFF
--- a/client/__tests__/utils.test.ts
+++ b/client/__tests__/utils.test.ts
@@ -1,4 +1,5 @@
 import {
+	formatAmount,
 	isValidDecimalInput,
 	processDecimalInput,
 	processDecimalInputOnBlur,
@@ -15,6 +16,39 @@ describe('shuffleArray', () => {
 				shuffleArray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).toString(),
 			).not.toEqual(inputArrString);
 		}
+	});
+});
+
+describe('formatAmount', () => {
+	it('returns integers unchanged as numbers', () => {
+		expect(formatAmount(0)).toBe(0);
+		expect(formatAmount(5)).toBe(5);
+		expect(formatAmount(120)).toBe(120);
+		expect(formatAmount(-7)).toBe(-7);
+	});
+
+	it('formats non-integer numbers to two decimal places as strings', () => {
+		expect(formatAmount(1.5)).toBe('1.50');
+		expect(formatAmount(12.34)).toBe('12.34');
+		expect(formatAmount(0.1)).toBe('0.10');
+		expect(formatAmount(-2.5)).toBe('-2.50');
+	});
+
+	it('rounds to two decimal places', () => {
+		expect(formatAmount(1.005)).toBe('1.00');
+		expect(formatAmount(1.006)).toBe('1.01');
+		expect(formatAmount(1.999)).toBe('2.00');
+	});
+
+	it('returns an empty string for undefined or null', () => {
+		expect(formatAmount(undefined)).toBe('');
+		expect(formatAmount(null)).toBe('');
+	});
+
+	it('returns an empty string for non-finite numbers', () => {
+		expect(formatAmount(NaN)).toBe('');
+		expect(formatAmount(Infinity)).toBe('');
+		expect(formatAmount(-Infinity)).toBe('');
 	});
 });
 

--- a/client/components/mma/upgrade/UpgradeSupportContainer.tsx
+++ b/client/components/mma/upgrade/UpgradeSupportContainer.tsx
@@ -60,12 +60,18 @@ const UpgradeSupportPageContainer = ({
 	);
 };
 
-function userIsNavigatingBackFromThankYouPage(hasCompleted: boolean) {
-	return (
-		hasCompleted &&
-		!location.pathname.includes('thank-you') &&
-		!location.pathname.includes('switch-thank-you')
-	);
+function userShouldBeRedirectedFromUpgradeFlow(
+	hasCompleted: boolean,
+	hasJourneyState: boolean,
+) {
+	const onThankYouPath =
+		location.pathname.includes('thank-you') ||
+		location.pathname.includes('switch-thank-you');
+
+	// Journey already completed but user navigated off the thank-you page,
+	// or landed on a thank-you page without any journey state at all
+	// (e.g. direct URL, refresh, or back navigation from a cross-origin page).
+	return hasCompleted ? !onThankYouPath : onThankYouPath && !hasJourneyState;
 }
 
 export const UpgradeSupportContainer = () => {
@@ -106,8 +112,13 @@ export const UpgradeSupportContainer = () => {
 		setJourneyCompleted(true);
 	}
 
-	if (userIsNavigatingBackFromThankYouPage(journeyCompleted)) {
-		return <Navigate to="/" />;
+	if (
+		userShouldBeRedirectedFromUpgradeFlow(
+			journeyCompleted,
+			!!routerState?.journeyCompleted,
+		)
+	) {
+		return <Navigate to="/" replace />;
 	}
 
 	const contribution = data.products.filter(isProduct)[0];

--- a/client/utilities/utils.ts
+++ b/client/utilities/utils.ts
@@ -28,7 +28,10 @@ export const shuffleArray = (array: unknown[]) => {
 	return array;
 };
 
-export function formatAmount(amount: number) {
+export function formatAmount(amount: number | null | undefined) {
+	if (typeof amount !== 'number' || !Number.isFinite(amount)) {
+		return '';
+	}
 	return Number.isInteger(amount) ? amount : amount.toFixed(2);
 }
 


### PR DESCRIPTION
Fixes Sentry crashes TypeError: undefined is not an object (evaluating 'e.toFixed') / Cannot read properties of undefined (reading 'toFixed') on the thank-you page, caused by chosenAmount being read from a location.state that wasn't preserved across navigation.

- https://the-guardian.sentry.io/issues/6315435809/?environment=theguardian.com&project=1208603&query=is%3Aunresolved&referrer=issue-stream&sort=freq
- https://the-guardian.sentry.io/issues/4668228837/?environment=theguardian.com&project=1208603&query=is%3Aunresolved&referrer=issue-stream&sort=freq

- Redirect users to / if they land on /upgrade-support/thank-you or /switch-thank-you without a completed journey in location.state (e.g. browser back from a cross-origin page, refresh, or direct URL). Consolidates the existing back-from-thank-you check into a single userShouldBeRedirectedFromUpgradeFlow guard.
- Harden formatAmount to return '' for null/undefined/non-finite input instead of throwing on .toFixed, as defense in depth.