### PR TITLE
Remove California Resident footer

### DIFF
--- a/client/components/shared/footer/Footerlinks.tsx
+++ b/client/components/shared/footer/Footerlinks.tsx
@@ -38,7 +38,7 @@ export const footerlinks: FooterLink[][] = [
 		},
 		{
 			title: 'Privacy settings',
-			titleUSA: 'California resident – Do Not Sell',
+			titleUSA: 'Do Not Sell or Share',
 			cmp: true,
 		},
 		{

--- a/client/components/shared/footer/Footerlinks.tsx
+++ b/client/components/shared/footer/Footerlinks.tsx
@@ -38,7 +38,7 @@ export const footerlinks: FooterLink[][] = [
 		},
 		{
 			title: 'Privacy settings',
-			titleUSA: 'Do Not Sell or Share',
+			titleUSA: 'US resident - Do Not Sell or Share',
 			cmp: true,
 		},
 		{


### PR DESCRIPTION
## What does this change?
This PR updates the copy for the US Privacy Settings copy from `California Residents - Do Not Sell` to `Do Not Sell or Share`
## Why?
US Team has asked.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="1909" height="1039" alt="Screenshot 2026-07-08 at 10 08 35" src="https://github.com/user-attachments/assets/13f43242-612c-4db7-9153-35663bbd6390" /> | <img width="1904" height="415" alt="Screenshot 2026-07-24 at 10 19 44" src="https://github.com/user-attachments/assets/490a2ff8-9767-4496-9ecd-ab1b11b4270e" /> |

[before

]: https://example.com/before.png
[after]: https://example.com/after.png

