### PR TITLE
Fix Help Centre back links using domain, not STAGE

### DIFF
--- a/client/utilities/helpCentreHome.ts
+++ b/client/utilities/helpCentreHome.ts
@@ -1,11 +1,4 @@
-import { conf } from '../../server/config';
 import { helpCentreHomeForDomain } from '../../shared/helpCentreConfig';
 
-export const getHelpCentreHomeUrl = (): string => {
-	const domain =
-		typeof window !== 'undefined' && window.guardian
-			? window.guardian.domain
-			: conf.DOMAIN;
-
-	return helpCentreHomeForDomain(domain);
-};
+export const getHelpCentreHomeUrl = (): string =>
+	helpCentreHomeForDomain(window.guardian?.domain ?? '');

--- a/client/utilities/helpCentreHome.ts
+++ b/client/utilities/helpCentreHome.ts
@@ -1,5 +1,11 @@
 import { conf } from '../../server/config';
-import { helpCentreHomeForStage } from '../../server/helpCentreRedirect';
+import { helpCentreHomeForDomain } from '../../shared/helpCentreConfig';
 
-export const getHelpCentreHomeUrl = (): string =>
-	helpCentreHomeForStage(conf.STAGE);
+export const getHelpCentreHomeUrl = (): string => {
+	const domain =
+		typeof window !== 'undefined' && window.guardian
+			? window.guardian.domain
+			: conf.DOMAIN;
+
+	return helpCentreHomeForDomain(domain);
+};

--- a/shared/__tests__/helpCentreConfig.test.ts
+++ b/shared/__tests__/helpCentreConfig.test.ts
@@ -1,0 +1,25 @@
+import { helpCentreHomeForDomain } from '../helpCentreConfig';
+
+describe('helpCentreHomeForDomain', () => {
+	test.each([
+		'theguardian.com',
+		'manage.theguardian.com',
+		'www.theguardian.com',
+	])('returns the prod help centre for %s', (domain) => {
+		expect(helpCentreHomeForDomain(domain)).toBe(
+			'https://help.theguardian.com',
+		);
+	});
+
+	test.each([
+		'code.dev-theguardian.com',
+		'manage.code.dev-theguardian.com',
+		'thegulocal.com',
+		'',
+		'unknown.example',
+	])('returns the code help centre for non-prod domain %s', (domain) => {
+		expect(helpCentreHomeForDomain(domain)).toBe(
+			'https://help.code.dev-theguardian.com',
+		);
+	});
+});

--- a/shared/__tests__/helpCentreConfig.test.ts
+++ b/shared/__tests__/helpCentreConfig.test.ts
@@ -7,15 +7,12 @@ describe('helpCentreHomeForDomain', () => {
 		);
 	});
 
-	test.each([
-		'code.dev-theguardian.com',
-		'manage.code.dev-theguardian.com',
-		'thegulocal.com',
-		'',
-		'unknown.example',
-	])('returns the code help centre for non-prod domain %s', (domain) => {
-		expect(helpCentreHomeForDomain(domain)).toBe(
-			'https://help.code.dev-theguardian.com',
-		);
-	});
+	test.each(['code.dev-theguardian.com', 'thegulocal.com'])(
+		'returns the code help centre for %s',
+		(domain) => {
+			expect(helpCentreHomeForDomain(domain)).toBe(
+				'https://help.code.dev-theguardian.com',
+			);
+		},
+	);
 });

--- a/shared/__tests__/helpCentreConfig.test.ts
+++ b/shared/__tests__/helpCentreConfig.test.ts
@@ -1,12 +1,8 @@
 import { helpCentreHomeForDomain } from '../helpCentreConfig';
 
 describe('helpCentreHomeForDomain', () => {
-	test.each([
-		'theguardian.com',
-		'manage.theguardian.com',
-		'www.theguardian.com',
-	])('returns the prod help centre for %s', (domain) => {
-		expect(helpCentreHomeForDomain(domain)).toBe(
+	test('returns the prod help centre for theguardian.com', () => {
+		expect(helpCentreHomeForDomain('theguardian.com')).toBe(
 			'https://help.theguardian.com',
 		);
 	});

--- a/shared/helpCentreConfig.ts
+++ b/shared/helpCentreConfig.ts
@@ -1,6 +1,5 @@
 export const DEFAULT_PAGE_TITLE = 'Help Centre | The Guardian';
 
-/** Client-side: use window.guardian.domain (STAGE is not available in the browser bundle). */
 export const helpCentreHomeForDomain = (domain: string): string =>
 	domain === 'theguardian.com'
 		? 'https://help.theguardian.com'

--- a/shared/helpCentreConfig.ts
+++ b/shared/helpCentreConfig.ts
@@ -1,1 +1,7 @@
 export const DEFAULT_PAGE_TITLE = 'Help Centre | The Guardian';
+
+/** Client-side: use window.guardian.domain (STAGE is not available in the browser bundle). */
+export const helpCentreHomeForDomain = (domain: string): string =>
+	domain === 'theguardian.com'
+		? 'https://help.theguardian.com'
+		: 'https://help.code.dev-theguardian.com';


### PR DESCRIPTION
conf.STAGE isn’t available in the client bundle, so Prod was falling through to the CODE Help Centre URL.

Back links now use window.guardian.domain (theguardian.com → Prod, otherwise CODE), matching how other client code picks environment.