### PR TITLE
Moved the Cancellation button when billing country is the US

### DIFF
--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
-import { palette, textSans17 } from '@guardian/source/foundations';
-import { Button, Stack } from '@guardian/source/react-components';
+import { palette } from '@guardian/source/foundations';
+import { Stack } from '@guardian/source/react-components';
 import {
 	InfoSummary,
 	SuccessSummary,
@@ -35,6 +35,7 @@ import {
 	BenefitsCopyAndToggle,
 	EndDateRow,
 	FutureProductRow,
+	GiftPaymentSection,
 	GiftPurchaseDateRow,
 	GuardianAdLiteCopy,
 	JoinDateRow,
@@ -48,6 +49,7 @@ import {
 	ProductUpsellButton,
 	StartDateRow,
 	TrialRemainingRow,
+	UsCancellationSection,
 	UserIdRow,
 } from './ProductCardSections';
 import {
@@ -362,83 +364,20 @@ export const ProductCard = ({
 					trackEvent={trackEvent}
 				/>
 
-				{!productDetail.isPaidTier && (
-					<Card.Section>
-						<h4 css={sectionHeadingCss}>Payment</h4>
-						<p
-							css={css`
-								${textSans17};
-								margin: 0;
-							`}
-						>
-							{isGifted ? 'Gift redemption' : 'Free'}
-						</p>
-					</Card.Section>
-				)}
-				{productDetail.billingCountry === 'United States' &&
-					!hasCancellationPending && (
-						<Card.Section>
-							<div css={productDetailLayoutCss}>
-								<div>
-									<h4 css={sectionHeadingCss}>
-										Cancel {groupedProductType.friendlyName}
-									</h4>
-									<p
-										css={css`
-											max-width: 350px;
-										`}
-									>
-										{!productDetail.subscription
-											.autoRenew &&
-										!productDetail.subscription
-											.nextPaymentDate ? (
-											<>
-												This is a one-off payment and
-												will not renew. You’ll continue
-												to enjoy your benefits until the
-												end of the current billing
-												period.
-											</>
-										) : (
-											<>
-												Stop your recurring payment, at
-												the end of current billing
-												period.
-											</>
-										)}
-									</p>
-								</div>
-								<div css={wideButtonLayoutCss}>
-									<Button
-										aria-label={`Cancel ${specificProductType.productTitle(
-											mainPlan,
-										)}`}
-										size="small"
-										cssOverrides={css`
-											justify-content: center;
-										`}
-										priority="tertiary"
-										onClick={() => {
-											trackEvent({
-												eventCategory:
-													'account_overview',
-												eventAction: 'click',
-												eventLabel: 'cancel_product',
-											});
-											navigate(
-												`/cancel/${specificProductType.urlPart}`,
-												{
-													state: { productDetail },
-												},
-											);
-										}}
-									>
-										Cancel {groupedProductType.friendlyName}
-									</Button>
-								</div>
-							</div>
-						</Card.Section>
-					)}
+				<GiftPaymentSection
+					productDetail={productDetail}
+					isGifted={isGifted}
+				/>
+
+				<UsCancellationSection
+					productDetail={productDetail}
+					groupedProductType={groupedProductType}
+					specificProductType={specificProductType}
+					mainPlan={mainPlan}
+					hasCancellationPending={hasCancellationPending}
+					navigate={navigate}
+					trackEvent={trackEvent}
+				/>
 			</Card>
 		</Stack>
 	);

--- a/client/components/mma/accountoverview/ProductCardSections.tsx
+++ b/client/components/mma/accountoverview/ProductCardSections.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { palette } from '@guardian/source/foundations';
+import { palette, textSans17 } from '@guardian/source/foundations';
 import {
 	Button,
 	SvgGift,
@@ -503,5 +503,100 @@ export const PaymentSection = ({
 				)}
 			</div>
 			<TaxExclusiveNotice taxExclusive={productDetail.taxExclusive} />
+		</Card.Section>
+	);
+
+// TODO I suspect this is never hit but I will leave it for not and clean up this file again once I move everything over.
+export const GiftPaymentSection = ({
+	productDetail,
+	isGifted,
+}: {
+	productDetail: ProductDetail;
+	isGifted: boolean;
+}) =>
+	!productDetail.isPaidTier && (
+		<Card.Section>
+			<h4 css={sectionHeadingCss}>Payment</h4>
+			<p
+				css={css`
+					${textSans17};
+					margin: 0;
+				`}
+			>
+				{isGifted ? 'Gift redemption' : 'Free'}
+			</p>
+		</Card.Section>
+	);
+
+export const UsCancellationSection = ({
+	productDetail,
+	groupedProductType,
+	specificProductType,
+	mainPlan,
+	hasCancellationPending,
+	navigate,
+	trackEvent,
+}: {
+	productDetail: ProductDetail;
+	groupedProductType: GroupedProductType;
+	specificProductType: ProductType;
+	mainPlan: SubscriptionPlan;
+	hasCancellationPending: boolean;
+	navigate: NavigateFunction;
+	trackEvent: (trackEventArgs: Event) => void;
+}) =>
+	productDetail.billingCountry === 'United States' &&
+	!hasCancellationPending && (
+		<Card.Section>
+			<div css={productDetailLayoutCss}>
+				<div>
+					<h4 css={sectionHeadingCss}>
+						Cancel {groupedProductType.friendlyName}
+					</h4>
+					<p
+						css={css`
+							max-width: 350px;
+						`}
+					>
+						{!productDetail.subscription.autoRenew &&
+						!productDetail.subscription.nextPaymentDate ? (
+							<>
+								This is a one-off payment and will not renew.
+								You’ll continue to enjoy your benefits until the
+								end of the current billing period.
+							</>
+						) : (
+							<>
+								Stop your recurring payment, at the end of
+								current billing period.
+							</>
+						)}
+					</p>
+				</div>
+				<div css={wideButtonLayoutCss}>
+					<Button
+						aria-label={`Cancel ${specificProductType.productTitle(
+							mainPlan,
+						)}`}
+						size="small"
+						cssOverrides={css`
+							justify-content: center;
+						`}
+						priority="tertiary"
+						onClick={() => {
+							trackEvent({
+								eventCategory: 'account_overview',
+								eventAction: 'click',
+								eventLabel: 'cancel_product',
+							});
+							navigate(`/cancel/${specificProductType.urlPart}`, {
+								state: { productDetail },
+							});
+						}}
+					>
+						Cancel {groupedProductType.friendlyName}
+					</Button>
+				</div>
+			</div>
 		</Card.Section>
 	);


### PR DESCRIPTION
### Current situation/background
Product cards in the account overview of MMA currently contain multiple sections, with each section having different potential components shown depending on various factors. It is all contained in conditional displays in around 500 lines of code, extra css variables and some css imports from `ProductCardStyle.tsx`. This makes the file hard to work with and review. 

### What does this PR change?
This PR moves another Payment section only visible when the subscription is not a paid plan (such as gifts) and the cancellation button visible to the US billing area. 

I will look further into the Payment section moved here, as I suspect it may not be hit, there is no accounts for gift recipients and I am not aware of any free plans that have a card that would have a payment section like the one below. For this PR I moved it as it is. I intend to go over the new file and clean it up more, and I'll try to see if any of the products currently use the said section. 

### Next steps/further info
Further PRs to follow moving sections of ProductCard one by one. 
Product card header: https://github.com/guardian/manage-frontend/pull/1674 
Benefits copy and toggle: https://github.com/guardian/manage-frontend/pull/1675 
Guardian Ad-Lite benefits copy: https://github.com/guardian/manage-frontend/pull/1676 
First PR on Billing and Payments: https://github.com/guardian/manage-frontend/pull/1680
Second PR on Billing and Payments: https://github.com/guardian/manage-frontend/pull/1681
Buttons in the Billing section: https://github.com/guardian/manage-frontend/pull/1682
Live Events promo codes and Payment Method: https://github.com/guardian/manage-frontend/pull/1683

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
--> 