### PR TITLE
Quiet expected upgrade-preview 400s in Sentry

### DIFF
--- a/client/utilities/hooks/useUpgradePreview.ts
+++ b/client/utilities/hooks/useUpgradePreview.ts
@@ -55,6 +55,11 @@ export const useUpgradeProduct = () => {
 				isTestUser,
 			});
 
+			if (!previewResponse) {
+				setPreviewError('Failed to fetch upgrade preview: 400');
+				return;
+			}
+
 			setMainPlan(mainPlan);
 			setSubscription(subscription);
 			setPreviewResponse(previewResponse);

--- a/client/utilities/hooks/useUpgradePreview.ts
+++ b/client/utilities/hooks/useUpgradePreview.ts
@@ -55,8 +55,10 @@ export const useUpgradeProduct = () => {
 				isTestUser,
 			});
 
-			if (!previewResponse) {
-				setPreviewError('Failed to fetch upgrade preview: 400');
+			if (previewResponse === null) {
+				setPreviewError(
+					'You are not currently eligible for an upgrade online. Please contact customer care to discuss your options.',
+				);
 				return;
 			}
 

--- a/client/utilities/hooks/useUpgradeProductLoader.ts
+++ b/client/utilities/hooks/useUpgradeProductLoader.ts
@@ -103,7 +103,7 @@ export const useUpgradeProductLoader = (): LoaderState => {
 					isTestUser: productDetail.isTestUser,
 				});
 
-				if (!preview) {
+				if (preview === null) {
 					setState({ isLoading: false, shouldRedirect: true });
 					return;
 				}

--- a/client/utilities/hooks/useUpgradeProductLoader.ts
+++ b/client/utilities/hooks/useUpgradeProductLoader.ts
@@ -103,6 +103,11 @@ export const useUpgradeProductLoader = (): LoaderState => {
 					isTestUser: productDetail.isTestUser,
 				});
 
+				if (!preview) {
+					setState({ isLoading: false, shouldRedirect: true });
+					return;
+				}
+
 				setMainPlan(fetchedMainPlan);
 				setSubscription(productDetail.subscription);
 				setPreviewResponse(preview);

--- a/client/utilities/productUtils.ts
+++ b/client/utilities/productUtils.ts
@@ -278,7 +278,7 @@ export const changePlanFetch = ({
 export const fetchUpgradePreviewData = async (params: {
 	subscriptionId: string;
 	isTestUser: boolean;
-}): Promise<UpgradePreviewResponse> => {
+}): Promise<UpgradePreviewResponse | null> => {
 	const response = await changePlanFetch({
 		subscriptionId: params.subscriptionId,
 		isTestUser: params.isTestUser,
@@ -286,6 +286,13 @@ export const fetchUpgradePreviewData = async (params: {
 		targetProduct: 'DigitalSubscription',
 		preview: true,
 	});
+
+	// A 400 means the user is ineligible for an online upgrade.
+	// Treat as "no preview available" rather than an error to avoid
+	// spurious Sentry noise for an expected business condition.
+	if (response.status === 400) {
+		return null;
+	}
 
 	if (!response.ok) {
 		throw new Error(`Failed to fetch upgrade preview: ${response.status}`);


### PR DESCRIPTION
### Current situation/background
https://the-guardian.sentry.io/issues/7303821377/?environment=theguardian.com&project=1208603&query=is%3Aunresolved&referrer=issue-stream&sort=freq

Treat Digital Plus upgrade-preview 400 responses as expected ineligibility (null) instead of throwing. Keep showing the existing “not eligible” UI, and only report unexpected failures (e.g. 5xx) to Sentry

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->
