### PR TITLE
Bumped path-to-regexp to 0.1.13 for the two dependencies that used 0.1.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,7 +188,9 @@
     "flatted": "^3.4.2",
     "follow-redirects": "^1.16.0",
     "serialize-javascript": "^7.0.3",
-    "tmp": "^0.2.7"
+    "tmp": "^0.2.7",
+    "express/path-to-regexp": "0.1.13",
+    "webpack-dev-server/path-to-regexp": "0.1.13"
   },
   "license": "UNLICENSED",
   "msw": {

--- a/package.json
+++ b/package.json
@@ -189,8 +189,8 @@
     "follow-redirects": "^1.16.0",
     "serialize-javascript": "^7.0.3",
     "tmp": "^0.2.7",
-    "express/path-to-regexp": "0.1.13",
-    "webpack-dev-server/path-to-regexp": "0.1.13"
+    "express/path-to-regexp": "^0.1.13",
+    "webpack-dev-server/path-to-regexp": "^0.1.13"
   },
   "license": "UNLICENSED",
   "msw": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11638,15 +11638,15 @@ path-scurry@^1.6.1:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
+path-to-regexp@0.1.13, path-to-regexp@~0.1.12:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.13.tgz#9b22ec16bc3ab88d05a0c7e369869421401ab17d"
+  integrity sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==
+
 path-to-regexp@^6.3.0:
   version "6.3.0"
   resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz"
   integrity sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==
-
-path-to-regexp@~0.1.12:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.12.tgz#d5e1a12e478a976d432ef3c58d534b9923164bb7"
-  integrity sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==
 
 path-type@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
### What does this PR change?
Adds a dependency resolution to bump 0.1.12 to 0.1.13. This PR should resolve the dependabot issue https://github.com/guardian/manage-frontend/security/dependabot/313 .

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->
