### PR TITLE
read extraTaxApplies not taxExclusive so the tax notice shows

### DIFF
--- a/client/components/mma/accountoverview/ManageProduct.tsx
+++ b/client/components/mma/accountoverview/ManageProduct.tsx
@@ -218,7 +218,7 @@ const InnerContent = ({
 				}
 			/>
 
-			<TaxExclusiveNotice taxExclusive={productDetail.taxExclusive} />
+			<TaxExclusiveNotice taxExclusive={productDetail.extraTaxApplies} />
 
 			{specificProductType.delivery?.showAddress?.(
 				productDetail.subscription,

--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -109,7 +109,7 @@ export const ProductCard = ({
 	const showProductUpsellButton =
 		isEligibleToUpsell &&
 		!hasCancellationPending &&
-		!productDetail.taxExclusive &&
+		!productDetail.extraTaxApplies &&
 		specificProductType.productType === 'supporterplus';
 
 	const productBenefits =

--- a/client/components/mma/accountoverview/ProductCardSections.tsx
+++ b/client/components/mma/accountoverview/ProductCardSections.tsx
@@ -626,7 +626,7 @@ export const PaymentSection = ({
 					</div>
 				)}
 			</div>
-			<TaxExclusiveNotice taxExclusive={productDetail.taxExclusive} />
+			<TaxExclusiveNotice taxExclusive={productDetail.extraTaxApplies} />
 		</Card.Section>
 	);
 

--- a/client/components/mma/accountoverview/manageProducts/ManageProductV2.tsx
+++ b/client/components/mma/accountoverview/manageProducts/ManageProductV2.tsx
@@ -232,7 +232,7 @@ const InnerContent = ({
 				</Stack>
 			</section>
 
-			<TaxExclusiveNotice taxExclusive={productDetail.taxExclusive} />
+			<TaxExclusiveNotice taxExclusive={productDetail.extraTaxApplies} />
 
 			<section
 				css={css`

--- a/client/components/mma/billing/Billing.tsx
+++ b/client/components/mma/billing/Billing.tsx
@@ -309,7 +309,7 @@ function renderProductBillingInfo([productGrouping, productDetails]: [
 								</div>
 							)}
 							<TaxExclusiveNotice
-								taxExclusive={productDetail.taxExclusive}
+								taxExclusive={productDetail.extraTaxApplies}
 							/>
 						</Fragment>
 					);

--- a/shared/productResponse.ts
+++ b/shared/productResponse.ts
@@ -120,7 +120,7 @@ export interface ProductDetail extends WithSubscription {
 	alertText?: string;
 	selfServiceCancellation: SelfServiceCancellation;
 	billingCountry?: string;
-	taxExclusive?: boolean;
+	extraTaxApplies?: boolean;
 }
 
 export interface CancelledProductDetail {


### PR DESCRIPTION
The Canada tax-exclusive notice wasn't showing. manage-frontend reads `productDetail.taxExclusive`, but members-data-api emits the field as `extraTaxApplies` (it was renamed in guardian/members-data-api#1251, off the back of the naming feedback on that PR). So `taxExclusive` is always undefined and the notice condition never fires.

This renames the `ProductDetail` field and its read sites to `extraTaxApplies` to match the API. The `TaxExclusiveNotice` component itself is unchanged, it just gets fed the right value now.

Spotted by Graham while testing the new CA plans. Original notice work was #1665 / #1666.

Verified locally: type-check, lint and the TaxExclusiveNotice tests pass.
