### PR TITLE
Moved billing buttons to ProductCardSections

### DIFF
--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -1,10 +1,6 @@
 import { css } from '@emotion/react';
 import { palette, textSans17 } from '@guardian/source/foundations';
-import {
-	Button,
-	Stack,
-	themeButtonReaderRevenueBrand,
-} from '@guardian/source/react-components';
+import { Button, Stack } from '@guardian/source/react-components';
 import {
 	InfoSummary,
 	SuccessSummary,
@@ -48,6 +44,9 @@ import {
 	MembershipTierLabelRow,
 	NextPaymentRow,
 	ProductCardHeader,
+	ProductManageButton,
+	ProductSwitchButton,
+	ProductUpsellButton,
 	StartDateRow,
 	TrialRemainingRow,
 	UserIdRow,
@@ -320,93 +319,33 @@ export const ProductCard = ({
 							</dl>
 						</div>
 						<div css={wideButtonLayoutCss}>
-							{showProductUpsellButton && (
-								<Button
-									aria-label={`Product Card Digital Plus Upsell Button`}
-									data-cy={`digital-plus-upsell-button`}
-									size="small"
-									priority="primary"
-									theme={themeButtonReaderRevenueBrand}
-									isLoading={isPreviewLoading}
-									disabled={
-										isPreviewLoading || hasPreviewError
-									}
-									cssOverrides={css`
-										justify-content: center;
-									`}
-									onClick={() => {
-										trackEvent({
-											eventCategory: 'account_overview',
-											eventAction: 'click',
-											eventLabel: `/${specificProductType.urlPart}/upgrade-product/information`,
-										});
-										void fetchUpgradePreview({
-											subscriptionId:
-												productDetail.subscription
-													.subscriptionId,
-											subscription:
-												productDetail.subscription,
-											mainPlan:
-												mainPlan as PaidSubscriptionPlan,
-											navigationPath: `/${specificProductType.urlPart}/upgrade-product/information?subscriptionId=${productDetail.subscription.subscriptionId}`,
-										});
-									}}
-								>
-									{`Upgrade to Digital plus`}
-								</Button>
-							)}
-							{!isGifted && (
-								<Button
-									aria-label={`${specificProductType.productTitle(
-										mainPlan,
-									)} : Manage ${
-										groupedProductType.friendlyName
-									}`}
-									data-cy={`Manage ${groupedProductType.friendlyName}`}
-									size="small"
-									priority="tertiary"
-									cssOverrides={css`
-										justify-content: center;
-									`}
-									onClick={() => {
-										trackEvent({
-											eventCategory: 'account_overview',
-											eventAction: 'click',
-											eventLabel: `manage_${specificProductType.urlPart}`,
-										});
-										navigate(
-											`/${specificProductType.urlPart}`,
-											{
-												state: {
-													productDetail:
-														productDetail,
-												},
-											},
-										);
-									}}
-								>
-									{`Manage ${groupedProductType.friendlyName}`}
-								</Button>
-							)}
-							{showSwitchButton && (
-								<Button
-									theme={themeButtonReaderRevenueBrand}
-									size="small"
-									cssOverrides={css`
-										justify-content: center;
-									`}
-									onClick={() =>
-										navigate(`/switch`, {
-											state: {
-												productDetail: productDetail,
-												user: user,
-											},
-										})
-									}
-								>
-									Change to all-access digital
-								</Button>
-							)}
+							<ProductUpsellButton
+								isPreviewLoading={isPreviewLoading}
+								hasPreviewError={hasPreviewError}
+								productDetail={productDetail}
+								specificProductType={specificProductType}
+								mainPlan={mainPlan}
+								showProductUpsellButton={
+									showProductUpsellButton
+								}
+								fetchUpgradePreview={fetchUpgradePreview}
+								trackEvent={trackEvent}
+							/>
+							<ProductManageButton
+								isGifted={isGifted}
+								specificProductType={specificProductType}
+								mainPlan={mainPlan}
+								groupedProductType={groupedProductType}
+								productDetail={productDetail}
+								navigate={navigate}
+								trackEvent={trackEvent}
+							/>
+							<ProductSwitchButton
+								showSwitchButton={showSwitchButton}
+								productDetail={productDetail}
+								user={user}
+								navigate={navigate}
+							/>
 						</div>
 					</div>
 				</Card.Section>

--- a/client/components/mma/accountoverview/ProductCardSections.tsx
+++ b/client/components/mma/accountoverview/ProductCardSections.tsx
@@ -1,15 +1,22 @@
 import { css } from '@emotion/react';
 import { palette } from '@guardian/source/foundations';
-import { SvgGift, SvgInfoRound } from '@guardian/source/react-components';
+import {
+	Button,
+	SvgGift,
+	SvgInfoRound,
+	themeButtonReaderRevenueBrand,
+} from '@guardian/source/react-components';
+import type { NavigateFunction } from 'react-router-dom';
+import type { Event } from '@/client/utilities/analytics';
+import type { FetchUpgradePreviewParams } from '@/client/utilities/hooks/useUpgradePreview';
 import { parseDate } from '@/shared/dates';
 import type {
+	MembersDataApiUser,
+	PaidSubscriptionPlan,
 	ProductDetail,
 	SubscriptionPlan,
-} from '../../../../shared/productResponse';
-import type {
-	GroupedProductType,
-	ProductType,
-} from '../../../../shared/productTypes';
+} from '@/shared/productResponse';
+import type { GroupedProductType, ProductType } from '@/shared/productTypes';
 import { Ribbon } from '../../shared/Ribbon';
 import { getGuardianWeeklyGiftBenefits } from '../shared/benefits/BenefitsConfiguration';
 import { BenefitsToggle } from '../shared/benefits/BenefitsToggle';
@@ -17,7 +24,9 @@ import { Card } from '../shared/Card';
 import type { NextPaymentDetails } from '../shared/NextPaymentDetails';
 import type { ProductCardConfiguration } from './ProductCardConfiguration';
 import {
+	benefitsSectionBackgroundColour,
 	benefitsTextCss,
+	centeredButtonCss,
 	giftRibbonColour,
 	giftRibbonCopyColour,
 	giftRibbonCss,
@@ -86,7 +95,10 @@ export const BenefitsCopyAndToggle = ({
 }) =>
 	cardConfig.getBenefitsSectionCopy &&
 	nextPaymentDetails && (
-		<Card.Section backgroundColor="#edf5fA" removeBorders>
+		<Card.Section
+			backgroundColor={benefitsSectionBackgroundColour}
+			removeBorders
+		>
 			<p css={benefitsTextCss}>
 				{cardConfig.getBenefitsSectionCopy(nextPaymentDetails)}
 			</p>
@@ -109,7 +121,7 @@ export const GuardianAdLiteCopy = ({
 }) =>
 	specificProductType.productType === 'guardianadlite' &&
 	nextPaymentDetails && (
-		<Card.Section backgroundColor="#edf5fA">
+		<Card.Section backgroundColor={benefitsSectionBackgroundColour}>
 			<p css={benefitsTextCss}>
 				You’re subscribed to {specificProductType.productTitle()} and
 				pay {nextPaymentDetails.paymentValueShort} a{' '}
@@ -271,4 +283,121 @@ export const FutureProductRow = ({
 			<dt>Switching to</dt>
 			<dd>{futureProductTitle}</dd>
 		</div>
+	);
+
+export const ProductUpsellButton = ({
+	isPreviewLoading,
+	hasPreviewError,
+	productDetail,
+	specificProductType,
+	mainPlan,
+	showProductUpsellButton,
+	trackEvent,
+	fetchUpgradePreview,
+}: {
+	isPreviewLoading: boolean;
+	hasPreviewError: boolean;
+	productDetail: ProductDetail;
+	specificProductType: ProductType;
+	mainPlan: SubscriptionPlan;
+	showProductUpsellButton: boolean;
+	trackEvent: (trackEventArgs: Event) => void;
+	fetchUpgradePreview: (
+		fetchUpgradePreviewArgs: FetchUpgradePreviewParams,
+	) => Promise<void>;
+}) =>
+	showProductUpsellButton && (
+		<Button
+			aria-label="Product Card Digital Plus Upsell Button"
+			data-cy="digital-plus-upsell-button"
+			size="small"
+			priority="primary"
+			theme={themeButtonReaderRevenueBrand}
+			isLoading={isPreviewLoading}
+			disabled={isPreviewLoading || hasPreviewError}
+			cssOverrides={centeredButtonCss}
+			onClick={() => {
+				trackEvent({
+					eventCategory: 'account_overview',
+					eventAction: 'click',
+					eventLabel: `/${specificProductType.urlPart}/upgrade-product/information`,
+				});
+				void fetchUpgradePreview({
+					subscriptionId: productDetail.subscription.subscriptionId,
+					subscription: productDetail.subscription,
+					mainPlan: mainPlan as PaidSubscriptionPlan,
+					navigationPath: `/${specificProductType.urlPart}/upgrade-product/information?subscriptionId=${productDetail.subscription.subscriptionId}`,
+				});
+			}}
+		>
+			Upgrade to Digital plus
+		</Button>
+	);
+
+export const ProductManageButton = ({
+	isGifted,
+	specificProductType,
+	mainPlan,
+	groupedProductType,
+	productDetail,
+	navigate,
+	trackEvent,
+}: {
+	isGifted: boolean;
+	specificProductType: ProductType;
+	mainPlan: SubscriptionPlan;
+	groupedProductType: GroupedProductType;
+	productDetail: ProductDetail;
+	navigate: NavigateFunction;
+	trackEvent: (trackEventArgs: Event) => void;
+}) =>
+	!isGifted && (
+		<Button
+			aria-label={`${specificProductType.productTitle(
+				mainPlan,
+			)} : Manage ${groupedProductType.friendlyName}`}
+			data-cy={`Manage ${groupedProductType.friendlyName}`}
+			size="small"
+			priority="tertiary"
+			cssOverrides={centeredButtonCss}
+			onClick={() => {
+				trackEvent({
+					eventCategory: 'account_overview',
+					eventAction: 'click',
+					eventLabel: `manage_${specificProductType.urlPart}`,
+				});
+				navigate(`/${specificProductType.urlPart}`, {
+					state: { productDetail },
+				});
+			}}
+		>
+			{`Manage ${groupedProductType.friendlyName}`}
+		</Button>
+	);
+
+export const ProductSwitchButton = ({
+	showSwitchButton,
+	productDetail,
+	user,
+	navigate,
+}: {
+	showSwitchButton: boolean;
+	productDetail: ProductDetail;
+	user: MembersDataApiUser | undefined;
+	navigate: NavigateFunction;
+}) =>
+	showSwitchButton &&
+	user && (
+		<Button
+			theme={themeButtonReaderRevenueBrand}
+			size="small"
+			cssOverrides={centeredButtonCss}
+			onClick={() =>
+				navigate(`/switch`, {
+					state: { productDetail, user },
+				})
+			}
+		>
+			Change to all-access digital
+		</Button>
 	);

--- a/client/components/mma/accountoverview/ProductCardStyles.ts
+++ b/client/components/mma/accountoverview/ProductCardStyles.ts
@@ -87,6 +87,12 @@ export const benefitsTextCss = css`
 	margin-bottom: ${space[2]}px;
 `;
 
+export const benefitsSectionBackgroundColour = '#edf5fa';
+
+export const centeredButtonCss = css`
+	justify-content: center;
+`;
+
 export const giftRibbonColour = (cardConfig: ProductCardConfiguration) =>
 	cardConfig.invertText ? palette.brand[400] : palette.brandAlt[400];
 export const giftRibbonCopyColour = (cardConfig: ProductCardConfiguration) =>

--- a/client/utilities/analytics.ts
+++ b/client/utilities/analytics.ts
@@ -3,7 +3,7 @@ import type { ProductDetail } from '../../shared/productResponse';
 import type { ProductType } from '../../shared/productTypes';
 import { getCookie } from './cookies';
 
-interface Event {
+export interface Event {
 	eventCategory: string;
 	eventAction: string;
 	product?: {

--- a/client/utilities/hooks/useUpgradePreview.ts
+++ b/client/utilities/hooks/useUpgradePreview.ts
@@ -12,7 +12,7 @@ import {
 } from '../../stores/UpgradeProductStore';
 import { changePlanFetch, fetchUpgradePreviewData } from '../productUtils';
 
-interface FetchUpgradePreviewParams {
+export interface FetchUpgradePreviewParams {
 	subscriptionId: string;
 	subscription: Subscription;
 	mainPlan: PaidSubscriptionPlan;


### PR DESCRIPTION
### Current situation/background
Product cards in the account overview of MMA currently contain multiple sections, with each section having different potential components shown depending on various factors. It is all contained in conditional displays in around 500 lines of code, extra css variables and some css imports from `ProductCardStyle.tsx`. This makes the file hard to work with and review. 

### What does this PR change?
This PR moves the buttons for upselling, switching, and managing plans; and cleans up a bit of the import statements and repeated inline css styling. 

### Next steps/further info
Further PRs to follow moving sections of ProductCard one by one. 
Product card header: https://github.com/guardian/manage-frontend/pull/1674 
Benefits copy and toggle: https://github.com/guardian/manage-frontend/pull/1675 
Guardian Ad-Lite benefits copy: https://github.com/guardian/manage-frontend/pull/1676 
First PR on Billing and Payments: https://github.com/guardian/manage-frontend/pull/1680
Second PR on Billing and Payments: https://github.com/guardian/manage-frontend/pull/1681

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
--> 
