### PR TITLE
Moved billing information rows to ProductCardSections

### DIFF
--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -3,7 +3,6 @@ import { palette, textSans17 } from '@guardian/source/foundations';
 import {
 	Button,
 	Stack,
-	SvgInfoRound,
 	themeButtonReaderRevenueBrand,
 } from '@guardian/source/react-components';
 import {
@@ -42,35 +41,22 @@ import {
 import {
 	BenefitsCopyAndToggle,
 	EndDateRow,
+	FutureProductRow,
 	GiftPurchaseDateRow,
 	GuardianAdLiteCopy,
 	JoinDateRow,
+	MembershipTierLabelRow,
+	NextPaymentRow,
 	ProductCardHeader,
 	StartDateRow,
+	TrialRemainingRow,
+	UserIdRow,
 } from './ProductCardSections';
 import {
 	keyValueCss,
 	productDetailLayoutCss,
 	sectionHeadingCss,
 } from './ProductCardStyles';
-
-const NewPriceAlert = () => {
-	const iconCss = css`
-		svg {
-			position: relative;
-			top: 7px;
-			margin-left: -4px;
-			fill: ${palette.brand[500]};
-		}
-	`;
-
-	return (
-		<span css={iconCss}>
-			<SvgInfoRound size="small" />
-			New price |{' '}
-		</span>
-	);
-};
 
 export const ProductCard = ({
 	productDetail,
@@ -286,25 +272,14 @@ export const ProductCard = ({
 						<div>
 							<h4 css={sectionHeadingCss}>Billing and payment</h4>
 							<dl css={keyValueCss}>
-								<div>
-									<dt>
-										{groupedProductType.showSupporterId
-											? 'Supporter ID'
-											: 'Subscription ID'}
-									</dt>
-									<dd data-qm-masking="blocklist">
-										{
-											productDetail.subscription
-												.subscriptionId
-										}
-									</dd>
-								</div>
-								{groupedProductType.tierLabel && (
-									<div>
-										<dt>{groupedProductType.tierLabel}</dt>
-										<dd>{productDetail.mmaProductKey}</dd>
-									</div>
-								)}
+								<UserIdRow
+									groupedProductType={groupedProductType}
+									productDetail={productDetail}
+								/>
+								<MembershipTierLabelRow
+									groupedProductType={groupedProductType}
+									productDetail={productDetail}
+								/>
 								<StartDateRow
 									subscriptionStartDate={
 										subscriptionStartDate
@@ -327,54 +302,21 @@ export const ProductCard = ({
 									userIsGifter={userIsGifter}
 									productDetail={productDetail}
 								/>
-								{specificProductType.showTrialRemainingIfApplicable &&
-									productDetail.subscription.trialLength >
-										0 &&
-									!isGifted &&
-									productDetail.subscription.readerType !==
-										'Patron' && (
-										<div>
-											<dt>Trial remaining</dt>
-											<dd>
-												{
-													productDetail.subscription
-														.trialLength
-												}{' '}
-												{productDetail.subscription
-													.trialLength !== 1
-													? 'days'
-													: 'day'}
-											</dd>
-										</div>
-									)}
-								{nextPaymentDetails &&
-									productDetail.subscription.autoRenew &&
-									!hasCancellationPending && (
-										<div>
-											<dt>
-												{nextPaymentDetails.paymentKey}
-											</dt>
-											<dd>
-												{nextPaymentDetails.isNewPaymentValue && (
-													<NewPriceAlert />
-												)}
-												{
-													nextPaymentDetails.paymentValue
-												}
-												{nextPaymentDetails.nextPaymentDateValue &&
-													productDetail.subscription
-														.readerType !==
-														'Patron' &&
-													` on ${nextPaymentDetails.nextPaymentDateValue}`}
-											</dd>
-										</div>
-									)}
-								{futureProductTitle && (
-									<div>
-										<dt>Switching to</dt>
-										<dd>{futureProductTitle}</dd>
-									</div>
-								)}
+								<TrialRemainingRow
+									specificProductType={specificProductType}
+									productDetail={productDetail}
+									isGifted={isGifted}
+								/>
+								<NextPaymentRow
+									nextPaymentDetails={nextPaymentDetails}
+									productDetail={productDetail}
+									hasCancellationPending={
+										hasCancellationPending
+									}
+								/>
+								<FutureProductRow
+									futureProductTitle={futureProductTitle}
+								/>
 							</dl>
 						</div>
 						<div css={wideButtonLayoutCss}>

--- a/client/components/mma/accountoverview/ProductCardSections.tsx
+++ b/client/components/mma/accountoverview/ProductCardSections.tsx
@@ -1,10 +1,15 @@
-import { SvgGift } from '@guardian/source/react-components';
+import { css } from '@emotion/react';
+import { palette } from '@guardian/source/foundations';
+import { SvgGift, SvgInfoRound } from '@guardian/source/react-components';
 import { parseDate } from '@/shared/dates';
 import type {
 	ProductDetail,
 	SubscriptionPlan,
 } from '../../../../shared/productResponse';
-import type { ProductType } from '../../../../shared/productTypes';
+import type {
+	GroupedProductType,
+	ProductType,
+} from '../../../../shared/productTypes';
 import { Ribbon } from '../../shared/Ribbon';
 import { getGuardianWeeklyGiftBenefits } from '../shared/benefits/BenefitsConfiguration';
 import { BenefitsToggle } from '../shared/benefits/BenefitsToggle';
@@ -18,6 +23,24 @@ import {
 	giftRibbonCss,
 	productCardTitleCss,
 } from './ProductCardStyles';
+
+const NewPriceAlert = () => {
+	const iconCss = css`
+		svg {
+			position: relative;
+			top: 7px;
+			margin-left: -4px;
+			fill: ${palette.brand[500]};
+		}
+	`;
+
+	return (
+		<span css={iconCss}>
+			<SvgInfoRound size="small" />
+			New price |{' '}
+		</span>
+	);
+};
 
 export const ProductCardHeader = ({
 	cardConfig,
@@ -156,5 +179,96 @@ export const EndDateRow = ({
 		<div>
 			<dt>End date</dt>
 			<dd>{parseDate(subscriptionEndDate).dateStr()}</dd>
+		</div>
+	);
+
+export const UserIdRow = ({
+	groupedProductType,
+	productDetail,
+}: {
+	groupedProductType: GroupedProductType;
+	productDetail: ProductDetail;
+}) => (
+	<div>
+		<dt>
+			{groupedProductType.showSupporterId
+				? 'Supporter ID'
+				: 'Subscription ID'}
+		</dt>
+		<dd data-qm-masking="blocklist">
+			{productDetail.subscription.subscriptionId}
+		</dd>
+	</div>
+);
+
+export const MembershipTierLabelRow = ({
+	groupedProductType,
+	productDetail,
+}: {
+	groupedProductType: GroupedProductType;
+	productDetail: ProductDetail;
+}) =>
+	groupedProductType.tierLabel && (
+		<div>
+			<dt>{groupedProductType.tierLabel}</dt>
+			<dd>{productDetail.mmaProductKey}</dd>
+		</div>
+	);
+
+export const TrialRemainingRow = ({
+	specificProductType,
+	productDetail,
+	isGifted,
+}: {
+	specificProductType: ProductType;
+	productDetail: ProductDetail;
+	isGifted: boolean;
+}) =>
+	specificProductType.showTrialRemainingIfApplicable &&
+	productDetail.subscription.trialLength > 0 &&
+	!isGifted &&
+	productDetail.subscription.readerType !== 'Patron' && (
+		<div>
+			<dt>Trial remaining</dt>
+			<dd>
+				{productDetail.subscription.trialLength}{' '}
+				{productDetail.subscription.trialLength !== 1 ? 'days' : 'day'}
+			</dd>
+		</div>
+	);
+
+export const NextPaymentRow = ({
+	nextPaymentDetails,
+	productDetail,
+	hasCancellationPending,
+}: {
+	nextPaymentDetails: NextPaymentDetails | undefined;
+	productDetail: ProductDetail;
+	hasCancellationPending: boolean;
+}) =>
+	nextPaymentDetails &&
+	productDetail.subscription.autoRenew &&
+	!hasCancellationPending && (
+		<div>
+			<dt>{nextPaymentDetails.paymentKey}</dt>
+			<dd>
+				{nextPaymentDetails.isNewPaymentValue && <NewPriceAlert />}
+				{nextPaymentDetails.paymentValue}
+				{nextPaymentDetails.nextPaymentDateValue &&
+					productDetail.subscription.readerType !== 'Patron' &&
+					` on ${nextPaymentDetails.nextPaymentDateValue}`}
+			</dd>
+		</div>
+	);
+
+export const FutureProductRow = ({
+	futureProductTitle,
+}: {
+	futureProductTitle: string | null;
+}) =>
+	futureProductTitle && (
+		<div>
+			<dt>Switching to</dt>
+			<dd>{futureProductTitle}</dd>
 		</div>
 	);


### PR DESCRIPTION
### Current situation/background
Product cards in the account overview of MMA currently contain multiple sections, with each section having different potential components shown depending on various factors. It is all contained in conditional displays in around 500 lines of code, extra css variables and some css imports from `ProductCardStyle.tsx`. This makes the file hard to work with and review. 

### What does this PR change?
This PR moves Supporter/Subscriber ID, membership tier, remaining trial days, next payment, and future plan rows to ProductCardSections. 

### Next steps/further info
Further PRs to follow moving sections of ProductCard one by one. 
Product card header: https://github.com/guardian/manage-frontend/pull/1674 
Benefits copy and toggle: https://github.com/guardian/manage-frontend/pull/1675 
Guardian Ad-Lite benefits copy: https://github.com/guardian/manage-frontend/pull/1676 
First PR on Billing and Payments: https://github.com/guardian/manage-frontend/pull/1680

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
--> 
