### PR TITLE
Moved Guardian Ad-Lite Copy to ProductCardSections

### DIFF
--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -40,9 +40,12 @@ import {
 	getGuardianWeeklyGiftBenefitsCopy,
 	productCardConfiguration,
 } from './ProductCardConfiguration';
-import { BenefitsCopy, ProductCardHeader } from './ProductCardSections';
 import {
-	benefitsTextCss,
+	BenefitsCopyAndToggle,
+	GuardianAdLiteCopy,
+	ProductCardHeader,
+} from './ProductCardSections';
+import {
 	keyValueCss,
 	productDetailLayoutCss,
 	sectionHeadingCss,
@@ -262,7 +265,7 @@ export const ProductCard = ({
 					isGifted={isGifted}
 				/>
 
-				<BenefitsCopy
+				<BenefitsCopyAndToggle
 					cardConfig={cardConfig}
 					nextPaymentDetails={nextPaymentDetails}
 					specificProductType={specificProductType}
@@ -270,18 +273,11 @@ export const ProductCard = ({
 					gwGiftSubscription={gwGiftSubscription}
 				/>
 
-				{specificProductType.productType === 'guardianadlite' &&
-					nextPaymentDetails && (
-						<Card.Section backgroundColor="#edf5fA">
-							<p css={benefitsTextCss}>
-								You’re subscribed to{' '}
-								{specificProductType.productTitle()} and pay{' '}
-								{nextPaymentDetails.paymentValueShort} a{' '}
-								{nextPaymentDetails.paymentInterval} for
-								non-personalised advertising.
-							</p>
-						</Card.Section>
-					)}
+				<GuardianAdLiteCopy
+					nextPaymentDetails={nextPaymentDetails}
+					specificProductType={specificProductType}
+				/>
+
 				<Card.Section>
 					<div css={productDetailLayoutCss}>
 						<div>

--- a/client/components/mma/accountoverview/ProductCardSections.tsx
+++ b/client/components/mma/accountoverview/ProductCardSections.tsx
@@ -44,7 +44,7 @@ export const ProductCardHeader = ({
 	</Card.Header>
 );
 
-export const BenefitsCopy = ({
+export const BenefitsCopyAndToggle = ({
 	cardConfig,
 	nextPaymentDetails,
 	specificProductType,
@@ -70,5 +70,24 @@ export const BenefitsCopy = ({
 					gwGiftSubscription ? getGuardianWeeklyGiftBenefits() : null
 				}
 			/>
+		</Card.Section>
+	);
+
+export const GuardianAdLiteCopy = ({
+	nextPaymentDetails,
+	specificProductType,
+}: {
+	nextPaymentDetails: NextPaymentDetails | undefined;
+	specificProductType: ProductType;
+}) =>
+	specificProductType.productType === 'guardianadlite' &&
+	nextPaymentDetails && (
+		<Card.Section backgroundColor="#edf5fA">
+			<p css={benefitsTextCss}>
+				You’re subscribed to {specificProductType.productTitle()} and
+				pay {nextPaymentDetails.paymentValueShort} a{' '}
+				{nextPaymentDetails.paymentInterval} for non-personalised
+				advertising.
+			</p>
 		</Card.Section>
 	);


### PR DESCRIPTION
### Current situation/background
Product cards in the account overview of MMA currently contain multiple sections, with each section having different potential components shown depending on various factors. It is all contained in conditional displays in around 500 lines of code, extra css variables and some css imports from `ProductCardStyle.tsx`. This makes the file hard to work with and review. 

### What does this PR change?
This PR moves the benefits copy text for the Guardian Ad-Lite product to `ProductCardSections.tsx`. 

### Next steps/further info
Further PRs to follow moving sections of ProductCard one by one. 
Product card header: https://github.com/guardian/manage-frontend/pull/1674 
Benefits copy and toggle: https://github.com/guardian/manage-frontend/pull/1675 

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
--> 
