### PR TITLE
add custom redirects for the most popular urls

### DIFF
--- a/server/__tests__/helpCentreRedirect.test.ts
+++ b/server/__tests__/helpCentreRedirect.test.ts
@@ -1,5 +1,6 @@
 import {
 	helpCentreHomeForStage,
+	redirectForPath,
 	shouldRetainHelpCentrePath,
 } from '../helpCentreRedirect';
 
@@ -47,4 +48,13 @@ describe('shouldRetainHelpCentrePath', () => {
 	])('does not retain %s', (path) => {
 		expect(shouldRetainHelpCentrePath(path)).toBe(false);
 	});
+});
+
+describe('redirectForPath redirects to custom urls where specified', () => {
+	expect(redirectForPath('/asdf')).toBe(
+		'https://help.code.dev-theguardian.com/',
+	);
+	expect(redirectForPath('/article/i-need-to-pause-my-delivery')).toBe(
+		'https://help.code.dev-theguardian.com/article/how-do-i-pause-my-delivery-for-a-holiday',
+	);
 });

--- a/server/__tests__/helpCentreRedirect.test.ts
+++ b/server/__tests__/helpCentreRedirect.test.ts
@@ -7,7 +7,7 @@ import {
 describe('helpCentreHomeForStage', () => {
 	test('returns the prod help centre for PROD', () => {
 		expect(helpCentreHomeForStage('PROD')).toBe(
-			'https://help.theguardian.com/',
+			'https://help.theguardian.com',
 		);
 	});
 
@@ -15,7 +15,7 @@ describe('helpCentreHomeForStage', () => {
 		'returns the code help centre for non-PROD stage %s',
 		(stage) => {
 			expect(helpCentreHomeForStage(stage)).toBe(
-				'https://help.code.dev-theguardian.com/',
+				'https://help.code.dev-theguardian.com',
 			);
 		},
 	);

--- a/server/__tests__/helpCentreRedirect.test.ts
+++ b/server/__tests__/helpCentreRedirect.test.ts
@@ -50,7 +50,7 @@ describe('shouldRetainHelpCentrePath', () => {
 	});
 });
 
-describe('redirectForPath redirects to custom urls where specified', () => {
+test('redirectForPath redirects to custom urls where specified', () => {
 	expect(redirectForPath('/asdf')).toBe(
 		'https://help.code.dev-theguardian.com/',
 	);

--- a/server/helpCentreRedirect.ts
+++ b/server/helpCentreRedirect.ts
@@ -2,10 +2,8 @@ import { conf } from './config';
 
 export const helpCentreHomeForStage = (stage: string): string =>
 	stage === 'PROD'
-		? 'https://help.theguardian.com/'
-		: 'https://help.code.dev-theguardian.com/';
-
-export const NEW_HELP_CENTRE_HOME = helpCentreHomeForStage(conf.STAGE);
+		? 'https://help.theguardian.com'
+		: 'https://help.code.dev-theguardian.com';
 
 /**
  * Paths under the `/help-centre` Express mount that should continue to be
@@ -28,3 +26,26 @@ export const shouldRetainHelpCentrePath = (path: string): boolean => {
 		normalised === '/contact-us' || normalised.startsWith('/contact-us/')
 	);
 };
+
+const customRedirects: Record<string, string> = {
+	'/article/contact-a-journalist-or-editorial-desk':
+		'/article/how-do-i-contact-the-newsroom-or-pitch-a-story',
+	'/article/i-need-to-pause-my-delivery':
+		'/article/how-do-i-pause-my-delivery-for-a-holiday',
+	'/article/i-want-to-cancel-my-subscription':
+		'/article/how-do-i-cancel-my-subscription-or-recurring-contribution',
+	'/article/i-want-to-cancel-my-regular-payments-to-you':
+		'/article/how-do-i-cancel-my-subscription-or-recurring-contribution',
+	'/article/im-a-print-subscriber-where-can-i-pick-up-my-papers':
+		'/article/how-do-i-redeem-my-newspaper-vouchers',
+	'/article/guardian-editions-app':
+		'/article/how-do-i-access-and-use-the-guardian-editions-app',
+	'/article/submit-an-idea-for-a-story':
+		'/article/how-do-i-contact-the-newsroom-or-pitch-a-story',
+};
+
+export function redirectForPath(path: string): string {
+	const helpCentreRoot = helpCentreHomeForStage(conf.STAGE);
+	const targetPath = customRedirects[path] ?? '/';
+	return helpCentreRoot + targetPath;
+}

--- a/server/helpCentreRedirect.ts
+++ b/server/helpCentreRedirect.ts
@@ -27,22 +27,24 @@ export const shouldRetainHelpCentrePath = (path: string): boolean => {
 	);
 };
 
-const customRedirects: Record<string, string> = {
-	'/article/contact-a-journalist-or-editorial-desk':
-		'/article/how-do-i-contact-the-newsroom-or-pitch-a-story',
-	'/article/i-need-to-pause-my-delivery':
-		'/article/how-do-i-pause-my-delivery-for-a-holiday',
-	'/article/i-want-to-cancel-my-subscription':
-		'/article/how-do-i-cancel-my-subscription-or-recurring-contribution',
-	'/article/i-want-to-cancel-my-regular-payments-to-you':
-		'/article/how-do-i-cancel-my-subscription-or-recurring-contribution',
-	'/article/im-a-print-subscriber-where-can-i-pick-up-my-papers':
-		'/article/how-do-i-redeem-my-newspaper-vouchers',
-	'/article/guardian-editions-app':
-		'/article/how-do-i-access-and-use-the-guardian-editions-app',
-	'/article/submit-an-idea-for-a-story':
-		'/article/how-do-i-contact-the-newsroom-or-pitch-a-story',
+// we want to keep one redirect per line for clarity:
+// prettier-ignore
+const articleRedirects: Record<string, string> = {
+	'contact-a-journalist-or-editorial-desk': 'how-do-i-contact-the-newsroom-or-pitch-a-story',
+	'i-need-to-pause-my-delivery': 'how-do-i-pause-my-delivery-for-a-holiday',
+	'i-want-to-cancel-my-subscription': 'how-do-i-cancel-my-subscription-or-recurring-contribution',
+	'i-want-to-cancel-my-regular-payments-to-you': 'how-do-i-cancel-my-subscription-or-recurring-contribution',
+	'im-a-print-subscriber-where-can-i-pick-up-my-papers': 'how-do-i-redeem-my-newspaper-vouchers',
+	'guardian-editions-app': 'how-do-i-access-and-use-the-guardian-editions-app',
+	'submit-an-idea-for-a-story': 'how-do-i-contact-the-newsroom-or-pitch-a-story',
 };
+
+const customRedirects = Object.fromEntries(
+	Object.entries(articleRedirects).map(([source, target]) => [
+		`/article/${source}`,
+		`/article/${target}`,
+	]),
+);
 
 export function redirectForPath(path: string): string {
 	const helpCentreRoot = helpCentreHomeForStage(conf.STAGE);

--- a/server/routes/helpCentreFrontend.ts
+++ b/server/routes/helpCentreFrontend.ts
@@ -1,9 +1,9 @@
-import { Router } from 'express';
 import type { NextFunction, Request, Response } from 'express';
+import { Router } from 'express';
 import { DEFAULT_PAGE_TITLE } from '../../shared/helpCentreConfig';
 import { conf } from '../config';
 import {
-	NEW_HELP_CENTRE_HOME,
+	redirectForPath,
 	shouldRetainHelpCentrePath,
 } from '../helpCentreRedirect';
 import { htmlAndScriptHashes } from '../html';
@@ -24,7 +24,7 @@ router.use((req: Request, res: Response, next: NextFunction) => {
 		return next();
 	}
 
-	return res.redirect(301, NEW_HELP_CENTRE_HOME);
+	return res.redirect(301, redirectForPath(req.path));
 });
 
 router.use(async (_: Request, res: Response) => {


### PR DESCRIPTION
following on from https://github.com/guardian/manage-frontend/pull/1727

We decided to add custom redirects for the top few pages based on search referral.  This is because
1. it provides a better experience for users who already know what information they need
2. it will retain more of the search ranking from existing incoming links (as search engines are likely to see the new page as more relevant, and therefore transfer the ranking over to the new page)

This PR adds the relevant code to do the redirect.

## Notes

To work out the high ranked pages we did this in bigquery just this morning:
```
select p.path
from `datatech-platform-prod.online_traffic.fact_page_view` p
where 1=1
and p.received_date > date '2026-07-01'
and p.host = 'manage.theguardian.com'
and p.referrer_category = 'Search Engine and other Google'
group by 1
order by count(1) desc
```
And we picked the top 10 roughly, discarding the ones that were not relevant.
<img width="529" height="491" alt="image" src="https://github.com/user-attachments/assets/d9b75715-54b1-4674-8a55-6cfb9195df10" />

ref https://docs.google.com/spreadsheets/d/18ez1UbxfYmN9xKToOilKP0e-DBCCRsxG8O1e5oNUPWg/edit?gid=0#gid=0

Tested in CODE
- redirect works from a known url
- catch all redirect works
- diagnostic information works