### PR TITLE
Express server Help Centre redirect

### DIFF
--- a/server/__tests__/helpCentreRedirect.test.ts
+++ b/server/__tests__/helpCentreRedirect.test.ts
@@ -1,0 +1,30 @@
+import { shouldRetainHelpCentrePath } from '../helpCentreRedirect';
+
+describe('shouldRetainHelpCentrePath', () => {
+	test.each([
+		'/contact-us',
+		'/contact-us/',
+		'/contact-us/billing',
+		'/contact-us/billing/something',
+		'/contact-us/a/b/c/d',
+		'/diagnostic-information',
+		'/diagnostic-information/',
+		'/public-diagnostic-information',
+		'/public-diagnostic-information/',
+	])('retains %s on manage', (path) => {
+		expect(shouldRetainHelpCentrePath(path)).toBe(true);
+	});
+
+	test.each([
+		'/',
+		'',
+		'/article/some-article',
+		'/topic/some-topic',
+		'/unknown-page',
+		'/contact-us-extra',
+		'/diagnostic-information-extra',
+		'/public-diagnostic-information-extra',
+	])('does not retain %s', (path) => {
+		expect(shouldRetainHelpCentrePath(path)).toBe(false);
+	});
+});

--- a/server/__tests__/helpCentreRedirect.test.ts
+++ b/server/__tests__/helpCentreRedirect.test.ts
@@ -1,4 +1,24 @@
-import { shouldRetainHelpCentrePath } from '../helpCentreRedirect';
+import {
+	helpCentreHomeForStage,
+	shouldRetainHelpCentrePath,
+} from '../helpCentreRedirect';
+
+describe('helpCentreHomeForStage', () => {
+	test('returns the prod help centre for PROD', () => {
+		expect(helpCentreHomeForStage('PROD')).toBe(
+			'https://help.theguardian.com/',
+		);
+	});
+
+	test.each(['CODE', 'DEV', 'code', ''])(
+		'returns the code help centre for non-PROD stage %s',
+		(stage) => {
+			expect(helpCentreHomeForStage(stage)).toBe(
+				'https://help.code.dev-theguardian.com/',
+			);
+		},
+	);
+});
 
 describe('shouldRetainHelpCentrePath', () => {
 	test.each([

--- a/server/helpCentreRedirect.ts
+++ b/server/helpCentreRedirect.ts
@@ -1,4 +1,11 @@
-export const NEW_HELP_CENTRE_HOME = 'https://help.theguardian.com/';
+import { conf } from './config';
+
+export const helpCentreHomeForStage = (stage: string): string =>
+	stage === 'PROD'
+		? 'https://help.theguardian.com/'
+		: 'https://help.code.dev-theguardian.com/';
+
+export const NEW_HELP_CENTRE_HOME = helpCentreHomeForStage(conf.STAGE);
 
 /**
  * Paths under the `/help-centre` Express mount that should continue to be

--- a/server/helpCentreRedirect.ts
+++ b/server/helpCentreRedirect.ts
@@ -1,0 +1,23 @@
+export const NEW_HELP_CENTRE_HOME = 'https://help.theguardian.com/';
+
+/**
+ * Paths under the `/help-centre` Express mount that should continue to be
+ * served by manage-frontend (not redirected to the new help centre).
+ *
+ * `path` is the path within the mount (e.g. `/contact-us`, not `/help-centre/contact-us`).
+ */
+export const shouldRetainHelpCentrePath = (path: string): boolean => {
+	const normalised =
+		path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path;
+
+	if (
+		normalised === '/diagnostic-information' ||
+		normalised === '/public-diagnostic-information'
+	) {
+		return true;
+	}
+
+	return (
+		normalised === '/contact-us' || normalised.startsWith('/contact-us/')
+	);
+};

--- a/server/routes/helpCentreFrontend.ts
+++ b/server/routes/helpCentreFrontend.ts
@@ -1,7 +1,11 @@
 import { Router } from 'express';
-import type { Request, Response } from 'express';
+import type { NextFunction, Request, Response } from 'express';
 import { DEFAULT_PAGE_TITLE } from '../../shared/helpCentreConfig';
 import { conf } from '../config';
+import {
+	NEW_HELP_CENTRE_HOME,
+	shouldRetainHelpCentrePath,
+} from '../helpCentreRedirect';
 import { htmlAndScriptHashes } from '../html';
 import { withIdentity } from '../middleware/identityMiddleware';
 import { createCsp } from '../server';
@@ -14,6 +18,14 @@ import {
 const router = Router();
 
 router.use(withIdentity());
+
+router.use((req: Request, res: Response, next: NextFunction) => {
+	if (shouldRetainHelpCentrePath(req.path)) {
+		return next();
+	}
+
+	return res.redirect(301, NEW_HELP_CENTRE_HOME);
+});
 
 router.use(async (_: Request, res: Response) => {
 	const title = DEFAULT_PAGE_TITLE;


### PR DESCRIPTION
The old Guardian help centre still lives under manage.theguardian.com/help-centre, but content has moved to the new help centre at help.theguardian.com. There isn’t a reliable one-to-one mapping from old articles to new ones, so traffic to the old paths needs to land on the new home page rather than deep-linked content.

This PR adds Express-layer permanent redirects so visits to /help-centre and its subpaths on manage go to https://help.theguardian.com/, while leaving contact-us (including nested form paths) and both diagnostic-information pages on manage for now, since those flows are still needed there.

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->
