### PR TITLE
Moved product card header into ProductCardSections

### DIFF
--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -1,9 +1,8 @@
 import { css } from '@emotion/react';
-import { palette, space, textSans17 } from '@guardian/source/foundations';
+import { palette, textSans17 } from '@guardian/source/foundations';
 import {
 	Button,
 	Stack,
-	SvgGift,
 	SvgInfoRound,
 	themeButtonReaderRevenueBrand,
 } from '@guardian/source/react-components';
@@ -32,7 +31,6 @@ import { GROUPED_PRODUCT_TYPES } from '@/shared/productTypes';
 import { wideButtonLayoutCss } from '../../../styles/ButtonStyles';
 import { trackEvent } from '../../../utilities/analytics';
 import { useUpgradeProduct } from '../../../utilities/hooks/useUpgradePreview';
-import { Ribbon } from '../../shared/Ribbon';
 import { ErrorIcon } from '../shared/assets/ErrorIcon';
 import { getGuardianWeeklyGiftBenefits } from '../shared/benefits/BenefitsConfiguration';
 import { BenefitsToggle } from '../shared/benefits/BenefitsToggle';
@@ -44,9 +42,10 @@ import {
 	getGuardianWeeklyGiftBenefitsCopy,
 	productCardConfiguration,
 } from './ProductCardConfiguration';
+import { ProductCardHeader } from './ProductCardSections';
 import {
+	benefitsTextCss,
 	keyValueCss,
-	productCardTitleCss,
 	productDetailLayoutCss,
 	sectionHeadingCss,
 } from './ProductCardStyles';
@@ -149,25 +148,6 @@ export const ProductCard = ({
 	const cardConfig = gwGiftSubscription
 		? getGuardianWeeklyGiftBenefitsCopy
 		: productCardConfiguration[specificProductType.productType];
-
-	const giftRibbonColour = cardConfig.invertText
-		? palette.brand[400]
-		: palette.brandAlt[400];
-	const giftRibbonCopyColour = cardConfig.invertText
-		? palette.brandAlt[400]
-		: palette.brand[400];
-	const giftRibbonCss = css`
-		position: absolute;
-		top: 50%;
-		transform: translateY(-50%);
-		right: 0;
-	`;
-
-	const benefitsTextCss = css`
-		${textSans17};
-		margin: 0;
-		margin-bottom: ${space[2]}px;
-	`;
 
 	const canBeInOfferPeriod =
 		specificProductType.productType === 'supporterplus';
@@ -278,29 +258,11 @@ export const ProductCard = ({
 				/>
 			)}
 			<Card>
-				<Card.Header
-					backgroundColor={cardConfig.colour}
-					minHeightOverride="auto"
-				>
-					<h3 css={productCardTitleCss(cardConfig.invertText)}>
-						{productTitle}
-					</h3>
-					{isGifted && (
-						<Ribbon
-							copy="Gift"
-							ribbonColour={giftRibbonColour}
-							copyColour={giftRibbonCopyColour}
-							icon={
-								<SvgGift
-									isAnnouncedByScreenReader
-									size="small"
-									theme={{ fill: giftRibbonCopyColour }}
-								/>
-							}
-							additionalCss={giftRibbonCss}
-						/>
-					)}
-				</Card.Header>
+				<ProductCardHeader
+					cardConfig={cardConfig}
+					productTitle={productTitle}
+					isGifted={isGifted}
+				/>
 
 				{cardConfig.getBenefitsSectionCopy && nextPaymentDetails && (
 					<Card.Section backgroundColor="#edf5fA" removeBorders>

--- a/client/components/mma/accountoverview/ProductCardConfiguration.ts
+++ b/client/components/mma/accountoverview/ProductCardConfiguration.ts
@@ -25,7 +25,7 @@ export const productColour = {
 	feastApp: palette.brand[800], // Same color as Live app (inAppPurchase)
 };
 
-interface ProductCardConfiguration {
+export interface ProductCardConfiguration {
 	colour: string;
 	invertText?: boolean;
 	getBenefitsSectionCopy?: (nextPaymentDetails: NextPaymentDetails) => string;

--- a/client/components/mma/accountoverview/ProductCardSections.tsx
+++ b/client/components/mma/accountoverview/ProductCardSections.tsx
@@ -1,0 +1,123 @@
+import { Button, SvgGift } from '@guardian/source/react-components';
+import { Ribbon } from '../../shared/Ribbon';
+import { Card } from '../shared/Card';
+import type { ProductCardConfiguration } from './ProductCardConfiguration';
+import {
+	centeredActionCss,
+	giftRibbonColour,
+	giftRibbonCopyColour,
+	giftRibbonCss,
+	keyValueCss,
+	leaveButtonCss,
+	productCardTitleCss,
+	productDetailLayoutCss,
+	sectionHeadingCss,
+	sharedMembershipTextCss,
+} from './ProductCardStyles';
+
+type SharedSubscriptionOwner = {
+	firstName: string;
+	lastName: string;
+	email: string;
+};
+
+export const SecondaryUserSections = ({
+	subscriptionName,
+	primarySubscriber,
+}: {
+	subscriptionName: string;
+	primarySubscriber: SharedSubscriptionOwner;
+}) => (
+	<>
+		<Card.Section>
+			<CardSectionSubscriptionDetails
+				subscriptionName={subscriptionName}
+				primarySubscriber={primarySubscriber}
+			/>
+		</Card.Section>
+		<Card.Section>
+			<CardSectionManageAccess subscriptionName={subscriptionName} />
+		</Card.Section>
+	</>
+);
+
+const CardSectionSubscriptionDetails = ({
+	subscriptionName,
+	primarySubscriber,
+}: {
+	subscriptionName: string;
+	primarySubscriber: SharedSubscriptionOwner;
+}) => (
+	<div css={productDetailLayoutCss}>
+		<div>
+			<h4 css={sectionHeadingCss}>Subscription details</h4>
+			<p css={sharedMembershipTextCss}>
+				Subscription: {subscriptionName} shared subscription <br />
+				Owner: {primarySubscriber.firstName}{' '}
+				{primarySubscriber.lastName}
+				<br /> <br />
+				You’ve been given access by {primarySubscriber.firstName}{' '}
+				{primarySubscriber.lastName} ({primarySubscriber.email}). To
+				access your benefits, sign in on your devices and the Guardian
+				app. Your account and activity are private and not shared with
+				the subscription owner.
+			</p>
+		</div>
+	</div>
+);
+
+const CardSectionManageAccess = ({
+	subscriptionName,
+}: {
+	subscriptionName: string;
+}) => (
+	<div css={keyValueCss}>
+		<div>
+			<h4 css={sectionHeadingCss}>Manage your access</h4>
+			<p css={sharedMembershipTextCss}>
+				You can leave this shared subscription at any time. If you
+				leave, you’ll lose your access to Digital plus benefits.
+			</p>
+		</div>
+		<div css={centeredActionCss}>
+			<Button
+				aria-label={`${subscriptionName} : Leave shared subscription`}
+				size="small"
+				priority="primary"
+				cssOverrides={leaveButtonCss}
+				onClick={() => undefined}
+			>
+				{`Leave subscription`}
+			</Button>
+		</div>
+	</div>
+);
+
+export const ProductCardHeader = ({
+	cardConfig,
+	productTitle,
+	isGifted,
+}: {
+	cardConfig: ProductCardConfiguration;
+	productTitle: string;
+	isGifted: boolean;
+}) => (
+	<Card.Header backgroundColor={cardConfig.colour} minHeightOverride="auto">
+		<h3 css={productCardTitleCss(cardConfig.invertText)}>{productTitle}</h3>
+		{isGifted && (
+			<Ribbon
+				copy="Gift"
+				ribbonColour={giftRibbonColour(cardConfig)}
+				copyColour={giftRibbonCopyColour(cardConfig)}
+				icon={
+					<SvgGift
+						isAnnouncedByScreenReader
+						size="small"
+						theme={{ fill: giftRibbonCopyColour(cardConfig) }}
+					/>
+				}
+				additionalCss={giftRibbonCss}
+			/>
+		)}
+	</Card.Header>
+);

--- a/client/components/mma/accountoverview/ProductCardSections.tsx
+++ b/client/components/mma/accountoverview/ProductCardSections.tsx
@@ -1,97 +1,13 @@
-import { Button, SvgGift } from '@guardian/source/react-components';
+import { SvgGift } from '@guardian/source/react-components';
 import { Ribbon } from '../../shared/Ribbon';
 import { Card } from '../shared/Card';
 import type { ProductCardConfiguration } from './ProductCardConfiguration';
 import {
-	centeredActionCss,
 	giftRibbonColour,
 	giftRibbonCopyColour,
 	giftRibbonCss,
-	keyValueCss,
-	leaveButtonCss,
 	productCardTitleCss,
-	productDetailLayoutCss,
-	sectionHeadingCss,
-	sharedMembershipTextCss,
 } from './ProductCardStyles';
-
-type SharedSubscriptionOwner = {
-	firstName: string;
-	lastName: string;
-	email: string;
-};
-
-export const SecondaryUserSections = ({
-	subscriptionName,
-	primarySubscriber,
-}: {
-	subscriptionName: string;
-	primarySubscriber: SharedSubscriptionOwner;
-}) => (
-	<>
-		<Card.Section>
-			<CardSectionSubscriptionDetails
-				subscriptionName={subscriptionName}
-				primarySubscriber={primarySubscriber}
-			/>
-		</Card.Section>
-		<Card.Section>
-			<CardSectionManageAccess subscriptionName={subscriptionName} />
-		</Card.Section>
-	</>
-);
-
-const CardSectionSubscriptionDetails = ({
-	subscriptionName,
-	primarySubscriber,
-}: {
-	subscriptionName: string;
-	primarySubscriber: SharedSubscriptionOwner;
-}) => (
-	<div css={productDetailLayoutCss}>
-		<div>
-			<h4 css={sectionHeadingCss}>Subscription details</h4>
-			<p css={sharedMembershipTextCss}>
-				Subscription: {subscriptionName} shared subscription <br />
-				Owner: {primarySubscriber.firstName}{' '}
-				{primarySubscriber.lastName}
-				<br /> <br />
-				You’ve been given access by {primarySubscriber.firstName}{' '}
-				{primarySubscriber.lastName} ({primarySubscriber.email}). To
-				access your benefits, sign in on your devices and the Guardian
-				app. Your account and activity are private and not shared with
-				the subscription owner.
-			</p>
-		</div>
-	</div>
-);
-
-const CardSectionManageAccess = ({
-	subscriptionName,
-}: {
-	subscriptionName: string;
-}) => (
-	<div css={keyValueCss}>
-		<div>
-			<h4 css={sectionHeadingCss}>Manage your access</h4>
-			<p css={sharedMembershipTextCss}>
-				You can leave this shared subscription at any time. If you
-				leave, you’ll lose your access to Digital plus benefits.
-			</p>
-		</div>
-		<div css={centeredActionCss}>
-			<Button
-				aria-label={`${subscriptionName} : Leave shared subscription`}
-				size="small"
-				priority="primary"
-				cssOverrides={leaveButtonCss}
-				onClick={() => undefined}
-			>
-				{`Leave subscription`}
-			</Button>
-		</div>
-	</div>
-);
 
 export const ProductCardHeader = ({
 	cardConfig,

--- a/client/components/mma/accountoverview/ProductCardStyles.ts
+++ b/client/components/mma/accountoverview/ProductCardStyles.ts
@@ -3,10 +3,12 @@ import {
 	from,
 	headlineBold20,
 	headlineBold24,
+	palette,
 	space,
 	textSans17,
 	textSansBold17,
 } from '@guardian/source/foundations';
+import type { ProductCardConfiguration } from './ProductCardConfiguration';
 import { textColour } from './ProductCardConfiguration';
 
 export const productCardTitleCss = (dark?: boolean) => css`
@@ -71,3 +73,38 @@ export const keyValueCss = css`
 		margin-left: 0;
 	}
 `;
+
+export const giftRibbonCss = css`
+	position: absolute;
+	top: 50%;
+	transform: translateY(-50%);
+	right: 0;
+`;
+
+export const benefitsTextCss = css`
+	${textSans17};
+	margin: 0;
+	margin-bottom: ${space[2]}px;
+`;
+
+export const sharedMembershipTextCss = css`
+	${textSans17};
+	margin: 0;
+`;
+
+export const centeredActionCss = css`
+	display: flex;
+	justify-content: center;
+`;
+
+export const leaveButtonCss = css`
+	justify-content: center;
+	border: none;
+	background: transparent;
+	text-decoration: underline;
+`;
+
+export const giftRibbonColour = (cardConfig: ProductCardConfiguration) =>
+	cardConfig.invertText ? palette.brand[400] : palette.brandAlt[400];
+export const giftRibbonCopyColour = (cardConfig: ProductCardConfiguration) =>
+	cardConfig.invertText ? palette.brandAlt[400] : palette.brand[400];

--- a/client/components/mma/accountoverview/ProductCardStyles.ts
+++ b/client/components/mma/accountoverview/ProductCardStyles.ts
@@ -87,23 +87,6 @@ export const benefitsTextCss = css`
 	margin-bottom: ${space[2]}px;
 `;
 
-export const sharedMembershipTextCss = css`
-	${textSans17};
-	margin: 0;
-`;
-
-export const centeredActionCss = css`
-	display: flex;
-	justify-content: center;
-`;
-
-export const leaveButtonCss = css`
-	justify-content: center;
-	border: none;
-	background: transparent;
-	text-decoration: underline;
-`;
-
 export const giftRibbonColour = (cardConfig: ProductCardConfiguration) =>
 	cardConfig.invertText ? palette.brand[400] : palette.brandAlt[400];
 export const giftRibbonCopyColour = (cardConfig: ProductCardConfiguration) =>


### PR DESCRIPTION
### Current situation/background
Product cards in the account overview of MMA currently contain multiple sections, with each section having different potential components shown depending on various factors. It is all contained in conditional displays in around 500 lines of code, extra css variables and some css imports from `ProductCardStyle.tsx`. This makes the file hard to work with and review. 

### What does this PR change?
This PR is the first step towards moving different separable components within ProductCard into a new file `ProductCardSections.tsx`, intended to become a collection of Card components which will be imported into `ProductCard.tsx` as needed. This PR moves the Card.Header section to the new file. 

### Next steps/further info
Further PRs to follow moving sections of ProductCard one by one. 

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->
