### PR TITLE
Moved info summaries above the product card to a new file

### DIFF
--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -1,15 +1,5 @@
-import { css } from '@emotion/react';
-import { palette } from '@guardian/source/foundations';
 import { Stack } from '@guardian/source/react-components';
-import {
-	InfoSummary,
-	SuccessSummary,
-} from '@guardian/source-development-kitchen/react-components';
-import { Link, useNavigate } from 'react-router-dom';
-import {
-	cancellationFormatDate,
-	DATE_FNS_LONG_OUTPUT_FORMAT,
-} from '@/shared/dates';
+import { useNavigate } from 'react-router-dom';
 import type {
 	MembersDataApiUser,
 	PaidSubscriptionPlan,
@@ -31,6 +21,11 @@ import {
 	getGuardianWeeklyGiftBenefitsCopy,
 	productCardConfiguration,
 } from './ProductCardConfiguration';
+import {
+	CancellationInfoRow,
+	OfferActiveInfoRow,
+	OfferPauseInfoRow,
+} from './ProductCardInfoSummaries';
 import {
 	BenefitsCopyAndToggle,
 	EndDateRow,
@@ -179,74 +174,26 @@ export const ProductCard = ({
 
 	return (
 		<Stack space={4}>
-			{hasCancellationPending && productDetail.subscription.end && (
-				<InfoSummary
-					message={`Your ${groupedProductType.friendlyName} has been cancelled`}
-					context={
-						<>
-							You are able to access your {productBenefits} until{' '}
-							<strong>
-								{cancellationFormatDate(
-									productDetail.subscription
-										.cancellationEffectiveDate,
-									DATE_FNS_LONG_OUTPUT_FORMAT,
-								)}
-							</strong>
-						</>
-					}
-				/>
-			)}
-			{canBeInOfferPeriod &&
-				isInOfferOrPausePeriod &&
-				isPaidSubscriptionPlan(mainPlan) &&
-				mainPlan.billingPeriod === 'month' && (
-					<SuccessSummary
-						message="Your offer is active"
-						context={
-							<>
-								Your free offer is active until{' '}
-								{nextPaymentDetails?.nextPaymentDateValue}. If
-								you have any questions, feel free to{' '}
-								{
-									<Link
-										to="/help-centre#contact-options"
-										css={css`
-											text-decoration: underline;
-											color: ${palette.brand[500]};
-										`}
-									>
-										contact our support team
-									</Link>
-								}
-								.
-							</>
-						}
-					/>
-				)}
-			{canBeInPausePeriod && isInOfferOrPausePeriod && (
-				<SuccessSummary
-					message="You have paused your support"
-					context={
-						<>
-							Your support is now paused until{' '}
-							{nextPaymentDetails?.nextPaymentDateValue}. If you
-							have any questions, feel free to{' '}
-							{
-								<Link
-									to="/help-centre#contact-options"
-									css={css`
-										text-decoration: underline;
-										color: ${palette.brand[500]};
-									`}
-								>
-									contact our support team
-								</Link>
-							}
-							.
-						</>
-					}
-				/>
-			)}
+			<CancellationInfoRow
+				hasCancellationPending={hasCancellationPending}
+				productDetail={productDetail}
+				groupedProductType={groupedProductType}
+				productBenefits={productBenefits}
+			/>
+
+			<OfferActiveInfoRow
+				canBeInOfferPeriod={canBeInOfferPeriod}
+				isInOfferOrPausePeriod={isInOfferOrPausePeriod}
+				nextPaymentDetails={nextPaymentDetails}
+				mainPlan={mainPlan}
+			/>
+
+			<OfferPauseInfoRow
+				canBeInPausePeriod={canBeInPausePeriod}
+				isInOfferOrPausePeriod={isInOfferOrPausePeriod}
+				nextPaymentDetails={nextPaymentDetails}
+			/>
+
 			<Card>
 				<ProductCardHeader
 					cardConfig={cardConfig}

--- a/client/components/mma/accountoverview/ProductCardInfoSummaries.tsx
+++ b/client/components/mma/accountoverview/ProductCardInfoSummaries.tsx
@@ -1,0 +1,124 @@
+import { css } from '@emotion/react';
+import { palette } from '@guardian/source/foundations';
+import {
+	InfoSummary,
+	SuccessSummary,
+} from '@guardian/source-development-kitchen/react-components';
+import { Link } from 'react-router-dom';
+import {
+	cancellationFormatDate,
+	DATE_FNS_LONG_OUTPUT_FORMAT,
+} from '@/shared/dates';
+import type {
+	ProductDetail,
+	SubscriptionPlan} from '@/shared/productResponse';
+import {
+	isPaidSubscriptionPlan
+} from '@/shared/productResponse';
+import type { GroupedProductType } from '@/shared/productTypes';
+import type { NextPaymentDetails } from '../shared/NextPaymentDetails';
+
+export const CancellationInfoRow = ({
+	hasCancellationPending,
+	productDetail,
+	groupedProductType,
+	productBenefits,
+}: {
+	hasCancellationPending: boolean;
+	productDetail: ProductDetail;
+	groupedProductType: GroupedProductType;
+	productBenefits: string;
+}) =>
+	hasCancellationPending &&
+	productDetail.subscription.end && (
+		<InfoSummary
+			message={`Your ${groupedProductType.friendlyName} has been cancelled`}
+			context={
+				<>
+					You are able to access your {productBenefits} until{' '}
+					<strong>
+						{cancellationFormatDate(
+							productDetail.subscription
+								.cancellationEffectiveDate,
+							DATE_FNS_LONG_OUTPUT_FORMAT,
+						)}
+					</strong>
+				</>
+			}
+		/>
+	);
+
+export const OfferActiveInfoRow = ({
+	canBeInOfferPeriod,
+	isInOfferOrPausePeriod,
+	nextPaymentDetails,
+	mainPlan,
+}: {
+	canBeInOfferPeriod: boolean;
+	isInOfferOrPausePeriod: boolean | '' | null; // Looks like there gotta be a better way?
+	nextPaymentDetails: NextPaymentDetails | undefined;
+	mainPlan: SubscriptionPlan;
+}) =>
+	canBeInOfferPeriod &&
+	isInOfferOrPausePeriod &&
+	isPaidSubscriptionPlan(mainPlan) &&
+	mainPlan.billingPeriod === 'month' && (
+		<SuccessSummary
+			message="Your offer is active"
+			context={
+				<>
+					Your free offer is active until{' '}
+					{nextPaymentDetails?.nextPaymentDateValue}. If you have any
+					questions, feel free to{' '}
+					{
+						<Link
+							to="/help-centre#contact-options"
+							css={css`
+								text-decoration: underline;
+								color: ${palette.brand[500]};
+							`}
+						>
+							contact our support team
+						</Link>
+					}
+					.
+				</>
+			}
+		/>
+	);
+
+export const OfferPauseInfoRow = ({
+	canBeInPausePeriod,
+	isInOfferOrPausePeriod,
+	nextPaymentDetails,
+}: {
+	canBeInPausePeriod: boolean;
+	isInOfferOrPausePeriod: boolean | '' | null;
+	nextPaymentDetails: NextPaymentDetails | undefined;
+}) =>
+	canBeInPausePeriod &&
+	isInOfferOrPausePeriod && (
+		<SuccessSummary
+			message="You have paused your support"
+			context={
+				<>
+					Your support is now paused until{' '}
+					{nextPaymentDetails?.nextPaymentDateValue}. If you
+					{nextPaymentDetails?.nextPaymentDateValue}. If you have any
+					questions, feel free to{' '}
+					{
+						<Link
+							to="/help-centre#contact-options"
+							css={css`
+								text-decoration: underline;
+								color: ${palette.brand[500]};
+							`}
+						>
+							contact our support team
+						</Link>
+					}
+					.
+				</>
+			}
+		/>
+	);


### PR DESCRIPTION
### Current situation/background
Product cards in the account overview of MMA currently contain multiple sections, with each section having different potential components shown depending on various factors. It is all contained in conditional displays in around 500 lines of code, extra css variables and some css imports from `ProductCardStyle.tsx`. This makes the file hard to work with and review. 

### What does this PR change?
This PR moves the three possible information summaries right above the product card into a new file called `ProductCardInfoSummaries.tsx`. A different file than the `ProductCardSections.tsx` since they are not directly part of the card itself but rather notices that appear on top of the card. 

### Next steps/further info
Further PRs to follow moving sections of ProductCard one by one. 
Product card header: https://github.com/guardian/manage-frontend/pull/1674 
Benefits copy and toggle: https://github.com/guardian/manage-frontend/pull/1675 
Guardian Ad-Lite benefits copy: https://github.com/guardian/manage-frontend/pull/1676 
First PR on Billing and Payments: https://github.com/guardian/manage-frontend/pull/1680
Second PR on Billing and Payments: https://github.com/guardian/manage-frontend/pull/1681
Buttons in the Billing section: https://github.com/guardian/manage-frontend/pull/1682
Live Events promo codes and Payment Method: https://github.com/guardian/manage-frontend/pull/1683
Cancellation button for US-based billing addresses: https://github.com/guardian/manage-frontend/pull/1684

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
--> 