### PR TITLE
Hide change amount for tax-exclusive plans and move tax notice outside product card

### DIFF
--- a/client/__tests__/components/updateAmount/supporterPlusUpdateAmount.test.tsx
+++ b/client/__tests__/components/updateAmount/supporterPlusUpdateAmount.test.tsx
@@ -215,3 +215,21 @@ it('updates amount is valid value is input', async () => {
 	expect(await screen.findByText(/Updating/)).toBeTruthy();
 	expect(await screen.findByText(/successfully updated/)).toBeTruthy();
 });
+
+it('hides the change amount button for tax exclusive plans', () => {
+	render(
+		<UpdateAmount
+			subscriptionId="A-123"
+			mainPlan={mainPlan('month')}
+			amountUpdateStateChange={jest.fn()}
+			nextPaymentDate="2050-10-29"
+			productType={productType}
+			isTestUser={false}
+			extraTaxApplies={true}
+		/>,
+	);
+
+	expect(screen.queryByText('Change amount')).not.toBeInTheDocument();
+	expect(screen.getByText('A-123')).toBeInTheDocument();
+	expect(screen.getByText('£5.00 GBP')).toBeInTheDocument();
+});

--- a/client/components/mma/accountoverview/ManageProduct.tsx
+++ b/client/components/mma/accountoverview/ManageProduct.tsx
@@ -186,6 +186,7 @@ const InnerContent = ({
 					amountUpdateStateChange={setOveriddenAmount}
 					isTestUser={productDetail.isTestUser}
 					futurePlan={productDetail.subscription.futurePlans[0]}
+					extraTaxApplies={productDetail.extraTaxApplies}
 				/>
 			) : (
 				<BasicProductInfoTable

--- a/client/components/mma/accountoverview/ProductCard.tsx
+++ b/client/components/mma/accountoverview/ProductCard.tsx
@@ -17,6 +17,7 @@ import { useUpgradeProduct } from '../../../utilities/hooks/useUpgradePreview';
 import { getGuardianWeeklyGiftBenefits } from '../shared/benefits/BenefitsConfiguration';
 import { Card } from '../shared/Card';
 import { getNextPaymentDetails } from '../shared/NextPaymentDetails';
+import { TaxExclusiveNotice } from '../shared/TaxExclusiveNotice';
 import {
 	getGuardianWeeklyGiftBenefitsCopy,
 	productCardConfiguration,
@@ -257,6 +258,12 @@ export const ProductCard = ({
 					trackEvent={trackEvent}
 				/>
 			</Card>
+
+			{productDetail.isPaidTier && (
+				<TaxExclusiveNotice
+					taxExclusive={productDetail.extraTaxApplies}
+				/>
+			)}
 		</Stack>
 	);
 };

--- a/client/components/mma/accountoverview/ProductCardSections.tsx
+++ b/client/components/mma/accountoverview/ProductCardSections.tsx
@@ -25,7 +25,6 @@ import { BenefitsToggle } from '../shared/benefits/BenefitsToggle';
 import { Card } from '../shared/Card';
 import type { NextPaymentDetails } from '../shared/NextPaymentDetails';
 import { PaymentMethodDisplay } from '../shared/PaymentMethodDisplay';
-import { TaxExclusiveNotice } from '../shared/TaxExclusiveNotice';
 import type { ProductCardConfiguration } from './ProductCardConfiguration';
 import {
 	benefitsSectionBackgroundColour,
@@ -626,7 +625,6 @@ export const PaymentSection = ({
 					</div>
 				)}
 			</div>
-			<TaxExclusiveNotice taxExclusive={productDetail.extraTaxApplies} />
 		</Card.Section>
 	);
 

--- a/client/components/mma/accountoverview/updateAmount/UpdateAmount.tsx
+++ b/client/components/mma/accountoverview/updateAmount/UpdateAmount.tsx
@@ -23,6 +23,7 @@ interface UpdateAmountProps {
 	amountUpdateStateChange: Dispatch<SetStateAction<number | null>>;
 	isTestUser: boolean;
 	futurePlan?: SubscriptionPlan | PaidSubscriptionPlan;
+	extraTaxApplies?: boolean;
 }
 
 export const UpdateAmount = (props: UpdateAmountProps) => {
@@ -104,16 +105,17 @@ export const UpdateAmount = (props: UpdateAmountProps) => {
 								}`,
 							},
 						],
-						actions: !isBillingFrequencySwitch
-							? [
-									{
-										text: 'Change amount',
-										onClick: () => {
-											setStatus(Status.EDITING);
+						actions:
+							!isBillingFrequencySwitch && !props.extraTaxApplies
+								? [
+										{
+											text: 'Change amount',
+											onClick: () => {
+												setStatus(Status.EDITING);
+											},
 										},
-									},
-							  ]
-							: [],
+								  ]
+								: [],
 					},
 				]}
 				separateEachRow

--- a/client/components/mma/shared/TaxExclusiveNotice.tsx
+++ b/client/components/mma/shared/TaxExclusiveNotice.tsx
@@ -8,7 +8,7 @@ interface TaxExclusiveNoticeProps {
 const noticeCss = css`
 	${textSans15};
 	color: ${palette.neutral[46]};
-	margin: ${space[2]}px 0 0;
+	margin: ${space[5]}px 0 0;
 `;
 
 export const TaxExclusiveNotice = ({

--- a/client/components/mma/shared/TaxExclusiveNotice.tsx
+++ b/client/components/mma/shared/TaxExclusiveNotice.tsx
@@ -7,7 +7,7 @@ interface TaxExclusiveNoticeProps {
 
 const noticeCss = css`
 	${textSans15};
-	color: ${palette.neutral[46]};
+	color: ${palette.neutral[7]};
 	margin: ${space[5]}px 0 0;
 `;
 


### PR DESCRIPTION
- Move "Taxes may apply to future payments" below the product card on account overview, to comply with design requirements, instead of inside it
- Hide the "Change amount" button on manage subscription when extraTaxApplies is true, since tax-exclusive pricing isn't supported in that flow yet

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->
