### PR TITLE
Fix “Back to Help Centre” links on retained pages

### DIFF
--- a/client/components/helpCentre/BackToHelpCentreLink.tsx
+++ b/client/components/helpCentre/BackToHelpCentreLink.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { palette, space, textSans17 } from '@guardian/source/foundations';
 import { SvgChevronLeftSingle } from '@guardian/source/react-components';
-import { Link } from 'react-router-dom';
+import { getHelpCentreHomeUrl } from '../../utilities/helpCentreHome';
 
 const dividerCss = css`
 	margin-top: ${space[12]}px;
@@ -31,11 +31,11 @@ const linkIconCss = css`
 
 export const BackToHelpCentreLink = () => (
 	<div css={dividerCss}>
-		<Link to="/help-centre" css={linkCss}>
+		<a href={getHelpCentreHomeUrl()} css={linkCss}>
 			<span css={linkIconCss}>
 				<SvgChevronLeftSingle />
 			</span>
 			Back to Help Centre
-		</Link>
+		</a>
 	</div>
 );

--- a/client/components/shared/SectionHeader.tsx
+++ b/client/components/shared/SectionHeader.tsx
@@ -10,8 +10,8 @@ import {
 } from '@guardian/source/foundations';
 import Color from 'color';
 import type { ReactNode } from 'react';
-import { Link } from 'react-router-dom';
 import { gridBase, gridItemPlacement } from '../../styles/grid';
+import { getHelpCentreHomeUrl } from '../../utilities/helpCentreHome';
 
 interface SectionHeaderProps {
 	title: ReactNode;
@@ -107,7 +107,7 @@ export const SectionHeader = (props: SectionHeaderProps) => {
 		<header css={headerCss}>
 			<div css={containerCss}>
 				<div css={divCss}>
-					<Link to="/help-centre" css={linkCss}>
+					<a href={getHelpCentreHomeUrl()} css={linkCss}>
 						{isLandingPage ? (
 							<span css={spanCss}>Help Centre</span>
 						) : (
@@ -116,7 +116,7 @@ export const SectionHeader = (props: SectionHeaderProps) => {
 								Back to Help Centre
 							</span>
 						)}
-					</Link>
+					</a>
 				</div>
 				<h1 css={h1Css(props.pageHasNav)}>{props.title}</h1>
 			</div>

--- a/client/utilities/helpCentreHome.ts
+++ b/client/utilities/helpCentreHome.ts
@@ -1,0 +1,5 @@
+import { conf } from '../../server/config';
+import { helpCentreHomeForStage } from '../../server/helpCentreRedirect';
+
+export const getHelpCentreHomeUrl = (): string =>
+	helpCentreHomeForStage(conf.STAGE);


### PR DESCRIPTION
Description: On contact-us and diagnostic-information, “Back to Help Centre” used React Router to /help-centre, so it never hit the Express 301 to the new Help Centre.

These controls now full-navigate to the stage-correct new Help Centre URL (help.theguardian.com / help.code.dev-theguardian.com).