### PR TITLE
Remove the cancel button for GW Gift subscriptions with US billing addresses

### DIFF
--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -322,6 +322,7 @@ export const ProductCard = ({
 					specificProductType={specificProductType}
 					mainPlan={mainPlan}
 					hasCancellationPending={hasCancellationPending}
+					isGifted={isGifted}
 					navigate={navigate}
 					trackEvent={trackEvent}
 				/>

--- a/client/components/mma/accountoverview/ProductCardSections.tsx
+++ b/client/components/mma/accountoverview/ProductCardSections.tsx
@@ -534,6 +534,7 @@ export const UsCancellationSection = ({
 	specificProductType,
 	mainPlan,
 	hasCancellationPending,
+	isGifted,
 	navigate,
 	trackEvent,
 }: {
@@ -542,11 +543,13 @@ export const UsCancellationSection = ({
 	specificProductType: ProductType;
 	mainPlan: SubscriptionPlan;
 	hasCancellationPending: boolean;
+	isGifted: boolean;
 	navigate: NavigateFunction;
 	trackEvent: (trackEventArgs: Event) => void;
 }) =>
 	productDetail.billingCountry === 'United States' &&
-	!hasCancellationPending && (
+	!hasCancellationPending &&
+	!isGifted && (
 		<Card.Section>
 			<div css={productDetailLayoutCss}>
 				<div>


### PR DESCRIPTION
### Current situation/background
Cancel subscription/membership buttons currently show for all non-cancelled products that have a US address for billing. This PR adds an extra check to remove this section from gift subscriptions, which are time-bound and prepaid subscriptions.

### What does this PR change?
Add an extra guard for displaying cancellation button section for US subs to ensure we don't show it on gift subscriptions. The users with US billing addresses that have bought a GW Gift subscription should not see the cancel subscription button. As these subscriptions are not renewed on a rolling basis, the cancel button here practically does not do anything. 

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->
