### PR TITLE
Add discounted Annual S+->D+ switch + Fix upgrade product payment copy (post #1642)

### DIFF
--- a/client/__tests__/upgradeProductPaymentCopy.test.ts
+++ b/client/__tests__/upgradeProductPaymentCopy.test.ts
@@ -272,7 +272,7 @@ describe('copy builders', () => {
 			nextPaymentDate: '2027-07-06',
 			discount: {
 				discountedPrice: 120,
-				upToPeriods: 1,
+				upToPeriods: 2,
 				upToPeriodsType: 'Years',
 			},
 		};
@@ -281,20 +281,37 @@ describe('copy builders', () => {
 			getConfirmationPaymentConditionsText({
 				preview,
 				isDiscountedOffer: true,
-				currency: '€',
+				currency: '£',
 				paymentInterval: 'year',
 			}),
-		).toContain(
-			'After this, from 06 July 2027, your payment will be €120 every year for 0 years',
+		).toBe(
+			"We will charge you a smaller amount today, to offset the payment you've already given us for the rest of the year. After this, from 06 July 2027, your payment will be £200 every year. Your next payment date will be 06 July 2027.",
 		);
+	});
+
+	it('formats yearly discounted thank-you payment text with every year wording', () => {
+		const preview: DiscountedUpgradePreview = {
+			amountPayableToday: 50,
+			proratedRefundAmount: 45,
+			targetCatalogPrice: 200,
+			nextPaymentDate: '2027-07-06',
+			discount: {
+				discountedPrice: 120,
+				upToPeriods: 2,
+				upToPeriodsType: 'Years',
+			},
+		};
+
 		expect(
-			getConfirmationPaymentConditionsText({
+			getThankYouPaymentConditionsText({
 				preview,
 				isDiscountedOffer: true,
-				currency: '€',
-				paymentInterval: 'year',
+				currency: '£',
+				billingPeriod: 'year',
 			}),
-		).toContain('then €200 every year');
+		).toBe(
+			'You will be charged £50 today. After this, from 06 July 2027, your payment will be £200 every year.',
+		);
 	});
 
 	it('formats non-discounted thank-you payment text', () => {

--- a/client/__tests__/upgradeProductPaymentCopy.test.ts
+++ b/client/__tests__/upgradeProductPaymentCopy.test.ts
@@ -1,8 +1,8 @@
-import { dateString } from '@/shared/dates';
 import type { UpgradePreviewResponse } from '@/shared/productSwitchTypes';
 import {
 	type DiscountedUpgradePreview,
 	formatDiscountPeriodLabel,
+	formatUpgradeNextPaymentDate,
 	getConfirmationDiscountHeaderText,
 	getConfirmationPaymentConditionsText,
 	getInformationDiscountHelperText,
@@ -112,11 +112,9 @@ describe('copy builders', () => {
 	});
 
 	it('formats confirmation payment text with remaining promo duration', () => {
-		const nextPaymentDateLong = dateString(
-			new Date(
-				mockUpgradePreviewResponseMonthlyDiscountGBP.nextPaymentDate,
-			),
-			'MMMM do',
+		const nextPaymentDateLong = formatUpgradeNextPaymentDate(
+			mockUpgradePreviewResponseMonthlyDiscountGBP.nextPaymentDate,
+			'month',
 		);
 
 		expect(
@@ -192,9 +190,9 @@ describe('copy builders', () => {
 			targetCatalogPrice: 14.99,
 			nextPaymentDate: '2026-03-15',
 		};
-		const nextPaymentDateLong = dateString(
-			new Date(preview.nextPaymentDate),
-			'MMMM do',
+		const nextPaymentDateLong = formatUpgradeNextPaymentDate(
+			preview.nextPaymentDate,
+			'month',
 		);
 
 		expect(
@@ -214,7 +212,6 @@ describe('copy builders', () => {
 				isDiscountedOffer: true,
 				currency: '£',
 				billingPeriod: 'month',
-				nextPaymentDateLong: 'March 15th',
 			}),
 		).toContain('£7.50');
 		expect(
@@ -223,9 +220,81 @@ describe('copy builders', () => {
 				isDiscountedOffer: true,
 				currency: '£',
 				billingPeriod: 'month',
-				nextPaymentDateLong: 'March 15th',
 			}),
 		).toContain('for 2 months');
+	});
+
+	it('formats yearly non-discounted confirmation payment text', () => {
+		const preview: UpgradePreviewResponse = {
+			amountPayableToday: 50,
+			proratedRefundAmount: 45,
+			targetCatalogPrice: 200,
+			nextPaymentDate: '2027-07-06',
+		};
+
+		expect(
+			getConfirmationPaymentConditionsText({
+				preview,
+				isDiscountedOffer: false,
+				currency: '€',
+				paymentInterval: 'year',
+			}),
+		).toBe(
+			"We will charge you a smaller amount today, to offset the payment you've already given us for the rest of the year. After this, from 06 July 2027, your payment will be €200 every year.",
+		);
+	});
+
+	it('formats yearly non-discounted thank-you payment text', () => {
+		const preview: UpgradePreviewResponse = {
+			amountPayableToday: 50,
+			proratedRefundAmount: 45,
+			targetCatalogPrice: 200,
+			nextPaymentDate: '2027-07-06',
+		};
+
+		expect(
+			getThankYouPaymentConditionsText({
+				preview,
+				isDiscountedOffer: false,
+				currency: '€',
+				billingPeriod: 'year',
+			}),
+		).toBe(
+			'You will be charged €50. After this, from 06 July 2027, your payment will be €200 every year.',
+		);
+	});
+
+	it('formats yearly discounted confirmation payment text with every year wording', () => {
+		const preview: DiscountedUpgradePreview = {
+			amountPayableToday: 50,
+			proratedRefundAmount: 45,
+			targetCatalogPrice: 200,
+			nextPaymentDate: '2027-07-06',
+			discount: {
+				discountedPrice: 120,
+				upToPeriods: 1,
+				upToPeriodsType: 'Years',
+			},
+		};
+
+		expect(
+			getConfirmationPaymentConditionsText({
+				preview,
+				isDiscountedOffer: true,
+				currency: '€',
+				paymentInterval: 'year',
+			}),
+		).toContain(
+			'After this, from 06 July 2027, your payment will be €120 every year for 0 years',
+		);
+		expect(
+			getConfirmationPaymentConditionsText({
+				preview,
+				isDiscountedOffer: true,
+				currency: '€',
+				paymentInterval: 'year',
+			}),
+		).toContain('then €200 every year');
 	});
 
 	it('formats non-discounted thank-you payment text', () => {
@@ -242,7 +311,6 @@ describe('copy builders', () => {
 				isDiscountedOffer: false,
 				currency: '£',
 				billingPeriod: 'month',
-				nextPaymentDateLong: 'March 15th',
 			}),
 		).toBe(
 			'You will be charged £5.50. From March 15th, your ongoing monthly payment will be £14.99.',

--- a/client/__tests__/upgradeProductPaymentCopy.test.ts
+++ b/client/__tests__/upgradeProductPaymentCopy.test.ts
@@ -1,3 +1,4 @@
+import { dateString } from '@/shared/dates';
 import type { UpgradePreviewResponse } from '@/shared/productSwitchTypes';
 import {
 	type DiscountedUpgradePreview,
@@ -111,15 +112,19 @@ describe('copy builders', () => {
 	});
 
 	it('formats confirmation payment text with remaining promo duration', () => {
+		const nextPaymentDateLong = dateString(
+			new Date(
+				mockUpgradePreviewResponseMonthlyDiscountGBP.nextPaymentDate,
+			),
+			'MMMM do',
+		);
+
 		expect(
 			getConfirmationPaymentConditionsText({
 				preview: mockUpgradePreviewResponseMonthlyDiscountGBP,
 				isDiscountedOffer: true,
 				currency: '£',
 				paymentInterval: 'month',
-				nextPaymentDate: 'April 1st',
-				nextPaymentDateDiscounted: 'March 15th',
-				nextPaymentDateDayDiscounted: '15th',
 			}),
 		).toContain('£7.50');
 		expect(
@@ -128,11 +133,16 @@ describe('copy builders', () => {
 				isDiscountedOffer: true,
 				currency: '£',
 				paymentInterval: 'month',
-				nextPaymentDate: 'April 1st',
-				nextPaymentDateDiscounted: 'March 15th',
-				nextPaymentDateDayDiscounted: '15th',
 			}),
 		).toContain('for 2 months');
+		expect(
+			getConfirmationPaymentConditionsText({
+				preview: mockUpgradePreviewResponseMonthlyDiscountGBP,
+				isDiscountedOffer: true,
+				currency: '£',
+				paymentInterval: 'month',
+			}),
+		).toContain(`From ${nextPaymentDateLong}`);
 	});
 
 	it('uses unknown when promo duration is missing in confirmation payment text', () => {
@@ -151,11 +161,50 @@ describe('copy builders', () => {
 				isDiscountedOffer: true,
 				currency: '£',
 				paymentInterval: 'month',
-				nextPaymentDate: 'April 1st',
-				nextPaymentDateDiscounted: 'March 15th',
-				nextPaymentDateDayDiscounted: '15th',
 			}),
 		).toContain('for unknown');
+	});
+
+	it('singularises remaining period label when count is one', () => {
+		const preview: DiscountedUpgradePreview = {
+			...mockUpgradePreviewResponseMonthlyDiscountGBP,
+			discount: {
+				discountedPrice: 7.5,
+				upToPeriods: 2,
+				upToPeriodsType: 'Months',
+			},
+		};
+
+		expect(
+			getConfirmationPaymentConditionsText({
+				preview,
+				isDiscountedOffer: true,
+				currency: '£',
+				paymentInterval: 'month',
+			}),
+		).toContain('for 1 month');
+	});
+
+	it('uses preview next payment date for non-discounted confirmation payment text', () => {
+		const preview: UpgradePreviewResponse = {
+			amountPayableToday: 5.5,
+			proratedRefundAmount: 4.5,
+			targetCatalogPrice: 14.99,
+			nextPaymentDate: '2026-03-15',
+		};
+		const nextPaymentDateLong = dateString(
+			new Date(preview.nextPaymentDate),
+			'MMMM do',
+		);
+
+		expect(
+			getConfirmationPaymentConditionsText({
+				preview,
+				isDiscountedOffer: false,
+				currency: '£',
+				paymentInterval: 'month',
+			}),
+		).toContain(`from ${nextPaymentDateLong}`);
 	});
 
 	it('formats thank-you payment text with remaining promo duration', () => {

--- a/client/__tests__/upgradeProductPaymentCopy.test.ts
+++ b/client/__tests__/upgradeProductPaymentCopy.test.ts
@@ -1,0 +1,202 @@
+import type { UpgradePreviewResponse } from '@/shared/productSwitchTypes';
+import {
+	type DiscountedUpgradePreview,
+	formatDiscountPeriodLabel,
+	getConfirmationDiscountHeaderText,
+	getConfirmationPaymentConditionsText,
+	getInformationDiscountHelperText,
+	getRemainingDiscountPeriods,
+	getThankYouPaymentConditionsText,
+	isDiscountedPreview,
+} from '../utilities/upgradeProductPaymentCopy';
+
+const mockUpgradePreviewResponseMonthlyDiscountGBP: DiscountedUpgradePreview = {
+	amountPayableToday: 3.0,
+	proratedRefundAmount: 4.5,
+	targetCatalogPrice: 14.99,
+	nextPaymentDate: '2026-03-15',
+	discount: {
+		discountedPrice: 7.5,
+		upToPeriods: 3,
+		upToPeriodsType: 'Months',
+	},
+};
+
+describe('isDiscountedPreview', () => {
+	it('returns true when discounted price is below catalog price', () => {
+		expect(
+			isDiscountedPreview(mockUpgradePreviewResponseMonthlyDiscountGBP),
+		).toBe(true);
+	});
+
+	it('returns true for 100% off promos', () => {
+		expect(
+			isDiscountedPreview({
+				...mockUpgradePreviewResponseMonthlyDiscountGBP,
+				discount: {
+					discountedPrice: 0,
+					upToPeriods: 3,
+					upToPeriodsType: 'Months',
+				},
+			}),
+		).toBe(true);
+	});
+
+	it('returns false when discounted price equals catalog price', () => {
+		expect(
+			isDiscountedPreview({
+				...mockUpgradePreviewResponseMonthlyDiscountGBP,
+				discount: {
+					discountedPrice: 14.99,
+					upToPeriods: 3,
+					upToPeriodsType: 'Months',
+				},
+			}),
+		).toBe(false);
+	});
+
+	it('returns false when discount is missing', () => {
+		expect(
+			isDiscountedPreview({
+				amountPayableToday: 3.0,
+				proratedRefundAmount: 4.5,
+				targetCatalogPrice: 14.99,
+				nextPaymentDate: '2026-03-15',
+			}),
+		).toBe(false);
+	});
+});
+
+describe('getRemainingDiscountPeriods', () => {
+	it('returns upToPeriods minus one for valid values', () => {
+		expect(getRemainingDiscountPeriods(3)).toBe(2);
+		expect(getRemainingDiscountPeriods(1)).toBe(0);
+	});
+
+	it('returns unknown for invalid values', () => {
+		expect(getRemainingDiscountPeriods(undefined)).toBe('unknown');
+		expect(getRemainingDiscountPeriods(0)).toBe('unknown');
+	});
+});
+
+describe('formatDiscountPeriodLabel', () => {
+	it('pluralises the period label', () => {
+		expect(formatDiscountPeriodLabel(3, 'Months')).toBe('3 months');
+	});
+
+	it('returns unknown for invalid values', () => {
+		expect(formatDiscountPeriodLabel(undefined, 'Months')).toBe('unknown');
+	});
+});
+
+describe('copy builders', () => {
+	it('formats information helper text with full promo duration and currency', () => {
+		expect(
+			getInformationDiscountHelperText(
+				mockUpgradePreviewResponseMonthlyDiscountGBP,
+				'£',
+				'month',
+			),
+		).toBe('For the next 3 months then £14.99/month');
+	});
+
+	it('formats confirmation header text with two-decimal currency', () => {
+		expect(
+			getConfirmationDiscountHeaderText(
+				mockUpgradePreviewResponseMonthlyDiscountGBP,
+				'£',
+				'month',
+			),
+		).toBe(' £7.50/month for 3 months');
+	});
+
+	it('formats confirmation payment text with remaining promo duration', () => {
+		expect(
+			getConfirmationPaymentConditionsText({
+				preview: mockUpgradePreviewResponseMonthlyDiscountGBP,
+				isDiscountedOffer: true,
+				currency: '£',
+				paymentInterval: 'month',
+				nextPaymentDate: 'April 1st',
+				nextPaymentDateDiscounted: 'March 15th',
+				nextPaymentDateDayDiscounted: '15th',
+			}),
+		).toContain('£7.50');
+		expect(
+			getConfirmationPaymentConditionsText({
+				preview: mockUpgradePreviewResponseMonthlyDiscountGBP,
+				isDiscountedOffer: true,
+				currency: '£',
+				paymentInterval: 'month',
+				nextPaymentDate: 'April 1st',
+				nextPaymentDateDiscounted: 'March 15th',
+				nextPaymentDateDayDiscounted: '15th',
+			}),
+		).toContain('for 2 months');
+	});
+
+	it('uses unknown when promo duration is missing in confirmation payment text', () => {
+		const preview: UpgradePreviewResponse = {
+			...mockUpgradePreviewResponseMonthlyDiscountGBP,
+			discount: {
+				discountedPrice: 7.5,
+				upToPeriods: 0,
+				upToPeriodsType: 'Months',
+			},
+		};
+
+		expect(
+			getConfirmationPaymentConditionsText({
+				preview,
+				isDiscountedOffer: true,
+				currency: '£',
+				paymentInterval: 'month',
+				nextPaymentDate: 'April 1st',
+				nextPaymentDateDiscounted: 'March 15th',
+				nextPaymentDateDayDiscounted: '15th',
+			}),
+		).toContain('for unknown');
+	});
+
+	it('formats thank-you payment text with remaining promo duration', () => {
+		expect(
+			getThankYouPaymentConditionsText({
+				preview: mockUpgradePreviewResponseMonthlyDiscountGBP,
+				isDiscountedOffer: true,
+				currency: '£',
+				billingPeriod: 'month',
+				nextPaymentDateLong: 'March 15th',
+			}),
+		).toContain('£7.50');
+		expect(
+			getThankYouPaymentConditionsText({
+				preview: mockUpgradePreviewResponseMonthlyDiscountGBP,
+				isDiscountedOffer: true,
+				currency: '£',
+				billingPeriod: 'month',
+				nextPaymentDateLong: 'March 15th',
+			}),
+		).toContain('for 2 months');
+	});
+
+	it('formats non-discounted thank-you payment text', () => {
+		const preview: UpgradePreviewResponse = {
+			amountPayableToday: 5.5,
+			proratedRefundAmount: 4.5,
+			targetCatalogPrice: 14.99,
+			nextPaymentDate: '2026-03-15',
+		};
+
+		expect(
+			getThankYouPaymentConditionsText({
+				preview,
+				isDiscountedOffer: false,
+				currency: '£',
+				billingPeriod: 'month',
+				nextPaymentDateLong: 'March 15th',
+			}),
+		).toBe(
+			'You will be charged £5.50. From March 15th, your ongoing monthly payment will be £14.99.',
+		);
+	});
+});

--- a/client/__tests__/upgradeProductPaymentCopy.test.ts
+++ b/client/__tests__/upgradeProductPaymentCopy.test.ts
@@ -285,7 +285,7 @@ describe('copy builders', () => {
 				paymentInterval: 'year',
 			}),
 		).toBe(
-			"We will charge you a smaller amount today, to offset the payment you've already given us for the rest of the year. After this, from 06 July 2027, your payment will be £200 every year. Your next payment date will be 06 July 2027.",
+			"We will charge you a smaller amount today, to offset the payment you've already given us for the rest of the year. After this, from 06 July 2027, your payment will be £200 every year. Your next payment date will be the 6th of July.",
 		);
 	});
 

--- a/client/__tests__/upgradeProductPaymentCopy.test.ts
+++ b/client/__tests__/upgradeProductPaymentCopy.test.ts
@@ -226,41 +226,41 @@ describe('copy builders', () => {
 
 	it('formats yearly non-discounted confirmation payment text', () => {
 		const preview: UpgradePreviewResponse = {
-			amountPayableToday: 50,
+			amountPayableToday: 55,
 			proratedRefundAmount: 45,
-			targetCatalogPrice: 200,
-			nextPaymentDate: '2027-07-06',
+			targetCatalogPrice: 149,
+			nextPaymentDate: '2027-01-15',
 		};
 
 		expect(
 			getConfirmationPaymentConditionsText({
 				preview,
 				isDiscountedOffer: false,
-				currency: '€',
+				currency: '£',
 				paymentInterval: 'year',
 			}),
 		).toBe(
-			"We will charge you a smaller amount today, to offset the payment you've already given us for the rest of the year. After this, from 06 July 2027, your payment will be €200 every year.",
+			"We will charge you a smaller amount today, to offset the payment you've already given us for the rest of the year. After this, from January 15th, your yearly payment will be £149",
 		);
 	});
 
 	it('formats yearly non-discounted thank-you payment text', () => {
 		const preview: UpgradePreviewResponse = {
-			amountPayableToday: 50,
+			amountPayableToday: 55,
 			proratedRefundAmount: 45,
-			targetCatalogPrice: 200,
-			nextPaymentDate: '2027-07-06',
+			targetCatalogPrice: 149,
+			nextPaymentDate: '2027-01-15',
 		};
 
 		expect(
 			getThankYouPaymentConditionsText({
 				preview,
 				isDiscountedOffer: false,
-				currency: '€',
+				currency: '£',
 				billingPeriod: 'year',
 			}),
 		).toBe(
-			'You will be charged €50. After this, from 06 July 2027, your payment will be €200 every year.',
+			'You will be charged £55. From January 15th, your ongoing yearly payment will be £149.',
 		);
 	});
 

--- a/client/components/mma/upgradeProduct/UpgradeProduct.stories.tsx
+++ b/client/components/mma/upgradeProduct/UpgradeProduct.stories.tsx
@@ -98,6 +98,18 @@ const mockUpgradePreviewResponseMonthlyDiscountGBP: UpgradePreviewResponse = {
 	},
 };
 
+const mockUpgradePreviewResponseAnnualDiscountGBP: UpgradePreviewResponse = {
+	amountPayableToday: 50.0,
+	proratedRefundAmount: 45.0,
+	targetCatalogPrice: 200,
+	nextPaymentDate: '2027-07-06',
+	discount: {
+		discountedPrice: 120,
+		upToPeriods: 2,
+		upToPeriodsType: 'Years',
+	},
+};
+
 const mswHandlersSuccess = (previewResponse: UpgradePreviewResponse) => [
 	http.post('/api/subscriptions/*/change-plan/preview', () => {
 		return HttpResponse.json(previewResponse);
@@ -168,6 +180,24 @@ InformationMonthlyDiscount.parameters = {
 };
 InformationMonthlyDiscount.storyName = 'Information Monthly - Discount';
 
+export const InformationAnnualDiscount: StoryFn<
+	typeof UpgradeProductInformation
+> = () => {
+	return <UpgradeProductInformation />;
+};
+InformationAnnualDiscount.decorators = [
+	createStorePopulatorDecorator(
+		supporterPlusAnnual(),
+		mockUpgradePreviewResponseAnnualDiscountGBP,
+	),
+];
+InformationAnnualDiscount.parameters = {
+	reactRouter: {
+		container: <StoryPageContainer />,
+	},
+};
+InformationAnnualDiscount.storyName = 'Information Annual - Discount';
+
 export const ConfirmationMonthly: StoryFn<
 	typeof UpgradeProductConfirmation
 > = () => {
@@ -222,6 +252,25 @@ ConfirmationMonthlyDiscount.parameters = {
 	msw: mswHandlersSuccess(mockUpgradePreviewResponseMonthlyDiscountGBP),
 };
 ConfirmationMonthlyDiscount.storyName = 'Confirmation Monthly - Discount';
+
+export const ConfirmationAnnualDiscount: StoryFn<
+	typeof UpgradeProductConfirmation
+> = () => {
+	return <UpgradeProductConfirmation />;
+};
+ConfirmationAnnualDiscount.decorators = [
+	createStorePopulatorDecorator(
+		supporterPlusAnnual(),
+		mockUpgradePreviewResponseAnnualDiscountGBP,
+	),
+];
+ConfirmationAnnualDiscount.parameters = {
+	reactRouter: {
+		container: <StoryPageContainer />,
+	},
+	msw: mswHandlersSuccess(mockUpgradePreviewResponseAnnualDiscountGBP),
+};
+ConfirmationAnnualDiscount.storyName = 'Confirmation Annual - Discount';
 
 export const ConfirmationDirectDebit: StoryFn<
 	typeof UpgradeProductConfirmation
@@ -327,3 +376,21 @@ ThankYouMonthlyDiscount.parameters = {
 	},
 };
 ThankYouMonthlyDiscount.storyName = 'Thank You Monthly - Discount';
+
+export const ThankYouAnnualDiscount: StoryFn<
+	typeof UpgradeProductThankYou
+> = () => {
+	return <UpgradeProductThankYou />;
+};
+ThankYouAnnualDiscount.decorators = [
+	createStorePopulatorDecorator(
+		supporterPlusAnnual(),
+		mockUpgradePreviewResponseAnnualDiscountGBP,
+	),
+];
+ThankYouAnnualDiscount.parameters = {
+	reactRouter: {
+		container: <StoryPageContainer />,
+	},
+};
+ThankYouAnnualDiscount.storyName = 'Thank You Annual - Discount';

--- a/client/components/mma/upgradeProduct/UpgradeProductConfirmation.tsx
+++ b/client/components/mma/upgradeProduct/UpgradeProductConfirmation.tsx
@@ -140,7 +140,11 @@ export const UpgradeProductConfirmation = () => {
 		false,
 	);
 
-	const paymentInterval = nextPaymentDetails?.paymentInterval ?? 'month';
+	if (!nextPaymentDetails) {
+		return null;
+	}
+
+	const { paymentInterval } = nextPaymentDetails;
 
 	const discountConditionsText =
 		isDiscountedOffer && isDiscountedPreview(previewResponse)
@@ -239,9 +243,7 @@ export const UpgradeProductConfirmation = () => {
 								{discountConditionsText}
 							</span>
 						) : (
-							<span>
-								{'/' + nextPaymentDetails?.paymentInterval}
-							</span>
+							<span>{'/' + paymentInterval}</span>
 						)}
 					</p>
 				</Card.Section>
@@ -297,16 +299,16 @@ export const UpgradeProductConfirmation = () => {
 			<div css={termsAndConditionsContainerCss}>
 				<p css={termsAndConditionsTextCss}>
 					This subscription auto-renews. You'll be charged the
-					applicable {nextPaymentDetails?.paymentInterval}ly amount at
-					each renewal unless you cancel. You can cancel your
-					subscription at any time before your next renewal date. To
-					cancel go to <a href="/">Manage My Account</a>. Cancellation
-					will take effect at the end of your current{' '}
-					{nextPaymentDetails?.paymentInterval}ly payment period.
-					There is also a cooling off period of 14 days from sign-up.
-					You can cancel your subscription within 14 days of sign-up
-					by <a href="/help-centre#call-us">contacting us</a> and
-					receive a full refund.
+					applicable {paymentInterval}ly amount at each renewal unless
+					you cancel. You can cancel your subscription at any time
+					before your next renewal date. To cancel go to{' '}
+					<a href="/">Manage My Account</a>. Cancellation will take
+					effect at the end of your current {paymentInterval}ly
+					payment period. There is also a cooling off period of 14
+					days from sign-up. You can cancel your subscription within
+					14 days of sign-up by{' '}
+					<a href="/help-centre#call-us">contacting us</a> and receive
+					a full refund.
 				</p>
 			</div>
 

--- a/client/components/mma/upgradeProduct/UpgradeProductConfirmation.tsx
+++ b/client/components/mma/upgradeProduct/UpgradeProductConfirmation.tsx
@@ -35,7 +35,6 @@ import {
 	isDiscountedPreview,
 } from '@/client/utilities/upgradeProductPaymentCopy';
 import { formatAmount } from '@/client/utilities/utils';
-import { dateString } from '@/shared/dates';
 import { PRODUCT_TYPES } from '@/shared/productTypes';
 import { Pill } from '../../shared/Pill';
 import { productCardConfiguration } from '../accountoverview/ProductCardConfiguration';
@@ -152,27 +151,11 @@ export const UpgradeProductConfirmation = () => {
 			  )
 			: '';
 
-	const nextPaymentDate = subscription.nextPaymentDate
-		? dateString(new Date(subscription.nextPaymentDate), 'MMMM do')
-		: nextPaymentDetails?.nextPaymentDateValue;
-
-	const nextPaymentDateDiscounted = dateString(
-		new Date(previewResponse.nextPaymentDate),
-		'MMMM do',
-	);
-	const nextPaymentDateDayDiscounted = dateString(
-		new Date(previewResponse.nextPaymentDate),
-		'do',
-	);
-
 	const paymentConditionsText = getConfirmationPaymentConditionsText({
 		preview: previewResponse,
 		isDiscountedOffer,
 		currency: mainPlan.currency,
 		paymentInterval,
-		nextPaymentDate,
-		nextPaymentDateDiscounted,
-		nextPaymentDateDayDiscounted,
 	});
 
 	let paymentMethodCopy = `We will take payment as before`;

--- a/client/components/mma/upgradeProduct/UpgradeProductConfirmation.tsx
+++ b/client/components/mma/upgradeProduct/UpgradeProductConfirmation.tsx
@@ -28,6 +28,12 @@ import {
 } from '@/client/styles/headings';
 import { trackEvent } from '@/client/utilities/analytics';
 import { useUpgradeProduct } from '@/client/utilities/hooks/useUpgradePreview';
+import {
+	formatCurrency,
+	getConfirmationDiscountHeaderText,
+	getConfirmationPaymentConditionsText,
+	isDiscountedPreview,
+} from '@/client/utilities/upgradeProductPaymentCopy';
 import { formatAmount } from '@/client/utilities/utils';
 import { dateString } from '@/shared/dates';
 import { PRODUCT_TYPES } from '@/shared/productTypes';
@@ -119,7 +125,12 @@ export const UpgradeProductConfirmation = () => {
 	} = useUpgradeProductStore();
 	const { executeUpgrade, isUpgrading, upgradeError } = useUpgradeProduct();
 
-	if (!mainPlan || !specificProductType || !subscription) {
+	if (
+		!mainPlan ||
+		!specificProductType ||
+		!subscription ||
+		!previewResponse
+	) {
 		return null;
 	}
 
@@ -130,44 +141,39 @@ export const UpgradeProductConfirmation = () => {
 		false,
 	);
 
-	const discountConditionsText = isDiscountedOffer
-		? ` ${mainPlan.currency}${previewResponse?.discount?.discountedPrice}/${
-				nextPaymentDetails?.paymentInterval
-		  } for ${
-				previewResponse?.discount?.upToPeriods
-		  } ${previewResponse?.discount?.upToPeriodsType.toLowerCase()}`
-		: '';
+	const paymentInterval = nextPaymentDetails?.paymentInterval ?? 'month';
 
-	let paymentConditionsText = `We will charge you a smaller amount today, to offset the payment you've already given us for the rest of the ${nextPaymentDetails?.paymentInterval}. `;
+	const discountConditionsText =
+		isDiscountedOffer && isDiscountedPreview(previewResponse)
+			? getConfirmationDiscountHeaderText(
+					previewResponse,
+					mainPlan.currency,
+					paymentInterval,
+			  )
+			: '';
+
 	const nextPaymentDate = subscription.nextPaymentDate
 		? dateString(new Date(subscription.nextPaymentDate), 'MMMM do')
 		: nextPaymentDetails?.nextPaymentDateValue;
 
-	if (isDiscountedOffer) {
-		const nextPaymentDateDiscounted = previewResponse?.nextPaymentDate
-			? dateString(new Date(previewResponse.nextPaymentDate), 'MMMM do')
-			: nextPaymentDetails?.nextPaymentDateValue;
-		const nextPaymentDateDayDiscounted = previewResponse?.nextPaymentDate
-			? dateString(new Date(previewResponse.nextPaymentDate), 'do')
-			: nextPaymentDetails?.nextPaymentDateValue;
+	const nextPaymentDateDiscounted = dateString(
+		new Date(previewResponse.nextPaymentDate),
+		'MMMM do',
+	);
+	const nextPaymentDateDayDiscounted = dateString(
+		new Date(previewResponse.nextPaymentDate),
+		'do',
+	);
 
-		paymentConditionsText += `From ${nextPaymentDateDiscounted}, your ${
-			nextPaymentDetails?.paymentInterval
-		}ly payment will be ${mainPlan.currency}${
-			previewResponse?.discount?.discountedPrice
-		} for ${
-			previewResponse?.discount?.upToPeriods &&
-			previewResponse?.discount?.upToPeriods > 0
-				? previewResponse?.discount?.upToPeriods - 1
-				: 0
-		} ${previewResponse?.discount?.upToPeriodsType.toLowerCase()} and then ${
-			mainPlan.currency
-		}${previewResponse?.targetCatalogPrice} per ${
-			nextPaymentDetails?.paymentInterval
-		}. The ${nextPaymentDateDayDiscounted} will be your next payment date.`;
-	} else {
-		paymentConditionsText += `After this, from ${nextPaymentDate}, your ${nextPaymentDetails?.paymentInterval}ly payment will be ${mainPlan.currency}${previewResponse?.targetCatalogPrice}`;
-	}
+	const paymentConditionsText = getConfirmationPaymentConditionsText({
+		preview: previewResponse,
+		isDiscountedOffer,
+		currency: mainPlan.currency,
+		paymentInterval,
+		nextPaymentDate,
+		nextPaymentDateDiscounted,
+		nextPaymentDateDayDiscounted,
+	});
 
 	let paymentMethodCopy = `We will take payment as before`;
 
@@ -233,8 +239,10 @@ export const UpgradeProductConfirmation = () => {
 									: 'none'};
 							`}
 						>
-							{mainPlan.currency}
-							{previewResponse?.targetCatalogPrice}
+							{formatCurrency(
+								mainPlan.currency,
+								previewResponse.targetCatalogPrice,
+							)}
 						</span>
 						{isDiscountedOffer ? (
 							<span
@@ -280,7 +288,7 @@ export const UpgradeProductConfirmation = () => {
 				<div css={whatHappensNowItemInfoCss}>
 					<h3 css={subheadingTextCss(false)}>
 						Your first payment will be {mainPlan.currency}
-						{formatAmount(previewResponse?.amountPayableToday)}
+						{formatAmount(previewResponse.amountPayableToday)}
 					</h3>
 					<p
 						css={[

--- a/client/components/mma/upgradeProduct/UpgradeProductInformation.tsx
+++ b/client/components/mma/upgradeProduct/UpgradeProductInformation.tsx
@@ -20,6 +20,11 @@ import {
 	subHeadingWithInformationCss,
 } from '@/client/styles/headings';
 import { trackEvent } from '@/client/utilities/analytics';
+import {
+	formatCurrency,
+	getInformationDiscountHelperText,
+	isDiscountedPreview,
+} from '@/client/utilities/upgradeProductPaymentCopy';
 import { PRODUCT_TYPES } from '@/shared/productTypes';
 import { Pill } from '../../shared/Pill';
 import {
@@ -103,7 +108,12 @@ export const UpgradeProductInformation = () => {
 		isDiscountedOffer,
 	} = useUpgradeProductStore();
 
-	if (!mainPlan || !specificProductType || !subscription) {
+	if (
+		!mainPlan ||
+		!specificProductType ||
+		!subscription ||
+		!previewResponse
+	) {
 		return null;
 	}
 
@@ -114,15 +124,14 @@ export const UpgradeProductInformation = () => {
 		false,
 	);
 
-	const discountConditionsText = isDiscountedOffer
-		? `For the next ${
-				previewResponse?.discount?.upToPeriods
-		  } ${previewResponse?.discount?.upToPeriodsType.toLowerCase()} then ${
-				mainPlan.currency
-		  }${previewResponse?.targetCatalogPrice}/${
-				nextPaymentDetails?.paymentInterval
-		  }`
-		: '';
+	const discountConditionsText =
+		isDiscountedOffer && isDiscountedPreview(previewResponse)
+			? getInformationDiscountHelperText(
+					previewResponse,
+					mainPlan.currency,
+					nextPaymentDetails?.paymentInterval ?? 'month',
+			  )
+			: '';
 
 	return (
 		<>
@@ -203,14 +212,23 @@ export const UpgradeProductInformation = () => {
 							>
 								{isDiscountedOffer && (
 									<span css={discountedPriceCss}>
-										{mainPlan.currency}
-										{previewResponse?.targetCatalogPrice}
+										{formatCurrency(
+											mainPlan.currency,
+											previewResponse.targetCatalogPrice,
+										)}
 									</span>
 								)}
-								{mainPlan.currency}
-								{isDiscountedOffer
-									? previewResponse?.discount?.discountedPrice
-									: previewResponse?.targetCatalogPrice}
+								{isDiscountedOffer &&
+								isDiscountedPreview(previewResponse)
+									? formatCurrency(
+											mainPlan.currency,
+											previewResponse.discount
+												.discountedPrice,
+									  )
+									: formatCurrency(
+											mainPlan.currency,
+											previewResponse.targetCatalogPrice,
+									  )}
 								/{nextPaymentDetails?.paymentInterval}
 							</h3>
 							{isDiscountedOffer && (

--- a/client/components/mma/upgradeProduct/UpgradeProductThankYou.tsx
+++ b/client/components/mma/upgradeProduct/UpgradeProductThankYou.tsx
@@ -20,8 +20,10 @@ import {
 	subHeadingWithInformationCss,
 } from '@/client/styles/headings';
 import { trackEvent } from '@/client/utilities/analytics';
-import { getThankYouPaymentConditionsText } from '@/client/utilities/upgradeProductPaymentCopy';
-import { dateString } from '@/shared/dates';
+import {
+	formatUpgradeNextPaymentDayLabel,
+	getThankYouPaymentConditionsText,
+} from '@/client/utilities/upgradeProductPaymentCopy';
 import {
 	signInContentContainerCss,
 	signInCss,
@@ -67,13 +69,9 @@ export const UpgradeProductThankYou = () => {
 		return null;
 	}
 
-	const nextPaymentDateLong = dateString(
-		new Date(previewResponse.nextPaymentDate),
-		'MMMM do',
-	);
-	const nextPaymentDateDay = dateString(
-		new Date(previewResponse.nextPaymentDate),
-		'do',
+	const nextPaymentDateDayLabel = formatUpgradeNextPaymentDayLabel(
+		previewResponse.nextPaymentDate,
+		mainPlan.billingPeriod,
 	);
 
 	const paymentConditionsText = getThankYouPaymentConditionsText({
@@ -81,7 +79,6 @@ export const UpgradeProductThankYou = () => {
 		isDiscountedOffer,
 		currency: mainPlan.currency,
 		billingPeriod: mainPlan.billingPeriod,
-		nextPaymentDateLong,
 	});
 
 	return (
@@ -121,7 +118,9 @@ export const UpgradeProductThankYou = () => {
 					>
 						<b css={whatHappensNowItemInformationBoldTextCss}>
 							{isDiscountedOffer
-								? `Your new payment date will be the ${nextPaymentDateDay}.`
+								? mainPlan.billingPeriod === 'year'
+									? `Your new payment date will be ${nextPaymentDateDayLabel}.`
+									: `Your new payment date will be the ${nextPaymentDateDayLabel}.`
 								: 'Your first payment will be today.'}
 						</b>{' '}
 						{paymentConditionsText}

--- a/client/components/mma/upgradeProduct/UpgradeProductThankYou.tsx
+++ b/client/components/mma/upgradeProduct/UpgradeProductThankYou.tsx
@@ -20,7 +20,7 @@ import {
 	subHeadingWithInformationCss,
 } from '@/client/styles/headings';
 import { trackEvent } from '@/client/utilities/analytics';
-import { formatAmount } from '@/client/utilities/utils';
+import { getThankYouPaymentConditionsText } from '@/client/utilities/upgradeProductPaymentCopy';
 import { dateString } from '@/shared/dates';
 import {
 	signInContentContainerCss,
@@ -76,24 +76,13 @@ export const UpgradeProductThankYou = () => {
 		'do',
 	);
 
-	let paymentConditionsText = `You will be charged ${mainPlan.currency}${previewResponse.amountPayableToday}. From ${nextPaymentDateLong}, your ongoing ${mainPlan.billingPeriod}ly payment will be ${mainPlan.currency}${previewResponse.targetCatalogPrice}.`;
-
-	if (isDiscountedOffer) {
-		paymentConditionsText = `You will be charged ${mainPlan.currency}${
-			previewResponse.amountPayableToday
-		} today. From ${nextPaymentDateLong}, your ongoing ${
-			mainPlan.billingPeriod
-		}ly payment will be ${mainPlan.currency}${formatAmount(
-			previewResponse.discount?.discountedPrice,
-		)} for ${
-			previewResponse?.discount?.upToPeriods &&
-			previewResponse?.discount?.upToPeriods > 0
-				? previewResponse?.discount?.upToPeriods - 1
-				: 0
-		} ${previewResponse.discount?.upToPeriodsType.toLowerCase()}, then you will be charged ${
-			mainPlan.currency
-		}${previewResponse.targetCatalogPrice} per ${mainPlan.billingPeriod}.`;
-	}
+	const paymentConditionsText = getThankYouPaymentConditionsText({
+		preview: previewResponse,
+		isDiscountedOffer,
+		currency: mainPlan.currency,
+		billingPeriod: mainPlan.billingPeriod,
+		nextPaymentDateLong,
+	});
 
 	return (
 		<>

--- a/client/stores/UpgradeProductStore.tsx
+++ b/client/stores/UpgradeProductStore.tsx
@@ -7,6 +7,7 @@ import {
 	type PaidSubscriptionPlan,
 } from '../../shared/productResponse';
 import type { UpgradePreviewResponse } from '../../shared/productSwitchTypes';
+import { isDiscountedPreview } from '../utilities/upgradeProductPaymentCopy';
 
 export enum UpgradePreviewLoadingState {
 	NotStarted = 'NotStarted',
@@ -70,9 +71,7 @@ export const useUpgradeProductStore = create<UpgradeProductStore>()(
 						previewResponse: response,
 						previewLoadingState: UpgradePreviewLoadingState.Loaded,
 						previewError: null,
-						isDiscountedOffer:
-							!!response.discount?.discountedPrice &&
-							response.discount.discountedPrice > 0,
+						isDiscountedOffer: isDiscountedPreview(response),
 					},
 					false,
 					'setPreviewResponse',

--- a/client/utilities/hooks/useUpgradePreview.ts
+++ b/client/utilities/hooks/useUpgradePreview.ts
@@ -53,7 +53,6 @@ export const useUpgradeProduct = () => {
 			const previewResponse = await fetchUpgradePreviewData({
 				subscriptionId,
 				isTestUser,
-				discountSwitchEnabled: mainPlan.billingPeriod === 'month',
 			});
 
 			setMainPlan(mainPlan);
@@ -97,7 +96,6 @@ export const useUpgradeProduct = () => {
 				mode: 'switchToBasePrice',
 				targetProduct: 'DigitalSubscription',
 				preview: false,
-				discountSwitchEnabled: mainPlan.billingPeriod === 'month',
 			});
 
 			if (!response.ok) {

--- a/client/utilities/hooks/useUpgradeProductLoader.ts
+++ b/client/utilities/hooks/useUpgradeProductLoader.ts
@@ -101,8 +101,6 @@ export const useUpgradeProductLoader = (): LoaderState => {
 				const preview = await fetchUpgradePreviewData({
 					subscriptionId,
 					isTestUser: productDetail.isTestUser,
-					discountSwitchEnabled:
-						fetchedMainPlan.billingPeriod === 'month',
 				});
 
 				setMainPlan(fetchedMainPlan);

--- a/client/utilities/productUtils.ts
+++ b/client/utilities/productUtils.ts
@@ -255,7 +255,7 @@ export const changePlanFetch = ({
 	targetProduct,
 	preview = false,
 	newAmount,
-	discountSwitchEnabled,
+	discountSwitchEnabled = true,
 }: ChangePlanOptions) => {
 	const endpoint = preview
 		? `/api/subscriptions/${subscriptionId}/change-plan/preview`
@@ -264,8 +264,8 @@ export const changePlanFetch = ({
 	const payload: ChangePlanPayload = {
 		mode,
 		targetProduct,
+		discountSwitchEnabled,
 		...(newAmount !== undefined && { newAmount }),
-		...(discountSwitchEnabled !== undefined && { discountSwitchEnabled }),
 	};
 
 	return fetch(endpoint, {
@@ -282,7 +282,6 @@ export const changePlanFetch = ({
 export const fetchUpgradePreviewData = async (params: {
 	subscriptionId: string;
 	isTestUser: boolean;
-	discountSwitchEnabled?: boolean;
 }): Promise<UpgradePreviewResponse> => {
 	const response = await changePlanFetch({
 		subscriptionId: params.subscriptionId,
@@ -290,7 +289,6 @@ export const fetchUpgradePreviewData = async (params: {
 		mode: 'switchToBasePrice',
 		targetProduct: 'DigitalSubscription',
 		preview: true,
-		discountSwitchEnabled: params.discountSwitchEnabled,
 	});
 
 	if (!response.ok) {

--- a/client/utilities/upgradeProductPaymentCopy.ts
+++ b/client/utilities/upgradeProductPaymentCopy.ts
@@ -164,12 +164,6 @@ export function getConfirmationPaymentConditionsText({
 				formatYearlyDiscountNextPaymentDate(preview.nextPaymentDate);
 			paymentConditionsText += `After this, from ${yearlyDiscountPaymentDate}, your payment will be ${formatCurrency(
 				currency,
-				discount.discountedPrice,
-			)} every year for ${formatRemainingDiscountPeriodLabel(
-				discount.upToPeriods,
-				discount.upToPeriodsType,
-			)} and then ${formatCurrency(
-				currency,
 				targetCatalogPrice,
 			)} every year. Your next payment date will be ${yearlyDiscountPaymentDate}.`;
 		} else {
@@ -219,12 +213,6 @@ export function getThankYouPaymentConditionsText({
 				currency,
 				amountPayableToday,
 			)} today. After this, from ${yearlyDiscountPaymentDate}, your payment will be ${formatCurrency(
-				currency,
-				discount.discountedPrice,
-			)} every year for ${formatRemainingDiscountPeriodLabel(
-				discount.upToPeriods,
-				discount.upToPeriodsType,
-			)}, then ${formatCurrency(
 				currency,
 				targetCatalogPrice,
 			)} every year.`;

--- a/client/utilities/upgradeProductPaymentCopy.ts
+++ b/client/utilities/upgradeProductPaymentCopy.ts
@@ -1,0 +1,165 @@
+import { formatAmount } from '@/client/utilities/utils';
+import { appendCorrectPluralisation } from '@/shared/generalTypes';
+import type {
+	SwitchDiscountResponse,
+	UpgradePreviewResponse,
+} from '@/shared/productSwitchTypes';
+
+export type DiscountedUpgradePreview = UpgradePreviewResponse & {
+	discount: SwitchDiscountResponse;
+};
+
+export function isDiscountedPreview(
+	preview: UpgradePreviewResponse | null | undefined,
+): preview is DiscountedUpgradePreview {
+	return (
+		preview != null &&
+		preview.discount != null &&
+		preview.discount.discountedPrice < preview.targetCatalogPrice
+	);
+}
+
+/** Payment-paragraph periods: API total minus the first discounted period already in flight. */
+export function getRemainingDiscountPeriods(
+	upToPeriods?: number,
+): number | 'unknown' {
+	if (upToPeriods == null || upToPeriods <= 0) {
+		return 'unknown';
+	}
+	return upToPeriods - 1;
+}
+
+export function formatCurrency(currency: string, amount?: number) {
+	return `${currency}${formatAmount(amount)}`;
+}
+
+export function formatDiscountPeriodLabel(
+	upToPeriods: number | undefined,
+	upToPeriodsType: SwitchDiscountResponse['upToPeriodsType'],
+): string {
+	if (upToPeriods == null || upToPeriods <= 0) {
+		return 'unknown';
+	}
+	return `${upToPeriods} ${appendCorrectPluralisation(
+		upToPeriodsType,
+		upToPeriods,
+	).toLowerCase()}`;
+}
+
+function formatRemainingDiscountPeriodLabel(
+	upToPeriods: number | undefined,
+	upToPeriodsType: SwitchDiscountResponse['upToPeriodsType'],
+): string {
+	const remaining = getRemainingDiscountPeriods(upToPeriods);
+	if (remaining === 'unknown') {
+		return 'unknown';
+	}
+	return `${remaining} ${upToPeriodsType.toLowerCase()}`;
+}
+
+export function getInformationDiscountHelperText(
+	preview: DiscountedUpgradePreview,
+	currency: string,
+	paymentInterval: string,
+): string {
+	const { discount, targetCatalogPrice } = preview;
+	return `For the next ${formatDiscountPeriodLabel(
+		discount.upToPeriods,
+		discount.upToPeriodsType,
+	)} then ${formatCurrency(currency, targetCatalogPrice)}/${paymentInterval}`;
+}
+
+export function getConfirmationDiscountHeaderText(
+	preview: DiscountedUpgradePreview,
+	currency: string,
+	paymentInterval: string,
+): string {
+	const { discount } = preview;
+	return ` ${formatCurrency(
+		currency,
+		discount.discountedPrice,
+	)}/${paymentInterval} for ${formatDiscountPeriodLabel(
+		discount.upToPeriods,
+		discount.upToPeriodsType,
+	)}`;
+}
+
+export function getConfirmationPaymentConditionsText({
+	preview,
+	isDiscountedOffer,
+	currency,
+	paymentInterval,
+	nextPaymentDate,
+	nextPaymentDateDiscounted,
+	nextPaymentDateDayDiscounted,
+}: {
+	preview: UpgradePreviewResponse;
+	isDiscountedOffer: boolean;
+	currency: string;
+	paymentInterval: string;
+	nextPaymentDate: string | undefined;
+	nextPaymentDateDiscounted: string;
+	nextPaymentDateDayDiscounted: string;
+}): string {
+	let paymentConditionsText = `We will charge you a smaller amount today, to offset the payment you've already given us for the rest of the ${paymentInterval}. `;
+
+	if (isDiscountedOffer && isDiscountedPreview(preview)) {
+		const { discount, targetCatalogPrice } = preview;
+		paymentConditionsText += `From ${nextPaymentDateDiscounted}, your ${paymentInterval}ly payment will be ${formatCurrency(
+			currency,
+			discount.discountedPrice,
+		)} for ${formatRemainingDiscountPeriodLabel(
+			discount.upToPeriods,
+			discount.upToPeriodsType,
+		)} and then ${formatCurrency(
+			currency,
+			targetCatalogPrice,
+		)} per ${paymentInterval}. The ${nextPaymentDateDayDiscounted} will be your next payment date.`;
+	} else {
+		paymentConditionsText += `After this, from ${nextPaymentDate}, your ${paymentInterval}ly payment will be ${formatCurrency(
+			currency,
+			preview.targetCatalogPrice,
+		)}`;
+	}
+
+	return paymentConditionsText;
+}
+
+export function getThankYouPaymentConditionsText({
+	preview,
+	isDiscountedOffer,
+	currency,
+	billingPeriod,
+	nextPaymentDateLong,
+}: {
+	preview: UpgradePreviewResponse;
+	isDiscountedOffer: boolean;
+	currency: string;
+	billingPeriod: string;
+	nextPaymentDateLong: string;
+}): string {
+	if (isDiscountedOffer && isDiscountedPreview(preview)) {
+		const { discount, targetCatalogPrice, amountPayableToday } = preview;
+		return `You will be charged ${formatCurrency(
+			currency,
+			amountPayableToday,
+		)} today. From ${nextPaymentDateLong}, your ongoing ${billingPeriod}ly payment will be ${formatCurrency(
+			currency,
+			discount.discountedPrice,
+		)} for ${formatRemainingDiscountPeriodLabel(
+			discount.upToPeriods,
+			discount.upToPeriodsType,
+		)}, then you will be charged ${formatCurrency(
+			currency,
+			targetCatalogPrice,
+		)} per ${billingPeriod}.`;
+	}
+
+	return `You will be charged ${formatCurrency(
+		currency,
+		preview.amountPayableToday,
+	)}. From ${nextPaymentDateLong}, your ongoing ${billingPeriod}ly payment will be ${formatCurrency(
+		currency,
+		preview.targetCatalogPrice,
+	)}.`;
+}

--- a/client/utilities/upgradeProductPaymentCopy.ts
+++ b/client/utilities/upgradeProductPaymentCopy.ts
@@ -1,4 +1,5 @@
 import { formatAmount } from '@/client/utilities/utils';
+import { dateString } from '@/shared/dates';
 import { appendCorrectPluralisation } from '@/shared/generalTypes';
 import type {
 	SwitchDiscountResponse,
@@ -54,7 +55,10 @@ function formatRemainingDiscountPeriodLabel(
 	if (remaining === 'unknown') {
 		return 'unknown';
 	}
-	return `${remaining} ${upToPeriodsType.toLowerCase()}`;
+	return `${remaining} ${appendCorrectPluralisation(
+		upToPeriodsType,
+		remaining,
+	).toLowerCase()}`;
 }
 
 export function getInformationDiscountHelperText(
@@ -89,23 +93,26 @@ export function getConfirmationPaymentConditionsText({
 	isDiscountedOffer,
 	currency,
 	paymentInterval,
-	nextPaymentDate,
-	nextPaymentDateDiscounted,
-	nextPaymentDateDayDiscounted,
 }: {
 	preview: UpgradePreviewResponse;
 	isDiscountedOffer: boolean;
 	currency: string;
 	paymentInterval: string;
-	nextPaymentDate: string | undefined;
-	nextPaymentDateDiscounted: string;
-	nextPaymentDateDayDiscounted: string;
 }): string {
+	const nextPaymentDateLong = dateString(
+		new Date(preview.nextPaymentDate),
+		'MMMM do',
+	);
+	const nextPaymentDateDay = dateString(
+		new Date(preview.nextPaymentDate),
+		'do',
+	);
+
 	let paymentConditionsText = `We will charge you a smaller amount today, to offset the payment you've already given us for the rest of the ${paymentInterval}. `;
 
 	if (isDiscountedOffer && isDiscountedPreview(preview)) {
 		const { discount, targetCatalogPrice } = preview;
-		paymentConditionsText += `From ${nextPaymentDateDiscounted}, your ${paymentInterval}ly payment will be ${formatCurrency(
+		paymentConditionsText += `From ${nextPaymentDateLong}, your ${paymentInterval}ly payment will be ${formatCurrency(
 			currency,
 			discount.discountedPrice,
 		)} for ${formatRemainingDiscountPeriodLabel(
@@ -114,9 +121,9 @@ export function getConfirmationPaymentConditionsText({
 		)} and then ${formatCurrency(
 			currency,
 			targetCatalogPrice,
-		)} per ${paymentInterval}. The ${nextPaymentDateDayDiscounted} will be your next payment date.`;
+		)} per ${paymentInterval}. The ${nextPaymentDateDay} will be your next payment date.`;
 	} else {
-		paymentConditionsText += `After this, from ${nextPaymentDate}, your ${paymentInterval}ly payment will be ${formatCurrency(
+		paymentConditionsText += `After this, from ${nextPaymentDateLong}, your ${paymentInterval}ly payment will be ${formatCurrency(
 			currency,
 			preview.targetCatalogPrice,
 		)}`;

--- a/client/utilities/upgradeProductPaymentCopy.ts
+++ b/client/utilities/upgradeProductPaymentCopy.ts
@@ -1,6 +1,7 @@
 import { formatAmount } from '@/client/utilities/utils';
 import { dateString } from '@/shared/dates';
 import { appendCorrectPluralisation } from '@/shared/generalTypes';
+import type { BillingPeriod } from '@/shared/productResponse';
 import type {
 	SwitchDiscountResponse,
 	UpgradePreviewResponse,
@@ -9,6 +10,30 @@ import type {
 export type DiscountedUpgradePreview = UpgradePreviewResponse & {
 	discount: SwitchDiscountResponse;
 };
+
+function isYearlyBilling(billingPeriod: string): billingPeriod is 'year' {
+	return billingPeriod === 'year';
+}
+
+/** @example formatUpgradeNextPaymentDate('2027-07-06', 'year') // "06 July 2027" */
+export function formatUpgradeNextPaymentDate(
+	nextPaymentDate: string,
+	billingPeriod: BillingPeriod,
+): string {
+	return dateString(
+		new Date(nextPaymentDate),
+		isYearlyBilling(billingPeriod) ? 'dd MMMM yyyy' : 'MMMM do',
+	);
+}
+
+export function formatUpgradeNextPaymentDayLabel(
+	nextPaymentDate: string,
+	billingPeriod: BillingPeriod,
+): string {
+	return isYearlyBilling(billingPeriod)
+		? formatUpgradeNextPaymentDate(nextPaymentDate, billingPeriod)
+		: dateString(new Date(nextPaymentDate), 'do');
+}
 
 export function isDiscountedPreview(
 	preview: UpgradePreviewResponse | null | undefined,
@@ -20,7 +45,12 @@ export function isDiscountedPreview(
 	);
 }
 
-/** Payment-paragraph periods: API total minus the first discounted period already in flight. */
+/**
+ * Converts API promo length to remaining billing periods for payment copy.
+ * The first discounted period is counted separately in the upgrade flow.
+ *
+ * @example getRemainingDiscountPeriods(3) // 2
+ */
 export function getRemainingDiscountPeriods(
 	upToPeriods?: number,
 ): number | 'unknown' {
@@ -34,6 +64,11 @@ export function formatCurrency(currency: string, amount?: number) {
 	return `${currency}${formatAmount(amount)}`;
 }
 
+/**
+ * Formats the full promo duration for header/helper copy.
+ *
+ * @example formatDiscountPeriodLabel(3, 'Months') // "3 months"
+ */
 export function formatDiscountPeriodLabel(
 	upToPeriods: number | undefined,
 	upToPeriodsType: SwitchDiscountResponse['upToPeriodsType'],
@@ -47,6 +82,12 @@ export function formatDiscountPeriodLabel(
 	).toLowerCase()}`;
 }
 
+/**
+ * Formats remaining promo duration for payment-paragraph copy (after the first period).
+ *
+ * @example formatRemainingDiscountPeriodLabel(3, 'Months') // "2 months"
+ * @example formatRemainingDiscountPeriodLabel(2, 'Months') // "1 month"
+ */
 function formatRemainingDiscountPeriodLabel(
 	upToPeriods: number | undefined,
 	upToPeriodsType: SwitchDiscountResponse['upToPeriodsType'],
@@ -97,31 +138,50 @@ export function getConfirmationPaymentConditionsText({
 	preview: UpgradePreviewResponse;
 	isDiscountedOffer: boolean;
 	currency: string;
-	paymentInterval: string;
+	paymentInterval: BillingPeriod;
 }): string {
-	const nextPaymentDateLong = dateString(
-		new Date(preview.nextPaymentDate),
-		'MMMM do',
+	const nextPaymentDateLong = formatUpgradeNextPaymentDate(
+		preview.nextPaymentDate,
+		paymentInterval,
 	);
-	const nextPaymentDateDay = dateString(
-		new Date(preview.nextPaymentDate),
-		'do',
+	const nextPaymentDateDay = formatUpgradeNextPaymentDayLabel(
+		preview.nextPaymentDate,
+		paymentInterval,
 	);
 
 	let paymentConditionsText = `We will charge you a smaller amount today, to offset the payment you've already given us for the rest of the ${paymentInterval}. `;
 
 	if (isDiscountedOffer && isDiscountedPreview(preview)) {
 		const { discount, targetCatalogPrice } = preview;
-		paymentConditionsText += `From ${nextPaymentDateLong}, your ${paymentInterval}ly payment will be ${formatCurrency(
+
+		if (isYearlyBilling(paymentInterval)) {
+			paymentConditionsText += `After this, from ${nextPaymentDateLong}, your payment will be ${formatCurrency(
+				currency,
+				discount.discountedPrice,
+			)} every year for ${formatRemainingDiscountPeriodLabel(
+				discount.upToPeriods,
+				discount.upToPeriodsType,
+			)} and then ${formatCurrency(
+				currency,
+				targetCatalogPrice,
+			)} every year. Your next payment date will be ${nextPaymentDateLong}.`;
+		} else {
+			paymentConditionsText += `From ${nextPaymentDateLong}, your ${paymentInterval}ly payment will be ${formatCurrency(
+				currency,
+				discount.discountedPrice,
+			)} for ${formatRemainingDiscountPeriodLabel(
+				discount.upToPeriods,
+				discount.upToPeriodsType,
+			)} and then ${formatCurrency(
+				currency,
+				targetCatalogPrice,
+			)} per ${paymentInterval}. The ${nextPaymentDateDay} will be your next payment date.`;
+		}
+	} else if (isYearlyBilling(paymentInterval)) {
+		paymentConditionsText += `After this, from ${nextPaymentDateLong}, your payment will be ${formatCurrency(
 			currency,
-			discount.discountedPrice,
-		)} for ${formatRemainingDiscountPeriodLabel(
-			discount.upToPeriods,
-			discount.upToPeriodsType,
-		)} and then ${formatCurrency(
-			currency,
-			targetCatalogPrice,
-		)} per ${paymentInterval}. The ${nextPaymentDateDay} will be your next payment date.`;
+			preview.targetCatalogPrice,
+		)} every year.`;
 	} else {
 		paymentConditionsText += `After this, from ${nextPaymentDateLong}, your ${paymentInterval}ly payment will be ${formatCurrency(
 			currency,
@@ -137,16 +197,36 @@ export function getThankYouPaymentConditionsText({
 	isDiscountedOffer,
 	currency,
 	billingPeriod,
-	nextPaymentDateLong,
 }: {
 	preview: UpgradePreviewResponse;
 	isDiscountedOffer: boolean;
 	currency: string;
-	billingPeriod: string;
-	nextPaymentDateLong: string;
+	billingPeriod: BillingPeriod;
 }): string {
+	const nextPaymentDateLong = formatUpgradeNextPaymentDate(
+		preview.nextPaymentDate,
+		billingPeriod,
+	);
+
 	if (isDiscountedOffer && isDiscountedPreview(preview)) {
 		const { discount, targetCatalogPrice, amountPayableToday } = preview;
+
+		if (isYearlyBilling(billingPeriod)) {
+			return `You will be charged ${formatCurrency(
+				currency,
+				amountPayableToday,
+			)} today. After this, from ${nextPaymentDateLong}, your payment will be ${formatCurrency(
+				currency,
+				discount.discountedPrice,
+			)} every year for ${formatRemainingDiscountPeriodLabel(
+				discount.upToPeriods,
+				discount.upToPeriodsType,
+			)}, then ${formatCurrency(
+				currency,
+				targetCatalogPrice,
+			)} every year.`;
+		}
+
 		return `You will be charged ${formatCurrency(
 			currency,
 			amountPayableToday,
@@ -160,6 +240,16 @@ export function getThankYouPaymentConditionsText({
 			currency,
 			targetCatalogPrice,
 		)} per ${billingPeriod}.`;
+	}
+
+	if (isYearlyBilling(billingPeriod)) {
+		return `You will be charged ${formatCurrency(
+			currency,
+			preview.amountPayableToday,
+		)}. After this, from ${nextPaymentDateLong}, your payment will be ${formatCurrency(
+			currency,
+			preview.targetCatalogPrice,
+		)} every year.`;
 	}
 
 	return `You will be charged ${formatCurrency(

--- a/client/utilities/upgradeProductPaymentCopy.ts
+++ b/client/utilities/upgradeProductPaymentCopy.ts
@@ -24,6 +24,12 @@ function formatYearlyDiscountNextPaymentDate(nextPaymentDate: string): string {
 	return dateString(new Date(nextPaymentDate), 'dd MMMM yyyy');
 }
 
+/** Day label for yearly next payment date copy. @example "the 6th of July" */
+function formatYearlyNextPaymentDayLabel(nextPaymentDate: string): string {
+	const date = new Date(nextPaymentDate);
+	return `the ${dateString(date, 'do')} of ${dateString(date, 'MMMM')}`;
+}
+
 /** @example formatUpgradeNextPaymentDate('2026-03-15', 'month') // "March 15th" */
 export function formatUpgradeNextPaymentDate(
 	nextPaymentDate: string,
@@ -37,7 +43,7 @@ export function formatUpgradeNextPaymentDayLabel(
 	billingPeriod: BillingPeriod,
 ): string {
 	return isYearlyBilling(billingPeriod)
-		? formatYearlyDiscountNextPaymentDate(nextPaymentDate)
+		? formatYearlyNextPaymentDayLabel(nextPaymentDate)
 		: dateString(new Date(nextPaymentDate), 'do');
 }
 
@@ -162,10 +168,13 @@ export function getConfirmationPaymentConditionsText({
 		if (isYearlyBilling(paymentInterval)) {
 			const yearlyDiscountPaymentDate =
 				formatYearlyDiscountNextPaymentDate(preview.nextPaymentDate);
+			const yearlyNextPaymentDayLabel = formatYearlyNextPaymentDayLabel(
+				preview.nextPaymentDate,
+			);
 			paymentConditionsText += `After this, from ${yearlyDiscountPaymentDate}, your payment will be ${formatCurrency(
 				currency,
 				targetCatalogPrice,
-			)} every year. Your next payment date will be ${yearlyDiscountPaymentDate}.`;
+			)} every year. Your next payment date will be ${yearlyNextPaymentDayLabel}.`;
 		} else {
 			paymentConditionsText += `From ${nextPaymentDateLong}, your ${paymentInterval}ly payment will be ${formatCurrency(
 				currency,

--- a/client/utilities/upgradeProductPaymentCopy.ts
+++ b/client/utilities/upgradeProductPaymentCopy.ts
@@ -15,15 +15,21 @@ function isYearlyBilling(billingPeriod: string): billingPeriod is 'year' {
 	return billingPeriod === 'year';
 }
 
-/** @example formatUpgradeNextPaymentDate('2027-07-06', 'year') // "06 July 2027" */
+function formatStandardNextPaymentDate(nextPaymentDate: string): string {
+	return dateString(new Date(nextPaymentDate), 'MMMM do');
+}
+
+/** Long date for yearly discounted payment copy. @example "06 July 2027" */
+function formatYearlyDiscountNextPaymentDate(nextPaymentDate: string): string {
+	return dateString(new Date(nextPaymentDate), 'dd MMMM yyyy');
+}
+
+/** @example formatUpgradeNextPaymentDate('2026-03-15', 'month') // "March 15th" */
 export function formatUpgradeNextPaymentDate(
 	nextPaymentDate: string,
-	billingPeriod: BillingPeriod,
+	_billingPeriod: BillingPeriod,
 ): string {
-	return dateString(
-		new Date(nextPaymentDate),
-		isYearlyBilling(billingPeriod) ? 'dd MMMM yyyy' : 'MMMM do',
-	);
+	return formatStandardNextPaymentDate(nextPaymentDate);
 }
 
 export function formatUpgradeNextPaymentDayLabel(
@@ -31,7 +37,7 @@ export function formatUpgradeNextPaymentDayLabel(
 	billingPeriod: BillingPeriod,
 ): string {
 	return isYearlyBilling(billingPeriod)
-		? formatUpgradeNextPaymentDate(nextPaymentDate, billingPeriod)
+		? formatYearlyDiscountNextPaymentDate(nextPaymentDate)
 		: dateString(new Date(nextPaymentDate), 'do');
 }
 
@@ -140,9 +146,8 @@ export function getConfirmationPaymentConditionsText({
 	currency: string;
 	paymentInterval: BillingPeriod;
 }): string {
-	const nextPaymentDateLong = formatUpgradeNextPaymentDate(
+	const nextPaymentDateLong = formatStandardNextPaymentDate(
 		preview.nextPaymentDate,
-		paymentInterval,
 	);
 	const nextPaymentDateDay = formatUpgradeNextPaymentDayLabel(
 		preview.nextPaymentDate,
@@ -155,7 +160,9 @@ export function getConfirmationPaymentConditionsText({
 		const { discount, targetCatalogPrice } = preview;
 
 		if (isYearlyBilling(paymentInterval)) {
-			paymentConditionsText += `After this, from ${nextPaymentDateLong}, your payment will be ${formatCurrency(
+			const yearlyDiscountPaymentDate =
+				formatYearlyDiscountNextPaymentDate(preview.nextPaymentDate);
+			paymentConditionsText += `After this, from ${yearlyDiscountPaymentDate}, your payment will be ${formatCurrency(
 				currency,
 				discount.discountedPrice,
 			)} every year for ${formatRemainingDiscountPeriodLabel(
@@ -164,7 +171,7 @@ export function getConfirmationPaymentConditionsText({
 			)} and then ${formatCurrency(
 				currency,
 				targetCatalogPrice,
-			)} every year. Your next payment date will be ${nextPaymentDateLong}.`;
+			)} every year. Your next payment date will be ${yearlyDiscountPaymentDate}.`;
 		} else {
 			paymentConditionsText += `From ${nextPaymentDateLong}, your ${paymentInterval}ly payment will be ${formatCurrency(
 				currency,
@@ -177,11 +184,6 @@ export function getConfirmationPaymentConditionsText({
 				targetCatalogPrice,
 			)} per ${paymentInterval}. The ${nextPaymentDateDay} will be your next payment date.`;
 		}
-	} else if (isYearlyBilling(paymentInterval)) {
-		paymentConditionsText += `After this, from ${nextPaymentDateLong}, your payment will be ${formatCurrency(
-			currency,
-			preview.targetCatalogPrice,
-		)} every year.`;
 	} else {
 		paymentConditionsText += `After this, from ${nextPaymentDateLong}, your ${paymentInterval}ly payment will be ${formatCurrency(
 			currency,
@@ -203,19 +205,20 @@ export function getThankYouPaymentConditionsText({
 	currency: string;
 	billingPeriod: BillingPeriod;
 }): string {
-	const nextPaymentDateLong = formatUpgradeNextPaymentDate(
+	const nextPaymentDateLong = formatStandardNextPaymentDate(
 		preview.nextPaymentDate,
-		billingPeriod,
 	);
 
 	if (isDiscountedOffer && isDiscountedPreview(preview)) {
 		const { discount, targetCatalogPrice, amountPayableToday } = preview;
 
 		if (isYearlyBilling(billingPeriod)) {
+			const yearlyDiscountPaymentDate =
+				formatYearlyDiscountNextPaymentDate(preview.nextPaymentDate);
 			return `You will be charged ${formatCurrency(
 				currency,
 				amountPayableToday,
-			)} today. After this, from ${nextPaymentDateLong}, your payment will be ${formatCurrency(
+			)} today. After this, from ${yearlyDiscountPaymentDate}, your payment will be ${formatCurrency(
 				currency,
 				discount.discountedPrice,
 			)} every year for ${formatRemainingDiscountPeriodLabel(
@@ -240,16 +243,6 @@ export function getThankYouPaymentConditionsText({
 			currency,
 			targetCatalogPrice,
 		)} per ${billingPeriod}.`;
-	}
-
-	if (isYearlyBilling(billingPeriod)) {
-		return `You will be charged ${formatCurrency(
-			currency,
-			preview.amountPayableToday,
-		)}. After this, from ${nextPaymentDateLong}, your payment will be ${formatCurrency(
-			currency,
-			preview.targetCatalogPrice,
-		)} every year.`;
 	}
 
 	return `You will be charged ${formatCurrency(


### PR DESCRIPTION
## Summary
Follow-up to #1642 that centralises upgrade payment/discount copy, fixes several post-merge bugs, and adds annual discount support in the preview API.
### Shared payment copy utility
- Adds `client/utilities/upgradeProductPaymentCopy.ts` with shared helpers for discount detection, currency formatting, date labels, and copy for Information / Confirmation / Thank You
- Refactors `UpgradeProductInformation`, `UpgradeProductConfirmation`, and `UpgradeProductThankYou` to use the shared builders instead of inline string assembly
### Discount detection & API
- Fixes `isDiscountedOffer` to use `discountedPrice < targetCatalogPrice` (avoids false positives when discounted price equals catalog price, e.g. 100% off edge cases)
- Enables discount preview/switch for **annual** subscriptions (removes monthly-only `discountSwitchEnabled` gating in upgrade hooks; defaults `discountSwitchEnabled` to `true` in `productUtils`)
### Copy & formatting fixes
- Uses `formatAmount` consistently for currency display (e.g. `£7.50` not `£7.5`)
- Uses `preview.nextPaymentDate` for payment copy instead of `subscription.nextPaymentDate`
- Correct promo duration pluralisation (`1 month` not `1 months`); missing `upToPeriods` falls back to `"unknown"` not `0`
- Payment paragraphs use `upToPeriods - 1` for remaining promo periods (first discounted period counted separately)
### Annual-specific copy
- **Non-discounted annual:** unchanged wording — e.g. `After this, from January 15th, your yearly payment will be £149`
- **Discounted annual:** new wording — e.g. `After this, from 06 July 2027, your payment will be £200 every year. Your next payment date will be the 6th of July.`
  - Promo duration is **not** repeated in the payment paragraph (shown in the card header instead)
  - Thank You uses matching `every year` copy and `the 6th of July` date label
- **Monthly discount** copy unchanged (promo duration still in payment paragraph)
### Safety guards
- Confirmation/Information require `previewResponse` before render
- Confirmation returns early if `nextPaymentDetails` is missing (avoids undefined payment interval)
### Storybook & tests
- Adds annual discount stories: Information / Confirmation / Thank You
- Adds 20 unit tests in `client/__tests__/upgradeProductPaymentCopy.test.ts`

## Test plan
- [x] `yarn jest client/__tests__/upgradeProductPaymentCopy.test.ts --verbose`
- [x] `yarn type-check`
- [X] Spot-check Storybook: `Information - Monthly Discount`, `Confirmation - Monthly Discount`, `Thank You - Monthly Discount` (expect `£7.50`, "3 months" in header, "2 months" in payment copy)
- [X] Manual smoke test discounted upgrade flow on CODE

## Notes
- Addresses unresolved review threads from #1642 (banner WIP threads intentionally skipped)
