### PR TITLE
Add in multiple accounts benefit

### DIFF
--- a/client/components/mma/shared/benefits/BenefitsConfiguration.ts
+++ b/client/components/mma/shared/benefits/BenefitsConfiguration.ts
@@ -87,7 +87,7 @@ const digitalPlusBenefitsSecondary = [
 
 const digitalPlusBenefitsPrimary = [
 	...digitalPlusBenefitsSecondary,
-	multipleAccounts,
+	{ description: 'Invite up to 3 people to share your account benefits' },
 ];
 
 export interface ProductBenefit {

--- a/client/components/mma/shared/benefits/BenefitsConfiguration.ts
+++ b/client/components/mma/shared/benefits/BenefitsConfiguration.ts
@@ -11,6 +11,11 @@ const supporterNewsletter = {
 	description: 'Get exclusive insight from our newsroom',
 };
 
+const multipleAccounts = {
+	name: 'Share your account with others.',
+	description: 'Invite up to 3 people to share your account benefits',
+};
+
 const uninterruptedReading = {
 	name: 'Uninterrupted reading.',
 	description: 'See far fewer asks for support',
@@ -65,7 +70,7 @@ const productPlusdigitalBenefits = [
 	},
 ];
 
-const digitalPlusBenefits = [
+const digitalPlusBenefitsSecondary = [
 	{ description: 'Far fewer asks for support' },
 	{ description: 'Ad-free reading on all your devices' },
 	{ description: 'Unlimited access to the premium Guardian and Feast apps' },
@@ -78,6 +83,11 @@ const digitalPlusBenefits = [
 		description:
 			'Access to the daily digital newspaper and our suite of e-magazines, including Guardian Weekly and The Long Read',
 	},
+];
+
+const digitalPlusBenefitsPrimary = [
+	...digitalPlusBenefitsSecondary,
+	multipleAccounts,
 ];
 
 export interface ProductBenefit {
@@ -137,7 +147,7 @@ export const benefitsConfiguration: Record<ProductTypeKeys, ProductBenefit[]> =
 			partnerOffers,
 		],
 		membership: [newsApp, uninterruptedReading, supporterNewsletter],
-		digipack: digitalPlusBenefits,
+		digipack: digitalPlusBenefitsPrimary,
 		digitalvoucher: [],
 		newspaper: [],
 		homedelivery: [],
@@ -202,6 +212,7 @@ export const getUpsellBenefits = (
 				{
 					description: 'Daily digital Guardian newspaper',
 				},
+				multipleAccounts,
 			];
 	}
 };

--- a/client/components/mma/shared/benefits/BenefitsConfiguration.ts
+++ b/client/components/mma/shared/benefits/BenefitsConfiguration.ts
@@ -11,11 +11,6 @@ const supporterNewsletter = {
 	description: 'Get exclusive insight from our newsroom',
 };
 
-const multipleAccounts = {
-	name: 'Share your account with others.',
-	description: 'Invite up to 3 people to share your account benefits',
-};
-
 const uninterruptedReading = {
 	name: 'Uninterrupted reading.',
 	description: 'See far fewer asks for support',

--- a/client/components/mma/shared/benefits/BenefitsConfiguration.ts
+++ b/client/components/mma/shared/benefits/BenefitsConfiguration.ts
@@ -212,7 +212,9 @@ export const getUpsellBenefits = (
 				{
 					description: 'Daily digital Guardian newspaper',
 				},
-				multipleAccounts,
+				{
+					description: 'Share your access with up to 3 others',
+				},
 			];
 	}
 };


### PR DESCRIPTION
Adding in the multiple accounts benefit to the config, and also separating 'Primary' and 'Secondary' users in the benefits config too.

Figma config before the benefits have been added: 
<img width="458" height="278" alt="image" src="https://github.com/user-attachments/assets/e5b882bc-c277-4379-8f75-5ef34b7f1ace" />

Here is what it looks like in CODE in the upgrade journey:

<img width="700" height="693" alt="image" src="https://github.com/user-attachments/assets/7eade44f-a1e8-4d73-8185-2b8a22c66393" />

And on the subscription overview page:

<img width="680" height="574" alt="image" src="https://github.com/user-attachments/assets/d1fc1a4e-85c1-42d2-8190-3c2bd2c0e820" />


https://app.asana.com/1/1210045093164357/project/1213134855566811/task/1213901137098929?focus=true

<!--
This Repo is owned by SR Value team - guardian/value
feel free to request a review or get in touch on chat here: https://mail.google.com/mail/u/0/#chat/space/AAAAuotUxTg
-->
