### PR TITLE
Handling array types in api call urls

### DIFF
--- a/server/__tests__/apiProxy.test.ts
+++ b/server/__tests__/apiProxy.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @jest-environment node
+ */
+
+import type { Request, Response } from 'express';
+import fetch from 'node-fetch';
+import { proxyApiHandler, straightThroughBodyHandler } from '../apiProxy';
+
+jest.mock('node-fetch');
+jest.mock('@/server/log');
+jest.mock('@/server/oktaConfig', () => ({
+	getConfig: () => ({ useOkta: true }),
+}));
+
+const mockedFetch = jest.mocked(fetch);
+
+const buildFetchResponse = () =>
+	({
+		status: 200,
+		ok: true,
+		headers: { get: () => undefined },
+		buffer: () => Promise.resolve(Buffer.from('{}')),
+	} as unknown as Awaited<ReturnType<typeof fetch>>);
+
+const buildRequest = (overrides: Partial<Request> = {}): Request =>
+	({
+		params: {},
+		query: {},
+		url: '/',
+		originalUrl: '/',
+		method: 'GET',
+		body: undefined,
+		header: () => undefined,
+		// signedCookies: {},
+		...overrides,
+	} as unknown as Request);
+
+const buildResponse = (): Response =>
+	({
+		locals: {},
+		status: jest.fn(),
+		header: jest.fn(),
+		send: jest.fn(),
+	} as unknown as Response);
+
+const handler = proxyApiHandler('testurl.com')(straightThroughBodyHandler);
+
+const getOutgoingUrl = () => mockedFetch.mock.calls[0][0] as string;
+
+describe('proxyApiHandler - parameterised path building', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockedFetch.mockResolvedValue(buildFetchResponse());
+	});
+
+	it('joins an array param with slashes', async () => {
+		const req = buildRequest({
+			params: { path: ['a', 'b', 'c'] },
+		});
+
+		await handler('proxy/:path', 'CODE', ['path'])(req, buildResponse());
+
+		expect(getOutgoingUrl()).toBe('https://testurl.com/proxy/a/b/c');
+	});
+
+	it('replaces a missing param with an empty string and strips the trailing slash', async () => {
+		const req = buildRequest({ params: {} });
+
+		await handler('user-attributes/me/:productId', 'CODE', ['productId'])(
+			req,
+			buildResponse(),
+		);
+
+		expect(getOutgoingUrl()).toBe('https://testurl.com/user-attributes/me');
+	});
+
+	it('replaces named params', async () => {
+		const req = buildRequest({
+			params: { productId: 'abc', action: 'cancel' },
+		});
+
+		await handler('user-attributes/me/:productId/:action', 'CODE', [
+			'productId',
+			'action',
+		])(req, buildResponse());
+
+		expect(getOutgoingUrl()).toBe(
+			'https://testurl.com/user-attributes/me/abc/cancel',
+		);
+	});
+
+	it('strips a trailing slash from the final path', async () => {
+		const req = buildRequest({ params: {} });
+
+		await handler('final/', 'CODE')(req, buildResponse());
+
+		expect(getOutgoingUrl()).toBe('https://testurl.com/final');
+	});
+});

--- a/server/apiProxy.ts
+++ b/server/apiProxy.ts
@@ -57,9 +57,7 @@ export const proxyApiHandler =
 				(evolvingPath: string, urlParamName: string) =>
 					evolvingPath.replace(
 						':' + urlParamName,
-						Array.isArray(req.params[urlParamName])
-							? req.params[urlParamName].join('/')
-							: req.params[urlParamName] || '',
+						req.params[urlParamName].toString() || '',
 					),
 				path,
 			)

--- a/server/apiProxy.ts
+++ b/server/apiProxy.ts
@@ -57,7 +57,9 @@ export const proxyApiHandler =
 				(evolvingPath: string, urlParamName: string) =>
 					evolvingPath.replace(
 						':' + urlParamName,
-						req.params[urlParamName] || '',
+						Array.isArray(req.params[urlParamName])
+							? req.params[urlParamName].join('/')
+							: req.params[urlParamName] || '',
 					),
 				path,
 			)

--- a/server/apiProxy.ts
+++ b/server/apiProxy.ts
@@ -57,7 +57,9 @@ export const proxyApiHandler =
 				(evolvingPath: string, urlParamName: string) =>
 					evolvingPath.replace(
 						':' + urlParamName,
-						req.params[urlParamName].toString() || '',
+						Array.isArray(req.params[urlParamName])
+							? req.params[urlParamName].join('/')
+							: req.params[urlParamName] || '',
 					),
 				path,
 			)


### PR DESCRIPTION
### Current situation/background
Started receiving this error from TypeScript pre-checks a few days ago while working on other features (address change blocks for MMA and secondary account product card). Current implementation does not account for array types in the API call urls, they default to falsy and return as ''. 

```
$ tsc --skipLibCheck
server/apiProxy.ts:60:7 - error TS2769: No overload matches this call.
  The last overload gave the following error.
    Argument of type 'string | string[]' is not assignable to parameter of type '(substring: string, ...args: any[]) => string'.
      Type 'string' is not assignable to type '(substring: string, ...args: any[]) => string'.

60       req.params[urlParamName] || '',
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  node_modules/typescript/lib/lib.es5.d.ts:470:5
    470     replace(searchValue: string | RegExp, replacer: (substring: string, ...args: any[]) => string): string;
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    The last overload is declared here.


Found 1 error in server/apiProxy.ts:60
```

### What does this PR change?
If the parameter passed through the url is an array of strings, this code should join them with '/', otherwise it fetches the parameter or return an empty string for this parameter if it is not defined. 

"example/:path" with params: { path: ['a', 'b', 'c'] } would call "example/a/b/c" endpoint instead of "example/"

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->
