### PR TITLE
fix: replace JSX namespace references with React.JSX

### DIFF
--- a/client/components/mma/shared/Heading.tsx
+++ b/client/components/mma/shared/Heading.tsx
@@ -34,7 +34,9 @@ export const Heading = (props: HeadingProps) => {
 		} ;
 	`;
 
-	const HeadingElement: keyof JSX.IntrinsicElements = `h${props.level ?? 2}`;
+	const HeadingElement: keyof React.JSX.IntrinsicElements = `h${
+		props.level ?? 2
+	}`;
 
 	return (
 		<div css={dividerStyles}>

--- a/client/components/mma/shared/images/GridImage.tsx
+++ b/client/components/mma/shared/images/GridImage.tsx
@@ -18,7 +18,7 @@ export type GridImg = {
 };
 type PropTypes = GridImg; // ----- Component ----- //
 
-export function GridImage(props: PropTypes): JSX.Element | null {
+export function GridImage(props: PropTypes): React.JSX.Element | null {
 	if (props.srcSizes.length < 1) {
 		return null;
 	}

--- a/shared/productTypes.ts
+++ b/shared/productTypes.ts
@@ -111,7 +111,7 @@ interface CancellationFlowProperties {
 		productDetail: ProductDetail,
 		productType: ProductType,
 	) => (restOfFlow: RestOfCancellationFlow) => ReactNode;
-	startPageBody: (productDetail: ProductDetail) => JSX.Element;
+	startPageBody: (productDetail: ProductDetail) => React.JSX.Element;
 	startPageOfferEffectiveDateOptions?: true;
 	hideReasonTitlePrefix?: true;
 	alternateSummaryMainPara?: string;


### PR DESCRIPTION
### Current situation/background
Builds fail due to `yarn run tsc --skipLibCheck` failing. This prevents me from committing my latest changes to the high severity vulnerability fixes. 

```
$ tsc --skipLibCheck
Error: client/components/mma/shared/Heading.tsx(37,30): error TS2503: Cannot find namespace 'JSX'.
Error: client/components/mma/shared/Heading.tsx(41,5): error TS2322: Type '{ children: ReactNode; css: (SerializedStyles | SerializedStyles[] | undefined)[]; }' is not assignable to type 'IntrinsicAttributes'.
  Property 'children' does not exist on type 'IntrinsicAttributes'.
Error: client/components/mma/shared/images/GridImage.tsx(21,46): error TS2503: Cannot find namespace 'JSX'.
Error: shared/productTypes.ts(114,51): error TS2503: Cannot find namespace 'JSX'.
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Error: Process completed with exit code 2.
```

### What does this PR change?
Replaces references of `JSX` in three files to `React.JSX`. 

### Next steps/further info
No changes to the behaviour or performance is expected to change. 



<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->
