### PR TITLE
Removed the help centre banner for Editions App sign-in notice

### DIFF
--- a/client/components/helpCentre/HelpCentrePage.tsx
+++ b/client/components/helpCentre/HelpCentrePage.tsx
@@ -78,14 +78,7 @@ const HelpCentreRouter = () => {
 	]
 	*/
 
-	const knownIssues: KnownIssueObj[] = [
-		{
-			date: '26 May 2026 12:00',
-			message:
-				'We are updating our app experience. From 26th May, you will be required to sign in to access the Editions app. Access is included with Digital Plus, Print, and Guardian Weekly subscriptions, or those with a direct app store subscription.',
-			link: 'https://manage.theguardian.com/help-centre/article/guardian-editions-app',
-		},
-	];
+	const knownIssues: KnownIssueObj[] = [];
 
 	return (
 		<Main signInStatus={signInStatus} isHelpCentrePage>


### PR DESCRIPTION
### What does this PR change?
Removes the help centre banner about mandatory sign-ins for the Editions app. Introduced by https://github.com/guardian/manage-frontend/pull/1645 ([Asana](https://app.asana.com/1/1210045093164357/project/1213134855566811/task/1214638043673961?focus=true)). 

This has been requested to remove this morning by CEX team.