### PR TITLE
Moved Billing and Payment section to a single TSX elements in ProductCardSections

### DIFF
--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -12,7 +12,6 @@ import {
 	isPaidSubscriptionPlan,
 } from '@/shared/productResponse';
 import { GROUPED_PRODUCT_TYPES } from '@/shared/productTypes';
-import { wideButtonLayoutCss } from '../../../styles/ButtonStyles';
 import { trackEvent } from '../../../utilities/analytics';
 import { useUpgradeProduct } from '../../../utilities/hooks/useUpgradePreview';
 import { Card } from '../shared/Card';
@@ -28,30 +27,14 @@ import {
 } from './ProductCardInfoSummaries';
 import {
 	BenefitsCopyAndToggle,
-	EndDateRow,
-	FutureProductRow,
+	BillingAndPaymentSection,
 	GiftPaymentSection,
-	GiftPurchaseDateRow,
 	GuardianAdLiteCopy,
-	JoinDateRow,
 	LiveEventsSection,
-	MembershipTierLabelRow,
-	NextPaymentRow,
 	PaymentSection,
 	ProductCardHeader,
-	ProductManageButton,
-	ProductSwitchButton,
-	ProductUpsellButton,
-	StartDateRow,
-	TrialRemainingRow,
 	UsCancellationSection,
-	UserIdRow,
 } from './ProductCardSections';
-import {
-	keyValueCss,
-	productDetailLayoutCss,
-	sectionHeadingCss,
-} from './ProductCardStyles';
 
 export const ProductCard = ({
 	productDetail,
@@ -214,89 +197,32 @@ export const ProductCard = ({
 					specificProductType={specificProductType}
 				/>
 
-				<Card.Section>
-					<div css={productDetailLayoutCss}>
-						<div>
-							<h4 css={sectionHeadingCss}>Billing and payment</h4>
-							<dl css={keyValueCss}>
-								<UserIdRow
-									groupedProductType={groupedProductType}
-									productDetail={productDetail}
-								/>
-								<MembershipTierLabelRow
-									groupedProductType={groupedProductType}
-									productDetail={productDetail}
-								/>
-								<StartDateRow
-									subscriptionStartDate={
-										subscriptionStartDate
-									}
-									shouldShowStartDate={shouldShowStartDate}
-								/>
-								<JoinDateRow
-									productDetail={productDetail}
-									shouldShowJoinDateNotStartDate={
-										shouldShowJoinDateNotStartDate
-									}
-								/>
-								<GiftPurchaseDateRow
-									userIsGifter={userIsGifter}
-									giftPurchaseDate={giftPurchaseDate}
-								/>
-								<EndDateRow
-									subscriptionEndDate={subscriptionEndDate}
-									isGifted={isGifted}
-									userIsGifter={userIsGifter}
-									productDetail={productDetail}
-								/>
-								<TrialRemainingRow
-									specificProductType={specificProductType}
-									productDetail={productDetail}
-									isGifted={isGifted}
-								/>
-								<NextPaymentRow
-									nextPaymentDetails={nextPaymentDetails}
-									productDetail={productDetail}
-									hasCancellationPending={
-										hasCancellationPending
-									}
-								/>
-								<FutureProductRow
-									futureProductTitle={futureProductTitle}
-								/>
-							</dl>
-						</div>
-						<div css={wideButtonLayoutCss}>
-							<ProductUpsellButton
-								isPreviewLoading={isPreviewLoading}
-								hasPreviewError={hasPreviewError}
-								productDetail={productDetail}
-								specificProductType={specificProductType}
-								mainPlan={mainPlan}
-								showProductUpsellButton={
-									showProductUpsellButton
-								}
-								fetchUpgradePreview={fetchUpgradePreview}
-								trackEvent={trackEvent}
-							/>
-							<ProductManageButton
-								isGifted={isGifted}
-								specificProductType={specificProductType}
-								mainPlan={mainPlan}
-								groupedProductType={groupedProductType}
-								productDetail={productDetail}
-								navigate={navigate}
-								trackEvent={trackEvent}
-							/>
-							<ProductSwitchButton
-								showSwitchButton={showSwitchButton}
-								productDetail={productDetail}
-								user={user}
-								navigate={navigate}
-							/>
-						</div>
-					</div>
-				</Card.Section>
+				<BillingAndPaymentSection
+					groupedProductType={groupedProductType}
+					productDetail={productDetail}
+					specificProductType={specificProductType}
+					shouldShowStartDate={shouldShowStartDate}
+					subscriptionStartDate={subscriptionStartDate}
+					subscriptionEndDate={subscriptionEndDate}
+					shouldShowJoinDateNotStartDate={
+						shouldShowJoinDateNotStartDate
+					}
+					userIsGifter={userIsGifter}
+					giftPurchaseDate={giftPurchaseDate}
+					isGifted={isGifted}
+					nextPaymentDetails={nextPaymentDetails}
+					hasCancellationPending={hasCancellationPending}
+					futureProductTitle={futureProductTitle}
+					isPreviewLoading={isPreviewLoading}
+					hasPreviewError={hasPreviewError}
+					mainPlan={mainPlan}
+					showProductUpsellButton={showProductUpsellButton}
+					showSwitchButton={showSwitchButton}
+					user={user}
+					navigate={navigate}
+					trackEvent={trackEvent}
+					fetchUpgradePreview={fetchUpgradePreview}
+				/>
 
 				<LiveEventsSection entitledToEvents={entitledToEvents} />
 

--- a/client/components/mma/accountoverview/ProductCardSections.tsx
+++ b/client/components/mma/accountoverview/ProductCardSections.tsx
@@ -138,7 +138,7 @@ export const GuardianAdLiteCopy = ({
 		</Card.Section>
 	);
 
-export const StartDateRow = ({
+const StartDateRow = ({
 	subscriptionStartDate,
 	shouldShowStartDate,
 }: {
@@ -153,7 +153,7 @@ export const StartDateRow = ({
 		</div>
 	);
 
-export const JoinDateRow = ({
+const JoinDateRow = ({
 	productDetail,
 	shouldShowJoinDateNotStartDate,
 }: {
@@ -167,7 +167,7 @@ export const JoinDateRow = ({
 		</div>
 	);
 
-export const GiftPurchaseDateRow = ({
+const GiftPurchaseDateRow = ({
 	userIsGifter,
 	giftPurchaseDate,
 }: {
@@ -182,7 +182,7 @@ export const GiftPurchaseDateRow = ({
 		</div>
 	);
 
-export const EndDateRow = ({
+const EndDateRow = ({
 	subscriptionEndDate,
 	isGifted,
 	userIsGifter,
@@ -201,7 +201,7 @@ export const EndDateRow = ({
 		</div>
 	);
 
-export const UserIdRow = ({
+const UserIdRow = ({
 	groupedProductType,
 	productDetail,
 }: {
@@ -220,7 +220,7 @@ export const UserIdRow = ({
 	</div>
 );
 
-export const MembershipTierLabelRow = ({
+const MembershipTierLabelRow = ({
 	groupedProductType,
 	productDetail,
 }: {
@@ -234,7 +234,7 @@ export const MembershipTierLabelRow = ({
 		</div>
 	);
 
-export const TrialRemainingRow = ({
+const TrialRemainingRow = ({
 	specificProductType,
 	productDetail,
 	isGifted,
@@ -256,7 +256,7 @@ export const TrialRemainingRow = ({
 		</div>
 	);
 
-export const NextPaymentRow = ({
+const NextPaymentRow = ({
 	nextPaymentDetails,
 	productDetail,
 	hasCancellationPending,
@@ -280,7 +280,7 @@ export const NextPaymentRow = ({
 		</div>
 	);
 
-export const FutureProductRow = ({
+const FutureProductRow = ({
 	futureProductTitle,
 }: {
 	futureProductTitle: string | null;
@@ -292,7 +292,7 @@ export const FutureProductRow = ({
 		</div>
 	);
 
-export const ProductUpsellButton = ({
+const ProductUpsellButton = ({
 	isPreviewLoading,
 	hasPreviewError,
 	productDetail,
@@ -341,7 +341,7 @@ export const ProductUpsellButton = ({
 		</Button>
 	);
 
-export const ProductManageButton = ({
+const ProductManageButton = ({
 	isGifted,
 	specificProductType,
 	mainPlan,
@@ -382,7 +382,7 @@ export const ProductManageButton = ({
 		</Button>
 	);
 
-export const ProductSwitchButton = ({
+const ProductSwitchButton = ({
 	showSwitchButton,
 	productDetail,
 	user,
@@ -408,6 +408,132 @@ export const ProductSwitchButton = ({
 			Change to all-access digital
 		</Button>
 	);
+
+export const BillingAndPaymentSection = ({
+	groupedProductType,
+	productDetail,
+	specificProductType,
+	shouldShowStartDate,
+	subscriptionStartDate,
+	subscriptionEndDate,
+	shouldShowJoinDateNotStartDate,
+	userIsGifter,
+	giftPurchaseDate,
+	isGifted,
+	nextPaymentDetails,
+	hasCancellationPending,
+	futureProductTitle,
+	isPreviewLoading,
+	hasPreviewError,
+	mainPlan,
+	showProductUpsellButton,
+	showSwitchButton,
+	user,
+	navigate,
+	trackEvent,
+	fetchUpgradePreview,
+}: {
+	groupedProductType: GroupedProductType;
+	productDetail: ProductDetail;
+	specificProductType: ProductType;
+	shouldShowStartDate: boolean;
+	subscriptionStartDate: string | undefined;
+	subscriptionEndDate: string | undefined;
+	shouldShowJoinDateNotStartDate: true | undefined;
+	userIsGifter: boolean;
+	giftPurchaseDate: string | null;
+	isGifted: boolean;
+	nextPaymentDetails: NextPaymentDetails | undefined;
+	hasCancellationPending: boolean;
+	futureProductTitle: string | null;
+	isPreviewLoading: boolean;
+	hasPreviewError: boolean;
+	mainPlan: SubscriptionPlan;
+	showProductUpsellButton: boolean;
+	showSwitchButton: boolean;
+	user: MembersDataApiUser | undefined;
+	navigate: NavigateFunction;
+	trackEvent: (trackEventArgs: Event) => void;
+	fetchUpgradePreview: (
+		fetchUpgradePreviewArgs: FetchUpgradePreviewParams,
+	) => Promise<void>;
+}) => (
+	<Card.Section>
+		<div css={productDetailLayoutCss}>
+			<div>
+				<h4 css={sectionHeadingCss}>Billing and payment</h4>
+				<dl css={keyValueCss}>
+					<UserIdRow
+						groupedProductType={groupedProductType}
+						productDetail={productDetail}
+					/>
+					<MembershipTierLabelRow
+						groupedProductType={groupedProductType}
+						productDetail={productDetail}
+					/>
+					<StartDateRow
+						subscriptionStartDate={subscriptionStartDate}
+						shouldShowStartDate={shouldShowStartDate}
+					/>
+					<JoinDateRow
+						productDetail={productDetail}
+						shouldShowJoinDateNotStartDate={
+							shouldShowJoinDateNotStartDate
+						}
+					/>
+					<GiftPurchaseDateRow
+						userIsGifter={userIsGifter}
+						giftPurchaseDate={giftPurchaseDate}
+					/>
+					<EndDateRow
+						subscriptionEndDate={subscriptionEndDate}
+						isGifted={isGifted}
+						userIsGifter={userIsGifter}
+						productDetail={productDetail}
+					/>
+					<TrialRemainingRow
+						specificProductType={specificProductType}
+						productDetail={productDetail}
+						isGifted={isGifted}
+					/>
+					<NextPaymentRow
+						nextPaymentDetails={nextPaymentDetails}
+						productDetail={productDetail}
+						hasCancellationPending={hasCancellationPending}
+					/>
+					<FutureProductRow futureProductTitle={futureProductTitle} />
+				</dl>
+			</div>
+			<div css={wideButtonLayoutCss}>
+				<ProductUpsellButton
+					isPreviewLoading={isPreviewLoading}
+					hasPreviewError={hasPreviewError}
+					productDetail={productDetail}
+					specificProductType={specificProductType}
+					mainPlan={mainPlan}
+					showProductUpsellButton={showProductUpsellButton}
+					fetchUpgradePreview={fetchUpgradePreview}
+					trackEvent={trackEvent}
+				/>
+				<ProductManageButton
+					isGifted={isGifted}
+					specificProductType={specificProductType}
+					mainPlan={mainPlan}
+					groupedProductType={groupedProductType}
+					productDetail={productDetail}
+					navigate={navigate}
+					trackEvent={trackEvent}
+				/>
+				<ProductSwitchButton
+					showSwitchButton={showSwitchButton}
+					productDetail={productDetail}
+					user={user}
+					navigate={navigate}
+				/>
+			</div>
+		</div>
+	</Card.Section>
+);
 
 export const LiveEventsSection = ({
 	entitledToEvents,


### PR DESCRIPTION
### Current situation/background
Product cards in the account overview of MMA currently contain multiple sections, with each section having different potential components shown depending on various factors. It is all contained in conditional displays in around 500 lines of code, extra css variables and some css imports from `ProductCardStyle.tsx`. This makes the file hard to work with and review. 

### What does this PR change?
The Billing and Payment section is a large card section with much information. This PR moves it into a single TSX component to be exported from ProductCardSections, rather than importing all its sub-components and combining them in ProductCard.tsx. 

### Next steps/further info
Further PRs to follow moving sections of ProductCard one by one. 
Product card header: https://github.com/guardian/manage-frontend/pull/1674 
Benefits copy and toggle: https://github.com/guardian/manage-frontend/pull/1675 
Guardian Ad-Lite benefits copy: https://github.com/guardian/manage-frontend/pull/1676 
First PR on Billing and Payments: https://github.com/guardian/manage-frontend/pull/1680
Second PR on Billing and Payments: https://github.com/guardian/manage-frontend/pull/1681
Buttons in the Billing section: https://github.com/guardian/manage-frontend/pull/1682
Live Events promo codes and Payment Method: https://github.com/guardian/manage-frontend/pull/1683
Cancellation button for US-based billing addresses: https://github.com/guardian/manage-frontend/pull/1684
Info summaries above the card into a new file: https://github.com/guardian/manage-frontend/pull/1686 

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
--> 