### PR TITLE
resolve ws vulnerability

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -14791,9 +14791,9 @@ ws@^7.3.1:
   integrity sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==
 
 ws@^8.11.0, ws@^8.18.0, ws@^8.2.3:
-  version "8.18.0"
-  resolved "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz"
-  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 xml-name-validator@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14786,9 +14786,9 @@ write-file-atomic@^4.0.2:
     signal-exit "^3.0.7"
 
 ws@^7.3.1:
-  version "7.5.10"
-  resolved "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz"
-  integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
+  version "7.5.11"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.11.tgz#9460daf1812bb81a423c5b9eac746941a86310fa"
+  integrity sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==
 
 ws@^8.11.0, ws@^8.18.0, ws@^8.2.3:
   version "8.18.0"


### PR DESCRIPTION
This is another attempt at resolving a ws vulnerability: https://github.com/guardian/manage-frontend/security/dependabot/354 (first attempt was here: https://github.com/guardian/manage-frontend/pull/1692)

Note that the first attempt wasn't well done become overriding a version on resolutions the way it was done, in the package.json overrides all versions everywhere and may by accident upgrade major versions. 

In this attempt we used an idea from @j-ruda-guardian by which we simply remove from the yarn.lock like the ws 7.x.x and 8.x.x entries and let `yarn install` upgrade from `7.5.10` to `7.5.11` and from `8.18.0` to `8.21.0` which are both patched. This ensures that the version update to a patched version is done, but without overriding the major version.