### PR TITLE
Moved start, join, purchase, and end date rows from billing to ProductCardSections

### DIFF
--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -14,7 +14,6 @@ import { Link, useNavigate } from 'react-router-dom';
 import {
 	cancellationFormatDate,
 	DATE_FNS_LONG_OUTPUT_FORMAT,
-	parseDate,
 } from '@/shared/dates';
 import type {
 	MembersDataApiUser,
@@ -42,8 +41,12 @@ import {
 } from './ProductCardConfiguration';
 import {
 	BenefitsCopyAndToggle,
+	EndDateRow,
+	GiftPurchaseDateRow,
 	GuardianAdLiteCopy,
+	JoinDateRow,
 	ProductCardHeader,
+	StartDateRow,
 } from './ProductCardSections';
 import {
 	keyValueCss,
@@ -302,47 +305,28 @@ export const ProductCard = ({
 										<dd>{productDetail.mmaProductKey}</dd>
 									</div>
 								)}
-								{subscriptionStartDate && shouldShowStartDate && (
-									<div>
-										<dt>Start date</dt>
-										<dd>
-											{parseDate(
-												subscriptionStartDate,
-											).dateStr()}
-										</dd>
-									</div>
-								)}
-								{shouldShowJoinDateNotStartDate && (
-									<div>
-										<dt>Join date</dt>
-										<dd>
-											{parseDate(
-												productDetail.joinDate,
-											).dateStr()}
-										</dd>
-									</div>
-								)}
-								{userIsGifter && giftPurchaseDate && (
-									<div>
-										<dt>Purchase date</dt>
-										<dd>
-											{parseDate(
-												giftPurchaseDate,
-											).dateStr()}
-										</dd>
-									</div>
-								)}
-								{((isGifted && !userIsGifter) ||
-									!productDetail.subscription.autoRenew) && (
-									<div>
-										<dt>End date</dt>
-										<dd>
-											{parseDate(
-												subscriptionEndDate,
-											).dateStr()}
-										</dd>
-									</div>
-								)}
+								<StartDateRow
+									subscriptionStartDate={
+										subscriptionStartDate
+									}
+									shouldShowStartDate={shouldShowStartDate}
+								/>
+								<JoinDateRow
+									productDetail={productDetail}
+									shouldShowJoinDateNotStartDate={
+										shouldShowJoinDateNotStartDate
+									}
+								/>
+								<GiftPurchaseDateRow
+									userIsGifter={userIsGifter}
+									giftPurchaseDate={giftPurchaseDate}
+								/>
+								<EndDateRow
+									subscriptionEndDate={subscriptionEndDate}
+									isGifted={isGifted}
+									userIsGifter={userIsGifter}
+									productDetail={productDetail}
+								/>
 								{specificProductType.showTrialRemainingIfApplicable &&
 									productDetail.subscription.trialLength >
 										0 &&

--- a/client/components/mma/accountoverview/ProductCardSections.tsx
+++ b/client/components/mma/accountoverview/ProductCardSections.tsx
@@ -151,6 +151,7 @@ export const EndDateRow = ({
 	userIsGifter: boolean;
 	productDetail: ProductDetail;
 }) =>
+	subscriptionEndDate &&
 	((isGifted && !userIsGifter) || !productDetail.subscription.autoRenew) && (
 		<div>
 			<dt>End date</dt>

--- a/client/components/mma/accountoverview/ProductCardSections.tsx
+++ b/client/components/mma/accountoverview/ProductCardSections.tsx
@@ -1,5 +1,9 @@
 import { SvgGift } from '@guardian/source/react-components';
-import type { SubscriptionPlan } from '../../../../shared/productResponse';
+import { parseDate } from '@/shared/dates';
+import type {
+	ProductDetail,
+	SubscriptionPlan,
+} from '../../../../shared/productResponse';
 import type { ProductType } from '../../../../shared/productTypes';
 import { Ribbon } from '../../shared/Ribbon';
 import { getGuardianWeeklyGiftBenefits } from '../shared/benefits/BenefitsConfiguration';
@@ -90,4 +94,66 @@ export const GuardianAdLiteCopy = ({
 				advertising.
 			</p>
 		</Card.Section>
+	);
+
+export const StartDateRow = ({
+	subscriptionStartDate,
+	shouldShowStartDate,
+}: {
+	subscriptionStartDate: string | undefined;
+	shouldShowStartDate: boolean;
+}) =>
+	subscriptionStartDate &&
+	shouldShowStartDate && (
+		<div>
+			<dt>Start date</dt>
+			<dd>{parseDate(subscriptionStartDate).dateStr()}</dd>
+		</div>
+	);
+
+export const JoinDateRow = ({
+	productDetail,
+	shouldShowJoinDateNotStartDate,
+}: {
+	productDetail: ProductDetail;
+	shouldShowJoinDateNotStartDate: true | undefined;
+}) =>
+	shouldShowJoinDateNotStartDate && (
+		<div>
+			<dt>Join date</dt>
+			<dd>{parseDate(productDetail.joinDate).dateStr()}</dd>
+		</div>
+	);
+
+export const GiftPurchaseDateRow = ({
+	userIsGifter,
+	giftPurchaseDate,
+}: {
+	userIsGifter: boolean;
+	giftPurchaseDate: string | null;
+}) =>
+	userIsGifter &&
+	giftPurchaseDate && (
+		<div>
+			<dt>Purchase date</dt>
+			<dd>{parseDate(giftPurchaseDate).dateStr()}</dd>
+		</div>
+	);
+
+export const EndDateRow = ({
+	subscriptionEndDate,
+	isGifted,
+	userIsGifter,
+	productDetail,
+}: {
+	subscriptionEndDate: string | undefined;
+	isGifted: boolean;
+	userIsGifter: boolean;
+	productDetail: ProductDetail;
+}) =>
+	((isGifted && !userIsGifter) || !productDetail.subscription.autoRenew) && (
+		<div>
+			<dt>End date</dt>
+			<dd>{parseDate(subscriptionEndDate).dateStr()}</dd>
+		</div>
 	);


### PR DESCRIPTION
### Current situation/background
Product cards in the account overview of MMA currently contain multiple sections, with each section having different potential components shown depending on various factors. It is all contained in conditional displays in around 500 lines of code, extra css variables and some css imports from `ProductCardStyle.tsx`. This makes the file hard to work with and review. 

### What does this PR change?
This PR moves start, join, gift purchase, and end dates for billing and payments to `ProductCardSections.tsx`. I decided to move Billing and Payment section over multiple PRs since it is a large code section and moving everything at once would be hundreds of lines of changes. 

### Next steps/further info
Further PRs to follow moving sections of ProductCard one by one. 
Product card header: https://github.com/guardian/manage-frontend/pull/1674 
Benefits copy and toggle: https://github.com/guardian/manage-frontend/pull/1675 
Guardian Ad-Lite benefits copy: https://github.com/guardian/manage-frontend/pull/1676 

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
--> 
