### PR TITLE
add help centre domain cnames (temporary values for authentication)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,5 +58,14 @@ jobs:
             manage-frontend:
               - ./manage-frontend.zip
 
-
-
+      - name: Upload help centre domain to Riff-Raff
+        uses: guardian/actions-riff-raff@v4
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          app: help-centre
+          configPath: ./help-centre/riff-raff.yaml
+          contentDirectories: |
+            cfn:
+              - ./cdk/cdk.out/HelpCentre-CODE.template.json
+              - ./cdk/cdk.out/HelpCentre-PROD.template.json

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -1,5 +1,6 @@
 import 'source-map-support/register';
 import { App } from 'aws-cdk-lib';
+import { HelpCentre } from '../lib/help-centre';
 import { ManageFrontend } from '../lib/manage-frontend';
 
 const app = new App();
@@ -22,3 +23,7 @@ new ManageFrontend(app, 'ManageFrontend-PROD', {
 	domain: 'manage.theguardian.com.origin.membership.guardianapis.com',
 	cloudFormationStackName: 'support-PROD-manage-frontend',
 });
+
+new HelpCentre(app, 'HelpCentre-CODE', 'CODE');
+
+new HelpCentre(app, 'HelpCentre-PROD', 'PROD');

--- a/cdk/lib/help-centre.ts
+++ b/cdk/lib/help-centre.ts
@@ -10,9 +10,9 @@ export class HelpCentre extends GuStack {
 		const app = 'help-centre';
 		const mappings = {
 			CODE: {
-				domainName: 'help.code.dev-theguardian.com',
-				resourceRecord:
-					'help.code.dev-theguardian.com.00d20000000nq5geaa.live.siteforce.com', // temp
+				domainName: 'guardian.map.fastly.net.',
+				resourceRecord: '',
+				//	'help.code.dev-theguardian.com.00d20000000nq5geaa.live.siteforce.com', // temp
 			},
 			PROD: {
 				domainName: 'help.theguardian.com',
@@ -25,7 +25,7 @@ export class HelpCentre extends GuStack {
 			app,
 			domainName,
 			resourceRecord,
-			ttl: Duration.minutes(1),
+			ttl: Duration.hours(1),
 		});
 	}
 }

--- a/cdk/lib/help-centre.ts
+++ b/cdk/lib/help-centre.ts
@@ -11,8 +11,8 @@ export class HelpCentre extends GuStack {
 		const mappings = {
 			CODE: {
 				domainName: 'help.code.dev-theguardian.com',
-				resourceRecord: 'guardian.map.fastly.net.',
-				//	'help.code.dev-theguardian.com.00d20000000nq5geaa.live.siteforce.com', // temp
+				resourceRecord:
+					'help.code.dev-theguardian.com.00d20000000nq5geaa.live.siteforce.com', // temp
 			},
 			PROD: {
 				domainName: 'help.theguardian.com',
@@ -25,7 +25,7 @@ export class HelpCentre extends GuStack {
 			app,
 			domainName,
 			resourceRecord,
-			ttl: Duration.hours(1),
+			ttl: Duration.minutes(5),
 		});
 	}
 }

--- a/cdk/lib/help-centre.ts
+++ b/cdk/lib/help-centre.ts
@@ -1,0 +1,31 @@
+import { GuStack } from '@guardian/cdk/lib/constructs/core';
+import { GuCname } from '@guardian/cdk/lib/constructs/dns/dns-records';
+import type { App } from 'aws-cdk-lib';
+import { Duration } from 'aws-cdk-lib';
+
+export class HelpCentre extends GuStack {
+	constructor(scope: App, id: string, stage: 'CODE' | 'PROD') {
+		super(scope, id, { stack: 'support', stage });
+
+		const app = 'help-centre';
+		const mappings = {
+			CODE: {
+				domainName: 'help.code.dev-theguardian.com',
+				resourceRecord:
+					'help.code.dev-theguardian.com.00d20000000nq5geaa.live.siteforce.com', // temp
+			},
+			PROD: {
+				domainName: 'help.theguardian.com',
+				resourceRecord:
+					'help.theguardian.com.00d20000000nq5geaa.live.siteforce.com', // temp
+			},
+		};
+		const { domainName, resourceRecord } = mappings[stage];
+		new GuCname(this, 'NS1Domain', {
+			app,
+			domainName,
+			resourceRecord,
+			ttl: Duration.minutes(1),
+		});
+	}
+}

--- a/cdk/lib/help-centre.ts
+++ b/cdk/lib/help-centre.ts
@@ -10,8 +10,8 @@ export class HelpCentre extends GuStack {
 		const app = 'help-centre';
 		const mappings = {
 			CODE: {
-				domainName: 'guardian.map.fastly.net.',
-				resourceRecord: '',
+				domainName: 'help.code.dev-theguardian.com',
+				resourceRecord: 'guardian.map.fastly.net.',
 				//	'help.code.dev-theguardian.com.00d20000000nq5geaa.live.siteforce.com', // temp
 			},
 			PROD: {

--- a/help-centre/riff-raff.yaml
+++ b/help-centre/riff-raff.yaml
@@ -1,0 +1,15 @@
+regions:
+  - eu-west-1
+stacks:
+  - support
+allowedStages:
+  - CODE
+  - PROD
+deployments:
+  cfn:
+    type: cloud-formation
+    app: help-centre
+    parameters:
+      templateStagePaths:
+        CODE: HelpCentre-CODE.template.json
+        PROD: HelpCentre-PROD.template.json


### PR DESCRIPTION
We would like to serve the salesforce experience version of the help centre via fastly.

The CODE version is here: https://help.code.dev-theguardian.com/

This requires quite a bit of setup, first we have to prove to salesforce that we own the domain by pointing  help.theguardian.com to a special value, then we have to change it to correctly point it to fastly.

Relevant docs:
https://help.salesforce.com/s/articleView?id=platform.domain_mgmt_enable_https.htm&type=5
https://help.salesforce.com/s/articleView?id=platform.custom_url_add.htm&type=5

## CODE only:

- Since the CODE CNAME record was created manually in NS1, we first need to "adopt" the record to CFN by creating it with the same details (done)

## CODE and PROD

- We need to CNAME the host name to a special (invalid) hostname, presumably to prove to salesforce that any incoming traffic with the host header of our customer facing domain is actually supposed to be picked up by our salesforce backend (and we are not stealing traffic from some unrelaited salesforce customer who is on the same tenant)
- Then we need to update it with the correct fastly name ( https://github.com/guardian/manage-frontend/pull/1713 )

This PR adds the Guardian DNS record entry needed to authenticate, (then we can do another PR to change it to the correct fastly hostname.)

## Testing:

Deployed to CODE and the record is available:
```
% dig +noall +answer CNAME help.code.dev-theguardian.com
help.code.dev-theguardian.com. 300 IN    CNAME    help.code.dev-theguardian.com.00d20000000nq5geaa.live.siteforce.com.
%
```
and the domain could be added in salesforce successfully.

Then the next PR https://github.com/guardian/manage-frontend/pull/1713 was also deployed to CODE, at which point the site started working 