### PR TITLE
Moved Live Events Promo codes and Payment Method to ProductCardSections

### DIFF
--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -25,11 +25,8 @@ import { GROUPED_PRODUCT_TYPES } from '@/shared/productTypes';
 import { wideButtonLayoutCss } from '../../../styles/ButtonStyles';
 import { trackEvent } from '../../../utilities/analytics';
 import { useUpgradeProduct } from '../../../utilities/hooks/useUpgradePreview';
-import { ErrorIcon } from '../shared/assets/ErrorIcon';
 import { Card } from '../shared/Card';
 import { getNextPaymentDetails } from '../shared/NextPaymentDetails';
-import { PaymentMethoDisplay } from '../shared/PaymentMethodDisplay';
-import { TaxExclusiveNotice } from '../shared/TaxExclusiveNotice';
 import {
 	getGuardianWeeklyGiftBenefitsCopy,
 	productCardConfiguration,
@@ -41,8 +38,10 @@ import {
 	GiftPurchaseDateRow,
 	GuardianAdLiteCopy,
 	JoinDateRow,
+	LiveEventsSection,
 	MembershipTierLabelRow,
 	NextPaymentRow,
+	PaymentSection,
 	ProductCardHeader,
 	ProductManageButton,
 	ProductSwitchButton,
@@ -349,87 +348,20 @@ export const ProductCard = ({
 						</div>
 					</div>
 				</Card.Section>
-				{entitledToEvents && (
-					<Card.Section>
-						<div>
-							<h4 css={sectionHeadingCss}>
-								Guardian Live - Ticket Tailor promo codes
-							</h4>
-							<div>
-								<dl css={keyValueCss}>
-									<dt>{window.atob('TFBQRlJFRTZHTFRY')}</dt>
-									<dd>
-										gives you 6 free tickets each year (1
-										per event)
-									</dd>
-								</dl>
-							</div>
-							<div>
-								<dl css={keyValueCss}>
-									<dt>{window.atob('TFBQMjAyR0xUWA==')}</dt>
-									<dd>
-										gives you 20% off an extra 2 tickets per
-										event
-									</dd>
-								</dl>
-							</div>
-						</div>
-					</Card.Section>
-				)}
-				{productDetail.isPaidTier && (
-					<Card.Section>
-						<div css={productDetailLayoutCss}>
-							<div>
-								<h4 css={sectionHeadingCss}>Payment method</h4>
-								<PaymentMethoDisplay
-									subscription={productDetail.subscription}
-									inPaymentFailure={hasPaymentFailure}
-								/>
-							</div>
-							{!isGifted && isSafeToUpdatePaymentMethod && (
-								<div css={wideButtonLayoutCss}>
-									<Button
-										aria-label={`${specificProductType.productTitle(
-											mainPlan,
-										)} : Update payment method`}
-										size="small"
-										cssOverrides={css`
-											justify-content: center;
-										`}
-										priority="tertiary"
-										icon={
-											hasPaymentFailure ? (
-												<ErrorIcon
-													fill={palette.neutral[100]}
-												/>
-											) : undefined
-										}
-										onClick={() => {
-											trackEvent({
-												eventCategory:
-													'account_overview',
-												eventAction: 'click',
-												eventLabel:
-													'manage_payment_method',
-											});
-											navigate(
-												`/payment/${specificProductType.urlPart}`,
-												{
-													state: { productDetail },
-												},
-											);
-										}}
-									>
-										Update payment method
-									</Button>
-								</div>
-							)}
-						</div>
-						<TaxExclusiveNotice
-							taxExclusive={productDetail.taxExclusive}
-						/>
-					</Card.Section>
-				)}
+
+				<LiveEventsSection entitledToEvents={entitledToEvents} />
+
+				<PaymentSection
+					productDetail={productDetail}
+					specificProductType={specificProductType}
+					hasPaymentFailure={hasPaymentFailure}
+					isGifted={isGifted}
+					isSafeToUpdatePaymentMethod={isSafeToUpdatePaymentMethod}
+					mainPlan={mainPlan}
+					navigate={navigate}
+					trackEvent={trackEvent}
+				/>
+
 				{!productDetail.isPaidTier && (
 					<Card.Section>
 						<h4 css={sectionHeadingCss}>Payment</h4>

--- a/client/components/mma/accountoverview/ProductCardSections.tsx
+++ b/client/components/mma/accountoverview/ProductCardSections.tsx
@@ -7,6 +7,7 @@ import {
 	themeButtonReaderRevenueBrand,
 } from '@guardian/source/react-components';
 import type { NavigateFunction } from 'react-router-dom';
+import { wideButtonLayoutCss } from '@/client/styles/ButtonStyles';
 import type { Event } from '@/client/utilities/analytics';
 import type { FetchUpgradePreviewParams } from '@/client/utilities/hooks/useUpgradePreview';
 import { parseDate } from '@/shared/dates';
@@ -18,10 +19,13 @@ import type {
 } from '@/shared/productResponse';
 import type { GroupedProductType, ProductType } from '@/shared/productTypes';
 import { Ribbon } from '../../shared/Ribbon';
+import { ErrorIcon } from '../shared/assets/ErrorIcon';
 import { getGuardianWeeklyGiftBenefits } from '../shared/benefits/BenefitsConfiguration';
 import { BenefitsToggle } from '../shared/benefits/BenefitsToggle';
 import { Card } from '../shared/Card';
 import type { NextPaymentDetails } from '../shared/NextPaymentDetails';
+import { PaymentMethodDisplay } from '../shared/PaymentMethodDisplay';
+import { TaxExclusiveNotice } from '../shared/TaxExclusiveNotice';
 import type { ProductCardConfiguration } from './ProductCardConfiguration';
 import {
 	benefitsSectionBackgroundColour,
@@ -30,7 +34,10 @@ import {
 	giftRibbonColour,
 	giftRibbonCopyColour,
 	giftRibbonCss,
+	keyValueCss,
 	productCardTitleCss,
+	productDetailLayoutCss,
+	sectionHeadingCss,
 } from './ProductCardStyles';
 
 const NewPriceAlert = () => {
@@ -400,4 +407,101 @@ export const ProductSwitchButton = ({
 		>
 			Change to all-access digital
 		</Button>
+	);
+
+export const LiveEventsSection = ({
+	entitledToEvents,
+}: {
+	entitledToEvents: boolean;
+}) =>
+	entitledToEvents && (
+		<Card.Section>
+			<div>
+				<h4 css={sectionHeadingCss}>
+					Guardian Live - Ticket Tailor promo codes
+				</h4>
+				<div>
+					<dl css={keyValueCss}>
+						<dt>{window.atob('TFBQRlJFRTZHTFRY')}</dt>
+						<dd>
+							gives you 6 free tickets each year (1 per event)
+						</dd>
+					</dl>
+				</div>
+				<div>
+					<dl css={keyValueCss}>
+						<dt>{window.atob('TFBQMjAyR0xUWA==')}</dt>
+						<dd>gives you 20% off an extra 2 tickets per event</dd>
+					</dl>
+				</div>
+			</div>
+		</Card.Section>
+	);
+
+export const PaymentSection = ({
+	productDetail,
+	specificProductType,
+	hasPaymentFailure,
+	isGifted,
+	isSafeToUpdatePaymentMethod,
+	mainPlan,
+	navigate,
+	trackEvent,
+}: {
+	productDetail: ProductDetail;
+	specificProductType: ProductType;
+	hasPaymentFailure: boolean;
+	isGifted: boolean;
+	isSafeToUpdatePaymentMethod: boolean;
+	mainPlan: SubscriptionPlan;
+	navigate: NavigateFunction;
+	trackEvent: (trackEventArgs: Event) => void;
+}) =>
+	productDetail.isPaidTier && (
+		<Card.Section>
+			<div css={productDetailLayoutCss}>
+				<div>
+					<h4 css={sectionHeadingCss}>Payment method</h4>
+					<PaymentMethodDisplay
+						subscription={productDetail.subscription}
+						inPaymentFailure={hasPaymentFailure}
+					/>
+				</div>
+				{!isGifted && isSafeToUpdatePaymentMethod && (
+					<div css={wideButtonLayoutCss}>
+						<Button
+							aria-label={`${specificProductType.productTitle(
+								mainPlan,
+							)} : Update payment method`}
+							size="small"
+							cssOverrides={css`
+								justify-content: center;
+							`}
+							priority="tertiary"
+							icon={
+								hasPaymentFailure ? (
+									<ErrorIcon fill={palette.neutral[100]} />
+								) : undefined
+							}
+							onClick={() => {
+								trackEvent({
+									eventCategory: 'account_overview',
+									eventAction: 'click',
+									eventLabel: 'manage_payment_method',
+								});
+								navigate(
+									`/payment/${specificProductType.urlPart}`,
+									{
+										state: { productDetail },
+									},
+								);
+							}}
+						>
+							Update payment method
+						</Button>
+					</div>
+				)}
+			</div>
+			<TaxExclusiveNotice taxExclusive={productDetail.taxExclusive} />
+		</Card.Section>
 	);

--- a/client/components/mma/shared/PaymentMethodDisplay.tsx
+++ b/client/components/mma/shared/PaymentMethodDisplay.tsx
@@ -6,7 +6,7 @@ import { DirectDebitDisplay } from './DirectDebitDisplay';
 import { PaypalDisplay } from './PaypalDisplay';
 import { SepaDisplay } from './SepaDisplay';
 
-export const PaymentMethoDisplay = ({
+export const PaymentMethodDisplay = ({
 	subscription,
 	inPaymentFailure,
 }: {


### PR DESCRIPTION
### Current situation/background
Product cards in the account overview of MMA currently contain multiple sections, with each section having different potential components shown depending on various factors. It is all contained in conditional displays in around 500 lines of code, extra css variables and some css imports from `ProductCardStyle.tsx`. This makes the file hard to work with and review. 

### What does this PR change?
This PR moves the Live Events Promo codes and Payment Method sections to ProductCardSections.tsx and fixes a typo. 

### Next steps/further info
Further PRs to follow moving sections of ProductCard one by one. 
Product card header: https://github.com/guardian/manage-frontend/pull/1674 
Benefits copy and toggle: https://github.com/guardian/manage-frontend/pull/1675 
Guardian Ad-Lite benefits copy: https://github.com/guardian/manage-frontend/pull/1676 
First PR on Billing and Payments: https://github.com/guardian/manage-frontend/pull/1680
Second PR on Billing and Payments: https://github.com/guardian/manage-frontend/pull/1681
Buttons in the Billing section: https://github.com/guardian/manage-frontend/pull/1682

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
--> 