### PR TITLE
Bumped websocket-driver to 0.7.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,7 +188,8 @@
     "serialize-javascript": "^7.0.3",
     "tmp": "^0.2.7",
     "express/path-to-regexp": "^0.1.13",
-    "webpack-dev-server/path-to-regexp": "^0.1.13"
+    "webpack-dev-server/path-to-regexp": "^0.1.13",
+    "websocket-driver": "^0.7.5"
   },
   "license": "UNLICENSED",
   "msw": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14533,10 +14533,10 @@ webpack@5.92.1:
     watchpack "^2.4.1"
     webpack-sources "^3.2.3"
 
-websocket-driver@>=0.5.1, websocket-driver@^0.7.4:
-  version "0.7.4"
-  resolved "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz"
-  integrity sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==
+websocket-driver@>=0.5.1, websocket-driver@^0.7.4, websocket-driver@^0.7.5:
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.5.tgz#569d22764ab21f2de20af0e74b411e8ae5a0fa46"
+  integrity sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==
   dependencies:
     http-parser-js ">=0.5.1"
     safe-buffer ">=5.1.0"


### PR DESCRIPTION
### Current situation/background
This PR aims to resolve the critical alert from dependabot on websocket-driver.

Link: https://github.com/guardian/manage-frontend/security/dependabot/363

### What does this PR change?
Adds a resolution to set websocket-driver to use 0.7.5 instead of 0.7.4 that is currently used as the default. 

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->
