### PR TITLE
Moved product benefits copy and toggle to ProductCardSections

### DIFF
--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -32,8 +32,6 @@ import { wideButtonLayoutCss } from '../../../styles/ButtonStyles';
 import { trackEvent } from '../../../utilities/analytics';
 import { useUpgradeProduct } from '../../../utilities/hooks/useUpgradePreview';
 import { ErrorIcon } from '../shared/assets/ErrorIcon';
-import { getGuardianWeeklyGiftBenefits } from '../shared/benefits/BenefitsConfiguration';
-import { BenefitsToggle } from '../shared/benefits/BenefitsToggle';
 import { Card } from '../shared/Card';
 import { getNextPaymentDetails } from '../shared/NextPaymentDetails';
 import { PaymentMethoDisplay } from '../shared/PaymentMethodDisplay';
@@ -42,7 +40,7 @@ import {
 	getGuardianWeeklyGiftBenefitsCopy,
 	productCardConfiguration,
 } from './ProductCardConfiguration';
-import { ProductCardHeader } from './ProductCardSections';
+import { BenefitsCopy, ProductCardHeader } from './ProductCardSections';
 import {
 	benefitsTextCss,
 	keyValueCss,
@@ -264,24 +262,14 @@ export const ProductCard = ({
 					isGifted={isGifted}
 				/>
 
-				{cardConfig.getBenefitsSectionCopy && nextPaymentDetails && (
-					<Card.Section backgroundColor="#edf5fA" removeBorders>
-						<p css={benefitsTextCss}>
-							{cardConfig.getBenefitsSectionCopy(
-								nextPaymentDetails,
-							)}
-						</p>
-						<BenefitsToggle
-							productType={specificProductType.productType}
-							subscriptionPlan={mainPlan}
-							overrideBenefits={
-								gwGiftSubscription
-									? getGuardianWeeklyGiftBenefits()
-									: null
-							}
-						/>
-					</Card.Section>
-				)}
+				<BenefitsCopy
+					cardConfig={cardConfig}
+					nextPaymentDetails={nextPaymentDetails}
+					specificProductType={specificProductType}
+					mainPlan={mainPlan}
+					gwGiftSubscription={gwGiftSubscription}
+				/>
+
 				{specificProductType.productType === 'guardianadlite' &&
 					nextPaymentDetails && (
 						<Card.Section backgroundColor="#edf5fA">

--- a/client/components/mma/accountoverview/ProductCardSections.tsx
+++ b/client/components/mma/accountoverview/ProductCardSections.tsx
@@ -1,8 +1,14 @@
 import { SvgGift } from '@guardian/source/react-components';
+import type { SubscriptionPlan } from '../../../../shared/productResponse';
+import type { ProductType } from '../../../../shared/productTypes';
 import { Ribbon } from '../../shared/Ribbon';
+import { getGuardianWeeklyGiftBenefits } from '../shared/benefits/BenefitsConfiguration';
+import { BenefitsToggle } from '../shared/benefits/BenefitsToggle';
 import { Card } from '../shared/Card';
+import type { NextPaymentDetails } from '../shared/NextPaymentDetails';
 import type { ProductCardConfiguration } from './ProductCardConfiguration';
 import {
+	benefitsTextCss,
 	giftRibbonColour,
 	giftRibbonCopyColour,
 	giftRibbonCss,
@@ -37,3 +43,32 @@ export const ProductCardHeader = ({
 		)}
 	</Card.Header>
 );
+
+export const BenefitsCopy = ({
+	cardConfig,
+	nextPaymentDetails,
+	specificProductType,
+	mainPlan,
+	gwGiftSubscription,
+}: {
+	cardConfig: ProductCardConfiguration;
+	nextPaymentDetails: NextPaymentDetails | undefined;
+	specificProductType: ProductType;
+	mainPlan: SubscriptionPlan;
+	gwGiftSubscription: boolean;
+}) =>
+	cardConfig.getBenefitsSectionCopy &&
+	nextPaymentDetails && (
+		<Card.Section backgroundColor="#edf5fA" removeBorders>
+			<p css={benefitsTextCss}>
+				{cardConfig.getBenefitsSectionCopy(nextPaymentDetails)}
+			</p>
+			<BenefitsToggle
+				productType={specificProductType.productType}
+				subscriptionPlan={mainPlan}
+				overrideBenefits={
+					gwGiftSubscription ? getGuardianWeeklyGiftBenefits() : null
+				}
+			/>
+		</Card.Section>
+	);


### PR DESCRIPTION
### Current situation/background
Product cards in the account overview of MMA currently contain multiple sections, with each section having different potential components shown depending on various factors. It is all contained in conditional displays in around 500 lines of code, extra css variables and some css imports from `ProductCardStyle.tsx`. This makes the file hard to work with and review. 

### What does this PR change?
This PR moves the product benefits copy and toggle into `ProductCardSections.tsx`. 

### Next steps/further info
Further PRs to follow moving sections of ProductCard one by one. 
ProductCard Header: https://github.com/guardian/manage-frontend/pull/1674 

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->
