### PR TITLE
Moved overrideBenefits to Card.Section level

### DIFF
--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -14,6 +14,7 @@ import {
 import { GROUPED_PRODUCT_TYPES } from '@/shared/productTypes';
 import { trackEvent } from '../../../utilities/analytics';
 import { useUpgradeProduct } from '../../../utilities/hooks/useUpgradePreview';
+import { getGuardianWeeklyGiftBenefits } from '../shared/benefits/BenefitsConfiguration';
 import { Card } from '../shared/Card';
 import { getNextPaymentDetails } from '../shared/NextPaymentDetails';
 import {
@@ -77,6 +78,9 @@ export const ProductCard = ({
 	const userIsGifter = isGifted && productDetail.isPaidTier;
 	const gwGiftSubscription =
 		isGifted && specificProductType.productType === 'guardianweekly';
+	const benefitsOverrideForGWGift = gwGiftSubscription
+		? getGuardianWeeklyGiftBenefits()
+		: undefined;
 	const giftPurchaseDate = productDetail.subscription.lastPaymentDate;
 	const shouldShowJoinDateNotStartDate =
 		groupedProductType.shouldShowJoinDateNotStartDate;
@@ -189,7 +193,7 @@ export const ProductCard = ({
 					nextPaymentDetails={nextPaymentDetails}
 					specificProductType={specificProductType}
 					mainPlan={mainPlan}
-					gwGiftSubscription={gwGiftSubscription}
+					overrideBenefits={benefitsOverrideForGWGift}
 				/>
 
 				<GuardianAdLiteCopy

--- a/client/components/mma/accountoverview/ProductCardSections.tsx
+++ b/client/components/mma/accountoverview/ProductCardSections.tsx
@@ -20,7 +20,7 @@ import type {
 import type { GroupedProductType, ProductType } from '@/shared/productTypes';
 import { Ribbon } from '../../shared/Ribbon';
 import { ErrorIcon } from '../shared/assets/ErrorIcon';
-import { getGuardianWeeklyGiftBenefits } from '../shared/benefits/BenefitsConfiguration';
+import type { ProductBenefit } from '../shared/benefits/BenefitsConfiguration';
 import { BenefitsToggle } from '../shared/benefits/BenefitsToggle';
 import { Card } from '../shared/Card';
 import type { NextPaymentDetails } from '../shared/NextPaymentDetails';
@@ -89,16 +89,16 @@ export const ProductCardHeader = ({
 
 export const BenefitsCopyAndToggle = ({
 	cardConfig,
-	nextPaymentDetails,
 	specificProductType,
 	mainPlan,
-	gwGiftSubscription,
+	nextPaymentDetails,
+	overrideBenefits,
 }: {
 	cardConfig: ProductCardConfiguration;
-	nextPaymentDetails: NextPaymentDetails | undefined;
 	specificProductType: ProductType;
 	mainPlan: SubscriptionPlan;
-	gwGiftSubscription: boolean;
+	nextPaymentDetails?: NextPaymentDetails | undefined;
+	overrideBenefits?: ProductBenefit[];
 }) =>
 	cardConfig.getBenefitsSectionCopy &&
 	nextPaymentDetails && (
@@ -112,9 +112,7 @@ export const BenefitsCopyAndToggle = ({
 			<BenefitsToggle
 				productType={specificProductType.productType}
 				subscriptionPlan={mainPlan}
-				overrideBenefits={
-					gwGiftSubscription ? getGuardianWeeklyGiftBenefits() : null
-				}
+				overrideBenefits={overrideBenefits}
 			/>
 		</Card.Section>
 	);

--- a/client/components/mma/accountoverview/ProductCardSections.tsx
+++ b/client/components/mma/accountoverview/ProductCardSections.tsx
@@ -65,7 +65,7 @@ export const ProductCardHeader = ({
 }: {
 	cardConfig: ProductCardConfiguration;
 	productTitle: string;
-	isGifted: boolean;
+	isGifted?: boolean;
 }) => (
 	<Card.Header backgroundColor={cardConfig.colour} minHeightOverride="auto">
 		<h3 css={productCardTitleCss(cardConfig.invertText)}>{productTitle}</h3>


### PR DESCRIPTION
### Current situation/background
ProductCard passes a boolean parameter to Benefits Toggle component if the user has the benefits through a GW Gift subscription. This is quite a specific case and the checks for this is done at ProductCard level. 

### What does this PR change?
Move the logic of overriding benefits to ProductCard level for better reusability. This way we can just pass a list of benefits to the Benefits Toggle card section without having to change the inner workings of the card section. A similar logic is present for determining which cardConfig is to be passed to benefits copy. 

### Next steps/further info
This is quite useful for reusing this component easily for the secondary user card that I will create later, as it may have a similar override necessary between Digital plus subscribers and secondary users. Primary users may see sharing their subscription as a benefit whereas secondary users would not have this benefit shown. 

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->
