### PR TITLE
make contact us email link clickable

### DIFF
--- a/client/__tests__/components/helpCentre/__snapshots__/helpCentreContactOptions.test.tsx.snap
+++ b/client/__tests__/components/helpCentre/__snapshots__/helpCentreContactOptions.test.tsx.snap
@@ -1077,12 +1077,22 @@ html:not(.src-focus-disabled) .emotion-9:focus {
 }
 
 .emotion-16 {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  color: #005689;
+}
+
+.emotion-16:visited {
+  color: #005689;
+}
+
+.emotion-17 {
   border-top: 1px solid #DCDCDC;
   border-left: 1px solid #DCDCDC;
   border-right: 1px solid #DCDCDC;
 }
 
-.emotion-17 {
+.emotion-18 {
   font-family: GuardianTextSans,"Guardian Text Sans Web","Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
   font-size: 1.25rem;
   line-height: 1.3;
@@ -1096,25 +1106,25 @@ html:not(.src-focus-disabled) .emotion-9:focus {
 }
 
 @media (min-width: 980px) {
-  .emotion-17 {
+  .emotion-18 {
     padding: 22px 0 22px 64px;
   }
 }
 
-.emotion-18 {
+.emotion-19 {
   position: absolute;
   top: 12px;
   left: 12px;
 }
 
 @media (min-width: 980px) {
-  .emotion-18 {
+  .emotion-19 {
     top: 16px;
     left: 16px;
   }
 }
 
-.emotion-19 {
+.emotion-20 {
   display: none;
   font-family: GuardianTextSans,"Guardian Text Sans Web","Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
   font-size: 1.0625rem;
@@ -1127,12 +1137,12 @@ html:not(.src-focus-disabled) .emotion-9:focus {
 }
 
 @media (min-width: 1300px) {
-  .emotion-19 {
+  .emotion-20 {
     display: block;
   }
 }
 
-.emotion-20 {
+.emotion-21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1145,12 +1155,12 @@ html:not(.src-focus-disabled) .emotion-9:focus {
   font-weight: normal;
 }
 
-.emotion-21 {
+.emotion-22 {
   width: 100%;
   border: 1px solid #DCDCDC;
 }
 
-.emotion-22 {
+.emotion-23 {
   font-family: GuardianTextSans,"Guardian Text Sans Web","Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
   font-size: 1.0625rem;
   line-height: 1.3;
@@ -1166,7 +1176,7 @@ html:not(.src-focus-disabled) .emotion-9:focus {
   border-bottom: 1px solid #DCDCDC;
 }
 
-.emotion-22:after {
+.emotion-23:after {
   content: "";
   display: block;
   width: 7px;
@@ -1184,7 +1194,7 @@ html:not(.src-focus-disabled) .emotion-9:focus {
   right: 17px;
 }
 
-.emotion-23 {
+.emotion-24 {
   display: none;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -1193,7 +1203,7 @@ html:not(.src-focus-disabled) .emotion-9:focus {
 }
 
 @media (min-width: 980px) {
-  .emotion-23 {
+  .emotion-24 {
     display: block;
     position: absolute;
     top: 50%;
@@ -1207,13 +1217,13 @@ html:not(.src-focus-disabled) .emotion-9:focus {
   }
 }
 
-.emotion-24 {
+.emotion-25 {
   display: block;
   background-color: #F6F6F6;
   padding: 16px;
 }
 
-.emotion-25 {
+.emotion-26 {
   font-family: GuardianTextSans,"Guardian Text Sans Web","Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
   font-size: 1.0625rem;
   line-height: 1.3;
@@ -1223,21 +1233,21 @@ html:not(.src-focus-disabled) .emotion-9:focus {
   margin-bottom: 0;
 }
 
-.emotion-25+p {
+.emotion-26+p {
   margin-top: 16px;
 }
 
-.emotion-26 {
+.emotion-27 {
   display: block;
   margin-bottom: 4px;
   font-weight: bold;
 }
 
-.emotion-27 {
+.emotion-28 {
   display: block;
 }
 
-.emotion-29 {
+.emotion-30 {
   font-family: GuardianTextSans,"Guardian Text Sans Web","Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
   font-size: 1.0625rem;
   line-height: 1.3;
@@ -1250,7 +1260,7 @@ html:not(.src-focus-disabled) .emotion-9:focus {
   cursor: pointer;
 }
 
-.emotion-29:after {
+.emotion-30:after {
   content: "";
   display: block;
   width: 7px;
@@ -1268,7 +1278,7 @@ html:not(.src-focus-disabled) .emotion-9:focus {
   right: 17px;
 }
 
-.emotion-29:before {
+.emotion-30:before {
   content: "";
   display: block;
   position: absolute;
@@ -1279,29 +1289,29 @@ html:not(.src-focus-disabled) .emotion-9:focus {
   background-color: #DCDCDC;
 }
 
-.emotion-31 {
+.emotion-32 {
   display: none;
   background-color: #F6F6F6;
   padding: 16px;
 }
 
-.emotion-34 {
+.emotion-35 {
   font-weight: normal;
 }
 
-.emotion-47 {
+.emotion-48 {
   margin-top: 36px;
   padding: 12px;
   background-color: #ecf3fe;
 }
 
 @media (min-width: 980px) {
-  .emotion-47 {
+  .emotion-48 {
     padding: 24px;
   }
 }
 
-.emotion-48 {
+.emotion-49 {
   margin: 0;
   font-family: GuardianTextSans,"Guardian Text Sans Web","Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
   font-size: 0.9375rem;
@@ -1311,7 +1321,7 @@ html:not(.src-focus-disabled) .emotion-9:focus {
   --source-text-decoration-thickness: 2px;
 }
 
-.emotion-49 {
+.emotion-50 {
   font-family: GuardianTextSans,"Guardian Text Sans Web","Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
   font-size: 0.9375rem;
   line-height: 1.3;
@@ -1322,7 +1332,7 @@ html:not(.src-focus-disabled) .emotion-9:focus {
   margin: 0;
 }
 
-.emotion-49 a {
+.emotion-50 a {
   color: #0077B6;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -1492,20 +1502,25 @@ html:not(.src-focus-disabled) .emotion-9:focus {
           <p
             class="emotion-15"
           >
-            customer.help@theguardian.com
+            <a
+              class="emotion-16"
+              href="mailto:customer.help@theguardian.com"
+            >
+              customer.help@theguardian.com
+            </a>
           </p>
         </div>
       </div>
     </div>
     <div
-      class="emotion-16"
+      class="emotion-17"
       id="call-us"
     >
       <h2
-        class="emotion-17"
+        class="emotion-18"
       >
         <i
-          class="emotion-18"
+          class="emotion-19"
         >
           <svg
             fill="none"
@@ -1535,47 +1550,47 @@ html:not(.src-focus-disabled) .emotion-9:focus {
         Call us
       </h2>
       <p
-        class="emotion-19"
+        class="emotion-20"
       >
         Speak with one of our customer service agents.
       </p>
     </div>
     <div
-      class="emotion-20"
+      class="emotion-21"
     >
       <div
-        class="emotion-21"
+        class="emotion-22"
       >
         <div>
           <h2
-            class="emotion-22"
+            class="emotion-23"
           >
             United Kingdom, Europe and rest of world
             <span
               aria-hidden="true"
-              class="emotion-23"
+              class="emotion-24"
             >
               Hide
             </span>
           </h2>
           <div
-            class="emotion-24"
+            class="emotion-25"
           >
             <p
-              class="emotion-25"
+              class="emotion-26"
             >
               <span
-                class="emotion-26"
+                class="emotion-27"
               >
                 +44 (0) 330 333 6767
               </span>
               <span
-                class="emotion-27"
+                class="emotion-28"
               >
                 8am - 6pm Monday - Friday (GMT/BST)
               </span>
               <span
-                class="emotion-27"
+                class="emotion-28"
               >
                 9am - 6pm Saturday - Sunday (GMT/BST)
               </span>
@@ -1584,46 +1599,46 @@ html:not(.src-focus-disabled) .emotion-9:focus {
         </div>
         <div>
           <h2
-            class="emotion-29"
+            class="emotion-30"
           >
             Australia, New Zealand, and Asia Pacific
             <span
               aria-hidden="true"
-              class="emotion-23"
+              class="emotion-24"
             >
               Show
             </span>
           </h2>
           <div
-            class="emotion-31"
+            class="emotion-32"
           >
             <p
-              class="emotion-25"
+              class="emotion-26"
             >
               <span
-                class="emotion-26"
+                class="emotion-27"
               >
                 1800 773 766
                 <span
-                  class="emotion-34"
+                  class="emotion-35"
                 >
                    
                   (within Australia)
                 </span>
               </span>
               <span
-                class="emotion-26"
+                class="emotion-27"
               >
                 +61 28076 8599
                 <span
-                  class="emotion-34"
+                  class="emotion-35"
                 >
                    
                   (outside Australia)
                 </span>
               </span>
               <span
-                class="emotion-27"
+                class="emotion-28"
               >
                 9am - 5pm Monday - Friday (AEDT)
               </span>
@@ -1632,46 +1647,46 @@ html:not(.src-focus-disabled) .emotion-9:focus {
         </div>
         <div>
           <h2
-            class="emotion-29"
+            class="emotion-30"
           >
             Canada and USA
             <span
               aria-hidden="true"
-              class="emotion-23"
+              class="emotion-24"
             >
               Show
             </span>
           </h2>
           <div
-            class="emotion-31"
+            class="emotion-32"
           >
             <p
-              class="emotion-25"
+              class="emotion-26"
             >
               <span
-                class="emotion-26"
+                class="emotion-27"
               >
                 1-844-632-2010
                 <span
-                  class="emotion-34"
+                  class="emotion-35"
                 >
                    
                   (toll free CAN/USA)
                 </span>
               </span>
               <span
-                class="emotion-26"
+                class="emotion-27"
               >
                 +1 917-900-4663
                 <span
-                  class="emotion-34"
+                  class="emotion-35"
                 >
                    
                   (outside CAN/USA)
                 </span>
               </span>
               <span
-                class="emotion-27"
+                class="emotion-28"
               >
                 9am - 5pm on weekdays (EST/EDT)
               </span>
@@ -1681,16 +1696,16 @@ html:not(.src-focus-disabled) .emotion-9:focus {
       </div>
     </div>
     <div
-      class="emotion-47"
+      class="emotion-48"
       id="livechatPrivacyNotice"
     >
       <h2
-        class="emotion-48"
+        class="emotion-49"
       >
         Data privacy notice
       </h2>
       <p
-        class="emotion-49"
+        class="emotion-50"
       >
         We use a type of cookie technology called an SDK (Software Development Kit) to ensure that our live chat services work correctly and meet your expectations. It cannot be switched off but it is removed at the end of the chat. If you do not wish for this cookie to be dropped on your device, please email or phone us instead. Live chats and phone calls will be recorded for monitoring and training purposes. Please do not disclose personal data of a sensitive nature in the live chat, such as health or financial information. A copy of the chat transcript will be emailed to you unless the chat contains payment card information, in which case no transcript will be sent. Click to find out more in our
          

--- a/client/components/helpCentre/HelpCentreEmailAndLiveChat.tsx
+++ b/client/components/helpCentre/HelpCentreEmailAndLiveChat.tsx
@@ -216,7 +216,16 @@ export const HelpCentreEmailAndLiveChat = (
 					compactLayout={props.compactLayout}
 				>
 					<p css={emailAndLiveChatPCss}>
-						customer.help@theguardian.com
+						<a
+							href="mailto:customer.help@theguardian.com"
+							css={{
+								textDecoration: 'underline',
+								color: palette.sport[300],
+								':visited': { color: palette.sport[300] },
+							}}
+						>
+							customer.help@theguardian.com
+						</a>
 					</p>
 				</HelpCentreContactBox>
 			</div>


### PR DESCRIPTION
On contact us, the email link isn't clickable.  This isn't ideal and causes user frustration

Go to https://manage.theguardian.com/help-centre/article/i-want-to-delete-my-account and click "contact us"
<img width="406" height="274" alt="image" src="https://github.com/user-attachments/assets/ad101f94-638f-4708-9f9c-ef208250a4bf" />


This PR makes it a clickable link
<img width="432" height="291" alt="image" src="https://github.com/user-attachments/assets/4e7bb1a6-a593-49f4-ada8-226e3b62c248" />

Tested locally
