### PR TITLE
Resolved the transitive dependency launch-editor to ^2.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,6 +182,7 @@
   "resolutions": {
     "http-proxy-middleware": "^2.0.7",
     "cross-spawn": "^7.0.5",
+    "launch-editor": "^2.14.1",
     "picomatch": "2.3.2",
     "@stylistic/eslint-plugin/picomatch": "4.0.4",
     "tinyglobby/picomatch": "4.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10283,13 +10283,13 @@ language-tags@^1.0.9:
   dependencies:
     language-subtag-registry "^0.3.20"
 
-launch-editor@^2.6.1:
-  version "2.8.0"
-  resolved "https://registry.npmjs.org/launch-editor/-/launch-editor-2.8.0.tgz"
-  integrity sha512-vJranOAJrI/llyWGRQqiDM+adrw+k83fvmmx3+nV47g3+36xM15jE+zyZ6Ffel02+xSvuM0b2GDRosXZkbb6wA==
+launch-editor@2.14.1, launch-editor@^2.6.1:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/launch-editor/-/launch-editor-2.14.1.tgz#f7e0da3f58aaea03fea01074d840b5f739ed7ddc"
+  integrity sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==
   dependencies:
-    picocolors "^1.0.0"
-    shell-quote "^1.8.1"
+    picocolors "^1.1.1"
+    shell-quote "^1.8.4"
 
 lazy-ass@^1.6.0:
   version "1.6.0"
@@ -12717,10 +12717,10 @@ shebang-regex@^3.0.0:
   resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@^1.8.1:
-  version "1.8.1"
-  resolved "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz"
-  integrity sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==
+shell-quote@^1.8.4:
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.4.tgz#2edd9a4dcefc96649e2e2cb12f637b1f1d92a190"
+  integrity sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==
 
 shimmer@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
### Current situation/background
New Dependabot alert from a few days ago. 

### What does this PR change?
Bumps the transitive dependency to a safer version (^2.14.1). 

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->
