### PR TITLE
Add redirect for new ads banner page in help centre

### DIFF
--- a/server/helpCentreRedirect.ts
+++ b/server/helpCentreRedirect.ts
@@ -37,6 +37,7 @@ const articleRedirects: Record<string, string> = {
 	'im-a-print-subscriber-where-can-i-pick-up-my-papers': 'how-do-i-redeem-my-newspaper-vouchers',
 	'guardian-editions-app': 'how-do-i-access-and-use-the-guardian-editions-app',
 	'submit-an-idea-for-a-story': 'how-do-i-contact-the-newsroom-or-pitch-a-story',
+	'why-am-i-still-seeing-adsbanners': 'why-am-i-still-seeing-ads-or-banners',
 };
 
 const customRedirects = Object.fromEntries(


### PR DESCRIPTION
Redirect to new ads banner page in the help centre as specified in: https://docs.google.com/spreadsheets/d/18ez1UbxfYmN9xKToOilKP0e-DBCCRsxG8O1e5oNUPWg/edit?gid=0#gid=0

This is a small PR to redirect an additional page for the 'why am i seeing the ads banner' page in the new help centre.

This is beneficial because users are currently being redirected to the main front page of the help centre when clicking a specific link. The new behaviour sends them straight to the relevant page url. This link is already in a newsletter and will reduce user friction as a result.