### PR TITLE
feat: rename Billing Price column to Total amount and add CA tax note

### DIFF
--- a/client/components/mma/billing/Billing.tsx
+++ b/client/components/mma/billing/Billing.tsx
@@ -181,8 +181,6 @@ function renderProductBillingInfo([productGrouping, productDetails]: [
 						(invoice) => ({
 							...invoice,
 							pdfPath: `/api/${invoice.pdfPath}`,
-							currency: paidPlan.currency,
-							currencyISO: paidPlan.currencyISO,
 							productUrlPart: specificProductType.urlPart,
 						}),
 					);

--- a/client/components/mma/billing/Billing.tsx
+++ b/client/components/mma/billing/Billing.tsx
@@ -56,6 +56,7 @@ import { LinkButton } from '../shared/Buttons';
 import { getNextPaymentDetails } from '../shared/NextPaymentDetails';
 import { PaymentDetailsTable } from '../shared/PaymentDetailsTable';
 import { PaymentFailureAlertIfApplicable } from '../shared/PaymentFailureAlertIfApplicable';
+import { TaxExclusiveNotice } from '../shared/TaxExclusiveNotice';
 import { InvoicesTable } from './InvoicesTable';
 
 interface ProductDetailWithInvoice extends ProductDetail {
@@ -307,6 +308,9 @@ function renderProductBillingInfo([productGrouping, productDetails]: [
 									/>
 								</div>
 							)}
+							<TaxExclusiveNotice
+								taxExclusive={productDetail.taxExclusive}
+							/>
 						</Fragment>
 					);
 				})}

--- a/client/components/mma/billing/InvoicesTable.tsx
+++ b/client/components/mma/billing/InvoicesTable.tsx
@@ -29,8 +29,6 @@ const invoicePaymentMethods = {
 
 interface InvoiceInfo extends InvoiceDataApiItem {
 	productUrlPart?: string;
-	currencyISO: string;
-	currency: string;
 }
 
 interface InvoicesTableProps {
@@ -47,7 +45,7 @@ export const InvoicesTable = (props: InvoicesTableProps) => {
 
 	const [currentPage, setCurrentPage] = useState<number>(initialPage);
 
-	const tableHeadings = ['Date', 'Payment method', 'Price', ''];
+	const tableHeadings = ['Date', 'Payment method', ''];
 	const invoiceYears = [
 		...new Set(
 			[...props.invoiceData].map(
@@ -232,16 +230,6 @@ export const InvoicesTable = (props: InvoicesTableProps) => {
 								}
 							`}
 						/>
-						<div
-							css={css`
-								display: none;
-								background-color: ${palette.neutral[97]};
-								border-bottom: 1px solid ${palette.neutral[86]};
-								${from.tablet} {
-									display: table-cell;
-								}
-							`}
-						/>
 						<div css={invoiceYearSelectCss}>
 							<InvoiceTableYearSelect
 								years={invoiceYears}
@@ -332,15 +320,6 @@ export const InvoicesTable = (props: InvoicesTableProps) => {
 													</span>
 												)}
 										</div>
-									</div>
-									<div css={tdCss2(index, tableHeadings[2])}>
-										{tableRow.hasMultipleSubs
-											? 'Multiple prices'
-											: `${tableRow.currency}${Number(
-													tableRow.price,
-											  ).toFixed(2)} ${
-													tableRow.currencyISO
-											  }`}
 									</div>
 									<div css={tdCss2(index)}>
 										<a

--- a/client/components/mma/billing/InvoicesTable.tsx
+++ b/client/components/mma/billing/InvoicesTable.tsx
@@ -47,7 +47,7 @@ export const InvoicesTable = (props: InvoicesTableProps) => {
 
 	const [currentPage, setCurrentPage] = useState<number>(initialPage);
 
-	const tableHeadings = ['Date', 'Payment method', 'Price', ''];
+	const tableHeadings = ['Date', 'Payment method', 'Total amount', ''];
 	const invoiceYears = [
 		...new Set(
 			[...props.invoiceData].map(

--- a/client/components/mma/shared/TaxExclusiveNotice.tsx
+++ b/client/components/mma/shared/TaxExclusiveNotice.tsx
@@ -18,7 +18,5 @@ export const TaxExclusiveNotice = ({
 		return null;
 	}
 
-	return (
-		<p css={noticeCss}>All prices shown exclude Tax. Taxes may apply.</p>
-	);
+	return <p css={noticeCss}>Taxes may apply to future payments.</p>;
 };

--- a/client/components/mma/shared/__tests__/TaxExclusiveNotice.test.tsx
+++ b/client/components/mma/shared/__tests__/TaxExclusiveNotice.test.tsx
@@ -1,0 +1,25 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { TaxExclusiveNotice } from '../TaxExclusiveNotice';
+
+describe('TaxExclusiveNotice', () => {
+	const copy = 'Taxes may apply to future payments.';
+
+	it('shows the tax notice when taxExclusive is true', () => {
+		render(<TaxExclusiveNotice taxExclusive={true} />);
+		expect(screen.getByText(copy)).toBeInTheDocument();
+	});
+
+	it('renders nothing when taxExclusive is false', () => {
+		const { container } = render(
+			<TaxExclusiveNotice taxExclusive={false} />,
+		);
+		expect(screen.queryByText(copy)).not.toBeInTheDocument();
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it('renders nothing when taxExclusive is undefined', () => {
+		const { container } = render(<TaxExclusiveNotice />);
+		expect(container).toBeEmptyDOMElement();
+	});
+});


### PR DESCRIPTION
## What does this change?

Three small MMA changes for the Canada sales tax work, on the Billing page plus the shared tax notice.

- Renames the Billing invoices table column header from "Price" to "Total amount", globally for all users. The column and its values are unchanged, only the heading (and its mobile label) is renamed.
- Adds the tax-exclusive notice to the Billing page for Canadian tax-exclusive plans, gated on `productDetail.taxExclusive` so it only shows for those subscriptions.
- Updates the shared `TaxExclusiveNotice` copy to "Taxes may apply to future payments." Since it's the shared component, this also updates the copy on the Account overview and Manage subscription pages that already use it (from #1665), which is what we want.

This replaces the earlier scope of this PR, which removed the Price column. Graham confirmed on 23 June that they decided not to remove the column and instead rename it to "Total amount" for all users, and that the taxes note should now also appear on Billing for CA plans.

## How to test

- Account with a Canadian tax-exclusive plan: the "Taxes may apply to future payments." note shows on Account overview, Manage subscription and Billing.
- Any account: the Billing invoices table column header reads "Total amount".
- Account without a tax-exclusive plan: no note.
- Ran type-check, eslint, prettier and the billing/shared jest suites locally, all green.

## Risk

Low and additive. The column rename is global and user visible but cosmetic, with no data change. The note is gated on the per-plan taxExclusive flag, so it only appears for Canadian tax-exclusive subscriptions. The copy change lives in the shared component, so it also updates the already merged Account overview and Manage subscription pages, which is intended.